### PR TITLE
Implement vectorized adstock transformations

### DIFF
--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -7,10 +7,7 @@ from xarray import DataArray
 
 from pymc_marketing.mmm.base import MMM
 from pymc_marketing.mmm.preprocessing import MaxAbsScaleChannels, MixMaxScaleTarget
-from pymc_marketing.mmm.transformers import (
-    geometric_adstock_vectorized,
-    logistic_saturation,
-)
+from pymc_marketing.mmm.transformers import geometric_adstock, logistic_saturation
 from pymc_marketing.mmm.validating import ValidateControlColumns
 
 
@@ -82,11 +79,12 @@ class DelayedSaturatedMMM(
 
             channel_adstock = pm.Deterministic(
                 name="channel_adstock",
-                var=geometric_adstock_vectorized(
+                var=geometric_adstock(
                     x=channel_data_,
                     alpha=alpha,
                     l_max=adstock_max_lag,
                     normalize=True,
+                    axis=0,
                 ),
                 dims=("date", "channel"),
             )

--- a/pymc_marketing/mmm/transformers.py
+++ b/pymc_marketing/mmm/transformers.py
@@ -32,7 +32,14 @@ def batched_convolution(x, w, axis: int = 0):
         l_max = w.shape[-1].eval()
     except Exception:
         l_max = None
-    x_shape, w_shape = params_broadcast_shapes([x.shape, w.shape], [1, 1])
+    (x_shape, w_shape), _ = params_broadcast_shapes(
+        param_shapes=[x.shape, w.shape],
+        ndims_params=[1, 1],
+        broadcastable_patterns=[
+            getattr(x, "broadcastable", tuple([s == 1 for s in x.shape])),
+            getattr(w, "broadcastable", tuple([s == 1 for s in w.shape])),
+        ],
+    )
     x = pt.broadcast_to(x, x_shape)
     w = pt.broadcast_to(w, w_shape)
     x_time = x.shape[-1]

--- a/pymc_marketing/mmm/utils.py
+++ b/pymc_marketing/mmm/utils.py
@@ -1,6 +1,14 @@
+from itertools import zip_longest
+
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
+from pytensor import tensor as pt
+from pytensor.raise_op import Assert
+from pytensor.tensor.basic import get_scalar_constant_value
+from pytensor.tensor.exceptions import NotScalarConstantError
+from pytensor.tensor.math import maximum
+from pytensor.tensor.var import TensorConstant
 
 
 def generate_fourier_modes(
@@ -33,3 +41,87 @@ def generate_fourier_modes(
             for func in ("sin", "cos")
         }
     )
+
+
+def params_broadcast_shapes(param_shapes, ndims_params, use_pytensor=True):
+    """Broadcast shape tuples except for some number of support dimensions.
+
+    Parameters
+    ==========
+    param_shapes : list of ndarray or Variable
+        The shapes to broadcast.
+    ndims_params : list of int
+        The number of dimensions for each shape that are to be considered support dimensions that
+        need not broadcast together.
+    use_pytensor : bool
+        If ``True``, use PyTensor maximum Op; otherwise, use NumPy.
+
+    Returns
+    =======
+    bcast_shapes : list of ndarray
+        The broadcasted values of `params`.
+    """
+    max_fn = maximum if use_pytensor else np.maximum
+
+    rev_extra_dims = []
+    for param_ind, (ndim_param, param_shape) in enumerate(
+        zip(ndims_params, param_shapes)
+    ):
+        # Try to get concrete shapes from the start
+        if isinstance(param_shape, TensorConstant):
+            param_shape = param_shape.value
+        # We need this in order to use `len`
+        param_shape = tuple(param_shape)
+        extras = tuple(param_shape[: (len(param_shape) - ndim_param)])
+
+        def max_bcast(x, y, i):
+            assert_op = Assert(
+                f"Failed to broadcast dynamically set shapes along axis {i} "
+                f"in the {param_ind} supplied param_shape"
+            )
+            try:
+                concrete_x = get_scalar_constant_value(x)
+            except NotScalarConstantError:
+                concrete_x = None
+            try:
+                concrete_y = get_scalar_constant_value(y)
+            except NotScalarConstantError:
+                concrete_y = None
+            if concrete_x == 1:
+                return y
+            if concrete_y == 1:
+                return x
+            if concrete_x is not None and concrete_y is not None:
+                if concrete_x == concrete_y:
+                    return x
+                raise ValueError(
+                    f"Cannot broadcast shapes {concrete_x} and {concrete_y} together"
+                )
+            return assert_op(
+                max_fn(x, y),
+                pt.or_(
+                    pt.eq(x, 1),
+                    pt.or_(
+                        pt.eq(y, 1),
+                        pt.eq(x, y),
+                    ),
+                ),
+            )
+
+        rev_extra_dims = [
+            max_bcast(a, b, i)
+            for i, (b, a) in enumerate(
+                zip_longest(reversed(extras), rev_extra_dims, fillvalue=1)
+            )
+        ]
+
+    extra_dims = tuple(reversed(rev_extra_dims))
+
+    bcast_shapes = [
+        (extra_dims + tuple(getattr(param_shape, "value", param_shape))[-ndim_param:])
+        if ndim_param > 0
+        else extra_dims
+        for ndim_param, param_shape in zip(ndims_params, param_shapes)
+    ]
+
+    return bcast_shapes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ addopts = [
     "-v",
     "--strict-markers",
     "--strict-config",
-    "--cov=mmm",
-    "--cov=pymmmc",
+    "--cov=pymc_marketing",
+    "--cov-report=term-missing",
 ]
 testpaths = "tests"


### PR DESCRIPTION
Closes #22 

- [X] Convert the old adstock transformations to use the vectorized convolution
- [x] Write tests for the vectorized convolution with multiple dimensions and broadcasting patterns
- [x] Maybe add an assert to prevent segfaults due to passing a incorrect axis?