### PR TITLE
MMM: improve validation check for dataframes with correct indices

### DIFF
--- a/pymc_marketing/mmm/validating.py
+++ b/pymc_marketing/mmm/validating.py
@@ -12,14 +12,6 @@ __all__ = [
 ]
 
 
-def _has_valid_indices(df: pd.DataFrame) -> bool:
-    return (
-        isinstance(df.index, pd.RangeIndex)
-        and df.index.start == 0
-        and df.index.stop == len(df)
-    )
-
-
 def validation_method_y(method: Callable) -> Callable:
     if not hasattr(method, "_tags"):
         method._tags = {}  # type: ignore
@@ -49,7 +41,11 @@ class ValidateDateColumn:
         if self.date_column not in data.columns:
             raise ValueError(f"date_col {self.date_column} not in data")
 
-        if not _has_valid_indices(data):
+        if (
+            not isinstance(data.index, pd.RangeIndex)
+            or data.index.start != 0
+            or data.index.stop != len(data)
+        ):
             raise ValueError(
                 "X or y has incorrect indices. Try to reset with `data.reset_index(inplace=True)`"
             )

--- a/pymc_marketing/mmm/validating.py
+++ b/pymc_marketing/mmm/validating.py
@@ -12,6 +12,14 @@ __all__ = [
 ]
 
 
+def _has_valid_indices(df: pd.DataFrame) -> bool:
+    return (
+        isinstance(df.index, pd.RangeIndex)
+        and df.index.start == 0
+        and df.index.stop == len(df)
+    )
+
+
 def validation_method_y(method: Callable) -> Callable:
     if not hasattr(method, "_tags"):
         method._tags = {}  # type: ignore
@@ -40,6 +48,12 @@ class ValidateDateColumn:
     def validate_date_col(self, data: pd.DataFrame) -> None:
         if self.date_column not in data.columns:
             raise ValueError(f"date_col {self.date_column} not in data")
+
+        if not _has_valid_indices(data):
+            raise ValueError(
+                "X or y has incorrect indices. Try to reset with `data.reset_index(inplace=True)`"
+            )
+
         if not data[self.date_column].is_unique:
             raise ValueError(f"date_col {self.date_column} has repeated values")
 


### PR DESCRIPTION
Fixes the issue discussed in #346 Data validation errors in MMM due to pandas index

Since seasonality seem to assume that the index is in order, I've opted to return the error to the user and be explicit about what needs to be fixed

<!-- readthedocs-preview pymc-marketing start -->
----
:books: Documentation preview :books:: https://pymc-marketing--402.org.readthedocs.build/en/402/

<!-- readthedocs-preview pymc-marketing end -->