### PR TITLE
Make channel_contributions contain a channel axis and exploit that in plots

### DIFF
--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -93,13 +93,13 @@ class DelayedSaturatedMMM(
                 var=logistic_saturation(x=channel_adstock, lam=lam),
                 dims=("date", "channel"),
             )
-            channel_contribution = pm.Deterministic(
-                name="channel_contribution",
-                var=pm.math.dot(channel_adstock_saturated, beta_channel),
-                dims="date",
+            channel_contributions = pm.Deterministic(
+                name="channel_contributions",
+                var=channel_adstock_saturated * beta_channel,
+                dims=("date", "channel"),
             )
 
-            mu_var = intercept + channel_contribution
+            mu_var = intercept + channel_contributions.sum(axis=-1)
 
             if control_data is not None:
                 control_data_ = pm.MutableData(
@@ -110,13 +110,13 @@ class DelayedSaturatedMMM(
                     name="gamma_control", mu=0, sigma=2, dims="control"
                 )
 
-                control_contribution = pm.Deterministic(
-                    name="control_contribution",
-                    var=pm.math.dot(control_data_, gamma_control),
-                    dims="date",
+                control_contributions = pm.Deterministic(
+                    name="control_contributions",
+                    var=control_data_ * gamma_control,
+                    dims=("date", "control"),
                 )
 
-                mu_var += control_contribution
+                mu_var += control_contributions.sum(axis=-1)
 
             mu = pm.Deterministic(name="mu", var=mu_var, dims="date")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ ipython>=8.1.1
 ipywidgets==7.7.2
 jax>=0.3.13
 matplotlib==3.5.1
+numpy>=1.17,!=1.24.0
 numpyro==0.9.2
 pymc>=5.0.0
 scikit-learn>=1.1.1

--- a/tests/mmm/test_base.py
+++ b/tests/mmm/test_base.py
@@ -1,8 +1,11 @@
 from unittest.mock import patch
 
+import arviz as az
 import numpy as np
 import pandas as pd
 import pytest
+import xarray as xr
+from matplotlib import pyplot as plt
 
 from pymc_marketing.mmm.base import MMM
 from pymc_marketing.mmm.preprocessing import preprocessing_method
@@ -28,6 +31,87 @@ toy_df = pd.DataFrame(
         "other_column_2": rng.normal(loc=0, scale=1, size=n),
     }
 )
+
+
+@pytest.fixture(scope="module", params=["without_controls", "with_controls"])
+def plotting_mmm(request):
+    class ToyMMM(MMM):
+        def build_model(self, data_df, **kwargs):
+            pass
+
+    mmm = ToyMMM(
+        toy_df,
+        target_column="y",
+        date_column="date",
+        channel_columns=["channel_1", "channel_2"],
+    )
+    rng = np.random.default_rng(42)
+    coords = {
+        "chain": range(4),
+        "draw": range(100),
+        "channel": mmm.channel_columns,
+        "date": toy_df.date,
+    }
+    likelihood_dims = ["chain", "draw", "date"]
+    alpha_dims = ["chain", "draw", "channel"]
+    channel_contrib_dims = ["chain", "draw", "date", "channel"]
+    prior_post = xr.Dataset(
+        {
+            "intercept": xr.DataArray(
+                rng.gamma(1, 1, size=(4, 100)),
+                coords={k: v for k, v in coords.items() if k in ["chain", "draw"]},
+                dims=["chain", "draw"],
+            ),
+            "alpha": xr.DataArray(
+                rng.gamma(1, 1, size=(4, 100, 2)),
+                coords={k: v for k, v in coords.items() if k in alpha_dims},
+                dims=alpha_dims,
+            ),
+            "channel_contributions": xr.DataArray(
+                rng.gamma(1, 1, size=(4, 100, len(toy_df), 2)),
+                coords={k: v for k, v in coords.items() if k in channel_contrib_dims},
+                dims=channel_contrib_dims,
+            ),
+        }
+    )
+    prior_post_pred = xr.Dataset(
+        {
+            "likelihood": xr.DataArray(
+                rng.gamma(1, 1, size=(4, 100, len(toy_df))),
+                coords={k: v for k, v in coords.items() if k in likelihood_dims},
+                dims=likelihood_dims,
+            )
+        }
+    )
+    if request.param == "with_controls":
+        mmm.control_columns = ["control_1", "control_2"]
+        coords["control"] = mmm.control_columns
+        control_contrib_dims = ["chain", "draw", "date", "control"]
+        prior_post["control_contributions"] = xr.DataArray(
+            rng.gamma(1, 1, size=(4, 100, len(toy_df), 2)),
+            coords={k: v for k, v in coords.items() if k in control_contrib_dims},
+            dims=control_contrib_dims,
+        )
+    mmm._prior_predictive = az.InferenceData(
+        prior=prior_post,
+        prior_predictive=prior_post_pred,
+    )
+    mmm._fit_result = az.InferenceData(
+        posterior=prior_post,
+        observed_data=xr.Dataset(
+            {
+                "likelihood": xr.DataArray(
+                    toy_df.y.values,
+                    coords={"date": coords["date"]},
+                    dims=["date"],
+                )
+            }
+        ),
+    )
+    mmm._posterior_predictive = az.InferenceData(
+        posterior_predictive=prior_post_pred,
+    )
+    return mmm
 
 
 class TestMMM:
@@ -95,3 +179,23 @@ class TestMMM:
         assert toy_validation_count == 1
         assert toy_preprocess_count == 1
         assert build_model_count == 1
+
+    @pytest.mark.parametrize(
+        argnames="func_plot_name, kwargs_plot",
+        argvalues=[
+            ("plot_prior_predictive", {"samples": 3}),
+            ("plot_posterior_predictive", {}),
+            ("plot_components_contributions", {}),
+            ("plot_channel_parameter", {"param_name": "alpha"}),
+            ("plot_contribution_curves", {}),
+            ("plot_channel_contribution_share_hdi", {"hdi_prob": 0.95}),
+        ],
+    )
+    def test_plots(
+        self,
+        plotting_mmm,
+        func_plot_name,
+        kwargs_plot,
+    ) -> None:
+        func = plotting_mmm.__getattribute__(func_plot_name)
+        assert isinstance(func(**kwargs_plot), plt.Figure)

--- a/tests/mmm/test_delayed_saturated_mmm.py
+++ b/tests/mmm/test_delayed_saturated_mmm.py
@@ -1,7 +1,6 @@
-from typing import Any, Dict, List
+from typing import List
 
 import arviz as az
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pymc as pm
@@ -161,23 +160,3 @@ class TestMMM:
             n_channel,
             draws * chains,
         )
-
-    @pytest.mark.parametrize(
-        argnames="func_plot_name, kwargs_plot",
-        argvalues=[
-            ("plot_prior_predictive", {"samples": 3}),
-            ("plot_posterior_predictive", {}),
-            ("plot_components_contributions", {}),
-            ("plot_channel_parameter", {"param_name": "alpha"}),
-            ("plot_contribution_curves", {}),
-            ("plot_channel_contribution_share_hdi", {"hdi_prob": 0.95}),
-        ],
-    )
-    def test_plots(
-        self,
-        mmm_fitted: DelayedSaturatedMMM,
-        func_plot_name: str,
-        kwargs_plot: Dict[str, Any],
-    ) -> None:
-        func = mmm_fitted.__getattribute__(func_plot_name)
-        assert isinstance(func(**kwargs_plot), plt.Figure)


### PR DESCRIPTION
Closes #118 

This PR does two things.
1. It adds a `channel` and `control` dimension to the `channel_contributions` and `control_contributions` respectively. These deterministics are then used in the `BaseMMM` plotting methods.
2. The plotting functionality tests were moved to the `mmm.test_base.py` script and were made to run a proxy fitted toy MMM.