### PR TITLE
Relax matplotlib dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,12 +13,12 @@ maintainers = [{ name = "PyMC Labs", email = "info@pymc-labs.io" }]
 
 dependencies = [
     "arviz>=0.13.0",
-    "matplotlib>=3.5.1",
+    "matplotlib>=3.5.1,!=3.6.1",
     "numpy>=1.17,!=1.24.0",
     "pandas",
     "pymc>=5.0.0",
     "scikit-learn>=1.1.1",
-    "seaborn>=0.12.1",
+    "seaborn>=0.12.2",
     "xarray"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,8 @@ maintainers = [{ name = "PyMC Labs", email = "info@pymc-labs.io" }]
 
 dependencies = [
     "arviz>=0.13.0",
-    "matplotlib>=3.5.1,!=3.6.1",
-    "numpy>=1.17,!=1.24.0",
+    "matplotlib>=3.5.1",
+    "numpy>=1.17",
     "pandas",
     "pymc>=5.0.0",
     "scikit-learn>=1.1.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ maintainers = [{ name = "PyMC Labs", email = "info@pymc-labs.io" }]
 
 dependencies = [
     "arviz>=0.13.0",
-    "matplotlib==3.5.1",
+    "matplotlib>=3.5.1",
     "numpy>=1.17,!=1.24.0",
     "pandas",
     "pymc>=5.0.0",


### PR DESCRIPTION
Shall we relax matplotlib's dependency? I do not remember wey we have a specific one.

Closes #120 