### PR TITLE
Fixing minor bugs in distribution classes

### DIFF
--- a/pymmmc/distributions.py
+++ b/pymmmc/distributions.py
@@ -6,6 +6,7 @@ from pymc.distributions.continuous import PositiveContinuous
 from pymc.distributions.dist_math import check_parameters
 
 __all__ = [
+    "ContContract",
     "ContNonContract",
 ]
 
@@ -38,7 +39,7 @@ class ContNonContractRV(RandomVariable):
         T = np.asarray(T)
         T0 = np.asarray(T0)
 
-        if size is None:
+        if size == ():
             size = np.broadcast_shapes(lam.shape, p.shape, T.shape, T0.shape)
 
         lam = np.broadcast_to(lam, size)
@@ -173,7 +174,7 @@ class ContContractRV(RandomVariable):
         T = np.asarray(T)
         T0 = np.asarray(T0)
 
-        if size is None:
+        if size == ():
             size = np.broadcast_shapes(lam.shape, p.shape, T.shape, T0.shape)
 
         lam = np.broadcast_to(lam, size)

--- a/pymmmc/tests/test_distributions.py
+++ b/pymmmc/tests/test_distributions.py
@@ -63,6 +63,7 @@ class TestContNonContract:
         "lam_size, p_size, cnc_size, expected_size",
         [
             (None, None, None, (2,)),
+            ((5,), None, None, (5, 2)),
             ((5,), None, (5,), (5, 2)),
             ((5, 1), (1, 3), (5, 3), (5, 3, 2)),
             (None, None, (5, 3), (5, 3, 2)),
@@ -137,6 +138,7 @@ class TestContContract:
         "lam_size, p_size, cc_size, expected_size",
         [
             (None, None, None, (3,)),
+            ((7,), None, None, (7, 3)),
             ((7,), None, (7,), (7, 3)),
             ((7, 1), (1, 5), (7, 5), (7, 5, 3)),
             (None, None, (7, 5), (7, 5, 3)),


### PR DESCRIPTION
This PR solves two minor bugs.

1. `ContContract` was not added in `__all__` of `pymmmc/distributions.py`
2. `size = pm.distributions.shape_utils.to_tuple(size)` will never be `None` because it will be converted to `()`. This was not initially caught in `test_distributions.py`, and now it is!