### PR TITLE
Remove unnecessary calls to PyTensor eval() from user-facing methods

### DIFF
--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -383,7 +383,7 @@ class BaseDelayedSaturatedMMM(MMM):
         channel_contribution_forward_pass = (
             beta_channel_posterior_expanded * logistic_saturation_posterior
         )
-        return channel_contribution_forward_pass.eval()
+        return channel_contribution_forward_pass
 
     @property
     def _serializable_model_config(self) -> Dict[str, Any]:
@@ -564,7 +564,7 @@ class DelayedSaturatedMMM(
             excluded=[1, 2],
             signature="(m, n) -> (m, n)",
         )
-        return target_transformed_vectorized(channel_contribution_forward_pass)
+        return target_transformed_vectorized(channel_contribution_forward_pass).eval()
 
     def get_channel_contributions_forward_pass_grid(
         self, start: float, stop: float, num: int
@@ -596,7 +596,7 @@ class DelayedSaturatedMMM(
             channel_contribution_forward_pass = self.channel_contributions_forward_pass(
                 channel_data=channel_data
             )
-            channel_contributions.append(channel_contribution_forward_pass)
+            channel_contributions.append(channel_contribution_forward_pass.eval())
         return DataArray(
             data=np.array(channel_contributions),
             dims=("delta", "chain", "draw", "date", "channel"),

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -9,8 +9,9 @@ import numpy.typing as npt
 import pandas as pd
 import pymc as pm
 import seaborn as sns
-from xarray import DataArray
 from pytensor.tensor.variable import TensorVariable
+from xarray import DataArray
+
 
 from pymc_marketing.mmm.base import MMM
 from pymc_marketing.mmm.preprocessing import MaxAbsScaleChannels, MaxAbsScaleTarget
@@ -557,8 +558,10 @@ class DelayedSaturatedMMM(
         array-like
             Transformed channel data.
         """
-        channel_contribution_forward_pass = super().channel_contributions_forward_pass_untransformed(
-            channel_data=channel_data
+        channel_contribution_forward_pass = (
+            super().channel_contributions_forward_pass_untransformed(
+                channel_data=channel_data
+            )
         )
         target_transformed_vectorized = np.vectorize(
             self.target_transformer.inverse_transform,

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -10,6 +10,7 @@ import pandas as pd
 import pymc as pm
 import seaborn as sns
 from xarray import DataArray
+from pytensor.tensor.variable import TensorVariable
 
 from pymc_marketing.mmm.base import MMM
 from pymc_marketing.mmm.preprocessing import MaxAbsScaleChannels, MaxAbsScaleTarget
@@ -344,9 +345,9 @@ class BaseDelayedSaturatedMMM(MMM):
             n_order=self.yearly_seasonality,
         )
 
-    def channel_contributions_forward_pass(
+    def channel_contributions_forward_pass_untransformed(
         self, channel_data: npt.NDArray[np.float_]
-    ) -> npt.NDArray[np.float_]:
+    ) -> TensorVariable:
         """Evaluate the channel contribution for a given channel data and a fitted model, ie. the forward pass.
         Parameters
         ----------
@@ -556,7 +557,7 @@ class DelayedSaturatedMMM(
         array-like
             Transformed channel data.
         """
-        channel_contribution_forward_pass = super().channel_contributions_forward_pass(
+        channel_contribution_forward_pass = super().channel_contributions_forward_pass_untransformed(
             channel_data=channel_data
         )
         target_transformed_vectorized = np.vectorize(
@@ -564,7 +565,7 @@ class DelayedSaturatedMMM(
             excluded=[1, 2],
             signature="(m, n) -> (m, n)",
         )
-        return target_transformed_vectorized(channel_contribution_forward_pass).eval()
+        return target_transformed_vectorized(channel_contribution_forward_pass.eval())
 
     def get_channel_contributions_forward_pass_grid(
         self, start: float, stop: float, num: int

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -12,7 +12,6 @@ import seaborn as sns
 from pytensor.tensor.variable import TensorVariable
 from xarray import DataArray
 
-
 from pymc_marketing.mmm.base import MMM
 from pymc_marketing.mmm.preprocessing import MaxAbsScaleChannels, MaxAbsScaleTarget
 from pymc_marketing.mmm.transformers import geometric_adstock, logistic_saturation


### PR DESCRIPTION
Fixes https://github.com/pymc-labs/pymc-marketing/issues/383. The calls to `eval()` have been moved out of the `BaseDelayedSaturatedMMM.channel_contributions_forward_pass()` method and to user-facing methods in `DelayedSaturatedMMM` .  It is not entirely clear to me whether `get_channel_contributions_forward_pass_grid()` is supposed to user-facing, but I assumed it is.

What do we think about the possibility of more clearly distinguishing between the user-facing methods that return numpy/xarray objects  and the internal methods that are working with tensors?  The user-facing methods could then just be light wrappers converting/`eval()`ing the tensors to numpy/xarray arrays.

<!-- readthedocs-preview pymc-marketing start -->
----
:books: Documentation preview :books:: https://pymc-marketing--386.org.readthedocs.build/en/386/

<!-- readthedocs-preview pymc-marketing end -->