### PR TITLE
Drop support for python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 env:
-  OLDEST_PYMC_VERSION: "5.5.0"
+  OLDEST_PYMC_VERSION: "5.6.1"
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.9", "3.11"]
         oldest-pymc: [false, true]
     steps:
       - uses: actions/checkout@v3
@@ -29,15 +29,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        config: [ {python-version: "3.8", oldest-pymc: false}, {python-version: "3.11", oldest-pymc: true}]
+        python-version: ["3.9", "3.11"]
+        oldest-pymc: [false, true]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: ${{ matrix.config.python-version }}
+          python-version: ${{ matrix.python-version }}
       - name: Install oldest version of PyMC
-        if: ${{ matrix.config.oldest-pymc }}
+        if: ${{ matrix.oldest-pymc }}
         run: pip install pymc==${{ env.OLDEST_PYMC_VERSION }}
       - name: Run tests
         run: |
@@ -45,7 +46,7 @@ jobs:
           pytest --cov-report=xml --no-cov-on-fail
       - name: Check oldest version of PyMC
         if: ${{ matrix.oldest-pymc }}
-        run: python -c "import pymc; assert pymc.__version__ == '${{  env.OLDEST_PYMC_VERSION }}'"
+        run: python -c "import pymc; assert pymc.__version__ == '${{ env.OLDEST_PYMC_VERSION }}'"
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,29 +29,28 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.11"]
-        oldest-pymc: [false, true]
+        config: [ {python-version: "3.9", oldest-pymc: false}, {python-version: "3.11", oldest-pymc: true}]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.config.python-version }}
       - name: Install oldest version of PyMC
-        if: ${{ matrix.oldest-pymc }}
+        if: ${{ matrix.config.oldest-pymc }}
         run: pip install pymc==${{ env.OLDEST_PYMC_VERSION }}
       - name: Run tests
         run: |
           pip install -e .[test]
           pytest --cov-report=xml --no-cov-on-fail
       - name: Check oldest version of PyMC
-        if: ${{ matrix.oldest-pymc }}
+        if: ${{ matrix.config.oldest-pymc }}
         run: python -c "import pymc; assert pymc.__version__ == '${{ env.OLDEST_PYMC_VERSION }}'"
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # use token for more robust uploads
-          name: ${{ matrix.python-version }}
+          name: ${{ matrix.config.python-version }}
           fail_ci_if_error: false
 
   all:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Build the sdist and the wheel
         run: |
           pip install build
@@ -62,7 +62,7 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Test pip install from test.pypi
         run: |
           python -m venv venv-test-pypi

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -394,7 +394,7 @@ class BaseDelayedSaturatedMMM(MMM):
         filepath = Path(str(fname))
         idata = az.from_netcdf(filepath)
         # needs to be converted, because json.loads was changing tuple to list
-        model_config = cls._convert_dims_to_tuple(
+        model_config = cls._model_config_formatting(
             json.loads(idata.attrs["model_config"])
         )
         model = cls(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "seaborn>=0.12.2",
     "xarray",
     "xarray-einstats>=0.5.1",
-    "pymc-experimental>=0.0.8",
+    "pymc-experimental=0.0.9",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
 docs = [
     "sphinx",
     "ipython!=8.7.0",
-    "myst-parser",
+    "myst-parser",x
     "myst-nb",
     "pydata-sphinx-theme>=0.12.0.dev0",
     "sphinx-copybutton",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "numpy>=1.17",
     "pandas",
     # NOTE: Keep minimum pymc version in sync with ci.yml `OLDEST_PYMC_VERSION`
-    "pymc>=5.5.0",
+    "pymc>=5.6.1",
     "scikit-learn>=1.1.1",
     "seaborn>=0.12.2",
     "xarray",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "seaborn>=0.12.2",
     "xarray",
     "xarray-einstats>=0.5.1",
-    "pymc-experimental=0.0.9",
+    "pymc-experimental==0.0.9",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["setuptools>=61.0"]
 [project]
 name = "pymc-marketing"
 description = "Marketing Statistical Models in PyMC"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 readme = "README.md"
 license = {file = "LICENSE"}
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "numpy>=1.17",
     "pandas",
     # NOTE: Keep minimum pymc version in sync with ci.yml `OLDEST_PYMC_VERSION`
-    "pymc>=5.6.1 <5.7.0",
+    "pymc>=5.6.1,<5.7.0",
     "scikit-learn>=1.1.1",
     "seaborn>=0.12.2",
     "xarray",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "numpy>=1.17",
     "pandas",
     # NOTE: Keep minimum pymc version in sync with ci.yml `OLDEST_PYMC_VERSION`
-    "pymc>=5.6.1",
+    "pymc>=5.6.1 <5.7.0",
     "scikit-learn>=1.1.1",
     "seaborn>=0.12.2",
     "xarray",
@@ -29,7 +29,7 @@ dependencies = [
 docs = [
     "sphinx",
     "ipython!=8.7.0",
-    "myst-parser",
+    "myst-parser",x
     "myst-nb",
     "pydata-sphinx-theme>=0.12.0.dev0",
     "sphinx-copybutton",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
 docs = [
     "sphinx",
     "ipython!=8.7.0",
-    "myst-parser",x
+    "myst-parser",
     "myst-nb",
     "pydata-sphinx-theme>=0.12.0.dev0",
     "sphinx-copybutton",


### PR DESCRIPTION
Since pymc-marketing doesn't support python 3.8 anymore, we need to update the CI's to reflect that, otherwise they will keep failing, blocking other current CI's

<!-- readthedocs-preview pymc-marketing start -->
----
:books: Documentation preview :books:: https://pymc-marketing--331.org.readthedocs.build/en/331/

<!-- readthedocs-preview pymc-marketing end -->