### PR TITLE
Support np.ndarray in model_config

### DIFF
--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -492,23 +492,21 @@ class BaseDelayedSaturatedMMM(MMM):
         Because of json serialization, model_config values that were originally tuples or numpy are being encoded as lists.
         This function converts them back to tuples and numpy arrays to ensure correct id encoding.
         """
-        for key in model_config:
-            if isinstance(model_config[key], dict):
-                for sub_key in model_config[key]:
-                    if isinstance(model_config[key][sub_key], list):
-                        # Check if "dims" key to convert it to tuple
-                        if sub_key == "dims":
-                            model_config[key][sub_key] = tuple(
-                                model_config[key][sub_key]
-                            )
-                        # Convert all other lists to numpy arrays
-                        else:
-                            model_config[key][sub_key] = np.array(
-                                model_config[key][sub_key]
-                            )
-            elif isinstance(model_config[key], list):
-                model_config[key] = np.array(model_config[key])
-        return model_config
+
+        def format_nested_dict(d: Dict) -> Dict:
+            for key, value in d.items():
+                if isinstance(value, dict):
+                    d[key] = format_nested_dict(value)
+                elif isinstance(value, list):
+                    # Check if the key is "dims" to convert it to tuple
+                    if key == "dims":
+                        d[key] = tuple(value)
+                    # Convert all other lists to numpy arrays
+                    else:
+                        d[key] = np.array(value)
+            return d
+
+        return format_nested_dict(model_config.copy())
 
 
 class DelayedSaturatedMMM(

--- a/tests/mmm/test_delayed_saturated_mmm.py
+++ b/tests/mmm/test_delayed_saturated_mmm.py
@@ -39,6 +39,33 @@ def toy_X() -> pd.DataFrame:
 
 
 @pytest.fixture(scope="class")
+def model_config_requiring_serialization() -> dict:
+    model_config = {
+        "intercept": {"mu": 0, "sigma": 2},
+        "beta_channel": {
+            "sigma": np.array([0.4533017, 0.25488063]),
+            "dims": ("channel",),
+        },
+        "alpha": {
+            "alpha": np.array([3, 3]),
+            "beta": np.array([3.55001301, 2.87092431]),
+            "dims": ("channel",),
+        },
+        "lam": {
+            "alpha": np.array([3, 3]),
+            "beta": np.array([4.12231653, 5.02896872]),
+            "dims": ("channel",),
+        },
+        "sigma": {"sigma": 2},
+        "gamma_control": {"mu": 0, "sigma": 2, "dims": ("control",)},
+        "mu": {"dims": ("date",)},
+        "likelihood": {"dims": ("date",)},
+        "gamma_fourier": {"mu": 0, "b": 1, "dims": "fourier_mode"},
+    }
+    return model_config
+
+
+@pytest.fixture(scope="class")
 def toy_y(toy_X: pd.DataFrame) -> pd.Series:
     return pd.Series(data=rng.integers(low=0, high=100, size=toy_X.shape[0]))
 
@@ -62,6 +89,46 @@ def mmm_fitted(
 
 
 class TestDelayedSaturatedMMM:
+    def test_save_load_with_not_serializable_model_config(
+        self, model_config_requiring_serialization, toy_X, toy_y
+    ):
+        def deep_equal(dict1, dict2):
+            for key, value in dict1.items():
+                if key not in dict2:
+                    return False
+                if isinstance(value, dict):
+                    if not deep_equal(value, dict2[key]):
+                        return False
+                elif isinstance(value, np.ndarray):
+                    if not np.array_equal(value, dict2[key]):
+                        return False
+                else:
+                    if value != dict2[key]:
+                        return False
+            return True
+
+        model = DelayedSaturatedMMM(
+            date_column="date",
+            channel_columns=["channel_1", "channel_2"],
+            adstock_max_lag=4,
+            model_config=model_config_requiring_serialization,
+        )
+        model.fit(
+            toy_X, toy_y, target_accept=0.81, draws=100, chains=2, random_seed=rng
+        )
+        model.save("test_save_load")
+        model2 = DelayedSaturatedMMM.load("test_save_load")
+        assert model.date_column == model2.date_column
+        assert model.control_columns == model2.control_columns
+        assert model.channel_columns == model2.channel_columns
+        assert model.adstock_max_lag == model2.adstock_max_lag
+        assert model.validate_data == model2.validate_data
+        assert model.yearly_seasonality == model2.yearly_seasonality
+        assert deep_equal(model.model_config, model2.model_config)
+
+        assert model.sampler_config == model2.sampler_config
+        os.remove("test_save_load")
+
     @pytest.mark.parametrize(
         argnames="adstock_max_lag",
         argvalues=[1, 4],


### PR DESCRIPTION
This PR addresses issue mentioned in #348. As on the development stage only certain priors were shown to use arrays, I didn't include it at the time, but seeing users trying to include them I've added more thorough algorithm to scan all the fields of model config and ensure their JSON serialization.

Closes #333 
Closes #348 

<!-- readthedocs-preview pymc-marketing start -->
----
:books: Documentation preview :books:: https://pymc-marketing--351.org.readthedocs.build/en/351/

<!-- readthedocs-preview pymc-marketing end -->