### PR TITLE
Scan implementation of Adstock Transformations

### DIFF
--- a/pymmmc/transformers.py
+++ b/pymmmc/transformers.py
@@ -1,3 +1,4 @@
+import aesara
 import aesara.tensor as at
 
 
@@ -8,7 +9,6 @@ def geometric_adstock(x, alpha: float = 0.0, l_max: int = 12, normalize: bool = 
     time period as ad exposure. The cumulative media effect is a weighted average
     of media spend in the current time-period (e.g. week) and previous `l_max` - 1
     periods (e.g. weeks). `l_max` is the maximum duration of carryover effect.
-
 
     Parameters
     ----------
@@ -31,8 +31,12 @@ def geometric_adstock(x, alpha: float = 0.0, l_max: int = 12, normalize: bool = 
     .. [1] Jin, Yuxue, et al. "Bayesian methods for media mix modeling
     with carryover and shape effects." (2017).
     """
-    cycles = [at.concatenate([at.zeros(i), x[: x.shape[0] - i]]) for i in range(l_max)]
-    x_cycle = at.stack(cycles)
+    x_cycle, _ = aesara.scan(
+        fn=lambda i, _, x: at.concatenate([at.zeros(i), x[: x.shape[0] - i]]),
+        sequences=at.arange(l_max),
+        outputs_info=at.zeros_like(x),
+        non_sequences=x,
+    )
     w = at.as_tensor_variable([at.power(alpha, i) for i in range(l_max)])
     w = w / at.sum(w) if normalize else w
     return at.dot(w, x_cycle)
@@ -40,11 +44,14 @@ def geometric_adstock(x, alpha: float = 0.0, l_max: int = 12, normalize: bool = 
 
 def geometric_adstock_vectorized(x, alpha, l_max: int = 12, normalize: bool = False):
     """Vectorized geometric adstock transformation."""
-    cycles = [
-        at.concatenate(tensor_list=[at.zeros(shape=x.shape)[:i], x[: x.shape[0] - i]])
-        for i in range(l_max)
-    ]
-    x_cycle = at.stack(cycles)
+    x_cycle, _ = aesara.scan(
+        fn=lambda i, _, x: at.concatenate(
+            tensor_list=[at.zeros(shape=x.shape)[:i], x[: x.shape[0] - i]]
+        ),
+        sequences=at.arange(l_max),
+        outputs_info=at.zeros_like(x),
+        non_sequences=x,
+    )
     x_cycle = at.transpose(x=x_cycle, axes=[1, 2, 0])
     w = at.as_tensor_variable([at.power(alpha, i) for i in range(l_max)])
     w = at.transpose(w)[None, ...]
@@ -65,7 +72,7 @@ def delayed_adstock(
     x : tensor
         Input tensor.
     alpha : float, by default 0.0
-         Retention rate of ad effect. Must be between 0 and 1.
+        Retention rate of ad effect. Must be between 0 and 1.
     theta : float, by default 0
         Delay of the peak effect. Must be between 0 and `l_max` - 1.
     l_max : int, by default 12
@@ -83,8 +90,12 @@ def delayed_adstock(
     .. [1] Jin, Yuxue, et al. "Bayesian methods for media mix modeling
     with carryover and shape effects." (2017).
     """
-    cycles = [at.concatenate([at.zeros(i), x[: x.shape[0] - i]]) for i in range(l_max)]
-    x_cycle = at.stack(cycles)
+    x_cycle, _ = aesara.scan(
+        fn=lambda i, _, x: at.concatenate([at.zeros(i), x[: x.shape[0] - i]]),
+        sequences=at.arange(l_max),
+        outputs_info=at.zeros_like(x),
+        non_sequences=x,
+    )
     w = at.as_tensor_variable(
         [at.power(alpha, ((i - theta) ** 2)) for i in range(l_max)]
     )
@@ -96,11 +107,14 @@ def delayed_adstock_vectorized(
     x, alpha, theta, l_max: int = 12, normalize: bool = False
 ):
     """Delayed adstock transformation."""
-    cycles = [
-        at.concatenate(tensor_list=[at.zeros(shape=x.shape)[:i], x[: x.shape[0] - i]])
-        for i in range(l_max)
-    ]
-    x_cycle = at.stack(cycles)
+    x_cycle, _ = aesara.scan(
+        fn=lambda i, _, x: at.concatenate(
+            tensor_list=[at.zeros(shape=x.shape)[:i], x[: x.shape[0] - i]]
+        ),
+        sequences=at.arange(l_max),
+        outputs_info=at.zeros_like(x),
+        non_sequences=x,
+    )
     x_cycle = at.transpose(x=x_cycle, axes=[1, 2, 0])
     w = at.as_tensor_variable(
         [at.power(alpha, ((i - theta) ** 2)) for i in range(l_max)]


### PR DESCRIPTION
In this PR change some `for` loops inside the adstock transformations for `scan`  implementation which [EDIT: I would like to see if ] should be faster. I have checked the implementation and it look ok (it passes all the uni-tests!) 
**However:** There is a problem when sampling with `jax`. You can try it out by simply running the `mmm_example.ipynb` notebook. I get an error:

```python
AttributeError                            Traceback (most recent call last)
/Users/juanitorduz/Documents/pymmmc/notebooks/mmm_example.ipynb Cell 30 in <cell line: 1>()
      [1](vscode-notebook-cell:/Users/juanitorduz/Documents/pymmmc/notebooks/mmm_example.ipynb#ch0000029?line=0) with model:
----> [2](vscode-notebook-cell:/Users/juanitorduz/Documents/pymmmc/notebooks/mmm_example.ipynb#ch0000029?line=1)     idata = pm.sampling_jax.sample_numpyro_nuts(
      [3](vscode-notebook-cell:/Users/juanitorduz/Documents/pymmmc/notebooks/mmm_example.ipynb#ch0000029?line=2)         target_accept=0.95, draws=6000, chains=4
      [4](vscode-notebook-cell:/Users/juanitorduz/Documents/pymmmc/notebooks/mmm_example.ipynb#ch0000029?line=3)     )
      [5](vscode-notebook-cell:/Users/juanitorduz/Documents/pymmmc/notebooks/mmm_example.ipynb#ch0000029?line=4)     posterior_predictive = pm.sample_posterior_predictive(trace=idata)

File ~/.local/share/virtualenvs/wolt-mmm-SmLb2E-L/lib/python3.9/site-packages/pymc/sampling_jax.py:482, in sample_numpyro_nuts(draws, tune, chains, target_accept, random_seed, initvals, model, var_names, progress_bar, keep_untransformed, chain_method, postprocessing_backend, idata_kwargs, nuts_kwargs)
    473 print("Compiling...", file=sys.stdout)
    475 init_params = _get_batched_jittered_initial_points(
    476     model=model,
    477     chains=chains,
    478     initvals=initvals,
    479     random_seed=random_seed,
    480 )
--> 482 logp_fn = get_jaxified_logp(model, negative_logp=False)
    484 if nuts_kwargs is None:
    485     nuts_kwargs = {}

File ~/.local/share/virtualenvs/wolt-mmm-SmLb2E-L/lib/python3.9/site-packages/pymc/sampling_jax.py:106, in get_jaxified_logp(model, negative_logp)
    104 if not negative_logp:
    105     model_logp = -model_logp
--> 106 logp_fn = get_jaxified_graph(inputs=model.value_vars, outputs=[model_logp])
    108 def logp_fn_wrap(x):
    109     return logp_fn(*x)[0]

File ~/.local/share/virtualenvs/wolt-mmm-SmLb2E-L/lib/python3.9/site-packages/pymc/sampling_jax.py:99, in get_jaxified_graph(inputs, outputs)
     96 mode.JAX.optimizer.optimize(fgraph)
     98 # We now jaxify the optimized fgraph
---> 99 return jax_funcify(fgraph)

File /usr/local/Cellar/python@3.9/3.9.13_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/functools.py:888, in singledispatch.<locals>.wrapper(*args, **kw)
    884 if not args:
    885     raise TypeError(f'{funcname} requires at least '
    886                     '1 positional argument')
--> 888 return dispatch(args[0].__class__)(*args, **kw)

File ~/.local/share/virtualenvs/wolt-mmm-SmLb2E-L/lib/python3.9/site-packages/aesara/link/jax/dispatch.py:670, in jax_funcify_FunctionGraph(fgraph, node, fgraph_name, **kwargs)
    663 @jax_funcify.register(FunctionGraph)
    664 def jax_funcify_FunctionGraph(
    665     fgraph,
   (...)
    668     **kwargs,
...
--> 407     inner_fg = FunctionGraph(op.inputs, op.outputs)
    408     jax_at_inner_func = jax_funcify(inner_fg, **kwargs)
    410     def scan(*outer_inputs):

AttributeError: 'Scan' object has no attribute 'inputs'
```

I have also recently faced a similar problem with other models using `scan`. Shall I open an issue on the PyMC repo?