### PR TITLE
Improve installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ mamba activate marketing_env
 
 See the official [PyMC installation guide](https://www.pymc.io/projects/docs/en/latest/installation.html) if more detail is needed.
 
-Alternatively you can install from GitHub directly:
+For testing purposes, if you wish to install the `main` branch directly from GitHub:
 
 ```bash
 pip install git+https://github.com/pymc-labs/pymc-marketing.git


### PR DESCRIPTION
Fix the discrepancy introduced in #253 between README.md and docs/source/index.md

<!-- readthedocs-preview pymc-marketing start -->
----
:books: Documentation preview :books:: https://pymc-marketing--254.org.readthedocs.build/en/254/

<!-- readthedocs-preview pymc-marketing end -->