### PR TITLE
MMM: scale contributions to original scale and allow custom colors

### DIFF
--- a/pymc_marketing/mmm/base.py
+++ b/pymc_marketing/mmm/base.py
@@ -411,7 +411,10 @@ class BaseMMM:
         return fig
 
     def plot_grouped_contribution_breakdown_over_time(
-        self, stack_groups: Optional[Dict[str, List[str]]] = None, **plt_kwargs: Any
+        self,
+        stack_groups: Optional[Dict[str, List[str]]] = None,
+        area_kwargs: Optional[Dict[str, Any]] = None,
+        **plt_kwargs: Any,
     ) -> plt.Figure:
         """Plot a time series area chart for all channel contributions.
 
@@ -496,8 +499,19 @@ class BaseMMM:
 
             all_contributions_over_time = pd.concat(grouped_buffer, axis="columns")
 
+        all_contributions_over_time_original_scale = pd.DataFrame(
+            data=self.get_target_transformer().inverse_transform(
+                all_contributions_over_time
+            ),
+            columns=all_contributions_over_time.columns,
+            index=all_contributions_over_time.index,
+        )
+
         fig, ax = plt.subplots(**plt_kwargs)
-        all_contributions_over_time.plot.area(stacked=True, ax=ax)
+        area_params = dict(stacked=True, ax=ax)
+        if area_kwargs is not None:
+            area_params.update(area_kwargs)
+        all_contributions_over_time_original_scale.plot.area(**area_params)
         ax.legend(title="groups", loc="center left", bbox_to_anchor=(1, 0.5))
         return fig
 

--- a/pymc_marketing/mmm/base.py
+++ b/pymc_marketing/mmm/base.py
@@ -412,6 +412,7 @@ class BaseMMM:
 
     def plot_grouped_contribution_breakdown_over_time(
         self,
+        original_scale: bool = False,
         stack_groups: Optional[Dict[str, List[str]]] = None,
         area_kwargs: Optional[Dict[str, Any]] = None,
         **plt_kwargs: Any,
@@ -438,6 +439,8 @@ class BaseMMM:
 
             Note: If you only pass {"Baseline": "intercept", "Online": ["Banners"]},
             you will not see the TV and Radio channels in the chart.
+        original_scale : bool, by default False
+            If True, the contributions are plotted in the original scale of the target.
 
         Returns
         -------
@@ -499,19 +502,20 @@ class BaseMMM:
 
             all_contributions_over_time = pd.concat(grouped_buffer, axis="columns")
 
-        all_contributions_over_time_original_scale = pd.DataFrame(
-            data=self.get_target_transformer().inverse_transform(
-                all_contributions_over_time
-            ),
-            columns=all_contributions_over_time.columns,
-            index=all_contributions_over_time.index,
-        )
+        if original_scale:
+            all_contributions_over_time = pd.DataFrame(
+                data=self.get_target_transformer().inverse_transform(
+                    all_contributions_over_time
+                ),
+                columns=all_contributions_over_time.columns,
+                index=all_contributions_over_time.index,
+            )
 
         fig, ax = plt.subplots(**plt_kwargs)
         area_params = dict(stacked=True, ax=ax)
         if area_kwargs is not None:
             area_params.update(area_kwargs)
-        all_contributions_over_time_original_scale.plot.area(**area_params)
+        all_contributions_over_time.plot.area(**area_params)
         ax.legend(title="groups", loc="center left", bbox_to_anchor=(1, 0.5))
         return fig
 

--- a/tests/mmm/test_base.py
+++ b/tests/mmm/test_base.py
@@ -210,7 +210,10 @@ class TestMMM:
             ("plot_grouped_contribution_breakdown_over_time", {}),
             (
                 "plot_grouped_contribution_breakdown_over_time",
-                {"stack_groups": {"controls": ["control_1"]}},
+                {
+                    "stack_groups": {"controls": ["control_1"]},
+                    "area_kwargs": {"alpha": 0.5},
+                },
             ),
         ],
     )

--- a/tests/mmm/test_base.py
+++ b/tests/mmm/test_base.py
@@ -212,6 +212,7 @@ class TestMMM:
                 "plot_grouped_contribution_breakdown_over_time",
                 {
                     "stack_groups": {"controls": ["control_1"]},
+                    "original_scale": True,
                     "area_kwargs": {"alpha": 0.5},
                 },
             ),


### PR DESCRIPTION
Builds upon https://github.com/pymc-labs/pymc-marketing/pull/247

- [x] Scale contributions to the original scale.
- [x] Allows custom colors.

<!-- readthedocs-preview pymc-marketing start -->
----
:books: Documentation preview :books:: https://pymc-marketing--251.org.readthedocs.build/en/251/

<!-- readthedocs-preview pymc-marketing end -->