### PR TITLE
Refactor mmm allow user defined priors

### DIFF
--- a/pymc_marketing/clv/models/basic.py
+++ b/pymc_marketing/clv/models/basic.py
@@ -1,17 +1,14 @@
 import json
-import types
 import warnings
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Union
 
 import arviz as az
 import numpy as np
 import pandas as pd
 import pymc as pm
-from pymc import str_for_dist
 from pymc.backends import NDArray
 from pymc.backends.base import MultiTrace
-from pytensor.tensor import TensorVariable
 from xarray import Dataset
 
 from pymc_marketing.model_builder import ModelBuilder
@@ -191,34 +188,6 @@ class CLVModel(ModelBuilder):
         # All previously used data is in idata.
 
         return model
-
-    @staticmethod
-    def _check_prior_ndim(prior, ndim: int = 0):
-        if prior.ndim != ndim:
-            raise ValueError(
-                f"Prior variable {prior} must be have {ndim} ndims, but it has {prior.ndim} ndims."
-            )
-
-    @staticmethod
-    def _create_distribution(dist: Dict, ndim: int = 0) -> TensorVariable:
-        try:
-            prior_distribution = getattr(pm, dist["dist"]).dist(**dist["kwargs"])
-            CLVModel._check_prior_ndim(prior_distribution, ndim)
-        except AttributeError:
-            raise ValueError(f"Distribution {dist['dist']} does not exist in PyMC")
-        return prior_distribution
-
-    @staticmethod
-    def _process_priors(
-        *priors: TensorVariable, check_ndim: bool = True
-    ) -> Tuple[TensorVariable, ...]:
-        """Check that each prior variable is unique and attach `str_repr` method."""
-        if len(priors) != len(set(priors)):
-            raise ValueError("Prior variables must be unique")
-        # Related to https://github.com/pymc-devs/pymc/issues/6311
-        for prior in priors:
-            prior.str_repr = types.MethodType(str_for_dist, prior)  # type: ignore
-        return priors
 
     @property
     def default_sampler_config(self) -> Dict:

--- a/pymc_marketing/model_builder.py
+++ b/pymc_marketing/model_builder.py
@@ -447,23 +447,6 @@ class ModelBuilder(ABC):
             prior.str_repr = types.MethodType(str_for_dist, prior)  # type: ignore
         return priors
 
-    def register_rv(
-        self,
-        name: str,
-        observed: Any | None = None,
-        total_size: Any | None = None,
-        dims: Any | None = None,
-        transform: None = None,
-    ):
-        """Register random variables and priors from model_config to the pm.model object."""
-        rv_var = self._create_distribution(self.model_config[name])
-        self._process_priors(rv_var)
-        setattr(self, name, rv_var)
-
-        dims = self.model_config[name].get("dims")
-        rv = self.model.register_rv(rv_var, name=name, dims=dims)
-        return rv
-
     def fit(
         self,
         X: pd.DataFrame,

--- a/tests/mmm/test_delayed_saturated_mmm.py
+++ b/tests/mmm/test_delayed_saturated_mmm.py
@@ -41,26 +41,41 @@ def toy_X() -> pd.DataFrame:
 @pytest.fixture(scope="class")
 def model_config_requiring_serialization() -> dict:
     model_config = {
-        "intercept": {"mu": 0, "sigma": 2},
+        "intercept": {"dist": "Normal", "kwargs": {"mu": 0, "sigma": 2}},
         "beta_channel": {
-            "sigma": np.array([0.4533017, 0.25488063]),
+            "dist": "HalfNormal",
+            "kwargs": {"sigma": np.array([0.4533017, 0.25488063])},
             "dims": ("channel",),
         },
         "alpha": {
-            "alpha": np.array([3, 3]),
-            "beta": np.array([3.55001301, 2.87092431]),
+            "dist": "Beta",
+            "kwargs": {
+                "alpha": np.array([3, 3]),
+                "beta": np.array([3.55001301, 2.87092431]),
+            },
             "dims": ("channel",),
         },
         "lam": {
-            "alpha": np.array([3, 3]),
-            "beta": np.array([4.12231653, 5.02896872]),
+            "dist": "Gamma",
+            "kwargs": {
+                "alpha": np.array([3, 3]),
+                "beta": np.array([4.12231653, 5.02896872]),
+            },
             "dims": ("channel",),
         },
-        "sigma": {"sigma": 2},
-        "gamma_control": {"mu": 0, "sigma": 2, "dims": ("control",)},
+        "sigma": {"dist": "HalfNormal", "kwargs": {"sigma": 2}},
+        "gamma_control": {
+            "dist": "Normal",
+            "kwargs": {"mu": 0, "sigma": 2},
+            "dims": ("control",),
+        },
+        "gamma_fourier": {
+            "dist": "Laplace",
+            "kwargs": {"mu": 0, "b": 1},
+            "dims": "fourier_mode",
+        },
         "mu": {"dims": ("date",)},
         "likelihood": {"dims": ("date",)},
-        "gamma_fourier": {"mu": 0, "b": 1, "dims": "fourier_mode"},
     }
     return model_config
 


### PR DESCRIPTION
This PR intends to add custom priors to the DelayedSaturation MMM model

There is an issue however and would love for some feedback and help on how to fix it.
The DelayedSaturation MMM uses priors with dims, but the CLV model I've copied from does not. I'm currious how to add that for the priors to make the code and tests pass?



<!-- readthedocs-preview pymc-marketing start -->
----
:books: Documentation preview :books:: https://pymc-marketing--408.org.readthedocs.build/en/408/

<!-- readthedocs-preview pymc-marketing end -->