### PR TITLE
Update PyMC dependency and LaTeX representation tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 env:
-  OLDEST_PYMC_VERSION: "5.1.2"
+  OLDEST_PYMC_VERSION: "5.3.0"
 
 jobs:
   lint:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "numpy>=1.17",
     "pandas",
     # NOTE: Keep minimum pymc version in sync with ci.yml `OLDEST_PYMC_VERSION`
-    "pymc>=5.1.2",
+    "pymc>=5.3.0",
     "scikit-learn>=1.1.1",
     "seaborn>=0.12.2",
     "xarray"

--- a/tests/clv/models/test_basic.py
+++ b/tests/clv/models/test_basic.py
@@ -63,7 +63,9 @@ class TestCLVModel:
 
     def test_repr(self):
         model = CLVModelTest()
-        assert model.__repr__() == "CLVModelTest\nx ~ N**+(0, 100)\ny ~ N(x, 1)"
+        assert (
+            model.__repr__() == "CLVModelTest\nx ~ HalfNormal(0, 100)\ny ~ Normal(x, 1)"
+        )
 
     def test_fit_override(self):
         with warnings.catch_warnings():
@@ -95,8 +97,8 @@ class TestCLVModel:
 
         assert ret_prior1 is prior1
         assert ret_prior2 is prior2
-        assert ret_prior1.str_repr() == "N(0, 1)"
-        assert ret_prior2.str_repr() == "N**+(0, 1)"
+        assert ret_prior1.str_repr() == "Normal(0, 1)"
+        assert ret_prior2.str_repr() == "HalfNormal(0, 1)"
 
         with pytest.raises(ValueError, match="Prior variables must be unique"):
             CLVModel._process_priors(prior1, prior2, prior1)

--- a/tests/clv/models/test_beta_geo.py
+++ b/tests/clv/models/test_beta_geo.py
@@ -319,7 +319,7 @@ class TestBetaGeoModel:
         assert model.__repr__().replace(" ", "") == (
             "BG/NBD"
             "\na~HalfFlat()"
-            "\nb~N**+(0,10)"
+            "\nb~HalfNormal(0,10)"
             "\nalpha~HalfFlat()"
             "\nr~HalfFlat()"
             "\nlikelihood~Potential(f(r,alpha,b,a))"

--- a/tests/clv/models/test_gamma_gamma.py
+++ b/tests/clv/models/test_gamma_gamma.py
@@ -232,7 +232,7 @@ class TestGammaGammaModel(BaseTestGammaGammaModel):
 
         assert model.__repr__().replace(" ", "") == (
             "Gamma-GammaModel(MeanTransactions)"
-            "\np~N**+(0,10)"
+            "\np~HalfNormal(0,10)"
             "\nq~HalfFlat()"
             "\nv~HalfFlat()"
             "\nlikelihood~Potential(f(q,p,v))"
@@ -350,7 +350,7 @@ class TestGammaGammaModelIndividual(BaseTestGammaGammaModel):
         assert model.__repr__().replace(" ", "") == (
             "Gamma-GammaModel(IndividualTransactions)"
             "\np~HalfFlat()"
-            "\nq~N**+(0,10)"
+            "\nq~HalfNormal(0,10)"
             "\nv~HalfFlat()"
             "\nnu~Gamma(q,f(v))"
             "\nspend~Gamma(p,f(nu))"

--- a/tests/clv/models/test_shifted_beta_geo.py
+++ b/tests/clv/models/test_shifted_beta_geo.py
@@ -111,10 +111,10 @@ class TestShiftedBetaGeoModel:
 
         assert model.__repr__().replace(" ", "") == (
             "Shifted-Beta-GeometricModel(IndividualCustomers)"
-            "\nalpha~N**+(0,10)"
+            "\nalpha~HalfNormal(0,10)"
             "\nbeta~HalfFlat()"
             "\ntheta~Beta(alpha,beta)"
-            f"\nchurn_censored~Censored(Geom(theta),-inf,{self.T})"
+            f"\nchurn_censored~Censored(Geometric(theta),-inf,{self.T})"
         )
 
     @pytest.mark.slow


### PR DESCRIPTION
Closes #244

I suspect that this should work. Let's see if tests pass

<!-- readthedocs-preview pymc-marketing start -->
----
:books: Documentation preview :books:: https://pymc-marketing--245.org.readthedocs.build/en/245/

<!-- readthedocs-preview pymc-marketing end -->