### PR TITLE
Correcting typo and adding feedback.

### DIFF
--- a/pymc_marketing/mmm/budget_optimizer.py
+++ b/pymc_marketing/mmm/budget_optimizer.py
@@ -52,14 +52,14 @@ def calculate_expected_contribution(
     total_expected_contribution = 0.0
     contributions = {}
 
-    for channel, channe_budget in budget.items():
+    for channel, channel_budget in budget.items():
         if method == "michaelis-menten":
             L, k = parameters[channel]
-            contributions[channel] = michaelis_menten(channe_budget, L, k)
+            contributions[channel] = michaelis_menten(channel_budget, L, k)
 
         elif method == "sigmoid":
             alpha, lam = parameters[channel]
-            contributions[channel] = extense_sigmoid(channe_budget, alpha, lam)
+            contributions[channel] = extense_sigmoid(channel_budget, alpha, lam)
 
         else:
             raise ValueError("`method` must be either 'michaelis-menten' or 'sigmoid'.")
@@ -164,7 +164,15 @@ def optimize_budget_distribution(
 
     if budget_ranges is None:
         budget_ranges = {
-            channel: (0, min(total_budget, parameters[channel][0]))
+            channel: (
+                0,
+                min(
+                    total_budget,
+                    9 * parameters[channel][1]
+                    if method == "michaelis-menten"
+                    else -np.log(0.1 / 1.9) / parameters[channel][1],
+                ),
+            )
             for channel in channels
         }
 

--- a/pymc_marketing/mmm/budget_optimizer.py
+++ b/pymc_marketing/mmm/budget_optimizer.py
@@ -166,12 +166,7 @@ def optimize_budget_distribution(
         budget_ranges = {
             channel: (
                 0,
-                min(
-                    total_budget,
-                    9 * parameters[channel][1]
-                    if method == "michaelis-menten"
-                    else -np.log(0.1 / 1.9) / parameters[channel][1],
-                ),
+                total_budget,
             )
             for channel in channels
         }

--- a/tests/mmm/test_budget_optimizer.py
+++ b/tests/mmm/test_budget_optimizer.py
@@ -72,7 +72,7 @@ def test_objective_distribution_invalid_method():
 
 # Testing optimize_budget_distribution with valid inputs
 @pytest.mark.parametrize(
-    "method,total_budget,budget_ranges,parameters,channels,expected_sum",
+    "method,total_budget,budget_ranges,parameters,channels,expected_result",
     [
         (
             "michaelis-menten",
@@ -80,7 +80,7 @@ def test_objective_distribution_invalid_method():
             {"channel1": (0, 50), "channel2": (0, 50)},
             {"channel1": (10, 5), "channel2": (20, 10)},
             ["channel1", "channel2"],
-            100,
+            {'channel1': 50.0, 'channel2': 50.0},
         ),
         (
             "sigmoid",
@@ -88,19 +88,18 @@ def test_objective_distribution_invalid_method():
             None,
             {"channel1": (1, 0.5), "channel2": (1, 0.5)},
             ["channel1", "channel2"],
-            2.0,
-        ),  # Updated this line
-        # Add more cases
+            {'channel1': 5.0, 'channel2': 5.0},
+        ),
     ],
 )
 def test_optimize_budget_distribution_valid(
-    method, total_budget, budget_ranges, parameters, channels, expected_sum
+    method, total_budget, budget_ranges, parameters, channels, expected_result
 ):
     result = optimize_budget_distribution(
         method, total_budget, budget_ranges, parameters, channels
     )
-    # Check if sum of budgets equals expected_sum
-    assert sum(result.values()) == pytest.approx(expected_sum, 0.001)
+    # Check if sum of budgets equals total_budget
+    assert sum(result.values()) == pytest.approx(total_budget, 0.001)
     # Check if budgets are within their ranges
     if budget_ranges:
         for channel in channels:
@@ -109,3 +108,6 @@ def test_optimize_budget_distribution_valid(
                 <= result[channel]
                 <= budget_ranges[channel][1]
             )
+    # Check if budgets are close to the expected values
+    for channel in channels:
+        assert result[channel] == pytest.approx(expected_result[channel], 0.001)

--- a/tests/mmm/test_budget_optimizer.py
+++ b/tests/mmm/test_budget_optimizer.py
@@ -80,7 +80,7 @@ def test_objective_distribution_invalid_method():
             {"channel1": (0, 50), "channel2": (0, 50)},
             {"channel1": (10, 5), "channel2": (20, 10)},
             ["channel1", "channel2"],
-            {'channel1': 50.0, 'channel2': 50.0},
+            {"channel1": 50.0, "channel2": 50.0},
         ),
         (
             "sigmoid",
@@ -88,7 +88,7 @@ def test_objective_distribution_invalid_method():
             None,
             {"channel1": (1, 0.5), "channel2": (1, 0.5)},
             ["channel1", "channel2"],
-            {'channel1': 5.0, 'channel2': 5.0},
+            {"channel1": 5.0, "channel2": 5.0},
         ),
     ],
 )


### PR DESCRIPTION
Hey team!

I received initial feedback from a friend regarding the optimizer function they used for their custom MMM. 

They pointed out a small typo and some bugs in the default parameters when the optimizer bounds are set to `None`. Although these were minor issues, I have made the corrections that were needed.

<!-- readthedocs-preview pymc-marketing start -->
----
:books: Documentation preview :books:: https://pymc-marketing--395.org.readthedocs.build/en/395/

<!-- readthedocs-preview pymc-marketing end -->