### PR TITLE
Add extra index url in pypi.yml

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Test pip install from test.pypi
         run: |
           python -m venv venv-test-pypi
-          venv-test-pypi/bin/python -m pip install --index-url https://test.pypi.org/simple/ pymc-marketing
+          venv-test-pypi/bin/python -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple pymc-marketing 
           # check import
           venv-test-pypi/bin/python -c "import pymc_marketing; assert pymc_marketing.__version__ == '${{  github.ref_name }}'"
 


### PR DESCRIPTION
Also, it changes the name from `pipy.yml` to `pypi.yml`

See 

* https://github.com/pymc-labs/pymc-marketing/actions/runs/4134290296/jobs/7145279333#step:6:20
* https://stackoverflow.com/questions/34514703/pip-install-from-pypi-works-but-from-testpypi-fails-cannot-find-requirements/34561435#34561435