### PR TITLE
MMM sklearn approach

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,14 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install oldest version of PyMC
+        if: ${{ matrix.oldest-pymc }}
+        run: pip install pymc==${{ env.OLDEST_PYMC_VERSION }}
       - name: Run lint
-        uses: pre-commit/action@v3.0.0
+        run: make check_lint
+      - name: Check oldest version of PyMC
+        if: ${{ matrix.oldest-pymc }}
+        run: python -c "import pymc; assert pymc.__version__ == '${{  env.OLDEST_PYMC_VERSION }}'"
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 env:
-  OLDEST_PYMC_VERSION: "5.3.0"
+  OLDEST_PYMC_VERSION: "5.5.0"
 
 jobs:
   lint:
@@ -22,14 +22,8 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install oldest version of PyMC
-        if: ${{ matrix.oldest-pymc }}
-        run: pip install pymc==${{ env.OLDEST_PYMC_VERSION }}
       - name: Run lint
-        run: make check_lint
-      - name: Check oldest version of PyMC
-        if: ${{ matrix.oldest-pymc }}
-        run: python -c "import pymc; assert pymc.__version__ == '${{  env.OLDEST_PYMC_VERSION }}'"
+        uses: pre-commit/action@v3.0.0
 
   test:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,31 +1,33 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 22.12.0
+  - repo: local
     hooks:
-      - id: black
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        args: [--profile, black]
-        types: [python]
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.2.0
-    hooks:
-      - id: mypy
-        args: [--ignore-missing-imports]
-        files: ^pymc_marketing/
-        additional_dependencies: [numpy>=1.20, pandas-stubs]
+    - id: black
+      name: black
+      entry: black
+      language: system
+      types: [python]
+    - id: flake8
+      name: flake8
+      entry: flake8
+      language: system
+      types: [python]
+    - id: isort
+      name: isort
+      entry: isort --profile black
+      language: system
+      types: [python]
+    - id: mypy
+      name: mypy
+      entry: mypy
+      language: system
+      types: [python]
+      files: ^pymc_marketing/
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:
-      - id: debug-statements
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
-      - id: check-yaml
-      - id: check-added-large-files
-        exclude: ^notebooks/
+     - id: debug-statements
+     - id: trailing-whitespace
+     - id: end-of-file-fixer
+     - id: check-yaml
+     - id: check-added-large-files
+       exclude: ^notebooks/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,33 +1,33 @@
 repos:
   - repo: local
     hooks:
-    - id: black
-      name: black
-      entry: black
-      language: system
-      types: [python]
-    - id: flake8
-      name: flake8
-      entry: flake8
-      language: system
-      types: [python]
-    - id: isort
-      name: isort
-      entry: isort --profile black
-      language: system
-      types: [python]
-    - id: mypy
-      name: mypy
-      entry: mypy
-      language: system
-      types: [python]
-      files: ^pymc_marketing/
+      - id: black
+        name: black
+        entry: black
+        language: system
+        types: [python]
+      - id: flake8
+        name: flake8
+        entry: flake8
+        language: system
+        types: [python]
+      - id: isort
+        name: isort
+        entry: isort --profile black
+        language: system
+        types: [python]
+      - id: mypy
+        name: mypy
+        entry: mypy
+        language: system
+        types: [python]
+        files: ^pymc_marketing/
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:
-     - id: debug-statements
-     - id: trailing-whitespace
-     - id: end-of-file-fixer
-     - id: check-yaml
-     - id: check-added-large-files
-       exclude: ^notebooks/
+      - id: debug-statements
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+        exclude: ^notebooks/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,27 +1,25 @@
 repos:
-  - repo: local
+  - repo: https://github.com/psf/black
+    rev: 22.12.0
     hooks:
       - id: black
-        name: black
-        entry: black
-        language: system
-        types: [python]
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
+    hooks:
       - id: flake8
-        name: flake8
-        entry: flake8
-        language: system
-        types: [python]
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
       - id: isort
-        name: isort
-        entry: isort --profile black
-        language: system
+        args: [--profile, black]
         types: [python]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.2.0
+    hooks:
       - id: mypy
-        name: mypy
-        entry: mypy
-        language: system
-        types: [python]
+        args: [--ignore-missing-imports]
         files: ^pymc_marketing/
+        additional_dependencies: [numpy>=1.20, pandas-stubs]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:

--- a/mypy.ini
+++ b/mypy.ini
@@ -17,3 +17,6 @@ ignore_missing_imports = True
 
 [mypy-scipy.*]
 ignore_missing_imports = True
+
+[mypy-pymc_experimental.*]
+ignore_missing_imports = True

--- a/pymc_marketing/mmm/__init__.py
+++ b/pymc_marketing/mmm/__init__.py
@@ -1,5 +1,8 @@
 from pymc_marketing.mmm import base, delayed_saturated_mmm, preprocessing, validating
 from pymc_marketing.mmm.base import MMM, BaseMMM
 from pymc_marketing.mmm.delayed_saturated_mmm import DelayedSaturatedMMM
-from pymc_marketing.mmm.preprocessing import preprocessing_method
-from pymc_marketing.mmm.validating import validation_method
+from pymc_marketing.mmm.preprocessing import (
+    preprocessing_method_X,
+    preprocessing_method_y,
+)
+from pymc_marketing.mmm.validating import validation_method_X, validation_method_y

--- a/pymc_marketing/mmm/base.py
+++ b/pymc_marketing/mmm/base.py
@@ -35,8 +35,6 @@ class BaseMMM(ModelBuilder):
         self,
         date_column: str,
         channel_columns: Union[List[str], Tuple[str]],
-        data: pd.DataFrame = None,
-        validate_data: bool = True,
         model_config: Optional[Dict] = None,
         sampler_config: Optional[Dict] = None,
         **kwargs,

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -11,19 +11,19 @@ from pymc_marketing.mmm.transformers import geometric_adstock, logistic_saturati
 from pymc_marketing.mmm.utils import generate_fourier_modes
 from pymc_marketing.mmm.validating import ValidateControlColumns
 
+__all__ = ["DelayedSaturatedMMM"]
 
-class DelayedSaturatedMMM(
-    MMM, MaxAbsScaleTarget, MaxAbsScaleChannels, ValidateControlColumns
-):
+
+class BaseDelayedSaturatedMMM(MMM):
     def __init__(
         self,
-        data: pd.DataFrame,
-        target_column: str,
         date_column: str,
         channel_columns: List[str],
+        data: pd.DataFrame = None,
+        model_config: Dict = {},
+        sampler_config: Dict = {},
         validate_data: bool = True,
         control_columns: Optional[List[str]] = None,
-        adstock_max_lag: int = 4,
         yearly_seasonality: Optional[int] = None,
         **kwargs,
     ) -> None:
@@ -31,16 +31,16 @@ class DelayedSaturatedMMM(
 
         Parameters
         ----------
-        data : pd.DataFrame
-            Training data.
-        target_column : str
-            Column name of the target variable.
         date_column : str
             Column name of the date variable.
         channel_columns : List[str]
             Column names of the media channel variables.
+        model_config : Dictionary, optional
+            dictionary of parameters that initialise model configuration. Class-default defined by the user default_model_config method.
+        sampler_config : Dictionary, optional
+            dictionary of parameters that initialise sampler configuration. Class-default defined by the user default_sampler_config method.
         validate_data : bool, optional
-            Whether to validate the data upon initialization, by default True.
+            Whether to validate the data before fitting to model, by default True.
         control_columns : Optional[List[str]], optional
             Column names of control variables to be added as additional regressors, by default None
         adstock_max_lag : int, optional
@@ -55,69 +55,181 @@ class DelayedSaturatedMMM(
         self.control_columns = control_columns
         self.adstock_max_lag = adstock_max_lag
         self.yearly_seasonality = yearly_seasonality
+        self.date_column = date_column
+        self.validate_data = validate_data
+
         super().__init__(
-            data=data,
-            target_column=target_column,
             date_column=date_column,
             channel_columns=channel_columns,
+            model_config=model_config,
+            sampler_config=sampler_config,
             validate_data=validate_data,
             adstock_max_lag=adstock_max_lag,
+        )
+    def _preprocess_channel_prior(self) -> TensorVariable:
+            if self.channel_prior is None
+            else change_dist_size(
+                dist=self.channel_prior, new_size=len(self.channel_columns)
+            )
+        )
+
+    @property
+    def default_sampler_config(self) -> Dict:
+        return {}
+
+    def generate_model_data(self, data=None, validate: bool = True) -> pd.DataFrame:
+        if data is None:
+            seed: int = sum(map(ord, "pymc_marketing"))
+            rng: np.random.Generator = np.random.default_rng(seed=seed)
+            date_data: pd.DatetimeIndex = pd.date_range(
+                start="2019-06-01", end="2021-12-31", freq="W-MON"
+            )
+            n: int = date_data.size
+            self.target_column = "y"
+            self.date_column = "date"
+            self.channel_columns = ["channel_1", "channel_2"]
+            self.control_columns = ["control_1", "control_2"]
+            self.data = pd.DataFrame(
+                data={
+                    "date": date_data,
+                    "y": rng.integers(low=0, high=100, size=n),
+                    "channel_1": rng.integers(low=0, high=400, size=n),
+                    "channel_2": rng.integers(low=0, high=50, size=n),
+                    "control_1": rng.gamma(shape=1000, scale=500, size=n),
+                    "control_2": rng.gamma(shape=100, scale=5, size=n),
+                    "other_column_1": rng.integers(low=0, high=100, size=n),
+                    "other_column_2": rng.normal(loc=0, scale=1, size=n),
+                }
+            )
+        else:
+            self.data = data
+        date_data = data[self.date_column]
+        target_data = data[self.target_column]
+        channel_data = data[self.channel_columns]
+        coords: Dict[str, Any] = {
+            "date": date_data,
+            "channel": self.channel_columns,
+        }
+
+        new_X_dict = {
+            self.date_column: date_data,
+        }
+        X_data = pd.DataFrame.from_dict(new_X_dict)
+        X_data = pd.concat([X_data, channel_data], axis=1)
+        control_data: Optional[Union[pd.DataFrame, pd.Series]] = None
+        if self.control_columns is not None:
+            control_data = X[self.control_columns]
+            coords["control"] = self.control_columns
+            X_data = pd.concat([X_data, control_data], axis=1)
+
+        fourier_features: Optional[pd.DataFrame] = None
+        if self.yearly_seasonality is not None:
+            fourier_features = self._get_fourier_models_data(X=X)
+            self.fourier_columns = fourier_features.columns
+            coords["fourier_mode"] = fourier_features.columns.to_numpy()
+
+        model_data_dict = {  # change variable name to model_data_dict
+            "channel_data_": {
+                "type": "MutableData",
+                "value": channel_data,
+                "dims": ("date", "channel"),
+            },
+            self.target_column: {
+                "type": "MutableData",
+                "value": target_data,
+                "dims": "date",
+            },
+            "control_data": {
+                "value": control_data,
+                "dims": ("date", "control"),
+            }
+            if control_data is not None
+            else None,
+            "fourier_features": {
+                "value": fourier_features,
+                "dims": ("date", "fourier_mode"),
+            }
+            if fourier_features is not None
+            else None,
+            "coords": coords,
+        }
+
+        model_data = pd.DataFrame.from_dict(
+            model_data_dict, orient="index"
+        )  # change how DataFrame is created
+        self.preprocessed_data = self.preprocess(model_data.copy())
+        return model_data
+
+    def _preprocess_channel_prior(self) -> TensorVariable:
+        return (
+            pm.HalfNormal.dist(sigma=2, shape=len(self.channel_columns))
+            if self.channel_prior is None
+            else change_dist_size(
+                dist=self.channel_prior, new_size=len(self.channel_columns)
+            )
         )
 
     def build_model(
         self,
-        data: pd.DataFrame,
-        adstock_max_lag: int = 4,
+        X: pd.DataFrame,
+        y: pd.Series,
+        **kwargs,
     ) -> None:
-        date_data = data[self.date_column]
-        target_data = data[self.target_column]
-        channel_data = data[self.channel_columns]
-
-        coords: Dict[str, Any] = {
-            "date": date_data,
-            "channel": channel_data.columns,
-        }
-
-        if self.control_columns is not None:
-            control_data: Optional[pd.DataFrame] = data[self.control_columns]
-            coords["control"] = data[self.control_columns].columns
+        self.output_var = "target"
+        if data is not None:
+            self.data = self.generate_model_data(data=data)
         else:
-            control_data = None
+            self.data = self.generate_model_data(data=self.data)
 
-        if self.yearly_seasonality is not None:
-            fourier_features = self._get_fourier_models_data()
-            coords["fourier_mode"] = fourier_features.columns.to_numpy()
-
-        else:
-            fourier_features = None
-
-        with pm.Model(coords=coords) as self.model:
+        if not model_config:
+            model_config = self.default_model_config
+        with pm.Model(coords=self.data["coords"]) as self.model:
             channel_data_ = pm.MutableData(
                 name="channel_data",
-                value=channel_data,
-                dims=("date", "channel"),
+                value=self.data["channel_data_"]["value"],
+                dims=self.data["channel_data_"]["dims"],
             )
 
-            target_ = pm.MutableData(name="target", value=target_data, dims="date")
+            target_ = pm.MutableData(
+                name="target",
+                value=self.preprocessed_data["y"],
+                dims="date",
+            )
 
-            intercept = pm.Normal(name="intercept", mu=0, sigma=2)
+            intercept = pm.Normal(
+                name="intercept",
+                mu=model_config["intercept"]["mu"],
+                sigma=model_config["intercept"]["sigma"],
+            )
 
             beta_channel = pm.HalfNormal(
-                name="beta_channel", sigma=2, dims="channel"
+                name="beta_channel",
+                sigma=model_config["beta_channel"]["sigma"],
+                dims=model_config["beta_channel"]["dims"],
             )  # ? Allow prior depend on channel costs?
 
-            alpha = pm.Beta(name="alpha", alpha=1, beta=3, dims="channel")
+            alpha = pm.Beta(
+                name="alpha",
+                alpha=model_config["alpha"]["alpha"],
+                beta=model_config["alpha"]["beta"],
+                dims=model_config["alpha"]["dims"],
+            )
 
-            lam = pm.Gamma(name="lam", alpha=3, beta=1, dims="channel")
+            lam = pm.Gamma(
+                name="lam",
+                alpha=model_config["lam"]["alpha"],
+                beta=model_config["lam"]["beta"],
+                dims=model_config["lam"]["dims"],
+            )
 
-            sigma = pm.HalfNormal(name="sigma", sigma=2)
+            sigma = pm.HalfNormal(name="sigma", sigma=model_config["sigma"]["sigma"])
 
             channel_adstock = pm.Deterministic(
                 name="channel_adstock",
                 var=geometric_adstock(
                     x=channel_data_,
                     alpha=alpha,
-                    l_max=adstock_max_lag,
+                    l_max=self.adstock_max_lag,
                     normalize=True,
                     axis=0,
                 ),
@@ -135,14 +247,18 @@ class DelayedSaturatedMMM(
             )
 
             mu_var = intercept + channel_contributions.sum(axis=-1)
-
-            if control_data is not None:
+            if self.data["control_data"] is not None:
                 control_data_ = pm.MutableData(
-                    name="control_data", value=control_data, dims=("date", "control")
+                    name="control_data",
+                    value=self.preprocessed_data["X"][self.control_columns],
+                    dims=("date", "control"),
                 )
 
                 gamma_control = pm.Normal(
-                    name="gamma_control", mu=0, sigma=2, dims="control"
+                    name="gamma_control",
+                    mu=model_config["gamma_control"]["mu"],
+                    sigma=model_config["gamma_control"]["sigma"],
+                    dims=model_config["gamma_control"]["dims"],
                 )
 
                 control_contributions = pm.Deterministic(
@@ -153,15 +269,18 @@ class DelayedSaturatedMMM(
 
                 mu_var += control_contributions.sum(axis=-1)
 
-            if fourier_features is not None:
+            if self.data["fourier_features"] is not None:
                 fourier_data_ = pm.MutableData(
                     name="fourier_data",
-                    value=fourier_features,
+                    value=self.preprocessed_data["X"][self.fourier_columns],
                     dims=("date", "fourier_mode"),
                 )
 
                 gamma_fourier = pm.Laplace(
-                    name="gamma_fourier", mu=0, b=1, dims="fourier_mode"
+                    name="gamma_fourier",
+                    mu=model_config["gamma_fourier"]["mu"],
+                    b=model_config["gamma_fourier"]["b"],
+                    dims=model_config["gamma_fourier"]["dims"],
                 )
 
                 fourier_contribution = pm.Deterministic(
@@ -172,17 +291,38 @@ class DelayedSaturatedMMM(
 
                 mu_var += fourier_contribution.sum(axis=-1)
 
-            mu = pm.Deterministic(name="mu", var=mu_var, dims="date")
+            mu = pm.Deterministic(
+                name="mu", var=mu_var, dims=model_config["mu"]["dims"]
+            )
 
             pm.Normal(
                 name="likelihood",
                 mu=mu,
                 sigma=sigma,
                 observed=target_,
-                dims="date",
+                dims=model_config["likelihood"]["dims"],
             )
 
-    def _get_fourier_models_data(self) -> pd.DataFrame:
+    @property
+    def default_model_config(self) -> Dict:
+        model_config: Dict = {
+            "intercept": {"mu": 0, "sigma": 2},
+            "beta_channel": {"sigma": 2, "dims": ("channel",)},
+            "alpha": {"alpha": 1, "beta": 3, "dims": ("channel",)},
+            "lam": {"alpha": 3, "beta": 1, "dims": ("channel",)},
+            "sigma": {"sigma": 2},
+            "gamma_control": {
+                "mu": 0,
+                "sigma": 2,
+                "dims": ("control",),
+            },
+            "mu": {"dims": ("date",)},
+            "likelihood": {"dims": ("date",)},
+            "gamma_fourier": {"mu": 0, "b": 1, "dims": "fourier_mode"},
+        }
+        return model_config
+
+    def _get_fourier_models_data(self, X) -> pd.DataFrame:
         """Generates fourier modes to model seasonality.
 
         References
@@ -191,12 +331,165 @@ class DelayedSaturatedMMM(
         """
         if self.yearly_seasonality is None:
             raise ValueError("yearly_seasonality must be specified.")
-
         date_data: pd.Series = pd.to_datetime(
-            arg=self.data[self.date_column], format="%Y-%m-%d"
+            arg=X[self.date_column], format="%Y-%m-%d"
         )
         periods: npt.NDArray[np.float_] = date_data.dt.dayofyear.to_numpy() / 365.25
         return generate_fourier_modes(
             periods=periods,
             n_order=self.yearly_seasonality,
         )
+
+    @property
+    def _serializable_model_config(self) -> Dict[str, Any]:
+        serializable_config = self.model_config.copy()
+        if type(serializable_config["beta_channel"]["sigma"]) == np.ndarray:
+            serializable_config["beta_channel"]["sigma"] = serializable_config[
+                "beta_channel"
+            ]["sigma"].tolist()
+        return serializable_config
+
+
+def _data_setter(
+    self,
+    X: Union[np.ndarray, pd.DataFrame],
+    y: Optional[Union[np.ndarray, pd.Series]] = None,
+) -> None:
+    """
+    Sets new data in the model.
+
+    This function accepts data in various formats and sets them into the
+    model using the PyMC's `set_data` method. The data corresponds to the
+    channel data and the target.
+
+    Parameters
+    ----------
+    X : Union[np.ndarray, pd.DataFrame]
+        Data for the channel. It can be a numpy array or pandas DataFrame.
+        If it's a DataFrame, the columns corresponding to self.channel_columns
+        are used. If it's an ndarray, it's used directly.
+    y : Union[np.ndarray, pd.Series], optional
+        Target data. It can be a numpy array or a pandas Series.
+        If it's a Series, its values are used. If it's an ndarray, it's used
+        directly. The default is None.
+
+    Raises
+    ------
+    RuntimeError
+        If the data for the channel is not provided in `X`.
+    TypeError
+        If `X` is not a pandas DataFrame or a numpy array, or
+        if `y` is not a pandas Series or a numpy array and is not None.
+
+    Returns
+    -------
+    None
+    """
+
+    new_channel_data: Union[np.ndarray, pd.DataFrame, None] = None
+    if isinstance(X, pd.DataFrame):
+        try:
+            new_channel_data = X[self.channel_columns]
+        except KeyError as e:
+            raise RuntimeError("New data must contain channel_data!", e)
+    elif isinstance(X, np.ndarray):
+        new_channel_data = (
+            X  # Adjust as necessary depending on the structure of your ndarray
+        )
+    else:
+        raise TypeError("X must be either a pandas DataFrame or a numpy array")
+
+    target = None
+    if y is not None:
+        if isinstance(y, pd.Series):
+            target = y.values
+        elif isinstance(y, np.ndarray):
+            target = y
+        else:
+            raise TypeError("y must be either a pandas Series or a numpy array")
+
+    with self.model:
+        pm.set_data(
+            {
+                "channel_data": new_channel_data,
+                "target": target,
+            }
+        )
+
+
+
+
+    @property
+    def _serializable_model_config(self) -> Dict[str, Any]:
+        serializable_config = self.model_config.copy()
+        return serializable_config
+
+    def _data_setter(
+        self,
+        X: Union[np.ndarray, pd.DataFrame],
+        y: Union[np.ndarray, pd.Series] = None,
+    ) -> None:
+        """
+        Sets new data in the model.
+
+        This function accepts data in various formats and sets them into the
+        model using the PyMC's `set_data` method. The data corresponds to the
+        channel data and the target.
+
+        Parameters
+        ----------
+        X : Union[np.ndarray, pd.DataFrame]
+            Data for the channel. It can be a numpy array or pandas DataFrame.
+            If it's a DataFrame, it should contain a column "channel_data".
+        y : Union[np.ndarray, pd.Series], optional
+            Target data. It can be a numpy array or a pandas Series.
+            If it's a Series, its values are used. If it's an ndarray, it's used
+            directly. The default is None.
+
+        Raises
+        ------
+        RuntimeError
+            If the data for the channel is not provided in `X`.
+        TypeError
+            If `y` is not a pandas Series or a numpy array.
+
+        Returns
+        -------
+        None
+        """
+        new_channel_data = None
+        if isinstance(X, pd.DataFrame):
+            try:
+                new_channel_data = X[self.channel_columns].to_numpy()
+            except KeyError as e:
+                raise RuntimeError("New data must contain channel_data!", e)
+        elif isinstance(X, np.ndarray):
+            new_channel_data = (
+                X  # Adjust as necessary depending on the structure of your ndarray
+            )
+        else:
+            raise TypeError("X must be either a pandas DataFrame or a numpy array")
+
+        target = None
+        if isinstance(y, pd.Series):
+            target = y.values
+        elif isinstance(y, np.ndarray):
+            target = y
+        else:
+            raise TypeError("y must be either a pandas Series or a numpy array")
+
+        with self.model:
+            pm.set_data(
+                {
+                    "channel_data": new_channel_data,
+                    "target": target,
+                }
+            )
+
+class DelayedSaturatedMMM(
+    MaxAbsScaleTarget,
+    MaxAbsScaleChannels,
+    ValidateControlColumns,
+    BaseDelayedSaturatedMMM,
+):
+    ...

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -4,6 +4,7 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 import pymc as pm
+from pymc.distributions.shape_utils import change_dist_size
 from pytensor.tensor import TensorVariable
 
 from pymc_marketing.mmm.base import MMM

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -4,6 +4,7 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 import pymc as pm
+from pytensor.tensor import TensorVariable
 
 from pymc_marketing.mmm.base import MMM
 from pymc_marketing.mmm.preprocessing import MaxAbsScaleChannels, MaxAbsScaleTarget

--- a/pymc_marketing/mmm/preprocessing.py
+++ b/pymc_marketing/mmm/preprocessing.py
@@ -5,42 +5,50 @@ from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import MaxAbsScaler, StandardScaler
 
 __all__ = [
-    "preprocessing_method",
+    "preprocessing_method_X",
+    "preprocessing_method_y",
     "MaxAbsScaleTarget",
     "MaxAbsScaleChannels",
     "StandardizeControls",
 ]
 
 
-def preprocessing_method(method: Callable) -> Callable:
+def preprocessing_method_X(method: Callable) -> Callable:
     if not hasattr(method, "_tags"):
         method._tags = {}  # type: ignore
-    method._tags["preprocessing"] = True  # type: ignore
+    method._tags["preprocessing_X"] = True  # type: ignore
+    return method
+
+
+def preprocessing_method_y(method: Callable) -> Callable:
+    if not hasattr(method, "_tags"):
+        method._tags = {}  # type: ignore
+    method._tags["preprocessing_y"] = True  # type: ignore
     return method
 
 
 class MaxAbsScaleTarget:
-    target_column: str
     target_transformer: Pipeline
 
-    @preprocessing_method
-    def max_abs_scale_target_data(self, data: pd.DataFrame) -> pd.DataFrame:
-        target_vector = data[self.target_column].to_numpy().reshape(-1, 1)
+    @preprocessing_method_y
+    def max_abs_scale_target_data(self, data: pd.Series) -> pd.Series:
+        target_vector = data.reshape(-1, 1)
         transformers = [("scaler", MaxAbsScaler())]
         pipeline = Pipeline(steps=transformers)
         self.target_transformer: Pipeline = pipeline.fit(X=target_vector)
-        data[self.target_column] = self.target_transformer.transform(
-            X=target_vector
-        ).flatten()
+        data = self.target_transformer.transform(X=target_vector).flatten()
         return data
 
 
 class MaxAbsScaleChannels:
     channel_columns: Union[List[str], Tuple[str]]
 
-    @preprocessing_method
+    @preprocessing_method_X
     def max_abs_scale_channel_data(self, data: pd.DataFrame) -> pd.DataFrame:
-        channel_data: Union[pd.DataFrame, pd.Series[Any]] = data[self.channel_columns]
+        channel_data: Union[
+            pd.DataFrame,
+            pd.Series[Any],
+        ] = data[self.channel_columns]
         transformers = [("scaler", MaxAbsScaler())]
         pipeline: Pipeline = Pipeline(steps=transformers)
         self.channel_transformer: Pipeline = pipeline.fit(X=channel_data.to_numpy())
@@ -53,7 +61,7 @@ class MaxAbsScaleChannels:
 class StandardizeControls:
     control_columns: List[str]  # TODO: Handle Optional[List[str]]
 
-    @preprocessing_method
+    @preprocessing_method_X
     def standardize_control_data(self, data: pd.DataFrame) -> pd.DataFrame:
         control_data: pd.DataFrame = data[self.control_columns]
         transformers = [("scaler", StandardScaler())]

--- a/pymc_marketing/mmm/validating.py
+++ b/pymc_marketing/mmm/validating.py
@@ -3,7 +3,8 @@ from typing import Callable, List, Optional, Tuple, Union
 import pandas as pd
 
 __all__ = [
-    "validation_method",
+    "validation_method_X",
+    "validation_method_y",
     "ValidateControlColumns",
     "ValidateTargetColumn",
     "ValidateDateColumn",
@@ -11,26 +12,31 @@ __all__ = [
 ]
 
 
-def validation_method(method: Callable) -> Callable:
+def validation_method_y(method: Callable) -> Callable:
     if not hasattr(method, "_tags"):
         method._tags = {}  # type: ignore
-    method._tags["validation"] = True  # type: ignore
+    method._tags["validation_y"] = True  # type: ignore
+    return method
+
+
+def validation_method_X(method: Callable) -> Callable:
+    if not hasattr(method, "_tags"):
+        method._tags = {}  # type: ignore
+    method._tags["validation_X"] = True  # type: ignore
     return method
 
 
 class ValidateTargetColumn:
-    target_column: str
-
-    @validation_method
-    def validate_target(self, data: pd.DataFrame) -> None:
-        if self.target_column not in data.columns:
-            raise ValueError(f"target {self.target_column} not in data")
+    @validation_method_y
+    def validate_target(self, data: pd.Series) -> None:
+        if len(data) == 0:
+            raise ValueError("y must have at least one element")
 
 
 class ValidateDateColumn:
     date_column: str
 
-    @validation_method
+    @validation_method_X
     def validate_date_col(self, data: pd.DataFrame) -> None:
         if self.date_column not in data.columns:
             raise ValueError(f"date_col {self.date_column} not in data")
@@ -41,7 +47,7 @@ class ValidateDateColumn:
 class ValidateChannelColumns:
     channel_columns: Union[List[str], Tuple[str]]
 
-    @validation_method
+    @validation_method_X
     def validate_channel_columns(self, data: pd.DataFrame) -> None:
         if not isinstance(self.channel_columns, (list, tuple)):
             raise ValueError("channel_columns must be a list or tuple")
@@ -62,7 +68,7 @@ class ValidateChannelColumns:
 class ValidateControlColumns:
     control_columns: Optional[List[str]]
 
-    @validation_method
+    @validation_method_X
     def validate_control_columns(self, data: pd.DataFrame) -> None:
         if self.control_columns is None:
             return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,11 @@ dependencies = [
     "numpy>=1.17",
     "pandas",
     # NOTE: Keep minimum pymc version in sync with ci.yml `OLDEST_PYMC_VERSION`
-    "pymc>=5.3.0",
+    "pymc>=5.5.0",
     "scikit-learn>=1.1.1",
     "seaborn>=0.12.2",
-    "xarray"
+    "xarray",
+    "pymc_experimental >= 0.0.7"
 ]
 
 [project.optional-dependencies]
@@ -80,5 +81,8 @@ addopts = [
     "--cov=pymc_marketing",
     "--cov-report=term-missing",
     "--color=yes",
+]
+filterwarnings = [
+    "ignore::DeprecationWarning:bokeh.core.property.primitive:37"
 ]
 testpaths = "tests"

--- a/tests/mmm/test_base.py
+++ b/tests/mmm/test_base.py
@@ -106,23 +106,6 @@ def toy_mmm(request, toy_X, toy_y):
     )
 
 
-class TestBaseMMM:
-    def test_bad_inheritance(self) -> None:
-        with pytest.raises(
-            NotImplementedError, match="Must implement build_model method in subclass"
-        ):
-
-            class BadMMM(BaseMMM):
-                pass
-
-            BadMMM(
-                data=toy_df,
-                target_column="y",
-                date_column="date",
-                channel_columns=["channel_1", "channel_2"],
-            )
-
-
 class TestMMM:
     @patch("pymc_marketing.mmm.base.MMM.validate_target")
     @patch("pymc_marketing.mmm.base.MMM.validate_date_col")

--- a/tests/mmm/test_base.py
+++ b/tests/mmm/test_base.py
@@ -106,6 +106,23 @@ def toy_mmm(request, toy_X, toy_y):
     )
 
 
+class TestBaseMMM:
+    def test_bad_inheritance(self) -> None:
+        with pytest.raises(
+            NotImplementedError, match="Must implement build_model method in subclass"
+        ):
+
+            class BadMMM(BaseMMM):
+                pass
+
+            BadMMM(
+                data=toy_df,
+                target_column="y",
+                date_column="date",
+                channel_columns=["channel_1", "channel_2"],
+            )
+
+
 class TestMMM:
     @patch("pymc_marketing.mmm.base.MMM.validate_target")
     @patch("pymc_marketing.mmm.base.MMM.validate_date_col")

--- a/tests/mmm/test_base.py
+++ b/tests/mmm/test_base.py
@@ -1,134 +1,109 @@
-from unittest.mock import patch
+import re
+from unittest.mock import Mock, patch
 
-import arviz as az
 import numpy as np
 import pandas as pd
+import pymc as pm
 import pytest
-import xarray as xr
-from matplotlib import pyplot as plt
+from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.pipeline import FunctionTransformer, Pipeline
 
 from pymc_marketing.mmm.base import MMM
-from pymc_marketing.mmm.preprocessing import MaxAbsScaleTarget, preprocessing_method
-from pymc_marketing.mmm.validating import validation_method
+from pymc_marketing.mmm.preprocessing import (
+    preprocessing_method_X,
+    preprocessing_method_y,
+)
+from pymc_marketing.mmm.validating import validation_method_X, validation_method_y
 
 seed: int = sum(map(ord, "pymc_marketing"))
 rng: np.random.Generator = np.random.default_rng(seed=seed)
-date_data: pd.DatetimeIndex = pd.date_range(
-    start="2019-06-01", end="2021-12-31", freq="W-MON"
-)
-
-n: int = date_data.size
-
-toy_df = pd.DataFrame(
-    data={
-        "date": date_data,
-        "y": rng.integers(low=0, high=100, size=n),
-        "channel_1": rng.integers(low=0, high=400, size=n),
-        "channel_2": rng.integers(low=0, high=50, size=n),
-        "control_1": rng.gamma(shape=1000, scale=500, size=n),
-        "control_2": rng.gamma(shape=100, scale=5, size=n),
-        "other_column_1": rng.integers(low=0, high=100, size=n),
-        "other_column_2": rng.normal(loc=0, scale=1, size=n),
-    }
-)
 
 
-@pytest.fixture(
-    scope="module",
-    params=[
-        "without_controls-default_transform",
-        "with_controls-default_transform",
-        "without_controls-target_transform",
-        "with_controls-target_transform",
-    ],
-)
-def plotting_mmm(request):
-    control, transform = request.param.split("-")
-    if transform == "default_transform":
+@pytest.fixture(scope="module")
+def toy_X() -> pd.DataFrame:
+    date_data: pd.DatetimeIndex = pd.date_range(
+        start="2019-06-01", end="2021-12-31", freq="W-MON"
+    )
+    n: int = date_data.size
 
-        class ToyMMM(MMM):
-            def build_model(self, data, **kwargs):
-                pass
+    return pd.DataFrame(
+        data={
+            "date": date_data,
+            "channel_1": rng.integers(low=0, high=400, size=n),
+            "channel_2": rng.integers(low=0, high=50, size=n),
+            "control_1": rng.gamma(shape=1000, scale=500, size=n),
+            "control_2": rng.gamma(shape=100, scale=5, size=n),
+            "other_column_1": rng.integers(low=0, high=100, size=n),
+            "other_column_2": rng.normal(loc=0, scale=1, size=n),
+        }
+    )
 
-    elif transform == "target_transform":
 
-        class ToyMMM(MMM, MaxAbsScaleTarget):
-            def build_model(self, data, **kwargs):
-                pass
+@pytest.fixture(scope="module")
+def toy_y(toy_X) -> pd.Series:
+    return pd.Series(rng.integers(low=0, high=100, size=toy_X.shape[0]), name="y")
 
-    mmm = ToyMMM(
-        toy_df,
-        target_column="y",
+
+@pytest.fixture(scope="module")
+def toy_mmm(request, toy_X, toy_y):
+    channel_columns = request.param["channel_columns"]
+
+    class ToyMMM(MMM):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.X = None
+            self.y = None
+            self.preprocessed_data = {"X": None, "y": None}
+
+        def build_model(*args, **kwargs):
+            pass
+
+        def generate_and_preprocess_model_data(self, X, y):
+            self.validate("X", X)
+            self.validate("y", y)
+            self.preprocessed_data["X"] = self.preprocess("X", X)
+            self.preprocessed_data["y"] = self.preprocess("y", y)
+            self.X = X
+            self.y = y
+
+        @property
+        def default_model_config(self):
+            pass
+
+        @property
+        def default_sampler_config(self):
+            pass
+
+        def _data_setter(self, X, y=None):
+            pass
+
+        def _serializable_model_config(self):
+            pass
+
+        @validation_method_X
+        def toy_validation_X(self, data):
+            pd.testing.assert_frame_equal(data, toy_X)
+            return None
+
+        @validation_method_y
+        def toy_validation_y(self, data):
+            pd.testing.assert_series_equal(data, toy_y)
+            return None
+
+        @preprocessing_method_X
+        def toy_preprocessing_X(self, data):
+            pd.testing.assert_frame_equal(data, toy_X)
+            return data
+
+        @preprocessing_method_y
+        def toy_preprocessing_y(self, data):
+            pd.testing.assert_series_equal(data, toy_y)
+            return data
+
+    return ToyMMM(
         date_column="date",
-        channel_columns=["channel_1", "channel_2"],
+        channel_columns=channel_columns,
     )
-    rng = np.random.default_rng(42)
-    coords = {
-        "chain": range(4),
-        "draw": range(100),
-        "channel": mmm.channel_columns,
-        "date": toy_df.date,
-    }
-    likelihood_dims = ["chain", "draw", "date"]
-    alpha_dims = ["chain", "draw", "channel"]
-    channel_contrib_dims = ["chain", "draw", "date", "channel"]
-    prior_post = xr.Dataset(
-        {
-            "intercept": xr.DataArray(
-                rng.gamma(1, 1, size=(4, 100)),
-                coords={k: v for k, v in coords.items() if k in ["chain", "draw"]},
-                dims=["chain", "draw"],
-            ),
-            "alpha": xr.DataArray(
-                rng.gamma(1, 1, size=(4, 100, 2)),
-                coords={k: v for k, v in coords.items() if k in alpha_dims},
-                dims=alpha_dims,
-            ),
-            "channel_contributions": xr.DataArray(
-                rng.gamma(1, 1, size=(4, 100, len(toy_df), 2)),
-                coords={k: v for k, v in coords.items() if k in channel_contrib_dims},
-                dims=channel_contrib_dims,
-            ),
-        }
-    )
-    prior_post_pred = xr.Dataset(
-        {
-            "likelihood": xr.DataArray(
-                rng.gamma(1, 1, size=(4, 100, len(toy_df))),
-                coords={k: v for k, v in coords.items() if k in likelihood_dims},
-                dims=likelihood_dims,
-            )
-        }
-    )
-    if control == "with_controls":
-        mmm.control_columns = ["control_1", "control_2"]
-        coords["control"] = mmm.control_columns
-        control_contrib_dims = ["chain", "draw", "date", "control"]
-        prior_post["control_contributions"] = xr.DataArray(
-            rng.gamma(1, 1, size=(4, 100, len(toy_df), 2)),
-            coords={k: v for k, v in coords.items() if k in control_contrib_dims},
-            dims=control_contrib_dims,
-        )
-    mmm._prior_predictive = az.InferenceData(
-        prior=prior_post,
-        prior_predictive=prior_post_pred,
-    )
-    mmm._fit_result = az.InferenceData(
-        posterior=prior_post,
-        observed_data=xr.Dataset(
-            {
-                "likelihood": xr.DataArray(
-                    toy_df.y.values,
-                    coords={"date": coords["date"]},
-                    dims=["date"],
-                )
-            }
-        ),
-    )
-    mmm._posterior_predictive = az.InferenceData(
-        posterior_predictive=prior_post_pred,
-    )
-    return mmm
 
 
 class TestMMM:
@@ -136,93 +111,159 @@ class TestMMM:
     @patch("pymc_marketing.mmm.base.MMM.validate_date_col")
     @patch("pymc_marketing.mmm.base.MMM.validate_channel_columns")
     @pytest.mark.parametrize(
-        argnames="channel_columns",
-        argvalues=[
-            (["channel_1"]),
-            (["channel_1", "channel_2"]),
+        "toy_mmm",
+        [
+            {"channel_columns": ["channel_1"]},
+            {"channel_columns": ["channel_1", "channel_2"]},
         ],
-        ids=[
-            "single_channel",
-            "multiple_channel",
-        ],
+        indirect=True,
     )
     def test_init(
         self,
         validate_channel_columns,
         validate_date_col,
         validate_target,
-        channel_columns,
+        toy_mmm,
+        toy_X,
+        toy_y,
     ) -> None:
-        validate_channel_columns.configure_mock(_tags={"validation": True})
-        validate_date_col.configure_mock(_tags={"validation": True})
-        validate_target.configure_mock(_tags={"validation": True})
-        toy_validation_count = 0
-        toy_preprocess_count = 0
-        build_model_count = 0
 
-        class ToyMMM(MMM):
-            def build_model(*args, **kwargs):
-                nonlocal build_model_count
-                build_model_count += 1
-                pd.testing.assert_frame_equal(kwargs["data"], toy_df)
-                return None
+        validate_channel_columns.configure_mock(_tags={"validation_X": True})
+        validate_date_col.configure_mock(_tags={"validation_X": True})
+        validate_target.configure_mock(_tags={"validation_y": True})
+        toy_mmm.generate_and_preprocess_model_data(toy_X, toy_y)
+        pd.testing.assert_frame_equal(toy_mmm.X, toy_X)
+        pd.testing.assert_frame_equal(toy_mmm.preprocessed_data["X"], toy_X)
+        pd.testing.assert_series_equal(toy_mmm.y, toy_y)
+        pd.testing.assert_series_equal(toy_mmm.preprocessed_data["y"], toy_y)
+        validate_target.assert_called_once_with(toy_mmm, toy_y)
+        validate_date_col.assert_called_once_with(toy_mmm, toy_X)
+        validate_channel_columns.assert_called_once_with(toy_mmm, toy_X)
 
-            @validation_method
-            def toy_validation(self, data):
-                nonlocal toy_validation_count
-                toy_validation_count += 1
-                pd.testing.assert_frame_equal(data, toy_df)
-                return None
 
-            @preprocessing_method
-            def toy_preprocessing(self, data):
-                nonlocal toy_preprocess_count
-                toy_preprocess_count += 1
-                pd.testing.assert_frame_equal(data, toy_df)
-                return data
+@pytest.fixture(scope="module")
+def test_mmm():
+    class ToyMMM(MMM):
+        mock_method1 = Mock()
+        mock_method2 = Mock()
+        validation_methods = [(mock_method1,), (mock_method2,)]
 
-        instance = ToyMMM(
-            data=toy_df,
-            target_column="y",
-            date_column="date",
-            channel_columns=channel_columns,
-        )
-        pd.testing.assert_frame_equal(instance.data, toy_df)
-        pd.testing.assert_frame_equal(instance.preprocessed_data, toy_df)
-        validate_target.assert_called_once_with(instance, toy_df)
-        validate_date_col.assert_called_once_with(instance, toy_df)
-        validate_channel_columns.assert_called_once_with(instance, toy_df)
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.X = None
+            self.y = None
+            self.preprocessed_data = {"X": None, "y": None}
 
-        assert toy_validation_count == 1
-        assert toy_preprocess_count == 1
-        assert build_model_count == 1
+        def build_model(self, toy_X, *args, **kwargs):
+            with pm.Model() as self.model:
+                intercept = pm.Normal("intercept", mu=0, sigma=1)
+                sigma = pm.HalfNormal("sigma", sigma=1)
+                slope = pm.Normal("slope", mu=0, sigma=1)
+                mu = intercept + slope
+                pm.Normal("y", mu=mu, sigma=sigma)
 
-    @pytest.mark.parametrize(
-        argnames="func_plot_name, kwargs_plot",
-        argvalues=[
-            ("plot_prior_predictive", {"samples": 3}),
-            ("plot_posterior_predictive", {}),
-            ("plot_posterior_predictive", {"original_scale": True}),
-            ("plot_components_contributions", {}),
-            ("plot_channel_parameter", {"param_name": "alpha"}),
-            ("plot_contribution_curves", {}),
-            ("plot_channel_contribution_share_hdi", {"hdi_prob": 0.95}),
-            ("plot_grouped_contribution_breakdown_over_time", {}),
-            (
-                "plot_grouped_contribution_breakdown_over_time",
-                {
-                    "stack_groups": {"controls": ["control_1"]},
-                    "original_scale": True,
-                    "area_kwargs": {"alpha": 0.5},
-                },
-            ),
-        ],
-    )
-    def test_plots(
-        self,
-        plotting_mmm,
-        func_plot_name,
-        kwargs_plot,
-    ) -> None:
-        func = plotting_mmm.__getattribute__(func_plot_name)
-        assert isinstance(func(**kwargs_plot), plt.Figure)
+        def generate_and_preprocess_model_data(self, toy_X, toy_y):
+            self.validate("X", toy_X)
+            self.validate("y", toy_y)
+            self.preprocessed_data["X"] = self.preprocess("X", toy_X)
+            self.preprocessed_data["y"] = self.preprocess("y", toy_y)
+            self.X = toy_X
+            self.y = toy_y
+
+        @property
+        def default_model_config(self):
+            return {"model": "model"}
+
+        @property
+        def default_sampler_config(self):
+            return {"draws": 1000, "tune": 1000}
+
+        @property
+        def output_var(self):
+            return "y"
+
+        def _data_setter(self, X, y=None):
+            pass
+
+        @property
+        def _serializable_model_config(self):
+            return {"model": "model"}
+
+    return ToyMMM(date_column="date", channel_columns=["channel_1"])
+
+
+class MyScaler(BaseEstimator, TransformerMixin):
+    def __init__(self, factor=1):
+        self.factor = factor
+
+    def fit(self, X, y=None):
+        return self  # Nothing happens in fit, so just return self
+
+    def transform(self, X):
+        return X * self.factor
+
+
+def test_validate_and_preprocess(toy_X, toy_y, test_mmm):
+
+    test_mmm
+
+    test_mmm.validate("X", toy_X)
+    test_mmm.mock_method1.assert_called_once_with(test_mmm, toy_X)
+
+    test_mmm.validate("y", toy_y)
+    test_mmm.mock_method2.assert_called_once_with(test_mmm, toy_y)
+
+    with pytest.raises(ValueError, match="Target must be either 'X' or 'y'"):
+        test_mmm.validate("invalid", toy_X)
+    with pytest.raises(ValueError, match="Target must be either 'X' or 'y'"):
+        test_mmm.preprocess("invalid", toy_X)
+
+
+def test_get_target_transformer_when_set(test_mmm):
+    # Arrange
+    mmm = test_mmm
+    expected_transformer = Pipeline(steps=[("your_step", MyScaler(10))])
+    mmm.target_transformer = expected_transformer
+
+    # Act
+    actual_transformer = mmm.get_target_transformer()
+
+    # Assert
+    assert actual_transformer == expected_transformer
+
+
+def test_get_target_transformer_when_not_set(test_mmm):
+    # Arrange
+    mmm = test_mmm
+    if hasattr(mmm, "target_transformer"):
+        del mmm.target_transformer
+    # Act
+    actual_transformer = mmm.get_target_transformer()
+
+    # Assert
+    assert isinstance(actual_transformer, Pipeline)
+    assert isinstance(actual_transformer.named_steps["scaler"], FunctionTransformer)
+
+
+def test_calling_prior_predictive_before_fit_raises_error(test_mmm, toy_X, toy_y):
+    # Arrange
+    test_mmm.idata = None
+    with pytest.raises(
+        RuntimeError,
+        match=re.escape("The model hasn't been fit yet, call .fit() first"),
+    ):
+        test_mmm.prior_predictive
+
+
+def test_calling_fit_result_before_fit_raises_error(test_mmm, toy_X, toy_y):
+    # Arrange
+    test_mmm.idata = None
+    with pytest.raises(
+        RuntimeError,
+        match=re.escape("The model hasn't been fit yet, call .fit() first"),
+    ):
+        test_mmm.fit_result
+    test_mmm.fit(toy_X, toy_y)
+    test_mmm.fit_result
+    assert test_mmm.idata is not None
+    assert "posterior" in test_mmm.idata

--- a/tests/mmm/test_delayed_saturated_mmm.py
+++ b/tests/mmm/test_delayed_saturated_mmm.py
@@ -6,14 +6,14 @@ import pandas as pd
 import pymc as pm
 import pytest
 
-from pymc_marketing.mmm.delayed_saturated_mmm import DelayedSaturatedMMM
+from pymc_marketing.mmm.delayed_saturated_mmm import BaseDelayedSaturatedMMM
 
 seed: int = sum(map(ord, "pymc_marketing"))
 rng: np.random.Generator = np.random.default_rng(seed=seed)
 
 
 @pytest.fixture(scope="class")
-def toy_df() -> pd.DataFrame:
+def toy_X() -> pd.DataFrame:
     date_data: pd.DatetimeIndex = pd.date_range(
         start="2019-06-01", end="2021-12-31", freq="W-MON"
     )
@@ -23,7 +23,6 @@ def toy_df() -> pd.DataFrame:
     return pd.DataFrame(
         data={
             "date": date_data,
-            "y": rng.integers(low=0, high=100, size=n),
             "channel_1": rng.integers(low=0, high=400, size=n),
             "channel_2": rng.integers(low=0, high=50, size=n),
             "control_1": rng.gamma(shape=1000, scale=500, size=n),
@@ -35,23 +34,29 @@ def toy_df() -> pd.DataFrame:
 
 
 @pytest.fixture(scope="class")
-def mmm(toy_df: pd.DataFrame) -> DelayedSaturatedMMM:
-    return DelayedSaturatedMMM(
-        data=toy_df,
-        target_column="y",
+def toy_y(toy_X: pd.DataFrame) -> pd.Series:
+    return pd.Series(data=rng.integers(low=0, high=100, size=toy_X.shape[0]))
+
+
+@pytest.fixture(scope="class")
+def mmm() -> BaseDelayedSaturatedMMM:
+    return BaseDelayedSaturatedMMM(
         date_column="date",
         channel_columns=["channel_1", "channel_2"],
+        adstock_max_lag=4,
         control_columns=["control_1", "control_2"],
     )
 
 
 @pytest.fixture(scope="class")
-def mmm_fitted(mmm: DelayedSaturatedMMM) -> DelayedSaturatedMMM:
-    mmm.fit(target_accept=0.8, draws=3, chains=2)
+def mmm_fitted(
+    mmm: BaseDelayedSaturatedMMM, toy_X: pd.DataFrame, toy_y: pd.Series
+) -> BaseDelayedSaturatedMMM:
+    mmm.fit(X=toy_X, y=toy_y, target_accept=0.8, draws=3, chains=2)
     return mmm
 
 
-class TestMMM:
+class TestDelayedSaturatedMMM:
     @pytest.mark.parametrize(
         argnames="adstock_max_lag",
         argvalues=[1, 4],
@@ -61,6 +66,11 @@ class TestMMM:
         argnames="control_columns",
         argvalues=[None, ["control_1"], ["control_1", "control_2"]],
         ids=["no_control", "one_control", "two_controls"],
+    )
+    @pytest.mark.parametrize(
+        argnames="channel_prior_flag",
+        argvalues=[False, True],
+        ids=["no_channel_prior", "channel_prior"],
     )
     @pytest.mark.parametrize(
         argnames="channel_columns",
@@ -80,25 +90,24 @@ class TestMMM:
     )
     def test_init(
         self,
-        toy_df: pd.DataFrame,
+        toy_X: pd.DataFrame,
+        toy_y: pd.Series,
         yearly_seasonality: Optional[int],
         channel_columns: List[str],
+        channel_prior_flag: bool,
         control_columns: List[str],
         adstock_max_lag: int,
     ) -> None:
-        mmm = DelayedSaturatedMMM(
-            data=toy_df,
-            target_column="y",
+        mmm = BaseDelayedSaturatedMMM(
             date_column="date",
             channel_columns=channel_columns,
             control_columns=control_columns,
             adstock_max_lag=adstock_max_lag,
             yearly_seasonality=yearly_seasonality,
         )
-
+        mmm.build_model(X=toy_X, y=toy_y)
         n_channel: int = len(mmm.channel_columns)
         samples: int = 3
-
         with mmm.model:
             prior_predictive: az.InferenceData = pm.sample_prior_predictive(
                 samples=samples, random_seed=rng
@@ -156,24 +165,39 @@ class TestMMM:
                 samples,
             )
 
+    def test_bad_priors(self, toy_df: pd.DataFrame) -> None:
+        with pytest.raises(ValueError):
+            BaseDelayedSaturatedMMM(
+                data=toy_df,
+                target_column="y",
+                date_column="date",
+                channel_columns=["channel_1", "channel_2"],
+                channel_prior=pm.HalfNormal.dist(sigma=3, shape=1),
+            )
+
     def test_fit(self, toy_df: pd.DataFrame) -> None:
         draws: int = 100
         chains: int = 2
 
-        mmm = DelayedSaturatedMMM(
-            data=toy_df,
-            target_column="y",
+        mmm = BaseDelayedSaturatedMMM(
             date_column="date",
             channel_columns=["channel_1", "channel_2"],
             control_columns=["control_1", "control_2"],
             adstock_max_lag=2,
             yearly_seasonality=2,
         )
+        assert mmm.model_config is not None
         n_channel: int = len(mmm.channel_columns)
         n_control: int = len(mmm.control_columns)
         fourier_terms: int = 2 * mmm.yearly_seasonality
-
-        mmm.fit(target_accept=0.81, draws=draws, chains=chains, random_seed=rng)
+        mmm.fit(
+            X=toy_X,
+            y=toy_y,
+            target_accept=0.81,
+            draws=draws,
+            chains=chains,
+            random_seed=rng,
+        )
         idata: az.InferenceData = mmm.fit_result
         assert (
             az.extract(data=idata, var_names=["intercept"], combined=True)
@@ -201,7 +225,7 @@ class TestMMM:
             original_scale=True
         )
         assert mean_model_contributions_ts.shape == (
-            toy_df.shape[0],
+            toy_X.shape[0],
             n_channel + n_control + fourier_terms + 1,
         )
         assert mean_model_contributions_ts.columns.tolist() == [
@@ -222,27 +246,66 @@ class TestMMM:
         ids=["no_yearly_seasonality", "yearly_seasonality=1", "yearly_seasonality=2"],
     )
     def test_get_fourier_models_data(
-        self, toy_df: pd.DataFrame, yearly_seasonality: Optional[int]
+        self, toy_X: pd.DataFrame, toy_y: pd.Series, yearly_seasonality: Optional[int]
     ) -> None:
-        mmm = DelayedSaturatedMMM(
-            data=toy_df,
-            target_column="y",
+        mmm = BaseDelayedSaturatedMMM(
             date_column="date",
             channel_columns=["channel_1", "channel_2"],
             control_columns=["control_1", "control_2"],
             adstock_max_lag=2,
             yearly_seasonality=yearly_seasonality,
         )
-
         if yearly_seasonality is None:
             with pytest.raises(ValueError):
-                mmm._get_fourier_models_data()
+                mmm._get_fourier_models_data(toy_X)
 
         else:
-            fourier_modes_data: Optional[pd.DataFrame] = mmm._get_fourier_models_data()
+            fourier_modes_data: Optional[pd.DataFrame] = mmm._get_fourier_models_data(
+                toy_X
+            )
             assert fourier_modes_data.shape == (
-                toy_df.shape[0],
+                toy_X.shape[0],
                 2 * yearly_seasonality,
             )
             assert fourier_modes_data.max().max() <= 1
             assert fourier_modes_data.min().min() >= -1
+
+    def test_data_setter(self, toy_X, toy_y):
+        base_delayed_saturated_mmm = BaseDelayedSaturatedMMM(
+            date_column="date",
+            channel_columns=["channel_1", "channel_2"],
+            adstock_max_lag=4,
+        )
+        base_delayed_saturated_mmm.fit(
+            X=toy_X, y=toy_y, target_accept=0.81, draws=100, chains=2, random_seed=rng
+        )
+
+        X_correct_ndarray = np.random.randint(low=0, high=100, size=(135, 2))
+        y_correct_ndarray = np.random.randint(low=0, high=100, size=135)
+
+        X_incorrect = "Incorrect data"
+        y_incorrect = "Incorrect data"
+
+        with pytest.raises(TypeError):
+            base_delayed_saturated_mmm._data_setter(X_incorrect, toy_y)
+
+        with pytest.raises(TypeError):
+            base_delayed_saturated_mmm._data_setter(toy_X, y_incorrect)
+
+        with pytest.raises(RuntimeError):
+            X_wrong_df = pd.DataFrame(
+                {"column1": np.random.rand(135), "column2": np.random.rand(135)}
+            )
+            base_delayed_saturated_mmm._data_setter(X_wrong_df, toy_y)
+
+        try:
+            base_delayed_saturated_mmm._data_setter(toy_X, toy_y)
+        except Exception as e:
+            pytest.fail(f"_data_setter failed with error {e}")
+
+        try:
+            base_delayed_saturated_mmm._data_setter(
+                X_correct_ndarray, y_correct_ndarray
+            )
+        except Exception as e:
+            pytest.fail(f"_data_setter failed with error {e}")

--- a/tests/mmm/test_delayed_saturated_mmm.py
+++ b/tests/mmm/test_delayed_saturated_mmm.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import pymc as pm
 import pytest
+from pytensor.tensor import TensorVariable
 
 from pymc_marketing.mmm.delayed_saturated_mmm import BaseDelayedSaturatedMMM
 
@@ -68,8 +69,8 @@ class TestDelayedSaturatedMMM:
         ids=["no_control", "one_control", "two_controls"],
     )
     @pytest.mark.parametrize(
-        argnames="channel_prior_flag",
-        argvalues=[False, True],
+        argnames="channel_prior",
+        argvalues=[None, pm.HalfNormal.dist(sigma=3)],
         ids=["no_channel_prior", "channel_prior"],
     )
     @pytest.mark.parametrize(
@@ -94,7 +95,7 @@ class TestDelayedSaturatedMMM:
         toy_y: pd.Series,
         yearly_seasonality: Optional[int],
         channel_columns: List[str],
-        channel_prior_flag: bool,
+        channel_prior: Optional[TensorVariable],
         control_columns: List[str],
         adstock_max_lag: int,
     ) -> None:

--- a/tests/mmm/test_delayed_saturated_mmm.py
+++ b/tests/mmm/test_delayed_saturated_mmm.py
@@ -101,6 +101,7 @@ class TestDelayedSaturatedMMM:
         mmm = BaseDelayedSaturatedMMM(
             date_column="date",
             channel_columns=channel_columns,
+            channel_prior=channel_prior,
             control_columns=control_columns,
             adstock_max_lag=adstock_max_lag,
             yearly_seasonality=yearly_seasonality,

--- a/tests/mmm/test_delayed_saturated_mmm.py
+++ b/tests/mmm/test_delayed_saturated_mmm.py
@@ -5,7 +5,6 @@ import numpy as np
 import pandas as pd
 import pymc as pm
 import pytest
-from pytensor.tensor import TensorVariable
 
 from pymc_marketing.mmm.delayed_saturated_mmm import BaseDelayedSaturatedMMM
 
@@ -69,11 +68,6 @@ class TestDelayedSaturatedMMM:
         ids=["no_control", "one_control", "two_controls"],
     )
     @pytest.mark.parametrize(
-        argnames="channel_prior",
-        argvalues=[None, pm.HalfNormal.dist(sigma=3)],
-        ids=["no_channel_prior", "channel_prior"],
-    )
-    @pytest.mark.parametrize(
         argnames="channel_columns",
         argvalues=[
             (["channel_1"]),
@@ -95,14 +89,12 @@ class TestDelayedSaturatedMMM:
         toy_y: pd.Series,
         yearly_seasonality: Optional[int],
         channel_columns: List[str],
-        channel_prior: Optional[TensorVariable],
         control_columns: List[str],
         adstock_max_lag: int,
     ) -> None:
         mmm = BaseDelayedSaturatedMMM(
             date_column="date",
             channel_columns=channel_columns,
-            channel_prior=channel_prior,
             control_columns=control_columns,
             adstock_max_lag=adstock_max_lag,
             yearly_seasonality=yearly_seasonality,
@@ -167,17 +159,7 @@ class TestDelayedSaturatedMMM:
                 samples,
             )
 
-    def test_bad_priors(self, toy_df: pd.DataFrame) -> None:
-        with pytest.raises(ValueError):
-            BaseDelayedSaturatedMMM(
-                data=toy_df,
-                target_column="y",
-                date_column="date",
-                channel_columns=["channel_1", "channel_2"],
-                channel_prior=pm.HalfNormal.dist(sigma=3, shape=1),
-            )
-
-    def test_fit(self, toy_df: pd.DataFrame) -> None:
+    def test_fit(self, toy_X: pd.DataFrame, toy_y: pd.Series) -> None:
         draws: int = 100
         chains: int = 2
 

--- a/tests/mmm/test_plotting.py
+++ b/tests/mmm/test_plotting.py
@@ -1,0 +1,109 @@
+import numpy as np
+import pandas as pd
+import pytest
+from matplotlib import pyplot as plt
+
+from pymc_marketing.mmm.delayed_saturated_mmm import BaseDelayedSaturatedMMM
+from pymc_marketing.mmm.preprocessing import MaxAbsScaleTarget
+
+seed: int = sum(map(ord, "pymc_marketing"))
+rng: np.random.Generator = np.random.default_rng(seed=seed)
+
+
+@pytest.fixture(scope="module")
+def toy_X() -> pd.DataFrame:
+    date_data: pd.DatetimeIndex = pd.date_range(
+        start="2019-06-01", end="2021-12-31", freq="W-MON"
+    )
+
+    n: int = date_data.size
+
+    return pd.DataFrame(
+        data={
+            "date": date_data,
+            "channel_1": rng.integers(low=0, high=400, size=n),
+            "channel_2": rng.integers(low=0, high=50, size=n),
+            "control_1": rng.gamma(shape=1000, scale=500, size=n),
+            "control_2": rng.gamma(shape=100, scale=5, size=n),
+            "other_column_1": rng.integers(low=0, high=100, size=n),
+            "other_column_2": rng.normal(loc=0, scale=1, size=n),
+        }
+    )
+
+
+@pytest.fixture(scope="module")
+def toy_y(toy_X) -> pd.Series:
+    return pd.Series(rng.integers(low=0, high=100, size=toy_X.shape[0]))
+
+
+class TestBasePlotting:
+    @pytest.fixture(
+        scope="module",
+        params=[
+            "without_controls-default_transform",
+            "with_controls-default_transform",
+            "without_controls-target_transform",
+            "with_controls-target_transform",
+        ],
+    )
+    def plotting_mmm(self, request, toy_X, toy_y):
+        control, transform = request.param.split("-")
+        if transform == "default_transform":
+
+            class ToyMMM(BaseDelayedSaturatedMMM):
+                pass
+
+        elif transform == "target_transform":
+
+            class ToyMMM(BaseDelayedSaturatedMMM, MaxAbsScaleTarget):
+                pass
+
+        if control == "without_controls":
+            mmm = ToyMMM(
+                date_column="date",
+                channel_columns=["channel_1", "channel_2"],
+                adstock_max_lag=4,
+            )
+        elif control == "with_controls":
+            mmm = ToyMMM(
+                date_column="date",
+                adstock_max_lag=4,
+                control_columns=["control_1", "control_2"],
+                channel_columns=["channel_1", "channel_2"],
+            )
+        # fit the model
+        mmm.fit(
+            X=toy_X,
+            y=toy_y,
+        )
+        mmm._prior_predictive = mmm.prior_predictive
+        mmm._fit_result = mmm.fit_result
+        mmm._posterior_predictive = mmm.posterior_predictive
+
+        return mmm
+
+    @pytest.mark.parametrize(
+        argnames="func_plot_name, kwargs_plot",
+        argvalues=[
+            ("plot_prior_predictive", {"samples": 3}),
+            ("plot_posterior_predictive", {}),
+            ("plot_posterior_predictive", {"original_scale": True}),
+            ("plot_components_contributions", {}),
+            ("plot_channel_parameter", {"param_name": "alpha"}),
+            ("plot_contribution_curves", {}),
+            ("plot_channel_contribution_share_hdi", {"hdi_prob": 0.95}),
+            ("plot_grouped_contribution_breakdown_over_time", {}),
+            (
+                "plot_grouped_contribution_breakdown_over_time",
+                {
+                    "stack_groups": {"controls": ["control_1"]},
+                    "original_scale": True,
+                    "area_kwargs": {"alpha": 0.5},
+                },
+            ),
+        ],
+    )
+    def test_plots(self, plotting_mmm, func_plot_name, kwargs_plot) -> None:
+        func = plotting_mmm.__getattribute__(func_plot_name)
+        assert isinstance(func(**kwargs_plot), plt.Figure)
+        plt.close("all")

--- a/tests/mmm/test_preprocessing.py
+++ b/tests/mmm/test_preprocessing.py
@@ -5,7 +5,7 @@ from pymc_marketing.mmm.preprocessing import (
     MaxAbsScaleChannels,
     MaxAbsScaleTarget,
     StandardizeControls,
-    preprocessing_method,
+    preprocessing_method_X,
 )
 
 seed: int = sum(map(ord, "pymc_marketing"))
@@ -16,10 +16,8 @@ date_data: pd.DatetimeIndex = pd.date_range(
 
 n: int = date_data.size
 
-toy_df = pd.DataFrame(
+toy_X = pd.DataFrame(
     data={
-        "date": date_data,
-        "y": rng.integers(low=0, high=100, size=n),
         "channel_1": rng.integers(low=0, high=400, size=n),
         "channel_2": rng.integers(low=0, high=50, size=n),
         "control_1": rng.gamma(shape=1000, scale=500, size=n),
@@ -28,13 +26,14 @@ toy_df = pd.DataFrame(
         "other_column_2": rng.normal(loc=0, scale=1, size=n),
     }
 )
+toy_y = pd.Series(rng.integers(low=0, high=100, size=n))
 
 
 def test_preprocessing_method():
     f = lambda x: x  # noqa: E731
     f.__doc__ = "bla"
-    vf = preprocessing_method(f)
-    assert getattr(vf, "_tags", {}).get("preprocessing", False)
+    vf = preprocessing_method_X(f)
+    assert getattr(vf, "_tags", {}).get("preprocessing_X", False)
     assert vf.__doc__ == f.__doc__
     assert vf.__name__ == f.__name__
 
@@ -42,19 +41,19 @@ def test_preprocessing_method():
         """bla"""
         return x
 
-    vf = preprocessing_method(f2)
-    assert getattr(vf, "_tags", {}).get("preprocessing", False)
+    vf = preprocessing_method_X(f2)
+    assert getattr(vf, "_tags", {}).get("preprocessing_X", False)
     assert vf.__doc__ == f2.__doc__
     assert vf.__name__ == f2.__name__
 
     class F:
-        @preprocessing_method
+        @preprocessing_method_X
         def f3(self, x):
             """bla"""
             return x
 
     vf = F().f3
-    assert getattr(vf, "_tags", {}).get("preprocessing", False)
+    assert getattr(vf, "_tags", {}).get("preprocessing_X", False)
     assert F.f3.__doc__ == vf.__doc__
     assert F.f3.__name__ == vf.__name__
     assert vf.__doc__ == "bla"
@@ -63,28 +62,27 @@ def test_preprocessing_method():
 
 def test_max_abs_scale_target():
     obj = MaxAbsScaleTarget()
-    obj.target_column = "y"
-    out = obj.max_abs_scale_target_data(toy_df)["y"]
-    temp = toy_df["y"]
+    out = obj.max_abs_scale_target_data(toy_y.to_numpy())
+    temp = toy_y
     assert out.min() == temp.min() / temp.max()
     assert out.max() == 1
-    pd.testing.assert_index_equal(out.index, toy_df.index)
+    # out and temp are both series, therefore the index comparison makes no longer sense
 
 
 def test_max_abs_scale_channels():
     obj = MaxAbsScaleChannels()
     obj.channel_columns = ["channel_1", "channel_2"]
-    out = obj.max_abs_scale_channel_data(toy_df)[obj.channel_columns]
-    temp = toy_df[obj.channel_columns]
+    out = obj.max_abs_scale_channel_data(toy_X)[obj.channel_columns]
+    temp = toy_X[obj.channel_columns]
     assert (out.max(axis=0) == 1).all()
     assert np.allclose(out.min(axis=0), temp.min(axis=0) / temp.max(axis=0))
-    pd.testing.assert_index_equal(out.index, toy_df.index)
+    pd.testing.assert_index_equal(out.index, toy_X[obj.channel_columns].index)
 
 
 def test_standardize_controls():
     obj = StandardizeControls()
     obj.control_columns = ["control_1", "control_2"]
-    out = obj.standardize_control_data(toy_df)[obj.control_columns]
+    out = obj.standardize_control_data(toy_X)[obj.control_columns]
     assert np.allclose(out.mean(axis=0), 0)
     assert np.allclose(out.std(axis=0), 1, atol=5e-3)
-    pd.testing.assert_index_equal(out.index, toy_df.index)
+    pd.testing.assert_index_equal(out.index, toy_X[obj.control_columns].index)

--- a/tests/mmm/test_validating.py
+++ b/tests/mmm/test_validating.py
@@ -7,7 +7,7 @@ from pymc_marketing.mmm.validating import (
     ValidateControlColumns,
     ValidateDateColumn,
     ValidateTargetColumn,
-    validation_method,
+    validation_method_X,
 )
 
 seed: int = sum(map(ord, "pymc_marketing"))
@@ -18,10 +18,9 @@ date_data: pd.DatetimeIndex = pd.date_range(
 
 n: int = date_data.size
 
-toy_df = pd.DataFrame(
+toy_X = pd.DataFrame(
     data={
         "date": date_data,
-        "y": rng.integers(low=0, high=100, size=n),
         "channel_1": rng.integers(low=0, high=400, size=n),
         "channel_2": rng.integers(low=0, high=50, size=n),
         "control_1": rng.gamma(shape=1000, scale=500, size=n),
@@ -30,13 +29,14 @@ toy_df = pd.DataFrame(
         "other_column_2": rng.normal(loc=0, scale=1, size=n),
     }
 )
+toy_y = pd.Series(data=rng.integers(low=0, high=100, size=n))
 
 
 def test_validation_method():
     f = lambda x: x  # noqa: E731
     f.__doc__ = "bla"
-    vf = validation_method(f)
-    assert getattr(vf, "_tags", {}).get("validation", False)
+    vf = validation_method_X(f)
+    assert getattr(vf, "_tags", {}).get("validation_X", False)
     assert vf.__doc__ == f.__doc__
     assert vf.__name__ == f.__name__
 
@@ -44,19 +44,19 @@ def test_validation_method():
         """bla"""
         return x
 
-    vf = validation_method(f2)
-    assert getattr(vf, "_tags", {}).get("validation", False)
+    vf = validation_method_X(f2)
+    assert getattr(vf, "_tags", {}).get("validation_X", False)
     assert vf.__doc__ == f2.__doc__
     assert vf.__name__ == f2.__name__
 
     class F:
-        @validation_method
+        @validation_method_X
         def f3(self, x):
             """bla"""
             return x
 
     vf = F().f3
-    assert getattr(vf, "_tags", {}).get("validation", False)
+    assert getattr(vf, "_tags", {}).get("validation_X", False)
     assert F.f3.__doc__ == vf.__doc__
     assert F.f3.__name__ == vf.__name__
     assert vf.__doc__ == "bla"
@@ -65,82 +65,84 @@ def test_validation_method():
 
 def test_validate_target():
     obj = ValidateTargetColumn()
-    obj.target_column = "y"
-    assert obj.validate_target(toy_df) is None
-
-    with pytest.raises(ValueError, match="target y not in data"):
-        obj.validate_target(toy_df.drop(columns=["y"]))
+    assert obj.validate_target(toy_y) is None
 
 
 def test_validate_date_col():
     obj = ValidateDateColumn()
     obj.date_column = "date"
-    assert obj.validate_date_col(toy_df) is None
+    assert obj.validate_date_col(toy_X) is None
     with pytest.raises(ValueError, match="date_col date not in data"):
-        obj.validate_date_col(toy_df.drop(columns=["date"]))
+        obj.validate_date_col(toy_X.drop(columns=["date"]))
     with pytest.raises(ValueError, match="date_col date has repeated values"):
-        obj.validate_date_col(pd.concat([toy_df, toy_df], ignore_index=True, axis=0))
+        obj.validate_date_col(pd.concat([toy_X, toy_X], ignore_index=True, axis=0))
 
 
 def test_channel_columns():
     obj = ValidateChannelColumns()
     obj.channel_columns = ["channel_1", "channel_2"]
-    assert obj.validate_channel_columns(toy_df) is None
+    assert obj.validate_channel_columns(toy_X) is None
 
     with pytest.raises(ValueError, match="channel_columns must be a list or tuple"):
         obj.channel_columns = {}
-        obj.validate_channel_columns(toy_df)
+        obj.validate_channel_columns(toy_X)
     with pytest.raises(ValueError, match="channel_columns must not be empty"):
         obj.channel_columns = []
-        obj.validate_channel_columns(toy_df)
+        obj.validate_channel_columns(toy_X)
     with pytest.raises(
         ValueError,
         match="channel_columns \['out_of_columns'\] not in data",  # noqa: W605
     ):
         obj.channel_columns = ["out_of_columns"]
-        obj.validate_channel_columns(toy_df)
+        obj.validate_channel_columns(toy_X)
     with pytest.raises(
         ValueError,
         match="channel_columns \['channel_1', 'channel_1'\] contains duplicates",  # noqa: E501, W605
     ):
         obj.channel_columns = ["channel_1", "channel_1"]
-        obj.validate_channel_columns(toy_df)
+        obj.validate_channel_columns(toy_X)
     with pytest.raises(
         ValueError,
         match="channel_columns \['channel_1'\] contains negative values",  # noqa: E501, W605
     ):
-        new_toy_df = toy_df.copy()
-        new_toy_df["channel_1"] -= 1e4
+        new_toy_X = toy_X.copy()
+        new_toy_X["channel_1"] -= 1e4
         obj.channel_columns = ["channel_1"]
-        obj.validate_channel_columns(new_toy_df)
+        obj.validate_channel_columns(new_toy_X)
 
 
 def test_control_columns():
     obj = ValidateControlColumns()
     obj.control_columns = None
-    assert obj.validate_control_columns(toy_df) is None
+    assert obj.validate_control_columns(toy_X) is None
     obj.control_columns = ["control_1", "control_2"]
-    assert obj.validate_control_columns(toy_df) is None
+    assert obj.validate_control_columns(toy_X) is None
 
     with pytest.raises(
         ValueError, match="control_columns must be None, a list or tuple"
     ):
         obj.control_columns = {}
-        obj.validate_control_columns(toy_df)
+        obj.validate_control_columns(toy_X)
     with pytest.raises(
         ValueError, match="If control_columns is not None, then it must not be empty"
     ):
         obj.control_columns = []
-        obj.validate_control_columns(toy_df)
+        obj.validate_control_columns(toy_X)
     with pytest.raises(
         ValueError,
         match="control_columns \['out_of_columns'\] not in data",  # noqa: W605
     ):
         obj.control_columns = ["out_of_columns"]
-        obj.validate_control_columns(toy_df)
+        obj.validate_control_columns(toy_X)
     with pytest.raises(
         ValueError,
         match="control_columns \['control_1', 'control_1'\] contains duplicates",  # noqa: E501, W605
     ):
         obj.control_columns = ["control_1", "control_1"]
-        obj.validate_control_columns(toy_df)
+        obj.validate_control_columns(toy_X)
+
+
+def test_y_len_0():
+    obj = ValidateTargetColumn()
+    with pytest.raises(ValueError, match="y must have at least one element"):
+        obj.validate_target(pd.Series())


### PR DESCRIPTION
This PR contains complete rework of MMM-based classes to adopt sklearn-based api, with full integration with ModelBuilder. Some tests might not be passing yet, as ModelBuilder was also slightly modified, because of that pymc-experimental needs to get a release. Locally all the tests were passing, still ToDo are:
Adaptation of notebooks, adding docstrings, more test coverage. Please share your thoughts on solutions included in this PR

@twiecki @ricardoV94 @juanitorduz 

<!-- readthedocs-preview pymc-marketing start -->
----
:books: Documentation preview :books:: https://pymc-marketing--295.org.readthedocs.build/en/295/

<!-- readthedocs-preview pymc-marketing end -->