### PR TITLE
Test oldest pymc version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,13 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }} # use token for more robust uploads
           name: ${{ matrix.python-version }}
           fail_ci_if_error: false
+
+  all:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: All checks
+    needs: [ lint, test ]
+    steps:
+      - name: Confirm checks passed
+        if: ${{ (needs.lint.result != 'success' || needs.test.result != 'success') }}
+        run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,39 +6,52 @@ on:
   push:
     branches: [main]
 
+env:
+  OLDEST_PYMC_VERSION: "5.1.2"
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
-
+        python-version: ["3.8", "3.11"]
+        oldest-pymc: [false, true]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install oldest version of PyMC
+        if: ${{ matrix.oldest-pymc }}
+        run: pip install pymc==${{ env.OLDEST_PYMC_VERSION }}
       - name: Run lint
-        run: |
-          make init
-          make check_lint
+        run: make check_lint
+      - name: Check oldest version of PyMC
+        if: ${{ matrix.oldest-pymc }}
+        run: python -c "import pymc; assert pymc.__version__ == '${{  env.OLDEST_PYMC_VERSION }}'"
+
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
-
+        config: [ {python-version: "3.8", oldest-pymc: false}, {python-version: "3.11", oldest-pymc: true}]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.config.python-version }}
+      - name: Install oldest version of PyMC
+        if: ${{ matrix.config.oldest-pymc }}
+        run: pip install pymc==${{ env.OLDEST_PYMC_VERSION }}
       - name: Run tests
         run: |
           pip install -e .[test]
           pytest --cov-report=xml --no-cov-on-fail
+      - name: Check oldest version of PyMC
+        if: ${{ matrix.oldest-pymc }}
+        run: python -c "import pymc; assert pymc.__version__ == '${{  env.OLDEST_PYMC_VERSION }}'"
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "matplotlib>=3.5.1",
     "numpy>=1.17",
     "pandas",
+    # NOTE: Keep minimum pymc version in sync with ci.yml `OLDEST_PYMC_VERSION`
     "pymc>=5.1.2",
     "scikit-learn>=1.1.1",
     "seaborn>=0.12.2",


### PR DESCRIPTION
Closes #193 

Ignore the (expected) tests. Those are the current required tests for PRs, after this one they would be replaced by the new `all`

<!-- readthedocs-preview pymc-marketing start -->
----
:books: Documentation preview :books:: https://pymc-marketing--235.org.readthedocs.build/en/235/

<!-- readthedocs-preview pymc-marketing end -->