### PR TITLE
enabling passing pymc step function reference in sampler_config

### DIFF
--- a/pymc_marketing/clv/models/basic.py
+++ b/pymc_marketing/clv/models/basic.py
@@ -116,12 +116,16 @@ class CLVModel(ModelBuilder):
             raise RuntimeError(
                 "The model hasn't been built yet, call .build_model() first or call .fit() instead."
             )
-
         with self.model:
             sampler_args = {**self.sampler_config, **kwargs}
             if "step" in sampler_args:
-                sampler_args["step"] = sampler_args["step"]()
-            idata = pm.sample(**sampler_args)
+                step_function_name = sampler_args["step"]
+                step_function = getattr(pm, step_function_name)
+                sampler_args["step"] = step_function()
+                idata = pm.sample(**sampler_args)
+                sampler_args["step"] = step_function_name
+            else:
+                idata = pm.sample(**sampler_args)
 
         self.set_idata_attrs(idata)
         return idata

--- a/pymc_marketing/clv/models/basic.py
+++ b/pymc_marketing/clv/models/basic.py
@@ -119,6 +119,8 @@ class CLVModel(ModelBuilder):
 
         with self.model:
             sampler_args = {**self.sampler_config, **kwargs}
+            if "step" in sampler_args:
+                sampler_args["step"] = sampler_args["step"]()
             idata = pm.sample(**sampler_args)
 
         self.set_idata_attrs(idata)

--- a/tests/clv/models/test_basic.py
+++ b/tests/clv/models/test_basic.py
@@ -208,7 +208,7 @@ class TestCLVModel:
 
     def test_step_selection_in_sample_config(self):
         sampler_config = {
-            "step": pm.Slice,
+            "step": "Slice",
         }
         model = CLVModelTest(sampler_config=sampler_config)
         model.fit()

--- a/tests/clv/models/test_basic.py
+++ b/tests/clv/models/test_basic.py
@@ -205,3 +205,11 @@ class TestCLVModel:
         serializable_config = model._serializable_model_config
         assert isinstance(serializable_config, dict)
         assert serializable_config == model.model_config
+
+    def test_step_selection_in_sample_config(self):
+        sampler_config = {
+            "step": pm.Slice,
+        }
+        model = CLVModelTest(sampler_config=sampler_config)
+        model.fit()
+        assert model.idata is not None


### PR DESCRIPTION
Addressing issue reported by @ColtAllen  in #319. Because of context requirement the step function should be passed as a reference in the sampler_config.

<!-- readthedocs-preview pymc-marketing start -->
----
:books: Documentation preview :books:: https://pymc-marketing--320.org.readthedocs.build/en/320/

<!-- readthedocs-preview pymc-marketing end -->