### PR TITLE
Improve MMM contribution plots

### DIFF
--- a/pymc_marketing/mmm/base.py
+++ b/pymc_marketing/mmm/base.py
@@ -377,7 +377,7 @@ class BaseMMM:
             coords=channel_contribution.coords,
         )
 
-    def plot_contribution_curves(self) -> plt.Figure:
+    def plot_direct_contribution_curves(self) -> plt.Figure:
         channel_contributions = self.compute_channel_contribution_original_scale().mean(
             ["chain", "draw"]
         )

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -257,7 +257,7 @@ class BaseDelayedSaturatedMMM(MMM):
             .T
         )
         beta_channel_posterior_expanded = np.expand_dims(
-            a=beta_channel_posterior, axis=-1
+            a=beta_channel_posterior, axis=1
         )
 
         geometric_adstock_posterior = geometric_adstock(

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -257,7 +257,7 @@ class BaseDelayedSaturatedMMM(MMM):
             .T
         )
         beta_channel_posterior_expanded = np.expand_dims(
-            a=beta_channel_posterior, axis=1
+            a=beta_channel_posterior, axis=-1
         )
 
         geometric_adstock_posterior = geometric_adstock(

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -331,6 +331,9 @@ class DelayedSaturatedMMM(
         array-like
             Grid of channel contributions.
         """
+        if start < 0:
+            raise ValueError("start must be greater than or equal to 0.")
+
         share_grid = np.linspace(start=start, stop=stop, num=num)
 
         channel_contributions = []
@@ -366,9 +369,6 @@ class DelayedSaturatedMMM(
         plt.Figure
             Plot of grid of channel contributions.
         """
-        if start < 0:
-            raise ValueError("start must be greater than or equal to 0.")
-
         share_grid = np.linspace(start=start, stop=stop, num=num)
         contributions = self.get_channel_contributions_forward_pass_grid(
             start=start, stop=stop, num=num

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -404,3 +404,4 @@ class DelayedSaturatedMMM(
             xlabel=r"$\delta$",
             ylabel="contribution (sales)",
         )
+        return fig

--- a/pymc_marketing/mmm/transformers.py
+++ b/pymc_marketing/mmm/transformers.py
@@ -1,3 +1,7 @@
+from typing import Union
+
+import numpy as np
+import numpy.typing as npt
 import pytensor.tensor as pt
 from pytensor.tensor.random.utils import params_broadcast_shapes
 
@@ -144,14 +148,14 @@ def delayed_adstock(
     return batched_convolution(x, w, axis=axis)
 
 
-def logistic_saturation(x, lam: float = 0.5):
+def logistic_saturation(x, lam: Union[npt.NDArray[np.float_], float] = 0.5):
     """Logistic saturation transformation.
 
     Parameters
     ----------
     x : tensor
         Input tensor.
-    lam : float, optional, by default 0.5
+    lam : float or array-like, optional, by default 0.5
         Saturation parameter.
 
     Returns

--- a/tests/mmm/test_base.py
+++ b/tests/mmm/test_base.py
@@ -213,7 +213,8 @@ class TestMMM:
             ("plot_posterior_predictive", {"original_scale": True}),
             ("plot_components_contributions", {}),
             ("plot_channel_parameter", {"param_name": "alpha"}),
-            ("plot_contribution_curves", {}),
+            ("plot_direct_contribution_curves", {}),
+            ("plot_channel_contributions_grid", {"start": 0, "stop": 1.5, "num": 11}),
             ("plot_channel_contribution_share_hdi", {"hdi_prob": 0.95}),
             ("plot_grouped_contribution_breakdown_over_time", {}),
             (

--- a/tests/mmm/test_base.py
+++ b/tests/mmm/test_base.py
@@ -214,7 +214,6 @@ class TestMMM:
             ("plot_components_contributions", {}),
             ("plot_channel_parameter", {"param_name": "alpha"}),
             ("plot_direct_contribution_curves", {}),
-            ("plot_channel_contributions_grid", {"start": 0, "stop": 1.5, "num": 11}),
             ("plot_channel_contribution_share_hdi", {"hdi_prob": 0.95}),
             ("plot_grouped_contribution_breakdown_over_time", {}),
             (

--- a/tests/mmm/test_delayed_saturated_mmm.py
+++ b/tests/mmm/test_delayed_saturated_mmm.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
 
 import arviz as az
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pymc as pm
@@ -297,3 +298,29 @@ class TestMMM:
             )
             assert fourier_modes_data.max().max() <= 1
             assert fourier_modes_data.min().min() >= -1
+
+    def test_get_channel_contributions_forward_pass_grid(
+        self, mmm_fitted: DelayedSaturatedMMM
+    ) -> None:
+        n_channels = len(mmm_fitted.channel_columns)
+        data_range = mmm_fitted.data.shape[0]
+        draws = 3
+        chains = 2
+        grid_size = 2
+        contributions: pd.DataFrame = (
+            mmm_fitted.get_channel_contributions_forward_pass_grid(
+                start=0, stop=1.5, num=grid_size
+            )
+        )
+        assert contributions.shape == (
+            grid_size,
+            draws * chains,
+            data_range,
+            n_channels,
+        )
+
+    def test_plot_channel_contributions_grid(
+        self, mmm_fitted: DelayedSaturatedMMM
+    ) -> None:
+        fig = mmm_fitted.plot_channel_contributions_grid(start=0, stop=1.5, num=2)
+        assert isinstance(fig, plt.Figure)

--- a/tests/mmm/test_delayed_saturated_mmm.py
+++ b/tests/mmm/test_delayed_saturated_mmm.py
@@ -307,14 +307,13 @@ class TestMMM:
         draws = 3
         chains = 2
         grid_size = 2
-        contributions: pd.DataFrame = (
-            mmm_fitted.get_channel_contributions_forward_pass_grid(
-                start=0, stop=1.5, num=grid_size
-            )
+        contributions = mmm_fitted.get_channel_contributions_forward_pass_grid(
+            start=0, stop=1.5, num=grid_size
         )
         assert contributions.shape == (
             grid_size,
-            draws * chains,
+            chains,
+            draws,
             data_range,
             n_channels,
         )

--- a/tests/mmm/test_delayed_saturated_mmm.py
+++ b/tests/mmm/test_delayed_saturated_mmm.py
@@ -322,13 +322,13 @@ class TestMMM:
     def test_bad_start_get_channel_contributions_forward_pass_grid(
         self, mmm_fitted: DelayedSaturatedMMM
     ) -> None:
-        pytest.raises(
+        with pytest.raises(
             expected_exception=ValueError,
             match="start must be greater than or equal to 0.",
-        )
-        mmm_fitted.get_channel_contributions_forward_pass_grid(
-            start=-0.5, stop=1.5, num=2
-        )
+        ):
+            mmm_fitted.get_channel_contributions_forward_pass_grid(
+                start=-0.5, stop=1.5, num=2
+            )
 
     def test_plot_channel_contributions_grid(
         self, mmm_fitted: DelayedSaturatedMMM

--- a/tests/mmm/test_delayed_saturated_mmm.py
+++ b/tests/mmm/test_delayed_saturated_mmm.py
@@ -329,8 +329,13 @@ class TestMMM:
                 start=-0.5, stop=1.5, num=2
             )
 
+    @pytest.mark.parametrize(
+        argnames="absolute_xrange",
+        argvalues=[False, True],
+        ids=["relative_xrange", "absolute_xrange"],
+    )
     def test_plot_channel_contributions_grid(
-        self, mmm_fitted: DelayedSaturatedMMM
+        self, mmm_fitted: DelayedSaturatedMMM, absolute_xrange: bool
     ) -> None:
         fig = mmm_fitted.plot_channel_contributions_grid(start=0, stop=1.5, num=2)
         assert isinstance(fig, plt.Figure)

--- a/tests/mmm/test_delayed_saturated_mmm.py
+++ b/tests/mmm/test_delayed_saturated_mmm.py
@@ -319,6 +319,17 @@ class TestMMM:
             n_channels,
         )
 
+    def test_bad_start_get_channel_contributions_forward_pass_grid(
+        self, mmm_fitted: DelayedSaturatedMMM
+    ) -> None:
+        pytest.raises(
+            expected_exception=ValueError,
+            match="start must be greater than or equal to 0.",
+        )
+        mmm_fitted.get_channel_contributions_forward_pass_grid(
+            start=-0.5, stop=1.5, num=2
+        )
+
     def test_plot_channel_contributions_grid(
         self, mmm_fitted: DelayedSaturatedMMM
     ) -> None:


### PR DESCRIPTION
Address https://github.com/pymc-labs/pymc-marketing/issues/259

Here we are more precise about the contribution plots and distinguish between direct and global contributions. The MMM notebook has been updated.

<!-- readthedocs-preview pymc-marketing start -->
----
:books: Documentation preview :books:: https://pymc-marketing--291.org.readthedocs.build/en/291/

<!-- readthedocs-preview pymc-marketing end -->