### PR TITLE
Speedup BetaGeoModel tests

### DIFF
--- a/tests/clv/models/test_beta_geo.py
+++ b/tests/clv/models/test_beta_geo.py
@@ -85,14 +85,15 @@ class TestBetaGeoModel:
 
     @pytest.mark.slow
     @pytest.mark.parametrize(
-        "N, rtol",
+        "N, fit_method, rtol",
         [
-            (500, 0.3),
-            (2000, 0.1),
-            (10000, 0.055),
+            (500, "mcmc", 0.3),
+            (2000, "mcmc", 0.1),
+            (10000, "mcmc", 0.055),
+            (2000, "map", 0.1),
         ],
     )
-    def test_model_convergence(self, N, rtol):
+    def test_model_convergence(self, N, fit_method, rtol):
         rng = np.random.default_rng(146)
         recency, frequency, _, T = self.generate_data(
             self.a_true, self.b_true, self.alpha_true, self.r_true, N, rng=rng
@@ -105,7 +106,8 @@ class TestBetaGeoModel:
             recency=recency,
             T=T,
         )
-        model.fit(chains=1, progressbar=False, random_seed=rng)
+        sample_kwargs = dict(random_seed=rng, chains=2) if fit_method == "mcmc" else {}
+        model.fit(fit_method=fit_method, progressbar=False, **sample_kwargs)
         fit = model.fit_result.posterior
         np.testing.assert_allclose(
             [fit["a"].mean(), fit["b"].mean(), fit["alpha"].mean(), fit["r"].mean()],

--- a/tests/clv/models/test_beta_geo.py
+++ b/tests/clv/models/test_beta_geo.py
@@ -1,89 +1,43 @@
+import arviz as az
 import numpy as np
 import pymc as pm
 import pytest
-
-# shorter name for black code style formatter
-from lifetimes.fitters.beta_geo_fitter import BetaGeoFitter as BGF
+from lifetimes.fitters.beta_geo_fitter import BetaGeoFitter
 
 from pymc_marketing.clv.distributions import continuous_contractual
 from pymc_marketing.clv.models.beta_geo import BetaGeoModel
 
 
 class TestBetaGeoModel:
-    # Hyperparameters
-    a_true = 0.8
-    b_true = 2.5
-    alpha_true = 3
-    r_true = 4
-    rng = np.random.default_rng(34)
-
-    N = 2000
-
-    @classmethod
-    def generate_data(cls, N):
+    @staticmethod
+    def generate_data(a, b, alpha, r, N, rng):
         # Subject level parameters
-        p = pm.draw(pm.Beta.dist(cls.a_true, cls.b_true, size=N), random_seed=cls.rng)
-        lam = pm.draw(
-            pm.Gamma.dist(cls.r_true, cls.alpha_true, size=N), random_seed=cls.rng
+        p = pm.Beta.dist(a, b, size=N)
+        lam = pm.Gamma.dist(r, alpha, size=N)
+        T = pm.DiscreteUniform.dist(lower=20, upper=40, size=N)
+
+        # Observations
+        data, T = pm.draw(
+            [
+                continuous_contractual(p=p, lam=lam, T=T, T0=0, size=N),
+                T,
+            ],
+            random_seed=rng,
         )
-
-        T = pm.draw(
-            pm.DiscreteUniform.dist(lower=20, upper=40, size=N), random_seed=cls.rng
-        )
-
-        data = continuous_contractual.rng_fn(cls.rng, lam, p, T, 0, size=N)
-
         return data[..., 0], data[..., 1], 1 - data[..., 2], T
 
     @classmethod
     def setup_class(cls):
+        cls.N = 500
+        cls.a_true = 0.8
+        cls.b_true = 2.5
+        cls.alpha_true = 3
+        cls.r_true = 4
+        rng = np.random.default_rng(34)
+
         cls.customer_id = list(range(cls.N))
-        cls.recency, cls.frequency, cls.alive, cls.T = cls.generate_data(cls.N)
-
-        # fit the model once for some tests
-        cls.fixed_model = BetaGeoModel(
-            customer_id=cls.customer_id,
-            frequency=cls.frequency,
-            recency=cls.recency,
-            T=cls.T,
-        )
-        cls.fixed_model.fit(chains=1, progressbar=False, random_seed=cls.rng)
-
-        cls.test_t = np.linspace(20, 38, 10)
-        cls.test_frequency = np.tile([1, 3, 5, 7, 9], 2)
-        cls.test_recency = np.tile([20, 30], 5)
-        cls.test_T = np.tile([25, 35], 5)
-
-        def overwrite_bgf_unload_params(self, *args, **kwargs):
-            """
-            The methods from BetaGeoFitter rely on a fitted model, i.e. estimates
-            for a, b, alpha and r. This function circumvents the need to use a
-            fitted model and uses the data-generating parameters for this test
-            instead.
-            """
-            return cls.r_true, cls.alpha_true, cls.a_true, cls.b_true
-
-        BGF._unload_params = overwrite_bgf_unload_params
-
-        BGF.conditional_expected_number_of_purchases_up_to_time = classmethod(
-            BGF.conditional_expected_number_of_purchases_up_to_time
-        )
-
-        cls.expected_test_num_purchases = (
-            BGF.conditional_expected_number_of_purchases_up_to_time(
-                t=cls.test_t,
-                frequency=cls.test_frequency,
-                recency=cls.test_recency,
-                T=cls.test_T,
-            )
-        )
-
-        BGF.expected_number_of_purchases_up_to_time = classmethod(
-            BGF.expected_number_of_purchases_up_to_time
-        )
-
-        cls.expected_test_num_purchases_new_customer = (
-            BGF.expected_number_of_purchases_up_to_time(t=cls.test_t)
+        cls.recency, cls.frequency, cls.alive, cls.T = cls.generate_data(
+            cls.a_true, cls.b_true, cls.alpha_true, cls.r_true, cls.N, rng=rng
         )
 
     @pytest.mark.parametrize("a_prior", (None, pm.HalfNormal.dist()))
@@ -129,6 +83,7 @@ class TestBetaGeoModel:
             "r_log__": (),
         }
 
+    @pytest.mark.slow
     @pytest.mark.parametrize(
         "N, rtol",
         [
@@ -138,7 +93,10 @@ class TestBetaGeoModel:
         ],
     )
     def test_model_convergence(self, N, rtol):
-        recency, frequency, _, T = self.generate_data(N)
+        rng = np.random.default_rng(146)
+        recency, frequency, _, T = self.generate_data(
+            self.a_true, self.b_true, self.alpha_true, self.r_true, N, rng=rng
+        )
 
         # b parameter has the largest mismatch of the four parameters
         model = BetaGeoModel(
@@ -147,7 +105,7 @@ class TestBetaGeoModel:
             recency=recency,
             T=T,
         )
-        model.fit(chains=1, progressbar=False, random_seed=self.rng)
+        model.fit(chains=1, progressbar=False, random_seed=rng)
         fit = model.fit_result.posterior
         np.testing.assert_allclose(
             [fit["a"].mean(), fit["b"].mean(), fit["alpha"].mean(), fit["r"].mean()],
@@ -160,63 +118,164 @@ class TestBetaGeoModel:
         The "true" prefix refers to the value obtained using 1) the closed form
         solution and 2) the data-generating parameter values.
         """
-        true_prob_alive = self.alive.mean()  # scalar
-        est_prob_alive = self.fixed_model.expected_probability_alive(
-            self.customer_id,
-            self.frequency,
-            self.recency,
-            self.T,
+        rng = np.random.default_rng(152)
+
+        N = 100
+        # Almost deterministic p = .02, which yield a p(alive) ~ 0.5
+        a = 0.02 * 10_000
+        b = 0.98 * 10_000
+        alpha = 3
+        r = 4
+
+        recency, frequency, alive, T = self.generate_data(a, b, alpha, r, N, rng=rng)
+        customer_id = list(range(N))
+
+        bg_model = BetaGeoModel(
+            customer_id=customer_id,
+            frequency=frequency,
+            recency=recency,
+            T=T,
         )
 
-        assert est_prob_alive.shape == (1, 1000, self.N)
+        fake_fit = az.from_dict(
+            {
+                "a": rng.normal(a, 1e-3, size=(2, 25)),
+                "b": rng.normal(b, 1e-3, size=(2, 25)),
+                "alpha": rng.normal(alpha, 1e-3, size=(2, 25)),
+                "r": rng.normal(r, 1e-3, size=(2, 25)),
+            }
+        )
+        bg_model._fit_result = fake_fit
+
+        est_prob_alive = bg_model.expected_probability_alive(
+            customer_id,
+            frequency,
+            recency,
+            T,
+        )
+
+        assert est_prob_alive.shape == (2, 25, N)
         assert est_prob_alive.dims == ("chain", "draw", "customer_id")
 
         np.testing.assert_allclose(
-            true_prob_alive.mean(),
+            alive.mean(),
             est_prob_alive.mean(),
             rtol=0.05,
         )
 
     def test_expected_num_purchases(self):
-        """
-        TODO: should we combine this test and the one below?
-        """
-        est_num_purchases = self.fixed_model.expected_num_purchases(
-            list(range(20, 40, 2)),
-            self.test_t,
-            self.test_frequency,
-            self.test_recency,
-            self.test_T,
+        customer_id = np.arange(10)
+        test_t = np.linspace(20, 38, 10)
+        test_frequency = np.tile([1, 3, 5, 7, 9], 2)
+        test_recency = np.tile([20, 30], 5)
+        test_T = np.tile([25, 35], 5)
+
+        bg_model = BetaGeoModel(
+            customer_id=customer_id,
+            frequency=test_frequency,
+            recency=test_recency,
+            T=test_T,
+        )
+        bg_model._fit_result = az.from_dict(
+            {
+                "a": np.full((2, 5), self.a_true),
+                "b": np.full((2, 5), self.b_true),
+                "alpha": np.full((2, 5), self.alpha_true),
+                "r": np.full((2, 5), self.r_true),
+            }
         )
 
-        assert est_num_purchases.shape == (1, 1000, 10)
-        assert est_num_purchases.dims == ("chain", "draw", "customer_id")
+        res_num_purchases = bg_model.expected_num_purchases(
+            customer_id,
+            test_t,
+            test_frequency,
+            test_recency,
+            test_T,
+        )
+        assert res_num_purchases.shape == (2, 5, 10)
+        assert res_num_purchases.dims == ("chain", "draw", "customer_id")
 
+        # Compare with lifetimes
+        lifetimes_bg_model = BetaGeoFitter()
+        lifetimes_bg_model.params_ = {
+            "a": self.a_true,
+            "b": self.b_true,
+            "alpha": self.alpha_true,
+            "r": self.r_true,
+        }
+        lifetimes_res_num_purchases = (
+            lifetimes_bg_model.conditional_expected_number_of_purchases_up_to_time(
+                t=test_t,
+                frequency=test_frequency,
+                recency=test_recency,
+                T=test_T,
+            )
+        )
         np.testing.assert_allclose(
-            self.expected_test_num_purchases,
-            est_num_purchases.mean(("chain", "draw")),
+            res_num_purchases.mean(("chain", "draw")),
+            lifetimes_res_num_purchases,
             rtol=0.1,
         )
 
     def test_expected_num_purchases_new_customer(self):
-        est_num_purchases = self.fixed_model.expected_num_purchases_new_customer(
-            self.test_t
+        customer_id = np.arange(10)
+        test_t = np.linspace(20, 38, 10)
+        test_frequency = np.tile([1, 3, 5, 7, 9], 2)
+        test_recency = np.tile([20, 30], 5)
+        test_T = np.tile([25, 35], 5)
+
+        bg_model = BetaGeoModel(
+            customer_id=customer_id,
+            frequency=test_frequency,
+            recency=test_recency,
+            T=test_T,
+        )
+        bg_model._fit_result = az.from_dict(
+            {
+                "a": np.full((2, 5), self.a_true),
+                "b": np.full((2, 5), self.b_true),
+                "alpha": np.full((2, 5), self.alpha_true),
+                "r": np.full((2, 5), self.r_true),
+            }
         )
 
-        assert est_num_purchases.shape == (1, 1000, 10)
-        assert est_num_purchases.dims == ("chain", "draw", "t")
+        res_num_purchases_new_customer = bg_model.expected_num_purchases_new_customer(
+            test_t
+        )
+        assert res_num_purchases_new_customer.shape == (2, 5, 10)
+        assert res_num_purchases_new_customer.dims == ("chain", "draw", "t")
+
+        # Compare with lifetimes
+        lifetimes_bg_model = BetaGeoFitter()
+        lifetimes_bg_model.params_ = {
+            "a": self.a_true,
+            "b": self.b_true,
+            "alpha": self.alpha_true,
+            "r": self.r_true,
+        }
+        lifetimes_res_num_purchases_new_customer = (
+            lifetimes_bg_model.expected_number_of_purchases_up_to_time(t=test_t)
+        )
 
         np.testing.assert_allclose(
-            self.expected_test_num_purchases,
-            est_num_purchases.mean(("chain", "draw")),
+            res_num_purchases_new_customer.mean(("chain", "draw")),
+            lifetimes_res_num_purchases_new_customer,
             rtol=1,
         )
 
     def test_model_repr(self):
-        assert self.fixed_model.__repr__().replace(" ", "") == (
+        model = BetaGeoModel(
+            customer_id=self.customer_id,
+            frequency=self.frequency,
+            recency=self.recency,
+            T=self.T,
+            b_prior=pm.HalfNormal.dist(10),
+        )
+
+        assert model.__repr__().replace(" ", "") == (
             "BG/NBD"
             "\na~HalfFlat()"
-            "\nb~HalfFlat()"
+            "\nb~N**+(0,10)"
             "\nalpha~HalfFlat()"
             "\nr~HalfFlat()"
             "\nlikelihood~Potential(f(r,alpha,b,a))"


### PR DESCRIPTION
This PR removes the costly fitting from the setup class. Even running a small test like `test_model_repr` would take around one minute as it would have to wait for the useless fitting (in the context of that test) to be done.

Also simplified the patching of the lifetimes reference model. It's enough to override `params_` after initializing it.

Finally added a `pytest.mark.slow` for the `test_model_convergence` so it doesn't run by default (it does run in our CI here). This way the tests take just ~2 seconds on my slow laptop.