### PR TITLE
Components

### DIFF
--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -1,4 +1,4 @@
-from functools import partial
+from functools import partial, wraps
 import json
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
@@ -24,6 +24,7 @@ __all__ = ["DelayedSaturatedMMM"]
 
 def deterministic_wrapper(func, name: str, model=None, dims=None): 
     """Same signature as func but creates a Deterministic variable too."""
+    @wraps(func)
     def wrapped_func(*args, **kwargs): 
         return pm.Deterministic(name=name, var=func(*args, **kwargs), dims=dims, model=model)
     


### PR DESCRIPTION
Had something like this in mind @ricardoV94 

Would this break the model loading? or were you saying that changes / refactor cannot happen in the `build_model` method. 

I assumed that since the `build_model` is called after the load that any refactored code would be used. Maybe this breaks the hashing part, but I need to look into that. 

At the moment, the forward pass of the model is defined a few times which make bugs like #400 much more prone. I think pulling out large blocks like this can help: 

1. reduce the copy and paste to perform elsewhere
2. Give users another options to perform marketing specific logic within `pymc.Model` block

<!-- readthedocs-preview pymc-marketing start -->
----
:books: Documentation preview :books:: https://pymc-marketing--404.org.readthedocs.build/en/404/

<!-- readthedocs-preview pymc-marketing end -->