### PR TITLE
Custom priors & Dist to MMM DelayedSaturated

### DIFF
--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -172,7 +172,7 @@ class BaseDelayedSaturatedMMM(MMM):
         model : pm.Model
             The PyMC model object containing all the defined stochastic and deterministic variables.
         """
-        model_config = self.model_config
+        # model_config = self.model_config
         self.intercept = self._create_distribution(self.model_config["intercept"])
         self.beta_channel = self._create_distribution(self.model_config["beta_channel"])
         self.lam = self._create_distribution(self.model_config["lam"])

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -320,7 +320,7 @@ class BaseDelayedSaturatedMMM(MMM):
                 mu_var += fourier_contribution.sum(axis=-1)
 
             mu = pm.Deterministic(
-                name="mu", var=mu_var, dims=model_config["mu"]["dims"]
+                name="mu", var=mu_var, dims=("date",)
             )
 
             pm.Normal(
@@ -328,7 +328,7 @@ class BaseDelayedSaturatedMMM(MMM):
                 mu=mu,
                 sigma=sigma,
                 observed=target_,
-                dims=model_config["likelihood"]["dims"],
+                dims=("date",),
             )
 
     @property


### PR DESCRIPTION
Hey guys, I'm applying the same configuration of the models on CLV to the MMM models, the idea is to be able to pass priors and custom distributions based on the user needs.

Everything was working properly on the mmm example notebook, except for the `fit()` method 😅 Here is the traceback, looks like is not directly related to the changes:

```
---------------------------------------------------------------------------
NotImplementedError                       Traceback (most recent call last)
<ipython-input-26-e8614295d821> in <cell line: 1>()
----> 1 mmm.fit(X=X, y=y, target_accept=0.95, chains=4, random_seed=rng)

10 frames
/content/pymc-marketing/pymc_marketing/model_builder.py in fit(self, X, y, progressbar, predictor_names, random_seed, **kwargs)
    475             with self.model:
    476                 sampler_args = {**self.sampler_config, **kwargs}
--> 477                 self.idata = pm.sample(**sampler_args)
    478 
    479         X_df = pd.DataFrame(X, columns=X.columns)

/usr/local/lib/python3.10/dist-packages/pymc/sampling/mcmc.py in sample(draws, tune, chains, cores, random_seed, progressbar, step, nuts_sampler, initvals, init, jitter_max_retries, n_init, trace, discard_tuned_samples, compute_convergence_checks, keep_warning_stat, return_inferencedata, idata_kwargs, nuts_sampler_kwargs, callback, mp_ctx, model, **kwargs)
    649 
    650     initial_points = None
--> 651     step = assign_step_methods(model, step, methods=pm.STEP_METHODS, step_kwargs=kwargs)
    652 
    653     if nuts_sampler != "pymc":

/usr/local/lib/python3.10/dist-packages/pymc/sampling/mcmc.py in assign_step_methods(model, step, methods, step_kwargs)
    209     methods_list: List[Type[BlockedStep]] = list(methods or pm.STEP_METHODS)
    210     selected_steps: Dict[Type[BlockedStep], List] = {}
--> 211     model_logp = model.logp()
    212 
    213     for var in model.value_vars:

/usr/local/lib/python3.10/dist-packages/pymc/model/core.py in logp(self, vars, jacobian, sum)
    738             return logp_factors
    739 
--> 740         logp_scalar = pt.sum([pt.sum(factor) for factor in logp_factors])
    741         logp_scalar_name = "__logp" if jacobian else "__logp_nojac"
    742         if self.name:

/usr/local/lib/python3.10/dist-packages/pymc/model/core.py in <listcomp>(.0)
    738             return logp_factors
    739 
--> 740         logp_scalar = pt.sum([pt.sum(factor) for factor in logp_factors])
    741         logp_scalar_name = "__logp" if jacobian else "__logp_nojac"
    742         if self.name:

/usr/local/lib/python3.10/dist-packages/pytensor/tensor/math.py in sum(input, axis, dtype, keepdims, acc_dtype)
   2502     """
   2503 
-> 2504     out = Sum(axis=axis, dtype=dtype, acc_dtype=acc_dtype)(input)
   2505 
   2506     if keepdims:

/usr/local/lib/python3.10/dist-packages/pytensor/graph/op.py in __call__(self, *inputs, **kwargs)
    302         """
    303         return_list = kwargs.pop("return_list", False)
--> 304         node = self.make_node(*inputs, **kwargs)
    305 
    306         if config.compute_test_value != "off":

/usr/local/lib/python3.10/dist-packages/pytensor/tensor/elemwise.py in make_node(self, input)
   1384 
   1385     def make_node(self, input):
-> 1386         input = as_tensor_variable(input)
   1387         inp_dims = input.type.ndim
   1388         inp_dtype = input.type.dtype

/usr/local/lib/python3.10/dist-packages/pytensor/tensor/__init__.py in as_tensor_variable(x, name, ndim, **kwargs)
     47 
     48     """
---> 49     return _as_tensor_variable(x, name, ndim, **kwargs)
     50 
     51 

/usr/lib/python3.10/functools.py in wrapper(*args, **kw)
    887                             '1 positional argument')
    888 
--> 889         return dispatch(args[0].__class__)(*args, **kw)
    890 
    891     funcname = getattr(func, '__name__', 'singledispatch function')

/usr/local/lib/python3.10/dist-packages/pytensor/tensor/__init__.py in _as_tensor_variable(x, name, ndim, **kwargs)
     54     x: TensorLike, name: Optional[str], ndim: Optional[int], **kwargs
     55 ) -> "TensorVariable":
---> 56     raise NotImplementedError(f"Cannot convert {x!r} to a tensor variable.")
     57 
     58 

NotImplementedError: Cannot convert None to a tensor variable.
```

I'll be debugging during the week but if anyone has an idea about what could be, perhaps I can save some time 👍 