### PR TITLE
Make code style black compatible

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,3 @@
 [flake8]
-max-line-length = 119
+max-line-length = 88
+extend-ignore = E203

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
-[tool.isort]
-profile = "black"
+[settings]
+profile = black

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ check_lint:
 	pip install -r requirements.txt
 	pip install -r lint-requirements.txt
 	flake8 .
-	isort --profile black --check-only .
+	isort --check-only .
 	black --diff --check --fast .
 
 test:


### PR DESCRIPTION
Fixes code style config, see https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html