### PR TITLE
Enable turning off data preprocessing in MMM

### DIFF
--- a/pymc_marketing/mmm/base.py
+++ b/pymc_marketing/mmm/base.py
@@ -37,6 +37,7 @@ class BaseMMM:
         date_column: str,
         channel_columns: Union[List[str], Tuple[str]],
         validate_data: bool = True,
+        preprocess_data: bool = True,
         **kwargs,
     ) -> None:
         self.data: pd.DataFrame = data
@@ -50,7 +51,11 @@ class BaseMMM:
 
         if validate_data:
             self.validate(self.data)
-        self.preprocessed_data = self.preprocess(self.data.copy())
+
+        if preprocess_data:
+            self.preprocessed_data = self.preprocess(self.data.copy())
+        else:
+            self.preprocessed_data = self.data.copy()
 
         self.build_model(
             data=self.preprocessed_data,

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -6,7 +6,7 @@ import pymc as pm
 from xarray import DataArray
 
 from pymc_marketing.mmm.base import MMM
-from pymc_marketing.mmm.preprocessing import MaxAbsScaleChannels, MixMaxScaleTarget
+from pymc_marketing.mmm.preprocessing import MaxAbsScaleChannels, MinMaxScaleTarget
 from pymc_marketing.mmm.transformers import (
     geometric_adstock_vectorized,
     logistic_saturation,
@@ -15,7 +15,7 @@ from pymc_marketing.mmm.validating import ValidateControlColumns
 
 
 class DelayedSaturatedMMM(
-    MMM, MixMaxScaleTarget, MaxAbsScaleChannels, ValidateControlColumns
+    MMM, MinMaxScaleTarget, MaxAbsScaleChannels, ValidateControlColumns
 ):
     def __init__(
         self,

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -15,7 +15,10 @@ from pymc_marketing.mmm.validating import ValidateControlColumns
 
 
 class DelayedSaturatedMMM(
-    MMM, MinMaxScaleTarget, MaxAbsScaleChannels, ValidateControlColumns
+    MMM,
+    MinMaxScaleTarget,
+    MaxAbsScaleChannels,
+    ValidateControlColumns
 ):
     def __init__(
         self,
@@ -24,6 +27,7 @@ class DelayedSaturatedMMM(
         date_column: str,
         channel_columns: List[str],
         validate_data: bool = True,
+        preprocess_data: bool = True,
         control_columns: Optional[List[str]] = None,
         adstock_max_lag: int = 4,
         **kwargs,
@@ -36,6 +40,7 @@ class DelayedSaturatedMMM(
             date_column=date_column,
             channel_columns=channel_columns,
             validate_data=validate_data,
+            preprocess_data=preprocess_data,
             adstock_max_lag=adstock_max_lag,
         )
 

--- a/pymc_marketing/mmm/preprocessing.py
+++ b/pymc_marketing/mmm/preprocessing.py
@@ -6,7 +6,7 @@ from sklearn.preprocessing import MaxAbsScaler, MinMaxScaler, StandardScaler
 
 __all__ = [
     "preprocessing_method",
-    "MixMaxScaleTarget",
+    "MinMaxScaleTarget",
     "MaxAbsScaleChannels",
     "StandardizeControls",
 ]
@@ -19,7 +19,7 @@ def preprocessing_method(method: Callable) -> Callable:
     return method
 
 
-class MixMaxScaleTarget:
+class MinMaxScaleTarget:
     @preprocessing_method
     def min_max_scale_target_data(self, data: pd.DataFrame) -> pd.DataFrame:
         target_vector = data[self.target_column].to_numpy().reshape(-1, 1)

--- a/tests/mmm/test_base.py
+++ b/tests/mmm/test_base.py
@@ -8,7 +8,7 @@ import xarray as xr
 from matplotlib import pyplot as plt
 
 from pymc_marketing.mmm.base import MMM
-from pymc_marketing.mmm.preprocessing import MixMaxScaleTarget, preprocessing_method
+from pymc_marketing.mmm.preprocessing import MinMaxScaleTarget, preprocessing_method
 from pymc_marketing.mmm.validating import validation_method
 
 seed: int = sum(map(ord, "pymc_marketing"))
@@ -52,7 +52,7 @@ def plotting_mmm(request):
 
     elif transform == "target_transform":
 
-        class ToyMMM(MMM, MixMaxScaleTarget):
+        class ToyMMM(MMM, MinMaxScaleTarget):
             def build_model(self, data, **kwargs):
                 pass
 

--- a/tests/mmm/test_preprocessing.py
+++ b/tests/mmm/test_preprocessing.py
@@ -3,7 +3,7 @@ import pandas as pd
 
 from pymc_marketing.mmm.preprocessing import (
     MaxAbsScaleChannels,
-    MixMaxScaleTarget,
+    MinMaxScaleTarget,
     StandardizeControls,
     preprocessing_method,
 )
@@ -62,7 +62,7 @@ def test_preprocessing_method():
 
 
 def test_min_max_scale_target():
-    obj = MixMaxScaleTarget()
+    obj = MinMaxScaleTarget()
     obj.target_column = "y"
     out = obj.min_max_scale_target_data(toy_df)["y"]
     assert out.min() == 0


### PR DESCRIPTION
In `DelayedSaturatedMMM`, the inherited preprocessors can't be adjusted or turned off. This PR adds a toggle to disable preprocessing.

It also fixes the minmax preprocessor name from `MixMaxScaleTarget` to `MinMaxScaleTarget`