### PR TITLE
Don't run prior and posterior predictive when calling `fit`

### DIFF
--- a/pymc_marketing/clv/models/basic.py
+++ b/pymc_marketing/clv/models/basic.py
@@ -293,7 +293,7 @@ class CLVModel(ModelBuilder):
     def output_var(self):
         pass
 
-    def generate_and_preprocess_model_data(
+    def _generate_and_preprocess_model_data(
         self,
         X: Union[pd.DataFrame, pd.Series],
         y: Union[pd.Series, np.ndarray[Any, Any]],

--- a/pymc_marketing/mmm/base.py
+++ b/pymc_marketing/mmm/base.py
@@ -42,7 +42,7 @@ class BaseMMM(ModelBuilder):
         **kwargs,
     ) -> None:
         self.X: Optional[pd.DataFrame] = None
-        self.y: Optional[pd.Series] = None
+        self.y: Optional[Union[pd.Series, np.ndarray]] = None
         self.date_column: str = date_column
         self.channel_columns: Union[List[str], Tuple[str]] = channel_columns
         self.n_channel: int = len(channel_columns)
@@ -69,8 +69,8 @@ class BaseMMM(ModelBuilder):
     def validation_methods(
         self,
     ) -> Tuple[
-        List[Callable[["BaseMMM", Union[pd.DataFrame, pd.Series]], None]],
-        List[Callable[["BaseMMM", Union[pd.DataFrame, pd.Series]], None]],
+        List[Callable[["BaseMMM", Union[pd.DataFrame, pd.Series, np.ndarray]], None]],
+        List[Callable[["BaseMMM", Union[pd.DataFrame, pd.Series, np.ndarray]], None]],
     ]:
         """
         A property that provides validation methods for features ("X") and the target variable ("y").
@@ -98,7 +98,9 @@ class BaseMMM(ModelBuilder):
             ],
         )
 
-    def validate(self, target: str, data: Union[pd.DataFrame, pd.Series]) -> None:
+    def validate(
+        self, target: str, data: Union[pd.DataFrame, pd.Series, np.ndarray]
+    ) -> None:
         """
         Validates the input data based on the specified target type.
 
@@ -110,7 +112,7 @@ class BaseMMM(ModelBuilder):
         target : str
             The type of target to be validated.
             Expected values are "X" for features and "y" for the target variable.
-        data : Union[pd.DataFrame, pd.Series]
+        data : Union[pd.DataFrame, pd.Series, np.ndarray]
             The input data to be validated.
 
         Raises
@@ -134,14 +136,14 @@ class BaseMMM(ModelBuilder):
     ) -> Tuple[
         List[
             Callable[
-                ["BaseMMM", Union[pd.DataFrame, pd.Series]],
-                Union[pd.DataFrame, pd.Series],
+                ["BaseMMM", Union[pd.DataFrame, pd.Series, np.ndarray]],
+                Union[pd.DataFrame, pd.Series, np.ndarray],
             ]
         ],
         List[
             Callable[
-                ["BaseMMM", Union[pd.DataFrame, pd.Series]],
-                Union[pd.DataFrame, pd.Series],
+                ["BaseMMM", Union[pd.DataFrame, pd.Series, np.ndarray]],
+                Union[pd.DataFrame, pd.Series, np.ndarray],
             ]
         ],
     ]:
@@ -171,8 +173,8 @@ class BaseMMM(ModelBuilder):
         )
 
     def preprocess(
-        self, target: str, data: Union[pd.DataFrame, pd.Series]
-    ) -> Union[pd.DataFrame, pd.Series]:
+        self, target: str, data: Union[pd.DataFrame, pd.Series, np.ndarray]
+    ) -> Union[pd.DataFrame, pd.Series, np.ndarray]:
         """
         Preprocess the provided data according to the specified target.
 
@@ -184,12 +186,12 @@ class BaseMMM(ModelBuilder):
         target : str
             Indicates whether the data represents features ("X") or the target variable ("y").
 
-        data : pd.DataFrame
+        data : Union[pd.DataFrame, pd.Series, np.ndarray]
             The data to be preprocessed.
 
         Returns
         -------
-        Union[pd.DataFrame, pd.Series]
+        Union[pd.DataFrame, pd.Series, np.ndarray]
             The preprocessed data.
 
         Raises

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -81,10 +81,11 @@ class BaseDelayedSaturatedMMM(MMM):
 
     @property
     def output_var(self):
+        """Defines target variable for the model"""
         return "y"
 
-    def generate_and_preprocess_model_data(  # type: ignore
-        self, X: Union[pd.DataFrame, pd.Series], y: pd.Series
+    def _generate_and_preprocess_model_data(  # type: ignore
+        self, X: Union[pd.DataFrame, pd.Series], y: Union[pd.Series, np.ndarray]
     ) -> None:
         """
         Applies preprocessing to the data before fitting the model.
@@ -93,8 +94,8 @@ class BaseDelayedSaturatedMMM(MMM):
 
         Parameters
         ----------
-        X : array, shape (n_obs, n_features)
-        y : array, shape (n_obs,)
+        X : Union[pd.DataFrame, pd.Series], shape (n_obs, n_features)
+        y : Union[pd.Series, np.ndarray], shape (n_obs,)
         """
         date_data = X[self.date_column]
         channel_data = X[self.channel_columns]
@@ -126,11 +127,11 @@ class BaseDelayedSaturatedMMM(MMM):
             self.validate("X", X_data)
             self.validate("y", y)
         self.preprocessed_data: Dict[str, Union[pd.DataFrame, pd.Series]] = {
-            "X": self.preprocess("X", X_data),
-            "y": self.preprocess("y", y),
+            "X": self.preprocess("X", X_data),  # type: ignore
+            "y": self.preprocess("y", y),  # type: ignore
         }
         self.X: pd.DataFrame = X_data
-        self.y: pd.Series = y
+        self.y: Union[pd.Series, np.ndarray] = y
 
     def _save_input_params(self, idata) -> None:
         """Saves input parameters to the attrs of idata."""
@@ -144,11 +145,35 @@ class BaseDelayedSaturatedMMM(MMM):
     def build_model(
         self,
         X: pd.DataFrame,
-        y: pd.Series,
+        y: Union[pd.Series, np.ndarray],
         **kwargs,
     ) -> None:
+        """
+        Builds a probabilistic model using PyMC for marketing mix modeling.
+
+        The model incorporates channels, control variables, and Fourier components, applying
+        adstock and saturation transformations to the channel data. The final model is
+        constructed with multiple factors contributing to the response variable.
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            The input data for the model, which should include columns for channels,
+            control variables (if applicable), and Fourier components (if applicable).
+
+        y : Union[pd.Series, np.ndarray]
+            The target/response variable for the modeling.
+
+        **kwargs : dict
+            Additional keyword arguments that might be required by underlying methods or utilities.
+
+        Attributes Set
+        ---------------
+        model : pm.Model
+            The PyMC model object containing all the defined stochastic and deterministic variables.
+        """
         model_config = self.model_config
-        self.generate_and_preprocess_model_data(X, y)
+        self._generate_and_preprocess_model_data(X, y)
         with pm.Model(coords=self.model_coords) as self.model:
             channel_data_ = pm.MutableData(
                 name="channel_data",

--- a/pymc_marketing/model_builder.py
+++ b/pymc_marketing/model_builder.py
@@ -565,7 +565,8 @@ class ModelBuilder(ABC):
                 prior_predictive = sample_kwargs.pop("prior_predictive")
             if "posterior_predictive" in sample_kwargs:
                 posterior_predictive = sample_kwargs.pop("posterior_predictive")
-
+        if sample_kwargs is not None and len(sample_kwargs) > 0:
+            sampler_config.update(**sample_kwargs)
         # Merge all arguments and pass to sample_model
         self.idata = self.sample_model(
             prior_predictive_kwargs=prior_predictive_kwargs,

--- a/tests/mmm/test_base.py
+++ b/tests/mmm/test_base.py
@@ -58,7 +58,7 @@ def toy_mmm(request, toy_X, toy_y):
         def build_model(*args, **kwargs):
             pass
 
-        def generate_and_preprocess_model_data(self, X, y):
+        def _generate_and_preprocess_model_data(self, X, y):
             self.validate("X", X)
             self.validate("y", y)
             self.preprocessed_data["X"] = self.preprocess("X", X)
@@ -135,7 +135,7 @@ class TestMMM:
         validate_channel_columns.configure_mock(_tags={"validation_X": True})
         validate_date_col.configure_mock(_tags={"validation_X": True})
         validate_target.configure_mock(_tags={"validation_y": True})
-        toy_mmm.generate_and_preprocess_model_data(toy_X, toy_y)
+        toy_mmm._generate_and_preprocess_model_data(toy_X, toy_y)
         pd.testing.assert_frame_equal(toy_mmm.X, toy_X)
         pd.testing.assert_frame_equal(toy_mmm.preprocessed_data["X"], toy_X)
         pd.testing.assert_series_equal(toy_mmm.y, toy_y)
@@ -166,7 +166,7 @@ def test_mmm():
                 mu = intercept + slope
                 pm.Normal("y", mu=mu, sigma=sigma)
 
-        def generate_and_preprocess_model_data(self, toy_X, toy_y):
+        def _generate_and_preprocess_model_data(self, toy_X, toy_y):
             self.validate("X", toy_X)
             self.validate("y", toy_y)
             self.preprocessed_data["X"] = self.preprocess("X", toy_X)

--- a/tests/mmm/test_plotting.py
+++ b/tests/mmm/test_plotting.py
@@ -76,7 +76,7 @@ class TestBasePlotting:
             X=toy_X,
             y=toy_y,
             sample_kwargs={
-                "prior_kwargs": {"samples": 100},
+                "prior_predictive_kwargs": {"samples": 100},
                 "prior_predictive": True,
                 "posterior_predictive": True,
             },

--- a/tests/mmm/test_plotting.py
+++ b/tests/mmm/test_plotting.py
@@ -75,6 +75,8 @@ class TestBasePlotting:
         mmm.fit(
             X=toy_X,
             y=toy_y,
+            prior_predictive=True,
+            posterior_predictive=True,
         )
         mmm._prior_predictive = mmm.prior_predictive
         mmm._fit_result = mmm.fit_result

--- a/tests/mmm/test_plotting.py
+++ b/tests/mmm/test_plotting.py
@@ -75,8 +75,11 @@ class TestBasePlotting:
         mmm.fit(
             X=toy_X,
             y=toy_y,
-            prior_predictive=True,
-            posterior_predictive=True,
+            sample_kwargs={
+                "prior_kwargs": {"samples": 100},
+                "prior_predictive": True,
+                "posterior_predictive": True,
+            },
         )
         mmm._prior_predictive = mmm.prior_predictive
         mmm._fit_result = mmm.fit_result

--- a/tests/mmm/test_plotting.py
+++ b/tests/mmm/test_plotting.py
@@ -75,12 +75,9 @@ class TestBasePlotting:
         mmm.fit(
             X=toy_X,
             y=toy_y,
-            sample_kwargs={
-                "prior_predictive_kwargs": {"samples": 100},
-                "prior_predictive": True,
-                "posterior_predictive": True,
-            },
         )
+        mmm.sample_prior_predictive(toy_X, toy_y, extend_idata=True, combined=True)
+        mmm.sample_posterior_predictive(toy_X, extend_idata=True, combined=True)
         mmm._prior_predictive = mmm.prior_predictive
         mmm._fit_result = mmm.fit_result
         mmm._posterior_predictive = mmm.posterior_predictive

--- a/tests/model_builder/test_model_builder.py
+++ b/tests/model_builder/test_model_builder.py
@@ -61,15 +61,9 @@ def fitted_model_instance(toy_X, toy_y):
     )
     model.fit(
         toy_X,
-        sample_kwargs={
-            "prior_predictive_kwargs": {"samples": 100},
-            "posterior_predictive_kwargs": {"predictions": True},
-            "prior_predictive": True,
-            "posterior_predictive": True,
-            "chains": 1,
-            "draws": 100,
-            "tune": 100,
-        },
+        chains=1,
+        draws=100,
+        tune=100,
     )
     return model
 
@@ -195,7 +189,7 @@ def test_empty_sampler_config_fit(toy_X, toy_y):
     sampler_config = {}
     model_builder = test_ModelBuilder(sampler_config=sampler_config)
     model_builder.idata = model_builder.fit(
-        X=toy_X, y=toy_y, sample_kwargs={"chains": 1, "draws": 100, "tune": 100}
+        X=toy_X, y=toy_y, chains=1, draws=100, tune=100
     )
     assert model_builder.idata is not None
     assert "posterior" in model_builder.idata.groups()
@@ -204,9 +198,7 @@ def test_empty_sampler_config_fit(toy_X, toy_y):
 def test_fit(fitted_model_instance):
     assert fitted_model_instance.idata is not None
     assert "posterior" in fitted_model_instance.idata.groups()
-    assert "predictions" in fitted_model_instance.idata.groups()
-    assert "prior" in fitted_model_instance.idata.groups()
-    assert fitted_model_instance.idata.prior.dims["draw"] == 100
+    assert fitted_model_instance.idata.posterior.dims["draw"] == 100
 
     prediction_data = pd.DataFrame(
         {"input": np.random.uniform(low=0, high=1, size=100)}
@@ -220,9 +212,7 @@ def test_fit(fitted_model_instance):
 
 def test_fit_no_y(toy_X):
     model_builder = test_ModelBuilder()
-    model_builder.idata = model_builder.fit(
-        X=toy_X, sample_kwargs={"chains": 1, "draws": 100, "tune": 100}
-    )
+    model_builder.idata = model_builder.fit(X=toy_X, chains=1, draws=100, tune=100)
     assert model_builder.model is not None
     assert model_builder.idata is not None
     assert "posterior" in model_builder.idata.groups()
@@ -270,11 +260,6 @@ def test_model_config_formatting():
     converted_model_config = model_builder._model_config_formatting(model_config)
     np.testing.assert_equal(converted_model_config["a"]["dims"], ("x",))
     np.testing.assert_equal(converted_model_config["a"]["loc"], np.array([0, 0]))
-
-
-def test_not_build_model_raises_runtime_error(not_fitted_model_instance):
-    with pytest.raises(RuntimeError):
-        not_fitted_model_instance.sample_model()
 
 
 def test_id():

--- a/tests/model_builder/test_model_builder.py
+++ b/tests/model_builder/test_model_builder.py
@@ -59,18 +59,21 @@ def fitted_model_instance(toy_X, toy_y):
         sampler_config=sampler_config,
         test_parameter="test_paramter",
     )
-    model.fit(toy_X)
+    model.fit(
+        toy_X,
+        sample_kwargs={
+            "prior_kwargs": {"samples": 100},
+            "posterior_kwargs": {"predictions": True},
+            "prior_predictive": True,
+            "posterior_predictive": True,
+        },
+    )
     return model
 
 
 @pytest.fixture(scope="module")
 def not_fitted_model_instance(toy_X, toy_y):
-    sampler_config = {
-        "draws": 100,
-        "tune": 100,
-        "chains": 2,
-        "target_accept": 0.95,
-    }
+    sampler_config = {"draws": 100, "tune": 100, "chains": 2, "target_accept": 0.95}
     model_config = {
         "a": {"loc": 0, "scale": 10, "dims": ("numbers",)},
         "b": {"loc": 0, "scale": 10},
@@ -185,6 +188,7 @@ def test_save_without_fit_raises_runtime_error():
         model_builder.save("saved_model")
 
 
+@pytest.mark.slow
 def test_empty_sampler_config_fit(toy_X, toy_y):
     sampler_config = {}
     model_builder = test_ModelBuilder(sampler_config=sampler_config)
@@ -194,6 +198,12 @@ def test_empty_sampler_config_fit(toy_X, toy_y):
 
 
 def test_fit(fitted_model_instance):
+    assert fitted_model_instance.idata is not None
+    assert "posterior" in fitted_model_instance.idata.groups()
+    assert "predictions" in fitted_model_instance.idata.groups()
+    assert "prior" in fitted_model_instance.idata.groups()
+    assert fitted_model_instance.idata.prior.dims["draw"] == 100
+
     prediction_data = pd.DataFrame(
         {"input": np.random.uniform(low=0, high=1, size=100)}
     )
@@ -204,6 +214,7 @@ def test_fit(fitted_model_instance):
     post_pred[fitted_model_instance.output_var].shape[0] == prediction_data.input.shape
 
 
+@pytest.mark.slow
 def test_fit_no_y(toy_X):
     model_builder = test_ModelBuilder()
     model_builder.idata = model_builder.fit(X=toy_X)

--- a/tests/model_builder/test_model_builder.py
+++ b/tests/model_builder/test_model_builder.py
@@ -62,10 +62,13 @@ def fitted_model_instance(toy_X, toy_y):
     model.fit(
         toy_X,
         sample_kwargs={
-            "prior_kwargs": {"samples": 100},
-            "posterior_kwargs": {"predictions": True},
+            "prior_predictive_kwargs": {"samples": 100},
+            "posterior_predictive_kwargs": {"predictions": True},
             "prior_predictive": True,
             "posterior_predictive": True,
+            "chains": 1,
+            "draws": 100,
+            "tune": 100,
         },
     )
     return model
@@ -188,11 +191,12 @@ def test_save_without_fit_raises_runtime_error():
         model_builder.save("saved_model")
 
 
-@pytest.mark.slow
 def test_empty_sampler_config_fit(toy_X, toy_y):
     sampler_config = {}
     model_builder = test_ModelBuilder(sampler_config=sampler_config)
-    model_builder.idata = model_builder.fit(X=toy_X, y=toy_y)
+    model_builder.idata = model_builder.fit(
+        X=toy_X, y=toy_y, sample_kwargs={"chains": 1, "draws": 100, "tune": 100}
+    )
     assert model_builder.idata is not None
     assert "posterior" in model_builder.idata.groups()
 
@@ -214,10 +218,11 @@ def test_fit(fitted_model_instance):
     post_pred[fitted_model_instance.output_var].shape[0] == prediction_data.input.shape
 
 
-@pytest.mark.slow
 def test_fit_no_y(toy_X):
     model_builder = test_ModelBuilder()
-    model_builder.idata = model_builder.fit(X=toy_X)
+    model_builder.idata = model_builder.fit(
+        X=toy_X, sample_kwargs={"chains": 1, "draws": 100, "tune": 100}
+    )
     assert model_builder.model is not None
     assert model_builder.idata is not None
     assert "posterior" in model_builder.idata.groups()

--- a/tests/model_builder/test_model_builder.py
+++ b/tests/model_builder/test_model_builder.py
@@ -73,7 +73,7 @@ class test_ModelBuilder(ModelBuilder):
 
     def build_model(self, X: pd.DataFrame, y: pd.Series, model_config=None):
         coords = {"numbers": np.arange(len(X))}
-        self.generate_and_preprocess_model_data(X, y)
+        self._generate_and_preprocess_model_data(X, y)
         with pm.Model(coords=coords) as self.model:
             if model_config is None:
                 model_config = self.default_model_config
@@ -112,7 +112,7 @@ class test_ModelBuilder(ModelBuilder):
     def _serializable_model_config(self):
         return self.model_config
 
-    def generate_and_preprocess_model_data(self, X: pd.DataFrame, y: pd.Series):
+    def _generate_and_preprocess_model_data(self, X: pd.DataFrame, y: pd.Series):
         self.X = X
         self.y = y
 

--- a/tests/model_builder/test_model_builder.py
+++ b/tests/model_builder/test_model_builder.py
@@ -63,6 +63,27 @@ def fitted_model_instance(toy_X, toy_y):
     return model
 
 
+@pytest.fixture(scope="module")
+def not_fitted_model_instance(toy_X, toy_y):
+    sampler_config = {
+        "draws": 100,
+        "tune": 100,
+        "chains": 2,
+        "target_accept": 0.95,
+    }
+    model_config = {
+        "a": {"loc": 0, "scale": 10, "dims": ("numbers",)},
+        "b": {"loc": 0, "scale": 10},
+        "obs_error": 2,
+    }
+    model = test_ModelBuilder(
+        model_config=model_config,
+        sampler_config=sampler_config,
+        test_parameter="test_paramter",
+    )
+    return model
+
+
 class test_ModelBuilder(ModelBuilder):
     def __init__(self, model_config=None, sampler_config=None, test_parameter=None):
         self.test_parameter = test_parameter
@@ -233,6 +254,11 @@ def test_model_config_formatting():
     converted_model_config = model_builder._model_config_formatting(model_config)
     np.testing.assert_equal(converted_model_config["a"]["dims"], ("x",))
     np.testing.assert_equal(converted_model_config["a"]["loc"], np.array([0, 0]))
+
+
+def test_not_build_model_raises_runtime_error(not_fitted_model_instance):
+    with pytest.raises(RuntimeError):
+        not_fitted_model_instance.sample_model()
 
 
 def test_id():


### PR DESCRIPTION
This PR contains the following changes:

sample_model() - removed from the fit() call, each sampling should be called directly and independently by it's corresponding function. Attributes handling moved to fit()
mypy fixes
docstrings updates and changes


<!-- readthedocs-preview pymc-marketing start -->
----
:books: Documentation preview :books:: https://pymc-marketing--365.org.readthedocs.build/en/365/

<!-- readthedocs-preview pymc-marketing end -->