### PR TITLE
improve pre-processing MMM

### DIFF
--- a/pymc_marketing/clv/utils.py
+++ b/pymc_marketing/clv/utils.py
@@ -168,6 +168,8 @@ def _find_first_transactions(
 
     if isinstance(observation_period_end, pd.Period):
         observation_period_end = observation_period_end.to_timestamp()
+    if isinstance(observation_period_end, str):
+        observation_period_end = pd.to_datetime(observation_period_end)
 
     if monetary_value_col:
         select_columns.append(monetary_value_col)
@@ -182,7 +184,7 @@ def _find_first_transactions(
         transactions.set_index(datetime_col).to_period(time_unit).to_timestamp()
     )
 
-    mask = pd.DatetimeIndex(transactions.index) <= observation_period_end
+    mask = pd.to_datetime(transactions.index) <= pd.to_datetime(observation_period_end)
 
     transactions = transactions.loc[mask].reset_index()
 

--- a/pymc_marketing/mmm/base.py
+++ b/pymc_marketing/mmm/base.py
@@ -204,15 +204,16 @@ class BaseMMM(ModelBuilder):
         >>> data = pd.DataFrame({"x1": [1, 2, 3], "y": [4, 5, 6]})
         >>> self.preprocess("X", data)
         """
+        data_cp = data.copy()
         if target == "X":
             for method in self.preprocessing_methods[0]:
-                data = method(self, data)
+                data_cp = method(self, data_cp)
         elif target == "y":
             for method in self.preprocessing_methods[1]:
-                data = method(self, data)
+                data_cp = method(self, data_cp)
         else:
             raise ValueError("Target must be either 'X' or 'y'")
-        return data
+        return data_cp
 
     def get_target_transformer(self) -> Pipeline:
         try:

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -173,6 +173,7 @@ class BaseDelayedSaturatedMMM(MMM):
             The PyMC model object containing all the defined stochastic and deterministic variables.
         """
         model_config = self.model_config
+        self._generate_and_preprocess_model_data(X, y)
         with pm.Model(coords=self.model_coords) as self.model:
             channel_data_ = pm.MutableData(
                 name="channel_data",

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -173,7 +173,6 @@ class BaseDelayedSaturatedMMM(MMM):
             The PyMC model object containing all the defined stochastic and deterministic variables.
         """
         model_config = self.model_config
-        self._generate_and_preprocess_model_data(X, y)
         with pm.Model(coords=self.model_coords) as self.model:
             channel_data_ = pm.MutableData(
                 name="channel_data",

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -351,7 +351,7 @@ class BaseDelayedSaturatedMMM(MMM):
         Parameters
         ----------
         channel_data : array-like
-            Input channel data.
+            Input channel data. Result of all the preprocessing steps.
         Returns
         -------
         array-like
@@ -550,7 +550,7 @@ class DelayedSaturatedMMM(
         Parameters
         ----------
         channel_data : array-like
-            Input channel data.
+            Input channel data. Result of all the preprocessing steps.
         Returns
         -------
         array-like
@@ -591,10 +591,7 @@ class DelayedSaturatedMMM(
         channel_contributions = []
         for delta in share_grid:
             channel_data = (
-                delta
-                * self.max_abs_scale_channel_data(data=self.X)[
-                    self.channel_columns
-                ].to_numpy()
+                delta * self.preprocessed_data["X"][self.channel_columns].to_numpy()
             )
             channel_contribution_forward_pass = self.channel_contributions_forward_pass(
                 channel_data=channel_data

--- a/pymc_marketing/mmm/preprocessing.py
+++ b/pymc_marketing/mmm/preprocessing.py
@@ -45,17 +45,18 @@ class MaxAbsScaleChannels:
 
     @preprocessing_method_X
     def max_abs_scale_channel_data(self, data: pd.DataFrame) -> pd.DataFrame:
+        data_cp = data.copy()
         channel_data: Union[
             pd.DataFrame,
             pd.Series[Any],
-        ] = data[self.channel_columns]
+        ] = data_cp[self.channel_columns]
         transformers = [("scaler", MaxAbsScaler())]
         pipeline: Pipeline = Pipeline(steps=transformers)
         self.channel_transformer: Pipeline = pipeline.fit(X=channel_data.to_numpy())
-        data[self.channel_columns] = self.channel_transformer.transform(
+        data_cp[self.channel_columns] = self.channel_transformer.transform(
             channel_data.to_numpy()
         )
-        return data
+        return data_cp
 
 
 class StandardizeControls:

--- a/tests/mmm/test_delayed_saturated_mmm.py
+++ b/tests/mmm/test_delayed_saturated_mmm.py
@@ -331,7 +331,9 @@ class TestDelayedSaturatedMMM:
     def test_channel_contributions_forward_pass_recovers_contribution(
         self, mmm_fitted: DelayedSaturatedMMM
     ) -> None:
-        channel_data = mmm_fitted.X[mmm_fitted.channel_columns].to_numpy()
+        channel_data = mmm_fitted.preprocessed_data["X"][
+            mmm_fitted.channel_columns
+        ].to_numpy()
         channel_contributions_forward_pass = (
             mmm_fitted.channel_contributions_forward_pass(channel_data=channel_data)
         )
@@ -356,7 +358,9 @@ class TestDelayedSaturatedMMM:
     def test_channel_contributions_forward_pass_is_consistent(
         self, mmm_fitted: DelayedSaturatedMMM
     ) -> None:
-        channel_data = mmm_fitted.X[mmm_fitted.channel_columns].to_numpy()
+        channel_data = mmm_fitted.preprocessed_data["X"][
+            mmm_fitted.channel_columns
+        ].to_numpy()
         channel_contributions_forward_pass = (
             mmm_fitted.channel_contributions_forward_pass(channel_data=channel_data)
         )


### PR DESCRIPTION
Closes https://github.com/pymc-labs/pymc-marketing/issues/375

The changes are small, but he big portion is just the notebook update.

- Make sure we use copies not to modify data in-place.
- This means `mmm.X` has the original channel data (not scaled!)
-  Update the mmm example notebook to make sure it is compatible with https://github.com/pymc-labs/pymc-marketing/pull/365
- Small `mypy` improvements 🤦 

<!-- readthedocs-preview pymc-marketing start -->
----
:books: Documentation preview :books:: https://pymc-marketing--376.org.readthedocs.build/en/376/

<!-- readthedocs-preview pymc-marketing end -->