### PR TITLE
relax jax requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ graphviz==0.19.1
 ipykernel==6.9.1
 ipython==8.1.1
 ipywidgets==7.7.0
-jax==0.3.13
+jax>=0.3.13
 matplotlib==3.5.1
 numpyro==0.9.2
 pymc>=4.0.0


### PR DESCRIPTION
I had conflicts when using `pymc 4.1.1` and `jax 0.3.13`