### PR TITLE
Remove unnecessary dependency on pymc test util

### DIFF
--- a/tests/clv/test_distributions.py
+++ b/tests/clv/test_distributions.py
@@ -4,7 +4,6 @@ import pytest
 from lifetimes import ParetoNBDFitter as PF
 from numpy.testing import assert_almost_equal
 from pymc import Model
-from pymc.tests.helpers import select_by_precision
 
 from pymc_marketing.clv.distributions import ContContract, ContNonContract, ParetoNBD
 
@@ -48,7 +47,7 @@ class TestContNonContract:
         assert_almost_equal(
             pm.logp(cnc, value).eval(),
             logp,
-            decimal=select_by_precision(float64=6, float32=2),
+            decimal=6,
             err_msg=str(pt),
         )
 
@@ -121,7 +120,7 @@ class TestContContract:
         assert_almost_equal(
             pm.logp(cc, value).eval(),
             logp,
-            decimal=select_by_precision(float64=6, float32=2),
+            decimal=6,
             err_msg=str(pt),
         )
 
@@ -217,7 +216,7 @@ class TestParetoNBD:
         assert_almost_equal(
             pm.logp(pareto_nbd, value).eval(),
             vectorized_logp(r, alpha, s, beta, value[..., 1], value[..., 0], T),
-            decimal=select_by_precision(float64=6, float32=2),
+            decimal=6,
             err_msg=str(pt),
         )
 


### PR DESCRIPTION
There was no need for `select_by_precision` because we only test with float64 here

Closes #189 