### PR TITLE
Add method `thin_fit_result` to CLV models

### DIFF
--- a/pymc_marketing/clv/models/basic.py
+++ b/pymc_marketing/clv/models/basic.py
@@ -2,13 +2,11 @@ import json
 import types
 import warnings
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Dict, Optional, Tuple, cast
 
 import arviz as az
-import numpy as np
-import pandas as pd
 import pymc as pm
-from pymc import str_for_dist
+from pymc import Model, str_for_dist
 from pymc.backends import NDArray
 from pymc.backends.base import MultiTrace
 from pytensor.tensor import TensorVariable
@@ -50,13 +48,16 @@ class CLVModel(ModelBuilder):
         self.build_model()  # type: ignore
 
         if fit_method == "mcmc":
-            self._fit_mcmc(**kwargs)
+            idata = self._fit_mcmc(**kwargs)
         elif fit_method == "map":
-            self._fit_MAP(**kwargs)
+            idata = self._fit_MAP(**kwargs)
         else:
             raise ValueError(
                 f"Fit method options are ['mcmc', 'map'], got: {fit_method}"
             )
+
+        self.set_idata_attrs(idata)
+        self.idata = idata
 
         with warnings.catch_warnings():
             warnings.filterwarnings(
@@ -92,47 +93,14 @@ class CLVModel(ModelBuilder):
         if self.sampler_config is not None:
             sampler_config = self.sampler_config.copy()
         sampler_config.update(**kwargs)
-        self.idata = self.sample_model(**sampler_config)
-        return self.idata
+        return pm.sample(**sampler_config, model=self.model)
 
-    def sample_model(self, **kwargs):
-        """
-        Sample from the PyMC model.
-
-        Parameters
-        ----------
-        **kwargs : dict
-            Additional keyword arguments to pass to the PyMC sampler.
-
-        Returns
-        -------
-        xarray.Dataset
-            The PyMC samples dataset.
-
-        Raises
-        ------
-        RuntimeError
-            If the PyMC model hasn't been built yet.
-
-        """
-        if self.model is None:
-            raise RuntimeError(
-                "The model hasn't been built yet, call .build_model() first or call .fit() instead."
-            )
-
-        with self.model:
-            sampler_args = {**self.sampler_config, **kwargs}
-            idata = pm.sample(**sampler_args)
-
-        self.set_idata_attrs(idata)
-        return idata
-
-    def _fit_MAP(self, **kwargs):
+    def _fit_MAP(self, **kwargs) -> az.InferenceData:
         """Find model maximum a posteriori using scipy optimizer"""
         model = self.model
         map_res = pm.find_MAP(model=model, **kwargs)
         # Filter non-value variables
-        value_vars_names = set(v.name for v in model.value_vars)
+        value_vars_names = set(v.name for v in cast(Model, model).value_vars)
         map_res = {k: v for k, v in map_res.items() if k in value_vars_names}
         # Convert map result to InferenceData
         map_strace = NDArray(model=model)
@@ -140,10 +108,7 @@ class CLVModel(ModelBuilder):
         map_strace.record(map_res)
         map_strace.close()
         trace = MultiTrace([map_strace])
-        idata = pm.to_inference_data(trace, model=model)
-        self.set_idata_attrs(idata)
-        self.idata = idata
-        return self.idata
+        return pm.to_inference_data(trace, model=model)
 
     @classmethod
     def load(cls, fname: str):
@@ -228,39 +193,6 @@ class CLVModel(ModelBuilder):
     def _serializable_model_config(self) -> Dict:
         return self.model_config
 
-    def sample_prior_predictive(  # type: ignore
-        self,
-        samples: int = 1000,
-        extend_idata: bool = True,
-        combined: bool = True,
-        **kwargs,
-    ):
-        if self.model is not None:
-            with self.model:  # sample with new input data
-                prior_pred: az.InferenceData = pm.sample_prior_predictive(
-                    samples, **kwargs
-                )
-                self.set_idata_attrs(prior_pred)
-                if extend_idata:
-                    if self.idata is not None:
-                        self.idata.extend(prior_pred)
-                    else:
-                        self.idata = prior_pred
-
-        prior_predictive_samples = az.extract(
-            prior_pred, "prior_predictive", combined=combined
-        )
-
-        return prior_predictive_samples
-
-    @property
-    def prior_predictive(self) -> az.InferenceData:
-        if self.idata is None or "prior_predictive" not in self.idata:
-            raise RuntimeError(
-                "No prior predictive samples available, call sample_prior_predictive() first"
-            )
-        return self.idata["prior_predictive"]
-
     @property
     def fit_result(self) -> Dataset:
         if self.idata is None or "posterior" not in self.idata:
@@ -293,11 +225,7 @@ class CLVModel(ModelBuilder):
     def output_var(self):
         pass
 
-    def _generate_and_preprocess_model_data(
-        self,
-        X: Union[pd.DataFrame, pd.Series],
-        y: Union[pd.Series, np.ndarray[Any, Any]],
-    ) -> None:
+    def _generate_and_preprocess_model_data(self, *args, **kwargs):
         pass
 
     def _data_setter(self):

--- a/pymc_marketing/clv/models/beta_geo.py
+++ b/pymc_marketing/clv/models/beta_geo.py
@@ -129,10 +129,10 @@ class BetaGeoModel(CLVModel):
         except KeyError:
             raise KeyError("T column is missing from data")
         super().__init__(
+            data=data,
             model_config=model_config,
             sampler_config=sampler_config,
         )
-        self.data = data
         self.a_prior = self._create_distribution(self.model_config["a_prior"])
         self.b_prior = self._create_distribution(self.model_config["b_prior"])
         self.alpha_prior = self._create_distribution(self.model_config["alpha_prior"])

--- a/pymc_marketing/clv/models/gamma_gamma.py
+++ b/pymc_marketing/clv/models/gamma_gamma.py
@@ -16,11 +16,13 @@ class BaseGammaGammaModel(CLVModel):
     def __init__(
         self,
         data: pd.DataFrame,
+        *,
         model_config: Optional[Dict] = None,
         sampler_config: Optional[Dict] = None,
     ):
-        super().__init__(model_config, sampler_config)
-        self.data = data
+        super().__init__(
+            data=data, model_config=model_config, sampler_config=sampler_config
+        )
         self.p_prior = self._create_distribution(self.model_config["p_prior"])
         self.q_prior = self._create_distribution(self.model_config["q_prior"])
         self.v_prior = self._create_distribution(self.model_config["v_prior"])

--- a/tests/clv/models/test_basic.py
+++ b/tests/clv/models/test_basic.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import pymc as pm
 import pytest
-from arviz import InferenceData
+from arviz import InferenceData, from_dict
 
 from pymc_marketing.clv.models.basic import CLVModel
 
@@ -12,36 +12,30 @@ from pymc_marketing.clv.models.basic import CLVModel
 class CLVModelTest(CLVModel):
     _model_type = "CLVModelTest"
 
-    def __init__(self, dataset=None, model_config=None, sampler_config=None):
-        super().__init__()
-        self.data = pd.DataFrame({"y": np.random.randn(100)})
-        self.a = self._create_distribution(self.model_config["a"])
-        self._process_priors(self.a)
+    def __init__(self, data=None, **kwargs):
+        if data is None:
+            data = pd.DataFrame({"y": np.random.randn(10)})
+        super().__init__(data=data, **kwargs)
+        self.x_prior = self._create_distribution(self.model_config["x"])
+        self._process_priors(self.x_prior)
 
     @property
     def default_model_config(self):
         return {
-            "a": {"dist": "Normal", "kwargs": {"mu": 0, "sigma": 1}},
-            "b": {"dist": "Normal", "kwargs": {"mu": 0, "sigma": 1}},
+            "x": {"dist": "Normal", "kwargs": {"mu": 0, "sigma": 1}},
         }
 
     def build_model(self):
         with pm.Model() as self.model:
-            self.a = pm.Normal("a", mu=0, sigma=1)
-            self.b = pm.Normal("b", mu=0, sigma=1)
-            self.y = pm.Normal(
-                "y", mu=self.a + self.b, sigma=1, observed=self.data["y"]
-            )
+            x = self.model.register_rv(self.x_prior, name="x")
+            pm.Normal("y", mu=x, sigma=1, observed=self.data["y"])
 
 
 class TestCLVModel:
     def test_repr(self):
         model = CLVModelTest()
         model.build_model()
-        assert (
-            model.__repr__()
-            == "CLVModelTest\na ~ Normal(0, 1)\nb ~ Normal(0, 1)\ny ~ Normal(f(a, b), 1)"
-        )
+        assert model.__repr__() == "CLVModelTest\nx ~ Normal(0, 1)\ny ~ Normal(x, 1)"
 
     def test_check_prior_ndim(self):
         prior = pm.Normal.dist(shape=(5,))  # ndim = 1
@@ -123,14 +117,12 @@ class TestCLVModel:
     def test_load(self):
         model = CLVModelTest()
         model.build_model()
-        model.fit(draws=100, chains=2, random_seed=1234)
+        model.fit(tune=0, chains=2, draws=5)
         model.save("test_model")
-        try:
-            model2 = model.load("test_model")
-            assert model2.fit_result is not None
-            assert model2.model is not None
-        finally:
-            os.remove("test_model")
+        model2 = model.load("test_model")
+        assert model2.fit_result is not None
+        assert model2.model is not None
+        os.remove("test_model")
 
     def test_default_sampler_config(self):
         model = CLVModelTest()
@@ -148,13 +140,12 @@ class TestCLVModel:
         with pytest.warns(UserWarning, match="Overriding pre-existing fit_result"):
             model.fit_result = fake_fit
         model.idata = None
-        model.sample_prior_predictive(samples=50, extend_idata=True)
         model.fit_result = fake_fit
 
     def test_fit_summary_for_mcmc(self):
         model = CLVModelTest()
         model.build_model()
-        model.fit()
+        model.fit(tune=0, chains=2, draws=5)
         summ = model.fit_summary()
         assert isinstance(summ, pd.DataFrame)
 
@@ -171,17 +162,31 @@ class TestCLVModel:
 
         # Now create an instance of MyClass
         mock_basic = CLVModelTest()
-
-        # Check that the property returns the new value
-        mock_basic.fit()
+        mock_basic.fit(tune=0, chains=2, draws=5)
         mock_basic.save("test_model")
-        try:
-            # Apply the monkeypatch for the property
-            monkeypatch.setattr(CLVModelTest, "id", property(mock_property))
-            with pytest.raises(
-                ValueError,
-                match="The file 'test_model' does not contain an inference data of the same model or configuration as 'CLVModelTest'",
-            ):
-                CLVModelTest.load("test_model")
-        finally:
-            os.remove("test_model")
+
+        # Apply the monkeypatch for the property
+        monkeypatch.setattr(CLVModelTest, "id", property(mock_property))
+        with pytest.raises(
+            ValueError,
+            match="Inference data not compatible with CLVModelTest",
+        ):
+            CLVModelTest.load("test_model")
+        os.remove("test_model")
+
+    def test_thin_fit_result(self):
+        data = pd.DataFrame(dict(y=[-3, -2, -1]))
+        model = CLVModelTest(data=data)
+        model.build_model()
+        fake_idata = from_dict(dict(x=np.random.normal(size=(4, 1000))))
+        fake_idata.add_groups(dict(fit_data=data.to_xarray()))
+        model.set_idata_attrs(fake_idata)
+        model.idata = fake_idata
+
+        thin_model = model.thin_fit_result(keep_every=20)
+        assert thin_model is not model
+        assert thin_model.idata is not model.idata
+        assert len(thin_model.idata.posterior["x"].chain) == 4
+        assert len(thin_model.idata.posterior["x"].draw) == 50
+        assert thin_model.data is not model.data
+        assert np.all(thin_model.data == model.data)


### PR DESCRIPTION
CLV summary statistic models can be quite memory intensive and fail with the standard 4k draws. Because these methods are all built assuming there is a `self.idata` lying around (called in multiple places), the two hacky solutions would be to pass a `thin` argument to every method or to modify idata inplace.

This PR instead adds a method that returns a copy of the CLV model with a thinned dataset. A user can then use the methods in this thinned model to obtain summary stats. 

Closes #374 

This PR also cleans up several internals in the CLVModel base-class.

# TODO
- [x] Add test using `customer_lifetime_value`



<!-- readthedocs-preview pymc-marketing start -->
----
:books: Documentation preview :books:: https://pymc-marketing--393.org.readthedocs.build/en/393/

<!-- readthedocs-preview pymc-marketing end -->