### PR TITLE
Assign custom priors to DelayedMMM

### DIFF
--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -125,7 +125,7 @@ class BaseDelayedSaturatedMMM(MMM):
                 beta_channel = []
                 for channel in self.channel_columns:
                     if channel in self.channel_priors:
-                        beta_channel.append(self.channel_priors[channel](name=f"beta_{channel}", dims="priors"))
+                        beta_channel.append(self.channel_priors[channel](name=f"beta_{channel}"))
                     else:
                         beta_channel.append(pm.HalfNormal.dist(sigma=2, dims="non-prior"))
                 beta_channel = pm.HalfNormal("beta_channel", pm.math.stack(beta_channel, axis=-1), dims="channel")

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -121,16 +121,12 @@ class BaseDelayedSaturatedMMM(MMM):
 
             intercept = pm.Normal(name="intercept", mu=0, sigma=2)
 
-            if self.channel_priors is None:
-                beta_channel = pm.HalfNormal(name="beta_channel", sigma=2, dims="channel")
-            else:
-                beta_channel = []
-                for channel in self.channel_columns:
-                    if channel in self.channel_priors:
-                        beta_channel.append(self.channel_priors[channel])
-                    else:
-                        beta_channel.append(pm.HalfNormal(name=f"beta_{channel}", sigma=2))
-                beta_channel = pm.HalfNormal('beta_channel', np.stack(beta_channel, axis=-1))
+            beta_channel = []
+            for channel in self.channel_columns:
+                if channel in self.channel_priors:
+                    beta_channel.append(self.channel_priors[channel](name=f"beta_{channel}"))
+                else:
+                    beta_channel.append(pm.HalfNormal(name=f"beta_{channel}", sigma=2))
             # ? Allow prior depend on channel costs?
 
             alpha = pm.Beta(name="alpha", alpha=1, beta=3, dims="channel")

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -128,7 +128,7 @@ class BaseDelayedSaturatedMMM(MMM):
                         beta_channel.append(self.channel_priors[channel](name=f"beta_{channel}"))
                     else:
                         beta_channel.append(pm.HalfNormal.dist(sigma=2))
-                beta_channel = pm.Deterministic("beta_channel", pm.math.stack(beta_channel, axis=-1))
+                beta_channel = pm.HalfNormal("beta_channel", pm.math.stack(beta_channel, axis=-1))
             else:
                 beta_channel = pm.HalfNormal(name="beta_channel", sigma=2, dims="channel")
             # ? Allow prior depend on channel costs?

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -127,7 +127,7 @@ class BaseDelayedSaturatedMMM(MMM):
                     if channel in self.channel_priors:
                         beta_channel.append(self.channel_priors[channel](name=f"beta_{channel}"))
                     else:
-                        beta_channel.append(pm.HalfNormal.dist(sigma=2, dims="non-prior"))
+                        beta_channel.append(pm.HalfNormal.dist(sigma=2))
                 beta_channel = pm.HalfNormal("beta_channel", pm.math.stack(beta_channel, axis=-1), dims="channel")
             else:
                 beta_channel = pm.HalfNormal(name="beta_channel", sigma=2, dims="channel")

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -122,15 +122,15 @@ class BaseDelayedSaturatedMMM(MMM):
             intercept = pm.Normal(name="intercept", mu=0, sigma=2)
 
             if self.channel_priors is not None:
-                prior_values = []
+                beta_channel = []
                 for channel in self.channel_columns:
                     if channel in self.channel_priors:
-                        prior_values.append(self.channel_priors[channel].random())
+                        beta_channel.append(self.channel_priors[channel](name=f"beta_{channel}"))
                     else:
-                        prior_values.append(pm.HalfNormal.dist(sigma=2).random())
-                beta_channel = pm.Normal("beta_channel", mu=prior_values, sigma=2, dims="channel")
+                        beta_channel.append(pm.HalfNormal.dist(sigma=2))
+                beta_channel = pm.Deterministic("beta_channel", pm.math.stack(beta_channel, axis=-1))
             else:
-                beta_channel = pm.HalfNormal("beta_channel", sigma=2, dims="channel")
+                beta_channel = pm.HalfNormal(name="beta_channel", sigma=2, dims="channel")
             # ? Allow prior depend on channel costs?
 
             alpha = pm.Beta(name="alpha", alpha=1, beta=3, dims="channel")

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -6,9 +6,6 @@ import pandas as pd
 import pymc as pm
 from pymc.distributions.shape_utils import change_dist_size
 from pytensor.tensor import TensorVariable
-
-import theano.tensor as tt
-
 from pymc_marketing.mmm.base import MMM
 from pymc_marketing.mmm.preprocessing import MaxAbsScaleChannels, MaxAbsScaleTarget
 from pymc_marketing.mmm.transformers import geometric_adstock, logistic_saturation
@@ -133,7 +130,7 @@ class BaseDelayedSaturatedMMM(MMM):
                         beta_channel.append(self.channel_priors[channel])
                     else:
                         beta_channel.append(pm.HalfNormal(name=f"beta_{channel}", sigma=2))
-                beta_channel = tt.stack(beta_channel, axis=-1)  
+                beta_channel = pm.HalfNormal('beta_channel', np.stack(beta_channel, axis=-1))
             # ? Allow prior depend on channel costs?
 
             alpha = pm.Beta(name="alpha", alpha=1, beta=3, dims="channel")

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -125,10 +125,10 @@ class BaseDelayedSaturatedMMM(MMM):
                 beta_channel = []
                 for channel in self.channel_columns:
                     if channel in self.channel_priors:
-                        beta_channel.append(self.channel_priors[channel](name=f"beta_{channel}"))
+                        beta_channel.append(self.channel_priors[channel](name=f"beta_{channel}", dims="priors"))
                     else:
-                        beta_channel.append(pm.HalfNormal.dist(sigma=2))
-                beta_channel = pm.HalfNormal("beta_channel", pm.math.stack(beta_channel, axis=-1))
+                        beta_channel.append(pm.HalfNormal.dist(sigma=2, dims="non-prior"))
+                beta_channel = pm.HalfNormal("beta_channel", pm.math.stack(beta_channel, axis=-1), dims="channel")
             else:
                 beta_channel = pm.HalfNormal(name="beta_channel", sigma=2, dims="channel")
             # ? Allow prior depend on channel costs?

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -128,9 +128,13 @@ class BaseDelayedSaturatedMMM(MMM):
                         beta_channel.append(self.channel_priors[channel](name=f"beta_{channel}"))
                     else:
                         beta_channel.append(pm.HalfNormal.dist(sigma=2))
-                beta_channel = pm.HalfNormal("beta_channel", pm.math.stack(beta_channel, axis=-1), dims="channel")
+                beta_channel = pm.DensityDist(
+                    'beta_channel', 
+                    pm.math.stack([var.logp for var in beta_channel]), 
+                    dims="channel")
             else:
                 beta_channel = pm.HalfNormal(name="beta_channel", sigma=2, dims="channel")
+
             # ? Allow prior depend on channel costs?
 
             alpha = pm.Beta(name="alpha", alpha=1, beta=3, dims="channel")

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -121,12 +121,16 @@ class BaseDelayedSaturatedMMM(MMM):
 
             intercept = pm.Normal(name="intercept", mu=0, sigma=2)
 
-            beta_channel = []
-            for channel in self.channel_columns:
-                if channel in self.channel_priors:
-                    beta_channel.append(self.channel_priors[channel](name=f"beta_{channel}"))
-                else:
-                    beta_channel.append(pm.HalfNormal(name=f"beta_{channel}", sigma=2))
+            if self.channel_priors is not None:
+                prior_values = []
+                for channel in self.channel_columns:
+                    if channel in self.channel_priors:
+                        prior_values.append(self.channel_priors[channel].random())
+                    else:
+                        prior_values.append(pm.HalfNormal.dist(sigma=2).random())
+                beta_channel = pm.Normal("beta_channel", mu=prior_values, sigma=2, dims="channel")
+            else:
+                beta_channel = pm.HalfNormal("beta_channel", sigma=2, dims="channel")
             # ? Allow prior depend on channel costs?
 
             alpha = pm.Beta(name="alpha", alpha=1, beta=3, dims="channel")


### PR DESCRIPTION
## Goal: Create a way to add custom prior to the model. 

The goal is to make a dictionary that represents the prior knowledge around the channel, something similar to the following example.

``` python
channel_priors = {
    'x1': lambda name: pm.Gamma(name, mu=5, sigma=1),
    # other channels go here...
}

mmm = DelayedSaturatedMMM(
    data=data,
    target_column="y",
    date_column="date_week",
    channel_columns=["x1", "x2"],
    control_columns=[
        "event_1",
        "event_2",
        "t",
    ],
    adstock_max_lag=8,
    yearly_seasonality=2,
    channel_priors=channel_priors
)
```

Already achieve a personal solution which I'm testing, applying the following code in the class `BaseDelayedSaturatedMMM`:

``` python
with pm.Model(coords=coords) as self.model:
    channel_data_ = pm.MutableData(
        name="channel_data",
        value=channel_data,
        dims=("date", "channel"),
    )

    target_ = pm.MutableData(name="target", value=target_data, dims="date")

    intercept = pm.Normal(name="intercept", mu=0, sigma=2)

    beta_channel = []
    for channel in self.channel_columns:
        if channel in self.channel_priors:
            beta_channel.append(self.channel_priors[channel](name=f"beta_{channel}"))
        else:
            beta_channel.append(pm.HalfNormal(name=f"beta_{channel}", sigma=2))
```

The issue is they didn't end all under `beta_channel`. Being problematic at the moment to plot.
Image:
<img width="1675" alt="Screenshot 2023-05-21 at 01 39 38" src="https://github.com/pymc-labs/pymc-marketing/assets/59846724/5fc835ef-af1c-41a8-9f43-e139d61afc76">

Additionally, by now I'm not even at the point to check if priors should be given on the scale of the original data and if so, not sure if the model is scaling them automatically.

### **Ongoing example, not tested already. Playing with the changes.**

 **Update**:
Possibly solve on [#286](https://github.com/pymc-labs/pymc-marketing/pull/286)

<!-- readthedocs-preview pymc-marketing start -->
----
:books: Documentation preview :books:: https://pymc-marketing--289.org.readthedocs.build/en/289/

<!-- readthedocs-preview pymc-marketing end -->