### PR TITLE
Make docs footer smaller and more responsive

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -4,15 +4,23 @@
 }
 
 /* Add a separating border line for all but the last item */
+/*
 .footer-item:not(:last-child) {
   border-right: 1px solid var(--pst-color-text-base);
   margin-right: .5em;
   padding-right: .5em;
 }
+*/
 
 .footer-item ul {
   list-style: none;
   display: flex;
+  padding-left: 0;
+  margin-bottom: 0;
+}
+
+.footer-item ul li {
+    padding-right: .5em;
 }
 
 .footer-item li a.nav-link {
@@ -21,12 +29,31 @@
 
 .footer-item li a.nav-link:hover {
   color:var(--pst-color-primary);
+  text-decoration: none;
+}
+
+/*  Remove footer icon text for small screen width and increase icons size */
+@media (max-width: 660px) {
+  .footer-item li a.nav-link i {
+    padding-right: 0.5em;
+    font-size: calc(var(--bs-body-font-size) * 1.5);
+  }
+  .footer-item li a.nav-link span{
+    font-size: 0;
+  }
 }
 
 footer.bd-footer {
   position: sticky;
   bottom: 0;
   background: var(--pst-color-on-background) !important;
+}
+
+/* Make footer non-sticky when lines start to wrap-around*/
+@media (max-width: 520px) {
+  footer.bd-footer {
+    position: inherit;
+  }
 }
 
 .pymc-marketing-name {

--- a/docs/source/_templates/footer-links.html
+++ b/docs/source/_templates/footer-links.html
@@ -1,28 +1,38 @@
 <ul>
 
   <li class="nav-item">
-    <a class="nav-link" href="https://twitter.com/pymc_labs"><i class="fa-brands fa-twitter" aria-hidden="true"></i>
-      Twitter</a>
+    <a class="nav-link" href="https://twitter.com/pymc_labs">
+      <i class="fa-brands fa-twitter" aria-hidden="true"></i>
+      <span>Twitter</span>
+    </a>
   </li>
 
   <li class="nav-item">
-    <a class="nav-link" href="https://github.com/pymc-labs"><i class="fa-brands fa-github" aria-hidden="true"></i>
-      GitHub</a>
+    <a class="nav-link" href="https://github.com/pymc-labs">
+      <i class="fa-brands fa-github" aria-hidden="true"></i>
+      <span>Github</span>
+    </a>
   </li>
 
   <li class="nav-item">
-    <a class="nav-link" href="https://www.linkedin.com/company/pymc-labs/"><i class="fa-brands fa-linkedin" aria-hidden="true"></i>
-      LinkedIn</a>
+    <a class="nav-link" href="https://www.linkedin.com/company/pymc-labs/">
+      <i class="fa-brands fa-linkedin" aria-hidden="true"></i>
+      <span>LinkedIn</span>
+    </a>
   </li>
 
   <li class="nav-item">
-    <a class="nav-link" href="https://www.youtube.com/c/PyMCLabs"><i class="fa-brands fa-youtube" aria-hidden="true"></i>
-      YouTube</a>
+    <a class="nav-link" href="https://www.youtube.com/c/PyMCLabs">
+      <i class="fa-brands fa-youtube" aria-hidden="true"></i>
+      <span>YouTube</span>
+    </a>
   </li>
 
   <li class="nav-item">
-    <a class="nav-link" href="https://www.meetup.com/pymc-labs-online-meetup/"><i class="fa-brands fa-meetup" aria-hidden="true"></i>
-      Meetup</a>
+    <a class="nav-link" href="https://www.meetup.com/pymc-labs-online-meetup/">
+      <i class="fa-brands fa-meetup" aria-hidden="true"></i>
+      <span>Meetup</span>
+    </a>
   </li>
 
 </ul>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -109,7 +109,8 @@ html_theme_options = {
     "navbar_align": "right",
     "navbar_start": ["navbar-logo", "navbar-name"],
     "navbar_end": ["theme-switcher"],
-    "footer_items": ["copyright", "sphinx-version", "theme-version", "footer-links"],
+    "footer_start": ["copyright", "footer-links"],
+    "footer_end": ["sphinx-version", "theme-version"],
     "github_url": "https://github.com/pymc-labs/pymc-marketing",
     "twitter_url": "https://twitter.com/pymc_labs",
     "icon_links": [


### PR DESCRIPTION
Preview: https://pymc-marketing--199.org.readthedocs.build/en/199/

Closes #191 

The footer now looks like this on my laptop:

![image](https://user-images.githubusercontent.com/28983449/224315047-688055cb-b301-4f71-bfa3-d10f8a680d66.png)

In addition, I tweaked it so that it looks like this on small screens (subject to fancy CSS support):

![image](https://user-images.githubusercontent.com/28983449/224315379-4b151d38-7ee7-4086-8d06-52626d0b8186.png)
