### PR TITLE
Install instructions added to README and docs. Quickstart added to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,17 @@ PyMC-Marketing is an open source Python package for Bayesian marketing analytics
 
 ## Installation
 
-You may have already set up an environment (e.g. `marketing_env`) you’d like to work in. It may look something like the following:
+Start by setting up an environment (e.g. `marketing_env`) with PyMC. It may look something like the following:
 
-```
-mamba create -c conda-forge -n marketing_env python=3.10 matplotlib jupyterlab ipykernel seaborn pandas "pymc>=5"
+```bash
+mamba create -c conda-forge -n marketing_env python=3.11 "pymc>=5"
 mamba activate marketing_env
-python -m ipykernel install --user --name marketing_env
 ```
 
 See the official [PyMC installation guide](https://www.pymc.io/projects/docs/en/latest/installation.html) if more detail is needed.
 
 Assuming you have an environment set up then install PyMC-Marketing with the following command. This will give you the latest version of the library from PyPI.
+
 ```bash
 pip install pymc-marketing
 ```

--- a/README.md
+++ b/README.md
@@ -11,6 +11,27 @@ PyMC-Marketing is an open source Python package for Bayesian marketing analytics
 
 ---
 
+## Installation
+
+You may have already set up an environment (e.g. `marketing_test_env`) you’d like to work in. It may look something like the following:
+
+```
+mamba create -n marketing_test_env python=3.10 matplotlib jupyterlab ipykernel seaborn pandas
+mamba activate marketing_test_env
+python -m ipykernel install --user --name marketing_test_env
+```
+
+Assuming you have an environment set up then install PyMC-Marketing with the following command. This will give you the latest version of the library from PyPI.
+```bash
+pip install pymc-marketing
+```
+
+Alternatively you can install from GitHub directly:
+
+```bash
+pip install git+https://github.com/pymc-labs/pymc-marketing.git
+```
+
 ## Bayesian Media Mix Models (MMMs) in PyMC
 
 In this package we provide an API for a Bayesian media mix model (MMM) specification following [Jin, Yuxue, et al. “Bayesian methods for media mix modeling with carryover and shape effects.” (2017).](https://research.google/pubs/pub46001/) Concretely, given a time series target variable $y_{t}$ (e.g. sales on conversions), media variables $x_{m, t}$ (e.g. impressions, clicks or costs) and a set of control covariates $z_{c, t}$ (e.g. holidays, special events) we consider a linear model of the form

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ PyMC-Marketing is an open source Python package for Bayesian marketing analytics
 You may have already set up an environment (e.g. `marketing_env`) you’d like to work in. It may look something like the following:
 
 ```
-mamba create -c conda-forge -n marketing_env python=3.10 matplotlib jupyterlab ipykernel seaborn pandas pymc
+mamba create -c conda-forge -n marketing_env python=3.10 matplotlib jupyterlab ipykernel seaborn pandas "pymc>=5"
 mamba activate marketing_env
 python -m ipykernel install --user --name marketing_env
 ```

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ PyMC-Marketing is an open source Python package for Bayesian marketing analytics
 
 ## Installation
 
-You may have already set up an environment (e.g. `marketing_test_env`) you’d like to work in. It may look something like the following:
+You may have already set up an environment (e.g. `marketing_env`) you’d like to work in. It may look something like the following:
 
 ```
-mamba create -c conda-forge -n marketing_test_env python=3.10 matplotlib jupyterlab ipykernel seaborn pandas pymc
-mamba activate marketing_test_env
-python -m ipykernel install --user --name marketing_test_env
+mamba create -c conda-forge -n marketing_env python=3.10 matplotlib jupyterlab ipykernel seaborn pandas pymc
+mamba activate marketing_env
+python -m ipykernel install --user --name marketing_env
 ```
 
 See the official [PyMC installation guide](https://www.pymc.io/projects/docs/en/latest/installation.html) if more detail is needed.

--- a/README.md
+++ b/README.md
@@ -16,10 +16,12 @@ PyMC-Marketing is an open source Python package for Bayesian marketing analytics
 You may have already set up an environment (e.g. `marketing_test_env`) you’d like to work in. It may look something like the following:
 
 ```
-mamba create -n marketing_test_env python=3.10 matplotlib jupyterlab ipykernel seaborn pandas
+mamba create -c conda-forge -n marketing_test_env python=3.10 matplotlib jupyterlab ipykernel seaborn pandas pymc
 mamba activate marketing_test_env
 python -m ipykernel install --user --name marketing_test_env
 ```
+
+See the official [PyMC installation guide](https://www.pymc.io/projects/docs/en/latest/installation.html) if more detail is needed.
 
 Assuming you have an environment set up then install PyMC-Marketing with the following command. This will give you the latest version of the library from PyPI.
 ```bash

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ PyMC-Marketing is an open source Python package for Bayesian marketing analytics
 Start by setting up an environment (e.g. `marketing_env`) with PyMC. It may look something like the following:
 
 ```bash
-mamba create -c conda-forge -n marketing_env python=3.11 "pymc>=5"
+mamba create -c conda-forge -n marketing_env python "pymc>=5"
 mamba activate marketing_env
 ```
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -59,17 +59,17 @@ To the reference guide
 
 ## Installation
 
-You may have already set up an environment (e.g. `marketing_env`) you’d like to work in. It may look something like the following:
+Start by setting up an environment (e.g. `marketing_env`) with PyMC. It may look something like the following:
 
-```
-mamba create -c conda-forge -n marketing_env python=3.10 matplotlib jupyterlab ipykernel seaborn pandas "pymc>=5"
+```bash
+mamba create -c conda-forge -n marketing_env python=3.11 "pymc>=5"
 mamba activate marketing_env
-python -m ipykernel install --user --name marketing_env
 ```
 
 See the official [PyMC installation guide](https://www.pymc.io/projects/docs/en/latest/installation.html) if more detail is needed.
 
 Assuming you have an environment set up then install PyMC-Marketing with the following command. This will give you the latest version of the library from PyPI.
+
 ```bash
 pip install pymc-marketing
 ```
@@ -82,10 +82,14 @@ pip install git+https://github.com/pymc-labs/pymc-marketing.git
 
 ## Quickstart
 
-Once you've installed the library (see above), you can get started.
+Once you've installed the library (see above), you can get started. If you want to work in a jupyter lab notebook then remember to do the following:
+
+```bash
+pip install jupyterlab
+python -m ipykernel install --user --name marketing_env
+```
 
 ### MMM Quickstart
-You could then get started in a Python session, or a jupyter lab notebook with:
 
 ```python
 import pandas as pd
@@ -123,8 +127,6 @@ model.plot_components_contributions();
 See the Example notebooks section for examples of further types of plot you can get, as well as introspect the results of the fitting.
 
 ### CLV Quickstart
-
-Again, in a Python session, or juputer lab notebook:
 
 ```python
 import matplotlib.pyplot as plt

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -62,7 +62,7 @@ To the reference guide
 Start by setting up an environment (e.g. `marketing_env`) with PyMC. It may look something like the following:
 
 ```bash
-mamba create -c conda-forge -n marketing_env python=3.11 "pymc>=5"
+mamba create -c conda-forge -n marketing_env python "pymc>=5"
 mamba activate marketing_env
 ```
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -59,12 +59,12 @@ To the reference guide
 
 ## Installation
 
-You may have already set up an environment (e.g. `marketing_test_env`) you’d like to work in. It may look something like the following:
+You may have already set up an environment (e.g. `marketing_env`) you’d like to work in. It may look something like the following:
 
 ```
-mamba create -c conda-forge -n marketing_test_env python=3.10 matplotlib jupyterlab ipykernel seaborn pandas pymc
-mamba activate marketing_test_env
-python -m ipykernel install --user --name marketing_test_env
+mamba create -c conda-forge -n marketing_env python=3.10 matplotlib jupyterlab ipykernel seaborn pandas pymc
+mamba activate marketing_env
+python -m ipykernel install --user --name marketing_env
 ```
 
 See the official [PyMC installation guide](https://www.pymc.io/projects/docs/en/latest/installation.html) if more detail is needed.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -117,7 +117,7 @@ Initiate fitting and get a visualization of some of the outputs with:
 
 ```python
 model.fit()
-model.plot_components_contributions()
+model.plot_components_contributions();
 ```
 
 See the Example notebooks section for examples of further types of plot you can get, as well as introspect the results of the fitting.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -62,10 +62,12 @@ To the reference guide
 You may have already set up an environment (e.g. `marketing_test_env`) you’d like to work in. It may look something like the following:
 
 ```
-mamba create -n marketing_test_env python=3.10 matplotlib jupyterlab ipykernel seaborn pandas
+mamba create -c conda-forge -n marketing_test_env python=3.10 matplotlib jupyterlab ipykernel seaborn pandas pymc
 mamba activate marketing_test_env
 python -m ipykernel install --user --name marketing_test_env
 ```
+
+See the official [PyMC installation guide](https://www.pymc.io/projects/docs/en/latest/installation.html) if more detail is needed.
 
 Assuming you have an environment set up then install PyMC-Marketing with the following command. This will give you the latest version of the library from PyPI.
 ```bash

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -62,7 +62,7 @@ To the reference guide
 You may have already set up an environment (e.g. `marketing_env`) you’d like to work in. It may look something like the following:
 
 ```
-mamba create -c conda-forge -n marketing_env python=3.10 matplotlib jupyterlab ipykernel seaborn pandas pymc
+mamba create -c conda-forge -n marketing_env python=3.10 matplotlib jupyterlab ipykernel seaborn pandas "pymc>=5"
 mamba activate marketing_env
 python -m ipykernel install --user --name marketing_env
 ```

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -2,14 +2,6 @@
 
 Bayesian MMMs and CLVs in PyMC.
 
-## Installation
-
-You can install from GitHub
-
-```bash
-pip install git+https://github.com/pymc-labs/pymc-marketing.git
-```
-
 ## Quick links
 
 :::::{grid} 1 1 2 2
@@ -64,6 +56,94 @@ To the reference guide
 :::
 ::::
 :::::
+
+## Installation
+
+You may have already set up an environment (e.g. `marketing_test_env`) you’d like to work in. It may look something like the following:
+
+```
+mamba create -n marketing_test_env python=3.10 matplotlib jupyterlab ipykernel seaborn pandas
+mamba activate marketing_test_env
+python -m ipykernel install --user --name marketing_test_env
+```
+
+Assuming you have an environment set up then install PyMC-Marketing with the following command. This will give you the latest version of the library from PyPI.
+```bash
+pip install pymc-marketing
+```
+
+Alternatively you can install from GitHub directly:
+
+```bash
+pip install git+https://github.com/pymc-labs/pymc-marketing.git
+```
+
+## Quickstart
+
+Once you've installed the library (see above), you can get started.
+
+### MMM Quickstart
+You could then get started in a Python session, or a jupyter lab notebook with:
+
+```python
+import pandas as pd
+from pymc_marketing import mmm
+
+
+data_url = "https://raw.githubusercontent.com/pymc-labs/pymc-marketing/main/datasets/mmm_example.csv"
+data = pd.read_csv(data_url, parse_dates=['date_week'])
+
+model = mmm.DelayedSaturatedMMM(
+    data_df=data,
+    target_column="y",
+    date_column="date_week",
+    channel_columns=["x1", "x2"],
+    control_columns=[
+        "event_1",
+        "event_2",
+        "t",
+        "sin_order_1",
+        "cos_order_1",
+        "sin_order_2",
+        "cos_order_2",
+    ],
+    adstock_max_lag=8,
+)
+```
+
+Initiate fitting and get a visualisation of some of the outputs with:
+
+```python
+model.fit()
+model.plot_components_contributions()
+```
+
+See the Example notebooks section for examples of further types of plot you can get, as well as introspect the results of the fitting.
+
+### CLV Quickstart
+
+Again, in a Python session, or juputer lab notebook:
+
+```python
+import matplotlib.pyplot as plt
+import pandas as pd
+import seaborn as sns
+from pymc_marketing import clv
+
+
+data_url = "https://raw.githubusercontent.com/pymc-labs/pymc-marketing/main/datasets/clv_quickstart.csv"
+data = pd.read_csv(data_url)
+
+beta_geo_model = clv.BetaGeoModel(
+    customer_id=data.index,
+    frequency=data["frequency"],
+    recency=data["recency"],
+    T=data["T"],
+)
+
+beta_geo_model.fit()
+```
+Once fitted, we can use the model to predict the number of future purchases for known customers, the probability that they are still alive, and get various visualizations plotted. See the Examples section for more on this.
 
 ## Support
 


### PR DESCRIPTION
Adds identical install instructions both to the GitHub README, and the docs.

Additionally adds concise quickstart material (for both MMM and CLV) to the docs only.

The quickstart uses pandas to directly import datasets from a GitHub url

EDIT: Ben manually giving the read the docs build link https://pymc-marketing--224.org.readthedocs.build/en/224/ (future PR's should auto do this)