### PR TITLE
Allow custom priors of the `BaseDelayedSaturatedMMM` model

### DIFF
--- a/pymc_marketing/mmm/base.py
+++ b/pymc_marketing/mmm/base.py
@@ -16,6 +16,7 @@ import pandas as pd
 import pymc as pm
 import seaborn as sns
 from pymc.util import RandomState
+from pytensor.tensor import TensorVariable
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import FunctionTransformer
 from xarray import DataArray
@@ -38,6 +39,7 @@ class BaseMMM:
         target_column: str,
         date_column: str,
         channel_columns: Union[List[str], Tuple[str]],
+        channel_prior: Optional[TensorVariable] = None,
         validate_data: bool = True,
         **kwargs,
     ) -> None:
@@ -45,6 +47,7 @@ class BaseMMM:
         self.target_column: str = target_column
         self.date_column: str = date_column
         self.channel_columns: Union[List[str], Tuple[str]] = channel_columns
+        self.channel_prior = channel_prior
         self.n_obs: int = data.shape[0]
         self.n_channel: int = len(channel_columns)
         self._fit_result: Optional[az.InferenceData] = None
@@ -110,7 +113,7 @@ class BaseMMM:
 
     @abstractmethod
     def build_model(self, *args, **kwargs) -> None:
-        raise NotImplementedError()
+        raise NotImplementedError("Must implement build_model method in subclass")
 
     def get_prior_predictive_data(self, *args, **kwargs) -> az.InferenceData:
         try:

--- a/pymc_marketing/mmm/base.py
+++ b/pymc_marketing/mmm/base.py
@@ -113,7 +113,7 @@ class BaseMMM:
 
     @abstractmethod
     def build_model(self, *args, **kwargs) -> None:
-        raise NotImplementedError("Must implement build_model method in subclass")
+        raise NotImplementedError()
 
     def get_prior_predictive_data(self, *args, **kwargs) -> az.InferenceData:
         try:

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -76,7 +76,7 @@ class BaseDelayedSaturatedMMM(MMM):
         self._validate_priors()
 
     def _validate_priors(self) -> None:
-        if self.channel_prior is not None and self.channel_prior.shape != (
+        if self.channel_prior is not None and self.channel_prior.shape.eval() != (
             len(self.channel_columns),
         ):
             raise ValueError(

--- a/tests/mmm/test_base.py
+++ b/tests/mmm/test_base.py
@@ -8,7 +8,7 @@ import pytest
 import xarray as xr
 from matplotlib import pyplot as plt
 
-from pymc_marketing.mmm.base import MMM
+from pymc_marketing.mmm.base import MMM, BaseMMM
 from pymc_marketing.mmm.preprocessing import MaxAbsScaleTarget, preprocessing_method
 from pymc_marketing.mmm.validating import validation_method
 
@@ -130,6 +130,23 @@ def plotting_mmm(request):
         posterior_predictive=prior_post_pred,
     )
     return mmm
+
+
+class TestBaseMMM:
+    def test_bad_inheritance(self) -> None:
+        with pytest.raises(
+            NotImplementedError, match="Must implement build_model method in subclass"
+        ):
+
+            class BadMMM(BaseMMM):
+                pass
+
+            BadMMM(
+                data=toy_df,
+                target_column="y",
+                date_column="date",
+                channel_columns=["channel_1", "channel_2"],
+            )
 
 
 class TestMMM:

--- a/tests/mmm/test_base.py
+++ b/tests/mmm/test_base.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import arviz as az
 import numpy as np
 import pandas as pd
+import pymc as pm
 import pytest
 import xarray as xr
 from matplotlib import pyplot as plt
@@ -136,6 +137,11 @@ class TestMMM:
     @patch("pymc_marketing.mmm.base.MMM.validate_date_col")
     @patch("pymc_marketing.mmm.base.MMM.validate_channel_columns")
     @pytest.mark.parametrize(
+        argnames="channel_prior",
+        argvalues=[None, pm.HalfNormal.dist(sigma=5)],
+        ids=["no_channel_prior", "channel_prior"],
+    )
+    @pytest.mark.parametrize(
         argnames="channel_columns",
         argvalues=[
             (["channel_1"]),
@@ -152,6 +158,7 @@ class TestMMM:
         validate_date_col,
         validate_target,
         channel_columns,
+        channel_prior,
     ) -> None:
         validate_channel_columns.configure_mock(_tags={"validation": True})
         validate_date_col.configure_mock(_tags={"validation": True})
@@ -186,6 +193,7 @@ class TestMMM:
             target_column="y",
             date_column="date",
             channel_columns=channel_columns,
+            channel_prior=channel_prior,
         )
         pd.testing.assert_frame_equal(instance.data, toy_df)
         pd.testing.assert_frame_equal(instance.preprocessed_data, toy_df)

--- a/tests/mmm/test_base.py
+++ b/tests/mmm/test_base.py
@@ -8,7 +8,7 @@ import pytest
 import xarray as xr
 from matplotlib import pyplot as plt
 
-from pymc_marketing.mmm.base import MMM, BaseMMM
+from pymc_marketing.mmm.base import MMM
 from pymc_marketing.mmm.preprocessing import MaxAbsScaleTarget, preprocessing_method
 from pymc_marketing.mmm.validating import validation_method
 
@@ -130,23 +130,6 @@ def plotting_mmm(request):
         posterior_predictive=prior_post_pred,
     )
     return mmm
-
-
-class TestBaseMMM:
-    def test_bad_inheritance(self) -> None:
-        with pytest.raises(
-            NotImplementedError, match="Must implement build_model method in subclass"
-        ):
-
-            class BadMMM(BaseMMM):
-                pass
-
-            BadMMM(
-                data=toy_df,
-                target_column="y",
-                date_column="date",
-                channel_columns=["channel_1", "channel_2"],
-            )
 
 
 class TestMMM:

--- a/tests/mmm/test_delayed_saturated_mmm.py
+++ b/tests/mmm/test_delayed_saturated_mmm.py
@@ -63,6 +63,11 @@ class TestMMM:
         ids=["no_control", "one_control", "two_controls"],
     )
     @pytest.mark.parametrize(
+        argnames="channel_prior_flag",
+        argvalues=[False, True],
+        ids=["no_channel_prior", "channel_prior"],
+    )
+    @pytest.mark.parametrize(
         argnames="channel_columns",
         argvalues=[
             (["channel_1"]),
@@ -83,14 +88,22 @@ class TestMMM:
         toy_df: pd.DataFrame,
         yearly_seasonality: Optional[int],
         channel_columns: List[str],
+        channel_prior_flag: bool,
         control_columns: List[str],
         adstock_max_lag: int,
     ) -> None:
+        # set channel prior (which depends on the number of channels)
+        channel_prior = (
+            pm.HalfNormal.dist(sigma=3, shape=len(channel_columns))
+            if channel_prior_flag
+            else None
+        )
         mmm = DelayedSaturatedMMM(
             data=toy_df,
             target_column="y",
             date_column="date",
             channel_columns=channel_columns,
+            channel_prior=channel_prior,
             control_columns=control_columns,
             adstock_max_lag=adstock_max_lag,
             yearly_seasonality=yearly_seasonality,
@@ -154,6 +167,16 @@ class TestMMM:
             ).to_numpy().shape == (
                 2 * yearly_seasonality,
                 samples,
+            )
+
+    def test_bad_priors(self, toy_df: pd.DataFrame) -> None:
+        with pytest.raises(ValueError):
+            DelayedSaturatedMMM(
+                data=toy_df,
+                target_column="y",
+                date_column="date",
+                channel_columns=["channel_1", "channel_2"],
+                channel_prior=pm.HalfNormal.dist(sigma=3, shape=1),
             )
 
     def test_fit(self, toy_df: pd.DataFrame) -> None:

--- a/tests/mmm/test_delayed_saturated_mmm.py
+++ b/tests/mmm/test_delayed_saturated_mmm.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import pymc as pm
 import pytest
+from pytensor.tensor import TensorVariable
 
 from pymc_marketing.mmm.delayed_saturated_mmm import DelayedSaturatedMMM
 
@@ -63,8 +64,8 @@ class TestMMM:
         ids=["no_control", "one_control", "two_controls"],
     )
     @pytest.mark.parametrize(
-        argnames="channel_prior_flag",
-        argvalues=[False, True],
+        argnames="channel_prior",
+        argvalues=[None, pm.HalfNormal.dist(sigma=3)],
         ids=["no_channel_prior", "channel_prior"],
     )
     @pytest.mark.parametrize(
@@ -88,16 +89,10 @@ class TestMMM:
         toy_df: pd.DataFrame,
         yearly_seasonality: Optional[int],
         channel_columns: List[str],
-        channel_prior_flag: bool,
+        channel_prior: Optional[TensorVariable],
         control_columns: List[str],
         adstock_max_lag: int,
     ) -> None:
-        # set channel prior (which depends on the number of channels)
-        channel_prior = (
-            pm.HalfNormal.dist(sigma=3, shape=len(channel_columns))
-            if channel_prior_flag
-            else None
-        )
         mmm = DelayedSaturatedMMM(
             data=toy_df,
             target_column="y",
@@ -167,16 +162,6 @@ class TestMMM:
             ).to_numpy().shape == (
                 2 * yearly_seasonality,
                 samples,
-            )
-
-    def test_bad_priors(self, toy_df: pd.DataFrame) -> None:
-        with pytest.raises(ValueError):
-            DelayedSaturatedMMM(
-                data=toy_df,
-                target_column="y",
-                date_column="date",
-                channel_columns=["channel_1", "channel_2"],
-                channel_prior=pm.HalfNormal.dist(sigma=3, shape=1),
             )
 
     def test_fit(self, toy_df: pd.DataFrame) -> None:


### PR DESCRIPTION
Closes https://github.com/pymc-labs/pymc-marketing/issues/271

<!-- readthedocs-preview pymc-marketing start -->
----
:books: Documentation preview :books:: https://pymc-marketing--286.org.readthedocs.build/en/286/

<!-- readthedocs-preview pymc-marketing end -->