### PR TITLE
fix wrong filename for logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <a href="https://github.com/pymc-labs/pymc-marketing"><img height="240px" src="docs/source/_static/logo-tight.jpg"></a>
+  <a href="https://github.com/pymc-labs/pymc-marketing"><img height="240px" src="docs/source/_static/marketing-logo-light.jpg"></a>
 </div>
 
 ----


### PR DESCRIPTION
Meh. Somehow didn't detect wrong filename for logo in the README.