### PR TITLE
Add yearly seasonality to MMM

### DIFF
--- a/pymc_marketing/mmm/base.py
+++ b/pymc_marketing/mmm/base.py
@@ -471,7 +471,7 @@ class BaseMMM:
             )
         else:
             contributions_fourier_over_time = pd.DataFrame(
-                index=contributions_fourier_over_time.index
+                index=contributions_channel_over_time.index
             )
 
         contributions_intercept_over_time = (
@@ -552,15 +552,13 @@ class BaseMMM:
                 )
                 grouped_buffer.append(grouped)
 
-            all_contributions_over_time_grouped = pd.concat(
-                grouped_buffer, axis="columns"
-            )
+            all_contributions_over_time = pd.concat(grouped_buffer, axis="columns")
 
         fig, ax = plt.subplots(**plt_kwargs)
         area_params = dict(stacked=True, ax=ax)
         if area_kwargs is not None:
             area_params.update(area_kwargs)
-        all_contributions_over_time_grouped.plot.area(**area_params)
+        all_contributions_over_time.plot.area(**area_params)
         ax.legend(title="groups", loc="center left", bbox_to_anchor=(1, 0.5))
         return fig
 

--- a/pymc_marketing/mmm/base.py
+++ b/pymc_marketing/mmm/base.py
@@ -411,7 +411,7 @@ class BaseMMM:
         fig.suptitle("Contribution Plots", fontsize=16)
         return fig
 
-    def get_mean_contributions_over_time(
+    def compute_mean_contributions_over_time(
         self, original_scale: bool = False
     ) -> pd.DataFrame:
         """Get the contributions of each channel over time.
@@ -538,7 +538,7 @@ class BaseMMM:
             Matplotlib figure with the plot.
         """
 
-        all_contributions_over_time = self.get_mean_contributions_over_time(
+        all_contributions_over_time = self.compute_mean_contributions_over_time(
             original_scale=original_scale
         )
 

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -40,13 +40,13 @@ class DelayedSaturatedMMM(
         channel_columns : List[str]
             Column names of the media channel variables.
         validate_data : bool, optional
-            Wether to validate the data upon initialization, by default True
+            Whether to validate the data upon initialization, by default True.
         control_columns : Optional[List[str]], optional
             Column names of control variables to be added as additional regressors, by default None
         adstock_max_lag : int, optional
             Number of lags to consider in the adstock transformation, by default 4
         yearly_seasonality : Optional[int], optional
-            Number of Fourier modes to model yearly seasonality, by default None
+            Number of Fourier modes to model yearly seasonality, by default None.
 
         References
         ----------
@@ -164,7 +164,7 @@ class DelayedSaturatedMMM(
                 )
 
                 fourier_contribution = pm.Deterministic(
-                    name="fourier_contribution",
+                    name="fourier_contributions",
                     var=fourier_data_ * gamma_fourier,
                     dims=("date", "fourier_mode"),
                 )

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -80,13 +80,14 @@ class DelayedSaturatedMMM(
 
         if self.control_columns is not None:
             control_data: Optional[pd.DataFrame] = data[self.control_columns]
-            coords["control"] = control_data.columns
+            coords["control"] = data[self.control_columns].columns
         else:
             control_data = None
 
         if self.yearly_seasonality is not None:
-            fourier_features: Optional[pd.DataFrame] = self._get_fourier_models_data()
+            fourier_features = self._get_fourier_models_data()
             coords["fourier_mode"] = fourier_features.columns.to_numpy()
+
         else:
             fourier_features = None
 
@@ -181,7 +182,7 @@ class DelayedSaturatedMMM(
                 dims="date",
             )
 
-    def _get_fourier_models_data(self) -> Optional[pd.DataFrame]:
+    def _get_fourier_models_data(self) -> pd.DataFrame:
         """Generates fourier modes to model seasonality.
 
         References
@@ -189,7 +190,7 @@ class DelayedSaturatedMMM(
         https://www.pymc.io/projects/examples/en/latest/time_series/Air_passengers-Prophet_with_Bayesian_workflow.html
         """
         if self.yearly_seasonality is None:
-            return None
+            raise ValueError("yearly_seasonality must be specified.")
 
         date_data: pd.Series = pd.to_datetime(
             arg=self.data[self.date_column], format="%Y-%m-%d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,5 +79,6 @@ addopts = [
     "--strict-config",
     "--cov=pymc_marketing",
     "--cov-report=term-missing",
+    "--color=yes",
 ]
 testpaths = "tests"

--- a/tests/mmm/test_delayed_saturated_mmm.py
+++ b/tests/mmm/test_delayed_saturated_mmm.py
@@ -197,7 +197,7 @@ class TestMMM:
             draws * chains,
         )
 
-        mean_model_contributions_ts = mmm.get_mean_contributions_over_time(
+        mean_model_contributions_ts = mmm.compute_mean_contributions_over_time(
             original_scale=True
         )
         assert mean_model_contributions_ts.shape == (

--- a/tests/mmm/test_delayed_saturated_mmm.py
+++ b/tests/mmm/test_delayed_saturated_mmm.py
@@ -5,7 +5,6 @@ import numpy as np
 import pandas as pd
 import pymc as pm
 import pytest
-from matplotlib import pyplot as plt
 
 from pymc_marketing.mmm.delayed_saturated_mmm import DelayedSaturatedMMM
 
@@ -114,57 +113,60 @@ class TestMMM:
             == samples
         )
         assert az.extract(
-            prior_predictive, group="prior", var_names=["beta_channel"], combined=True
+            data=prior_predictive,
+            group="prior",
+            var_names=["beta_channel"],
+            combined=True,
         ).to_numpy().shape == (
             n_channel,
             samples,
         )
         assert az.extract(
-            prior_predictive, group="prior", var_names=["alpha"], combined=True
+            data=prior_predictive, group="prior", var_names=["alpha"], combined=True
         ).to_numpy().shape == (
             n_channel,
             samples,
         )
         assert az.extract(
-            prior_predictive, group="prior", var_names=["lam"], combined=True
+            data=prior_predictive, group="prior", var_names=["lam"], combined=True
         ).to_numpy().shape == (
             n_channel,
             samples,
         )
 
-    @pytest.mark.parametrize(
-        argnames="yearly_seasonality",
-        argvalues=[None, 2],
-        ids=["no_yearly_seasonality", "yearly_seasonality"],
-    )
-    @pytest.mark.parametrize(
-        argnames="control_columns",
-        argvalues=[None, ["control_1"], ["control_1", "control_2"]],
-        ids=["no_control", "one_control", "two_controls"],
-    )
-    @pytest.mark.parametrize(
-        argnames="channel_columns",
-        argvalues=[["channel_1", "channel_2"]],
-        ids=["multiple_channel"],
-    )
-    def test_fit(
-        self,
-        toy_df: pd.DataFrame,
-        channel_columns: List[str],
-        control_columns: Optional[List[str]],
-        yearly_seasonality: Optional[int],
-    ) -> None:
-        draws: int = 20
+        if control_columns is not None:
+            n_control = len(control_columns)
+            assert az.extract(
+                data=prior_predictive,
+                group="prior",
+                var_names=["gamma_control"],
+                combined=True,
+            ).to_numpy().shape == (
+                n_control,
+                samples,
+            )
+        if yearly_seasonality is not None:
+            assert az.extract(
+                data=prior_predictive,
+                group="prior",
+                var_names=["gamma_fourier"],
+                combined=True,
+            ).to_numpy().shape == (
+                2 * yearly_seasonality,
+                samples,
+            )
+
+    def test_fit(self, toy_df: pd.DataFrame) -> None:
+        draws: int = 100
         chains: int = 2
 
         mmm = DelayedSaturatedMMM(
             data=toy_df,
             target_column="y",
             date_column="date",
-            channel_columns=channel_columns,
-            control_columns=control_columns,
+            channel_columns=["channel_1", "channel_2"],
+            control_columns=["control_1", "control_2"],
             adstock_max_lag=2,
-            yearly_seasonality=yearly_seasonality,
         )
         n_channel: int = len(mmm.channel_columns)
         mmm.fit(target_accept=0.81, draws=draws, chains=chains, random_seed=rng)
@@ -184,23 +186,12 @@ class TestMMM:
         assert az.extract(
             data=idata, var_names=["lam"], combined=True
         ).to_numpy().shape == (n_channel, draws * chains)
-
-        if control_columns is not None:
-            n_control = len(control_columns)
-            assert az.extract(
-                data=idata, var_names=["gamma_control"], combined=True
-            ).to_numpy().shape == (
-                n_control,
-                draws * chains,
-            )
-        if yearly_seasonality is not None:
-            assert az.extract(
-                data=idata, var_names=["gamma_fourier"], combined=True
-            ).to_numpy().shape == (
-                2 * yearly_seasonality,
-                draws * chains,
-            )
-        assert isinstance(mmm.plot_components_contributions(), plt.Figure)
+        assert az.extract(
+            data=idata, var_names=["gamma_control"], combined=True
+        ).to_numpy().shape == (
+            n_channel,
+            draws * chains,
+        )
 
     @pytest.mark.parametrize(
         argnames="yearly_seasonality",
@@ -220,11 +211,12 @@ class TestMMM:
             yearly_seasonality=yearly_seasonality,
         )
 
-        fourier_modes_data: Optional[pd.DataFrame] = mmm._get_fourier_models_data()
-
         if yearly_seasonality is None:
-            assert fourier_modes_data is None
+            with pytest.raises(ValueError):
+                mmm._get_fourier_models_data()
+
         else:
+            fourier_modes_data: Optional[pd.DataFrame] = mmm._get_fourier_models_data()
             assert fourier_modes_data.shape == (
                 toy_df.shape[0],
                 2 * yearly_seasonality,


### PR DESCRIPTION
Closes https://github.com/pymc-labs/pymc-marketing/issues/54

We want to add seasonality as external regressor (see [Jin, Yuxue, et al. “Bayesian methods for media mix modeling with carryover and shape effects.” (2017).](https://research.google/pubs/pub46001/)) using Fourier modes (ala Prophet, see [here](https://facebook.github.io/prophet/docs/seasonality,_holiday_effects,_and_regressors.html#fourier-order-for-seasonalities).

- [x] Add implementation
- [x] Add tests
- [x] Update notebook
- [x] Fix notebook after rebase (https://github.com/pymc-labs/pymc-marketing/pull/247 and https://github.com/pymc-labs/pymc-marketing/pull/251)

<!-- readthedocs-preview pymc-marketing start -->
----
:books: Documentation preview :books:: https://pymc-marketing--242.org.readthedocs.build/en/242/

<!-- readthedocs-preview pymc-marketing end -->