### PR TITLE
Refactor validation and preprocessing to rely on mixin classes

### DIFF
--- a/pymmmc/mmm/__init__.py
+++ b/pymmmc/mmm/__init__.py
@@ -1,3 +1,5 @@
-from pymmmc.mmm import base, delayed_saturated_mmm
-from pymmmc.mmm.base import BaseMMM, RescaledMMM
+from pymmmc.mmm import base, delayed_saturated_mmm, preprocessing, validating
+from pymmmc.mmm.base import MMM, BaseMMM
 from pymmmc.mmm.delayed_saturated_mmm import DelayedSaturatedMMM
+from pymmmc.mmm.preprocessing import preprocessing_method
+from pymmmc.mmm.validating import validation_method

--- a/pymmmc/mmm/delayed_saturated_mmm.py
+++ b/pymmmc/mmm/delayed_saturated_mmm.py
@@ -3,11 +3,15 @@ from typing import Any, Dict, List, Optional
 import pandas as pd
 import pymc as pm
 
-from pymmmc.mmm.base import RescaledMMM, validation_method
+from pymmmc.mmm.base import MMM
+from pymmmc.mmm.preprocessing import MaxAbsScaleChannels, MixMaxScaleTarget
+from pymmmc.mmm.validating import ValidateControlColumns
 from pymmmc.transformers import geometric_adstock_vectorized, logistic_saturation
 
 
-class DelayedSaturatedMMM(RescaledMMM):
+class DelayedSaturatedMMM(
+    MMM, MixMaxScaleTarget, MaxAbsScaleChannels, ValidateControlColumns
+):
     def __init__(
         self,
         data_df: pd.DataFrame,
@@ -120,10 +124,3 @@ class DelayedSaturatedMMM(RescaledMMM):
                 observed=target_,
                 dims="date",
             )
-
-    @validation_method
-    def _validate_control_columns(self, data_df) -> None:
-        if self.control_columns is not None and not set(self.control_columns).issubset(
-            data_df.columns
-        ):
-            raise ValueError(f"control_columns {self.control_columns} not in data_df")

--- a/pymmmc/mmm/preprocessing.py
+++ b/pymmmc/mmm/preprocessing.py
@@ -1,0 +1,58 @@
+from typing import Callable
+
+import pandas as pd
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import MaxAbsScaler, MinMaxScaler, StandardScaler
+
+__all__ = [
+    "preprocessing_method",
+    "MixMaxScaleTarget",
+    "MaxAbsScaleChannels",
+    "StandardizeControls",
+]
+
+
+def preprocessing_method(method: Callable) -> Callable:
+    if not hasattr(method, "_tags"):
+        method._tags = {}
+    method._tags["preprocessing"] = True
+    return method
+
+
+class MixMaxScaleTarget:
+    @preprocessing_method
+    def min_max_scale_target_data(self, data_df: pd.DataFrame) -> pd.DataFrame:
+        target_vector = data_df[self.target_column].to_numpy().reshape(-1, 1)
+        transformers = [("scaler", MinMaxScaler())]
+        pipeline = Pipeline(steps=transformers)
+        self.target_transformer: Pipeline = pipeline.fit(X=target_vector)
+        data_df[self.target_column] = self.target_transformer.transform(
+            X=target_vector
+        ).flatten()
+        return data_df
+
+
+class MaxAbsScaleChannels:
+    @preprocessing_method
+    def max_abs_scale_channel_data(self, data_df: pd.DataFrame) -> pd.DataFrame:
+        channel_data: pd.DataFrame = data_df[self.channel_columns]
+        transformers = [("scaler", MaxAbsScaler())]
+        pipeline: Pipeline = Pipeline(steps=transformers)
+        self.channel_transformer: Pipeline = pipeline.fit(X=channel_data.to_numpy())
+        data_df[self.channel_columns] = self.channel_transformer.transform(
+            channel_data.to_numpy()
+        )
+        return data_df
+
+
+class StandardizeControls:
+    @preprocessing_method
+    def standardize_control_data(self, data_df: pd.DataFrame) -> pd.DataFrame:
+        control_data: pd.DataFrame = data_df[self.control_columns]
+        transformers = [("scaler", StandardScaler())]
+        pipeline: Pipeline = Pipeline(steps=transformers)
+        self.control_transformer: Pipeline = pipeline.fit(X=control_data.to_numpy())
+        data_df[self.control_columns] = self.control_transformer.transform(
+            control_data.to_numpy()
+        )
+        return data_df

--- a/pymmmc/mmm/validating.py
+++ b/pymmmc/mmm/validating.py
@@ -1,0 +1,72 @@
+from typing import Callable
+
+import pandas as pd
+
+__all__ = [
+    "validation_method",
+    "ValidateControlColumns",
+    "ValidateTargetColumn",
+    "ValidateDateColumn",
+    "ValidateChannelColumns",
+]
+
+
+def validation_method(method: Callable) -> Callable:
+    if not hasattr(method, "_tags"):
+        method._tags = {}
+    method._tags["validation"] = True
+    return method
+
+
+class ValidateTargetColumn:
+    @validation_method
+    def validate_target(self, data_df: pd.DataFrame) -> None:
+        if self.target_column not in data_df.columns:
+            raise ValueError(f"target {self.target_column} not in data_df")
+
+
+class ValidateDateColumn:
+    @validation_method
+    def validate_date_col(self, data_df: pd.DataFrame) -> None:
+        if self.date_column not in data_df.columns:
+            raise ValueError(f"date_col {self.date_column} not in data_df")
+        if not data_df[self.date_column].is_unique:
+            raise ValueError(f"date_col {self.date_column} has repeated values")
+
+
+class ValidateChannelColumns:
+    @validation_method
+    def validate_channel_columns(self, data_df: pd.DataFrame) -> None:
+        if not isinstance(self.channel_columns, (list, tuple)):
+            raise ValueError("channel_columns must be a list or tuple")
+        if len(self.channel_columns) == 0:
+            raise ValueError("channel_columns must not be empty")
+        if not set(self.channel_columns).issubset(data_df.columns):
+            raise ValueError(f"channel_columns {self.channel_columns} not in data_df")
+        if len(set(self.channel_columns)) != len(self.channel_columns):
+            raise ValueError(
+                f"channel_columns {self.channel_columns} contains duplicates"
+            )
+        if (data_df[self.channel_columns] < 0).any().any():
+            raise ValueError(
+                f"channel_columns {self.channel_columns} contains negative values"
+            )
+
+
+class ValidateControlColumns:
+    @validation_method
+    def validate_control_columns(self, data_df: pd.DataFrame) -> None:
+        if self.control_columns is None:
+            return None
+        if not isinstance(self.control_columns, (list, tuple)):
+            raise ValueError("control_columns must be None, a list or tuple")
+        if len(self.control_columns) == 0:
+            raise ValueError(
+                "If control_columns is not None, then it must not be empty"
+            )
+        if not set(self.control_columns).issubset(data_df.columns):
+            raise ValueError(f"control_columns {self.control_columns} not in data_df")
+        if len(set(self.control_columns)) != len(self.control_columns):
+            raise ValueError(
+                f"control_columns {self.control_columns} contains duplicates"
+            )

--- a/pymmmc/tests/mmm/test_base.py
+++ b/pymmmc/tests/mmm/test_base.py
@@ -4,7 +4,9 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from pymmmc.mmm.base import RescaledMMM, preprocessing_method, validation_method
+from pymmmc.mmm.base import MMM
+from pymmmc.mmm.preprocessing import preprocessing_method
+from pymmmc.mmm.validating import validation_method
 
 seed: int = sum(map(ord, "pymmmc"))
 rng: np.random.Generator = np.random.default_rng(seed=seed)
@@ -28,43 +30,10 @@ toy_df = pd.DataFrame(
 )
 
 
-@pytest.fixture(scope="module")
-def toy_mmm_class():
-    class ToyMMM(RescaledMMM):
-        def build_model(*args, **kwargs):
-            return None
-
-    return ToyMMM
-
-
-@pytest.fixture(
-    scope="module",
-    params=[["channel_1"], ["channel_1", "channel_2"]],
-    ids=[
-        "single_channel",
-        "multiple_channel",
-    ],
-)
-def channel_columns(request):
-    return request.param
-
-
-@pytest.fixture(scope="module")
-def toy_mmm(channel_columns, toy_mmm_class):
-    return toy_mmm_class(
-        data_df=toy_df,
-        target_column="y",
-        date_column="date",
-        channel_columns=channel_columns,
-    )
-
-
-class TestRescaledMMM:
-    @patch("pymmmc.mmm.RescaledMMM.validate_target")
-    @patch("pymmmc.mmm.RescaledMMM.validate_date_col")
-    @patch("pymmmc.mmm.RescaledMMM.validate_channel_columns")
-    @patch("pymmmc.mmm.RescaledMMM.min_max_scale_target_data", return_value=toy_df)
-    @patch("pymmmc.mmm.RescaledMMM.max_abs_scale_channel_data", return_value=toy_df)
+class TestMMM:
+    @patch("pymmmc.mmm.base.MMM.validate_target")
+    @patch("pymmmc.mmm.base.MMM.validate_date_col")
+    @patch("pymmmc.mmm.base.MMM.validate_channel_columns")
     @pytest.mark.parametrize(
         argnames="channel_columns",
         argvalues=[
@@ -78,15 +47,11 @@ class TestRescaledMMM:
     )
     def test_init(
         self,
-        max_abs_scale_channel_data,
-        min_max_scale_target_data,
         validate_channel_columns,
         validate_date_col,
         validate_target,
         channel_columns,
     ) -> None:
-        max_abs_scale_channel_data.configure_mock(_tags={"preprocessing": True})
-        min_max_scale_target_data.configure_mock(_tags={"preprocessing": True})
         validate_channel_columns.configure_mock(_tags={"validation": True})
         validate_date_col.configure_mock(_tags={"validation": True})
         validate_target.configure_mock(_tags={"validation": True})
@@ -94,22 +59,25 @@ class TestRescaledMMM:
         toy_preprocess_count = 0
         build_model_count = 0
 
-        class ToyMMM(RescaledMMM):
+        class ToyMMM(MMM):
             def build_model(*args, **kwargs):
                 nonlocal build_model_count
                 build_model_count += 1
+                pd.testing.assert_frame_equal(kwargs["data_df"], toy_df)
                 return None
 
             @validation_method
             def toy_validation(self, data):
                 nonlocal toy_validation_count
                 toy_validation_count += 1
+                pd.testing.assert_frame_equal(data, toy_df)
                 return None
 
             @preprocessing_method
             def toy_preprocessing(self, data):
                 nonlocal toy_preprocess_count
                 toy_preprocess_count += 1
+                pd.testing.assert_frame_equal(data, toy_df)
                 return data
 
         instance = ToyMMM(
@@ -123,82 +91,7 @@ class TestRescaledMMM:
         validate_target.assert_called_once_with(instance, toy_df)
         validate_date_col.assert_called_once_with(instance, toy_df)
         validate_channel_columns.assert_called_once_with(instance, toy_df)
-        min_max_scale_target_data.assert_called_once()
-        max_abs_scale_channel_data.assert_called_once()
-
-        call_arg_0, call_arg_1 = min_max_scale_target_data.call_args_list[0][0]
-        assert call_arg_0 is instance
-        pd.testing.assert_frame_equal(call_arg_1, toy_df)
-        call_arg_0, call_arg_1 = max_abs_scale_channel_data.call_args_list[0][0]
-        assert call_arg_0 is instance
-        pd.testing.assert_frame_equal(call_arg_1, toy_df)
 
         assert toy_validation_count == 1
         assert toy_preprocess_count == 1
         assert build_model_count == 1
-
-    def test_validate_target(self, toy_mmm):
-        with pytest.raises(ValueError, match="target y not in data_df"):
-            toy_mmm.validate_target(toy_df.drop(columns=["y"]))
-
-    def test_validate_date_col(self, toy_mmm):
-        with pytest.raises(ValueError, match="date_col date not in data_df"):
-            toy_mmm.validate_date_col(toy_df.drop(columns=["date"]))
-        with pytest.raises(ValueError, match="date_col date has repeated values"):
-            toy_mmm.validate_date_col(
-                pd.concat([toy_df, toy_df], ignore_index=True, axis=0)
-            )
-
-    def test_channel_columns(self, toy_mmm_class):
-        global toy_df
-        with pytest.raises(ValueError, match="channel_columns must be a list or tuple"):
-            toy_mmm_class(
-                data_df=toy_df,
-                target_column="y",
-                date_column="date",
-                channel_columns={},
-            )
-        with pytest.raises(ValueError, match="channel_columns must not be empty"):
-            toy_mmm_class(
-                data_df=toy_df,
-                target_column="y",
-                date_column="date",
-                channel_columns=[],
-            )
-        with pytest.raises(
-            ValueError,
-            match="channel_columns \['out_of_columns'\] not in data_df",  # noqa: W605
-        ):
-            toy_mmm_class(
-                data_df=toy_df,
-                target_column="y",
-                date_column="date",
-                channel_columns=["out_of_columns"],
-            )
-        with pytest.raises(
-            ValueError,
-            match="channel_columns \['channel_1', 'channel_1'\] contains duplicates",  # noqa: E501, W605
-        ):
-            toy_mmm_class(
-                data_df=toy_df,
-                target_column="y",
-                date_column="date",
-                channel_columns=["channel_1", "channel_1"],
-            )
-        with pytest.raises(
-            ValueError,
-            match="channel_columns \['channel_1'\] contains negative values",  # noqa: E501, W605
-        ):
-            new_toy_df = toy_df.copy()
-            new_toy_df["channel_1"] -= 1e4
-            toy_mmm_class(
-                data_df=new_toy_df,
-                target_column="y",
-                date_column="date",
-                channel_columns=["channel_1"],
-            )
-
-    def test_preprocessing(self, toy_mmm):
-        assert toy_mmm.preprocessed_data["y"].min() == 0
-        assert toy_mmm.preprocessed_data["y"].max() == 1
-        assert np.all(toy_mmm.preprocessed_data[toy_mmm.channel_columns].max() == 1)

--- a/pymmmc/tests/mmm/test_preprocessing.py
+++ b/pymmmc/tests/mmm/test_preprocessing.py
@@ -1,0 +1,89 @@
+import numpy as np
+import pandas as pd
+
+from pymmmc.mmm.preprocessing import (
+    MaxAbsScaleChannels,
+    MixMaxScaleTarget,
+    StandardizeControls,
+    preprocessing_method,
+)
+
+seed: int = sum(map(ord, "pymmmc"))
+rng: np.random.Generator = np.random.default_rng(seed=seed)
+date_data: pd.DatetimeIndex = pd.date_range(
+    start="2019-06-01", end="2021-12-31", freq="W-MON"
+)
+
+n: int = date_data.size
+
+toy_df = pd.DataFrame(
+    data={
+        "date": date_data,
+        "y": rng.integers(low=0, high=100, size=n),
+        "channel_1": rng.integers(low=0, high=400, size=n),
+        "channel_2": rng.integers(low=0, high=50, size=n),
+        "control_1": rng.gamma(shape=1000, scale=500, size=n),
+        "control_2": rng.gamma(shape=100, scale=5, size=n),
+        "other_column_1": rng.integers(low=0, high=100, size=n),
+        "other_column_2": rng.normal(loc=0, scale=1, size=n),
+    }
+)
+
+
+def test_preprocessing_method():
+    f = lambda x: x  # noqa: E731
+    f.__doc__ = "bla"
+    vf = preprocessing_method(f)
+    assert getattr(vf, "_tags", {}).get("preprocessing", False)
+    assert vf.__doc__ == f.__doc__
+    assert vf.__name__ == f.__name__
+
+    def f2(x):
+        """bla"""
+        return x
+
+    vf = preprocessing_method(f2)
+    assert getattr(vf, "_tags", {}).get("preprocessing", False)
+    assert vf.__doc__ == f2.__doc__
+    assert vf.__name__ == f2.__name__
+
+    class F:
+        @preprocessing_method
+        def f3(self, x):
+            """bla"""
+            return x
+
+    vf = F().f3
+    assert getattr(vf, "_tags", {}).get("preprocessing", False)
+    assert F.f3.__doc__ == vf.__doc__
+    assert F.f3.__name__ == vf.__name__
+    assert vf.__doc__ == "bla"
+    assert vf.__name__ == "f3"
+
+
+def test_min_max_scale_target():
+    obj = MixMaxScaleTarget()
+    obj.target_column = "y"
+    out = obj.min_max_scale_target_data(toy_df)["y"]
+    assert out.min() == 0
+    assert out.max() == 1
+    pd.testing.assert_index_equal(out.index, toy_df.index)
+
+
+def test_max_abs_scale_channels():
+    obj = MaxAbsScaleChannels()
+    obj.channel_columns = ["channel_1", "channel_2"]
+    out = obj.max_abs_scale_channel_data(toy_df)[obj.channel_columns]
+    temp = toy_df[obj.channel_columns]
+    assert (out.max(axis=0) == 1).all()
+    assert np.allclose(out.min(axis=0), temp.min(axis=0) / temp.max(axis=0))
+    pd.testing.assert_index_equal(out.index, toy_df.index)
+
+
+def test_standardize_controls():
+    obj = StandardizeControls()
+    obj.control_columns = ["control_1", "control_2"]
+    out = obj.standardize_control_data(toy_df)[obj.control_columns]
+    assert np.allclose(out.mean(axis=0), 0)
+    assert np.allclose(out.std(axis=0), 1, atol=5e-3)
+    pd.testing.assert_index_equal(out.index, toy_df.index)

--- a/pymmmc/tests/mmm/test_validating.py
+++ b/pymmmc/tests/mmm/test_validating.py
@@ -1,0 +1,146 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from pymmmc.mmm.validating import (
+    ValidateChannelColumns,
+    ValidateControlColumns,
+    ValidateDateColumn,
+    ValidateTargetColumn,
+    validation_method,
+)
+
+seed: int = sum(map(ord, "pymmmc"))
+rng: np.random.Generator = np.random.default_rng(seed=seed)
+date_data: pd.DatetimeIndex = pd.date_range(
+    start="2019-06-01", end="2021-12-31", freq="W-MON"
+)
+
+n: int = date_data.size
+
+toy_df = pd.DataFrame(
+    data={
+        "date": date_data,
+        "y": rng.integers(low=0, high=100, size=n),
+        "channel_1": rng.integers(low=0, high=400, size=n),
+        "channel_2": rng.integers(low=0, high=50, size=n),
+        "control_1": rng.gamma(shape=1000, scale=500, size=n),
+        "control_2": rng.gamma(shape=100, scale=5, size=n),
+        "other_column_1": rng.integers(low=0, high=100, size=n),
+        "other_column_2": rng.normal(loc=0, scale=1, size=n),
+    }
+)
+
+
+def test_validation_method():
+    f = lambda x: x  # noqa: E731
+    f.__doc__ = "bla"
+    vf = validation_method(f)
+    assert getattr(vf, "_tags", {}).get("validation", False)
+    assert vf.__doc__ == f.__doc__
+    assert vf.__name__ == f.__name__
+
+    def f2(x):
+        """bla"""
+        return x
+
+    vf = validation_method(f2)
+    assert getattr(vf, "_tags", {}).get("validation", False)
+    assert vf.__doc__ == f2.__doc__
+    assert vf.__name__ == f2.__name__
+
+    class F:
+        @validation_method
+        def f3(self, x):
+            """bla"""
+            return x
+
+    vf = F().f3
+    assert getattr(vf, "_tags", {}).get("validation", False)
+    assert F.f3.__doc__ == vf.__doc__
+    assert F.f3.__name__ == vf.__name__
+    assert vf.__doc__ == "bla"
+    assert vf.__name__ == "f3"
+
+
+def test_validate_target():
+    obj = ValidateTargetColumn()
+    obj.target_column = "y"
+    assert obj.validate_target(toy_df) is None
+
+    with pytest.raises(ValueError, match="target y not in data_df"):
+        obj.validate_target(toy_df.drop(columns=["y"]))
+
+
+def test_validate_date_col():
+    obj = ValidateDateColumn()
+    obj.date_column = "date"
+    assert obj.validate_date_col(toy_df) is None
+    with pytest.raises(ValueError, match="date_col date not in data_df"):
+        obj.validate_date_col(toy_df.drop(columns=["date"]))
+    with pytest.raises(ValueError, match="date_col date has repeated values"):
+        obj.validate_date_col(pd.concat([toy_df, toy_df], ignore_index=True, axis=0))
+
+
+def test_channel_columns():
+    obj = ValidateChannelColumns()
+    obj.channel_columns = ["channel_1", "channel_2"]
+    assert obj.validate_channel_columns(toy_df) is None
+
+    with pytest.raises(ValueError, match="channel_columns must be a list or tuple"):
+        obj.channel_columns = {}
+        obj.validate_channel_columns(toy_df)
+    with pytest.raises(ValueError, match="channel_columns must not be empty"):
+        obj.channel_columns = []
+        obj.validate_channel_columns(toy_df)
+    with pytest.raises(
+        ValueError,
+        match="channel_columns \['out_of_columns'\] not in data_df",  # noqa: W605
+    ):
+        obj.channel_columns = ["out_of_columns"]
+        obj.validate_channel_columns(toy_df)
+    with pytest.raises(
+        ValueError,
+        match="channel_columns \['channel_1', 'channel_1'\] contains duplicates",  # noqa: E501, W605
+    ):
+        obj.channel_columns = ["channel_1", "channel_1"]
+        obj.validate_channel_columns(toy_df)
+    with pytest.raises(
+        ValueError,
+        match="channel_columns \['channel_1'\] contains negative values",  # noqa: E501, W605
+    ):
+        new_toy_df = toy_df.copy()
+        new_toy_df["channel_1"] -= 1e4
+        obj.channel_columns = ["channel_1"]
+        obj.validate_channel_columns(new_toy_df)
+
+
+def test_control_columns():
+    obj = ValidateControlColumns()
+    obj.control_columns = None
+    assert obj.validate_control_columns(toy_df) is None
+    obj.control_columns = ["control_1", "control_2"]
+    assert obj.validate_control_columns(toy_df) is None
+
+    with pytest.raises(
+        ValueError, match="control_columns must be None, a list or tuple"
+    ):
+        obj.control_columns = {}
+        obj.validate_control_columns(toy_df)
+    with pytest.raises(
+        ValueError, match="If control_columns is not None, then it must not be empty"
+    ):
+        obj.control_columns = []
+        obj.validate_control_columns(toy_df)
+    with pytest.raises(
+        ValueError,
+        match="control_columns \['out_of_columns'\] not in data_df",  # noqa: W605
+    ):
+        obj.control_columns = ["out_of_columns"]
+        obj.validate_control_columns(toy_df)
+    with pytest.raises(
+        ValueError,
+        match="control_columns \['control_1', 'control_1'\] contains duplicates",  # noqa: E501, W605
+    ):
+        obj.control_columns = ["control_1", "control_1"]
+        obj.validate_control_columns(toy_df)


### PR DESCRIPTION
Closes #70
Closes #71

This PR was based off of a comment from @juanitorduz, where he suggested to use mixin classes to implement the validation and preprocessing steps of the models. After playing a bit with the idea, I liked it. I think that it makes things more modular and easier to customize in other kinds of models.