### PR TITLE
Use MaxAbsScaler instead of MinMaxScaler for Target MMM

### DIFF
--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -1,12 +1,10 @@
 from typing import Any, Dict, List, Optional
 
-import arviz as az
 import pandas as pd
 import pymc as pm
-from xarray import DataArray
 
 from pymc_marketing.mmm.base import MMM
-from pymc_marketing.mmm.preprocessing import MaxAbsScaleChannels, MixMaxScaleTarget
+from pymc_marketing.mmm.preprocessing import MaxAbsScaleChannels, MaxAbsScaleTarget
 from pymc_marketing.mmm.transformers import (
     geometric_adstock_vectorized,
     logistic_saturation,
@@ -15,7 +13,7 @@ from pymc_marketing.mmm.validating import ValidateControlColumns
 
 
 class DelayedSaturatedMMM(
-    MMM, MixMaxScaleTarget, MaxAbsScaleChannels, ValidateControlColumns
+    MMM, MaxAbsScaleTarget, MaxAbsScaleChannels, ValidateControlColumns
 ):
     def __init__(
         self,
@@ -129,21 +127,3 @@ class DelayedSaturatedMMM(
                 observed=target_,
                 dims="date",
             )
-
-    def compute_channel_contribution_original_scale(self) -> DataArray:
-        beta_channel_samples_extended: DataArray = az.extract(
-            data=self.fit_result, var_names=["beta_channel"], combined=False
-        ).expand_dims({"date": self.n_obs}, axis=2)
-
-        channel_transformed: DataArray = az.extract(
-            data=self.fit_result,
-            var_names=["channel_adstock_saturated"],
-            combined=False,
-        )
-
-        normalization_factor: float = self.target_transformer.named_steps[
-            "scaler"
-        ].scale_.item()
-        return (
-            beta_channel_samples_extended * channel_transformed
-        ) / normalization_factor

--- a/pymc_marketing/mmm/preprocessing.py
+++ b/pymc_marketing/mmm/preprocessing.py
@@ -2,11 +2,11 @@ from typing import Callable
 
 import pandas as pd
 from sklearn.pipeline import Pipeline
-from sklearn.preprocessing import MaxAbsScaler, MinMaxScaler, StandardScaler
+from sklearn.preprocessing import MaxAbsScaler, StandardScaler
 
 __all__ = [
     "preprocessing_method",
-    "MixMaxScaleTarget",
+    "MaxAbsScaleTarget",
     "MaxAbsScaleChannels",
     "StandardizeControls",
 ]
@@ -19,11 +19,11 @@ def preprocessing_method(method: Callable) -> Callable:
     return method
 
 
-class MixMaxScaleTarget:
+class MaxAbsScaleTarget:
     @preprocessing_method
-    def min_max_scale_target_data(self, data: pd.DataFrame) -> pd.DataFrame:
+    def max_abs_scale_target_data(self, data: pd.DataFrame) -> pd.DataFrame:
         target_vector = data[self.target_column].to_numpy().reshape(-1, 1)
-        transformers = [("scaler", MinMaxScaler())]
+        transformers = [("scaler", MaxAbsScaler())]
         pipeline = Pipeline(steps=transformers)
         self.target_transformer: Pipeline = pipeline.fit(X=target_vector)
         data[self.target_column] = self.target_transformer.transform(

--- a/tests/mmm/test_base.py
+++ b/tests/mmm/test_base.py
@@ -8,7 +8,7 @@ import xarray as xr
 from matplotlib import pyplot as plt
 
 from pymc_marketing.mmm.base import MMM
-from pymc_marketing.mmm.preprocessing import MixMaxScaleTarget, preprocessing_method
+from pymc_marketing.mmm.preprocessing import MaxAbsScaleTarget, preprocessing_method
 from pymc_marketing.mmm.validating import validation_method
 
 seed: int = sum(map(ord, "pymc_marketing"))
@@ -52,7 +52,7 @@ def plotting_mmm(request):
 
     elif transform == "target_transform":
 
-        class ToyMMM(MMM, MixMaxScaleTarget):
+        class ToyMMM(MMM, MaxAbsScaleTarget):
             def build_model(self, data, **kwargs):
                 pass
 

--- a/tests/mmm/test_preprocessing.py
+++ b/tests/mmm/test_preprocessing.py
@@ -3,7 +3,7 @@ import pandas as pd
 
 from pymc_marketing.mmm.preprocessing import (
     MaxAbsScaleChannels,
-    MixMaxScaleTarget,
+    MaxAbsScaleTarget,
     StandardizeControls,
     preprocessing_method,
 )
@@ -61,11 +61,12 @@ def test_preprocessing_method():
     assert vf.__name__ == "f3"
 
 
-def test_min_max_scale_target():
-    obj = MixMaxScaleTarget()
+def test_max_abs_scale_target():
+    obj = MaxAbsScaleTarget()
     obj.target_column = "y"
-    out = obj.min_max_scale_target_data(toy_df)["y"]
-    assert out.min() == 0
+    out = obj.max_abs_scale_target_data(toy_df)["y"]
+    temp = toy_df["y"]
+    assert out.min() == temp.min() / temp.max()
     assert out.max() == 1
     pd.testing.assert_index_equal(out.index, toy_df.index)
 


### PR DESCRIPTION
Use MaxAbsScaler instead of MinMaxScaler for Target MMM. This is important when computing ROAS. It also makes the transformation (and inverse transformations easier) 