### PR TITLE
Add HSGP prior

### DIFF
--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -309,6 +309,7 @@ class BaseDelayedSaturatedMMM(MMM):
     
         # Loop over the stacked priors and stack them along axis 1.
         for param, priors_list in stacked_priors.items():
+            print(param)
             if priors_list: priors[param] = pm.math.stack(priors_list, axis=1)
 
         return priors

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -213,14 +213,10 @@ class BaseDelayedSaturatedMMM(MMM):
                 var=logistic_saturation(x=channel_adstock, lam=lam),
                 dims=("date", "channel"),
             )
-
-            #Debug for shape error of channel contributions
-            print("Shape of channel_adstock_saturated:", channel_adstock_saturated.shape.eval())
-            print("Shape of beta_channel:", beta_channel.shape.eval())
-
+ 
             channel_contributions = pm.Deterministic(
                 name="channel_contributions",
-                var=channel_adstock_saturated.T * beta_channel,
+                var=channel_adstock_saturated * beta_channel,
                 dims=("date", "channel"),
             )
 

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -300,7 +300,7 @@ class BaseDelayedSaturatedMMM(MMM):
 
                 if prior_type == "tvp":
                     if length > 1:
-                        stacked_priors[param] = self.create_tvp_priors(param, config, length)
+                        stacked_priors[param] = self.create_tvp_priors(param, config, length, positive=is_positive)
                     else:
                         priors[param] = self.gp_wrapper(name=param, X=np.arange(len(self.X[self.date_column]))[:, None], positive=is_positive)
                     continue
@@ -340,9 +340,8 @@ class BaseDelayedSaturatedMMM(MMM):
 
         return likelihood_func(name="likelihood", mu=mu, observed=target_, dims=dims, **sub_priors)
 
-    def create_tvp_priors(self, param, config, length):
-        return [self.gp_wrapper(name=f"{param}_{i}", X=np.arange(len(self.X[self.date_column]))[:, None]) for i in range(length)]
-
+    def create_tvp_priors(self, param, config, length, positive=False):
+        return [self.gp_wrapper(name=f"{param}_{i}", X=np.arange(len(self.X[self.date_column]))[:, None], positive=positive) for i in range(length)]
 
     def gp_wrapper(self, name, X, mean=0, positive=False, **kwargs):
         return self.gp_coeff(X, name, mean=mean, positive=positive, **kwargs)
@@ -358,7 +357,7 @@ class BaseDelayedSaturatedMMM(MMM):
         f_raw = gp.prior(f"{name}_tvp_raw", X=X)
     
         if positive:
-            f_output = pm.Deterministic(f"{name}", pt.exp(pt.log(f_raw), dims=("date")))
+            f_output = pm.Deterministic(f"{name}", pt.exp(f_raw), dims=("date"))
         else:
             f_output = pm.Deterministic(f"{name}", f_raw, dims=("date"))
     

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -296,6 +296,7 @@ class BaseDelayedSaturatedMMM(MMM):
 
                 # Check if this parameter should be positive
                 is_positive = param in positive_params
+                print(is_positive)
 
                 if prior_type == "tvp":
                     if length > 1:
@@ -352,13 +353,8 @@ class BaseDelayedSaturatedMMM(MMM):
         ell = pm.InverseGamma(f"ell_{name}", **params)
         eta = pm.Exponential(f"_eta_{name}", lam=1 / 0.5)
         cov = eta ** 2 * pm.gp.cov.ExpQuad(1, ls=ell)
-    
-        if positive:
-            mean_func = pm.gp.mean.Constant(c=-pm.math.log(2))
-        else:
-            mean_func = pm.gp.mean.Constant(c=0)
         
-        gp = pm.gp.HSGP(m=[20], mean_func=mean_func, c=1.3, cov_func=cov)
+        gp = pm.gp.HSGP(m=[20], c=1.3, cov_func=cov)
         f_raw = gp.prior(f"{name}_tvp_raw", X=X)
     
         f_output = pm.Deterministic(f"{name}", pm.math.log1pexp(f_raw) if positive else f_raw, dims=("date"))

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -315,7 +315,6 @@ class BaseDelayedSaturatedMMM(MMM):
 
         return priors
 
-
     def create_likelihood(self, model_config, target_, mu):
         likelihood_config = model_config.get("likelihood", {})
         likelihood_type = likelihood_config.get("type")
@@ -328,6 +327,10 @@ class BaseDelayedSaturatedMMM(MMM):
         if likelihood_func is None:
             raise ValueError(f"Invalid likelihood type {likelihood_type}")
 
+        # Transform mu if the likelihood type is Lognormal or HurdleLognormal
+        if likelihood_type in ['LogNormal', 'HurdleLogNormal']:
+            mu = pt.log(mu)
+
         # Create sub-priors
         sub_priors = {}
         for param, config in likelihood_config.items():
@@ -337,6 +340,9 @@ class BaseDelayedSaturatedMMM(MMM):
                         sub_priors[sub_param] = self.create_priors_from_config({sub_param: sub_config})[sub_param]
                 else:
                     sub_priors[param] = self.create_priors_from_config({param: config})[param]
+
+        return likelihood_func(name="likelihood", mu=mu, observed=target_, dims=dims, **sub_priors)
+
 
         return likelihood_func(name="likelihood", mu=mu, observed=target_, dims=dims, **sub_priors)
 

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -330,6 +330,8 @@ class BaseDelayedSaturatedMMM(MMM):
         # Transform mu if the likelihood type is Lognormal or HurdleLognormal
         if likelihood_type in ['LogNormal', 'HurdleLogNormal']:
             mu = pt.log(mu)
+            sigma = pm.HalfNormal(name="sigma", sigma=0.1)
+            u = pm.Uniform("sturtural_noise_part")
 
         # Create sub-priors
         sub_priors = {}
@@ -341,10 +343,8 @@ class BaseDelayedSaturatedMMM(MMM):
                 else:
                     sub_priors[param] = self.create_priors_from_config({param: config})[param]
 
-        return likelihood_func(name="likelihood", mu=mu, observed=target_, dims=dims, **sub_priors)
-
-
-        return likelihood_func(name="likelihood", mu=mu, observed=target_, dims=dims, **sub_priors)
+        return likelihood_func(name="likelihood", mu=mu, observed=target_, sigma=sigma * (1-u) ** .5, dims=dims,  **sub_priors)
+      #  return likelihood_func(name="likelihood", mu=mu, observed=target_, dims=dims,  **sub_priors)
 
     def create_tvp_priors(self, param, config, length, positive=False):
         dims = config.get("dims", None)  # Extracting dims from the config

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -306,6 +306,7 @@ class BaseDelayedSaturatedMMM(MMM):
                     try:
                         length = dimensions.get(config.get("dims", [None, None])[1], 1)
                     except IndexError:
+                        print("indexerror so building it diffeent way")
                         priors[param] = self.gp_wrapper(name=param, X=np.arange(len(self.X[self.date_column]))[:, None], mean=0, positive=is_positive, **kwargs)
                         continue
 

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -292,7 +292,7 @@ class BaseDelayedSaturatedMMM(MMM):
 
             prior_type = config.get("type")
             if prior_type is not None:
-                dim, length = config.get("dims")[0], dimensions.get(config.get("dims")[0], 1)
+                length = dimensions.get(config.get("dims", [None])[0], 1)
 
                 # Check if this parameter should be positive
                 is_positive = param in positive_params

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -293,17 +293,14 @@ class BaseDelayedSaturatedMMM(MMM):
 
             prior_type = config.get("type")
             if prior_type is not None:
-                length = dimensions.get(config.get("dims", [None])[0], 1)
 
                 # Check if this parameter should be positive
                 is_positive = param in positive_params
                 print(is_positive)
 
                 if prior_type == "tvp":
-                    if length > 1:
-                        priors[param] = self.create_tvp_priors(param, config, length, positive=is_positive)
-                    else:
-                        priors[param] = self.gp_wrapper(name=param, X=np.arange(len(self.X[self.date_column]))[:, None], positive=is_positive)
+                        print("making tvp priors")
+                        priors[param] = self.create_tvp_priors(param, config, positive=is_positive)
                     continue
 
                 dist_func = getattr(pm, prior_type, None)

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -348,11 +348,12 @@ class BaseDelayedSaturatedMMM(MMM):
         
         gp = pm.gp.HSGP(m=[20], c=1.3, cov_func=cov)
         f_raw = gp.prior(f"{param}_tvp_raw", X=np.arange(len(self.X[self.date_column]))[:, None], dims=dims)
+        print(f_raw.shape.eval())
 
         if positive:
             f = np.exp(f_raw)
         else:
-            f = np.exp(f_raw) 
+            f = f_raw 
         return f
 
 

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -357,10 +357,12 @@ class BaseDelayedSaturatedMMM(MMM):
         return self.gp_coeff(X, name, config=config, positive=positive, **kwargs)
 
     def gp_coeff(self, X, name, mean=0.0, positive=False, config=None):
-        params = pm.find_constrained_prior(pm.Gamma, 1, 2, init_guess={"alpha": 1, "beta": 1}, mass=0.9)
+        params = pm.find_constrained_prior(pm.Gamma, 2, 4, init_guess={"alpha": 1, "beta": 1}, mass=0.9)
         ell = pm.Gamma(f"ell_{name}", **params)
         eta = pm.Exponential(f"_eta_{name}", lam=0.1)
-        cov = eta ** 2 * pm.gp.cov.ExpQuad(1, ls=ell)
+  #      cov = eta ** 2 * pm.gp.cov.ExpQuad(1, ls=ell)
+
+        cov = eta ** 2 * pm.gp.cov.Matern32(1, ls=ell)
     
         gp = pm.gp.HSGP(m=[40], c=4, cov_func=cov)
         f_raw = gp.prior(f"{name}_tvp_raw", X=X)

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -282,37 +282,30 @@ class BaseDelayedSaturatedMMM(MMM):
             likelihood = self.create_likelihood(self.model_config, target_, mu)
 
     def create_priors_from_config(self, model_config):
-        # Initialize an empty dictionary for storing priors and dimensions.
         priors, dimensions = {}, {"channel": len(self.channel_columns), "control": len(self.control_columns)}
-        stacked_priors = {"channel": [], "control": []}
+        stacked_priors = {}
 
-        # Loop over the model configuration items.
         for param, config in model_config.items():
-            # Skip the 'likelihood' part.
             if param == "likelihood": continue
             prior_type = config.get("type")
         
-            # If the prior type is 'tvp' (Time Varying Parameter).
             if prior_type == "tvp":
-                # Get the dimension and its length, default length is 1.
                 dim, length = config.get("dims")[0], dimensions.get(config.get("dims")[0], 1)
-                stacked_priors[dim].extend(self.create_tvp_priors(param, config, length))
+                stacked_priors[param] = self.create_tvp_priors(param, config, length)
                 continue
 
             if prior_type:
                 dist_func = getattr(pm, prior_type, None)
-                if dist_func is None: raise ValueError(f"Invalid distribution type {prior_type}")
-            
-                # Remove the 'type' key and create a new prior.
+                if not dist_func: raise ValueError(f"Invalid distribution type {prior_type}")
                 config_copy = {k: v for k, v in config.items() if k != "type"}
                 priors[param] = dist_func(name=param, **config_copy)
-    
-        # Loop over the stacked priors and stack them along axis 1.
+
         for param, priors_list in stacked_priors.items():
             print(param)
             if priors_list: priors[param] = pm.math.stack(priors_list, axis=1)
 
         return priors
+
 
 
 

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -359,7 +359,7 @@ class BaseDelayedSaturatedMMM(MMM):
     def gp_coeff(self, X, name, mean=0.0, positive=False, config=None):
         params = pm.find_constrained_prior(pm.Gamma, 8, 12, init_guess={"alpha": 12, "beta": 1}, mass=0.75)
         ell = pm.Gamma(f"ell_{name}", **params)
-        eta = pm.Exponential(f"_eta_{name}", lam=10)
+        eta = pm.Exponential(f"_eta_{name}", lam=0.1)
         cov = eta ** 2 * pm.gp.cov.ExpQuad(1, ls=ell)
     
         gp = pm.gp.HSGP(m=[200], c=2, cov_func=cov)

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -357,12 +357,12 @@ class BaseDelayedSaturatedMMM(MMM):
         return self.gp_coeff(X, name, config=config, positive=positive, **kwargs)
 
     def gp_coeff(self, X, name, mean=0.0, positive=False, config=None):
-        params = pm.find_constrained_prior(pm.Gamma, 8, 12, init_guess={"alpha": 12, "beta": 1}, mass=0.75)
+        params = pm.find_constrained_prior(pm.Gamma, 1, 2, init_guess={"alpha": 1, "beta": 1}, mass=0.9)
         ell = pm.Gamma(f"ell_{name}", **params)
         eta = pm.Exponential(f"_eta_{name}", lam=0.1)
         cov = eta ** 2 * pm.gp.cov.ExpQuad(1, ls=ell)
     
-        gp = pm.gp.HSGP(m=[200], c=2, cov_func=cov)
+        gp = pm.gp.HSGP(m=[40], c=4, cov_func=cov)
         f_raw = gp.prior(f"{name}_tvp_raw", X=X)
     
 

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -343,7 +343,7 @@ class BaseDelayedSaturatedMMM(MMM):
         print(dims)
         gp_list = [self.gp_wrapper(name=f"{param}_{i}", X=np.arange(len(self.X[self.date_column]))[:, None], positive=positive) for i in range(length)]
         stacked_gp = pt.stack(gp_list, axis=1)
-        return pm.Deterministic(f"{param}", stacked_gp, dims=dims)
+        return pm.Deterministic(f"{param}_test", stacked_gp, dims=dims)
 
 
     def gp_wrapper(self, name, X, mean=0, positive=False, **kwargs):

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -341,9 +341,9 @@ class BaseDelayedSaturatedMMM(MMM):
     def create_tvp_priors(self, param, config, length, positive=False):
         dims = config.get("dims", None)  # Extracting dims from the config
         gp_list = [self.gp_wrapper(name=f"{param}_{i}", X=np.arange(len(self.X[self.date_column]))[:, None], positive=positive) for i in range(length)]
-        concatenated_gp = pt.concatenate(gp_list, axis=1)
-        print("Concatenated shape:", concatenated_gp.shape.eval())
-        return pm.Deterministic(f"{param}", concatenated_gp, dims=dims)
+        stacked_gp = pt.stack(gp_list, axis=1)
+        print("stacked shape:", stacked_gp.shape.eval())
+        return pm.Deterministic(f"{param}", stacked_gp, dims=dims)
 
 
     def gp_wrapper(self, name, X, mean=0, positive=False, **kwargs):

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -357,7 +357,7 @@ class BaseDelayedSaturatedMMM(MMM):
         return self.gp_coeff(X, name, config=config, positive=positive, **kwargs)
 
     def gp_coeff(self, X, name, mean=0.0, positive=False, config=None):
-        params = pm.find_constrained_prior(pm.Gamma, 4, 8, init_guess={"alpha": 1, "beta": 1}, mass=0.8)
+        params = pm.find_constrained_prior(pm.Gamma, 8, 12, init_guess={"alpha": 1, "beta": 1}, mass=0.8)
         ell = pm.Gamma(f"ell_{name}", **params)
         eta = pm.Exponential(f"_eta_{name}", lam=1)
   #      cov = eta ** 2 * pm.gp.cov.ExpQuad(1, ls=ell)

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -303,7 +303,7 @@ class BaseDelayedSaturatedMMM(MMM):
 
                 if prior_type == "tvp":
                     if param in ["intercept", "lam", "alpha", "sigma"]:
-                        priors[param] = self.gp_wrapper(name=param, X=np.arange(len(self.X[self.date_column]))[:, None], mean=0, positive=is_positive, **kwargs)
+                        priors[param] = self.gp_wrapper(name=param, X=np.arange(len(self.X[self.date_column]))[:, None], mean=0, positive=is_positive)
                         continue
 
                     length = dimensions.get(config.get("dims", [None, None])[1], 1)

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -299,10 +299,10 @@ class BaseDelayedSaturatedMMM(MMM):
             prior_type = config.get("type")
 
             if prior_type == "tvp":
-                dim = config.get("dims")
-                priors_list = self.create_tvp_priors(param, config, dimensions[dim])
-                stacked_priors[dim].extend(priors_list)
+                priors_list = self.create_tvp_priors(param, config, dimensions[config.get("dims")[0]])
+                stacked_priors[config.get("dims")[0]].extend(priors_list)
                 continue
+
 
             if prior_type:
                 dist_func = getattr(pm, prior_type, None)

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -354,7 +354,7 @@ class BaseDelayedSaturatedMMM(MMM):
         cov = eta ** 2 * pm.gp.cov.ExpQuad(1, ls=ell)
     
         if positive:
-            mean_func = pm.gp.mean.Constant(c=-log(2))
+            mean_func = pm.gp.mean.Constant(c=-pm.math.log(2))
         else:
             mean_func = pm.gp.mean.Constant(c=0)
         

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -357,7 +357,10 @@ class BaseDelayedSaturatedMMM(MMM):
         gp = pm.gp.HSGP(m=[20], c=1.3, cov_func=cov)
         f_raw = gp.prior(f"{name}_tvp_raw", X=X)
     
-        f_output = pm.Deterministic(f"{name}", pm.math.exp(f_raw) if positive else f_raw, dims=("date"))
+        if positive:
+            f_output = pm.Deterministic(f"{name}", pt.exp(pt.log(f_raw), dims=("date"))
+        else:
+            f_output = pm.Deterministic(f"{name}", f_raw, dims=("date"))
     
         return f_output
 

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -356,14 +356,13 @@ class BaseDelayedSaturatedMMM(MMM):
     def gp_wrapper(self, name, X, config, positive=False, **kwargs):
         return self.gp_coeff(X, name, config=config, positive=positive, **kwargs)
 
-
     def gp_coeff(self, X, name, mean=0.0, positive=False, config=None):
-        params = pm.find_constrained_prior(pm.InverseGamma, 0.5, 2, init_guess={"alpha": 2, "beta": 1}, mass=0.95)
+        params = pm.find_constrained_prior(pm.InverseGamma, 8, 12, init_guess={"alpha": 1, "beta": 1}, mass=0.90)
         ell = pm.InverseGamma(f"ell_{name}", **params)
         eta = pm.Exponential(f"_eta_{name}", lam=1 / 0.5)
         cov = eta ** 2 * pm.gp.cov.ExpQuad(1, ls=ell)
     
-        gp = pm.gp.HSGP(m=[20], c=1.3, cov_func=cov)
+        gp = pm.gp.HSGP(m=[40], c=2, cov_func=cov)
         f_raw = gp.prior(f"{name}_tvp_raw", X=X)
     
 

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -347,7 +347,7 @@ class BaseDelayedSaturatedMMM(MMM):
         cov = eta ** 2 * pm.gp.cov.ExpQuad(1, ls=ell)
         
         gp = pm.gp.HSGP(m=[20], c=1.3, cov_func=cov)
-        f_raw = gp.prior(f"{param}_tvp_raw", X=p.arange(len(self.X[self.date_column]))[:, None], dims=dims)
+        f_raw = gp.prior(f"{param}_tvp_raw", X=np.arange(len(self.X[self.date_column]))[:, None], dims=dims)
 
         if positive:
             f = np.exp(f_raw)

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -220,7 +220,7 @@ class BaseDelayedSaturatedMMM(MMM):
 
             channel_contributions = pm.Deterministic(
                 name="channel_contributions",
-                var=channel_adstock_saturated * beta_channel,
+                var=channel_adstock_saturated.T * beta_channel,
                 dims=("date", "channel"),
             )
 

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -357,9 +357,9 @@ class BaseDelayedSaturatedMMM(MMM):
         return self.gp_coeff(X, name, config=config, positive=positive, **kwargs)
 
     def gp_coeff(self, X, name, mean=0.0, positive=False, config=None):
-        params = pm.find_constrained_prior(pm.Gamma, 2, 4, init_guess={"alpha": 1, "beta": 1}, mass=0.9)
+        params = pm.find_constrained_prior(pm.Gamma, 4, 8, init_guess={"alpha": 1, "beta": 1}, mass=0.8)
         ell = pm.Gamma(f"ell_{name}", **params)
-        eta = pm.Exponential(f"_eta_{name}", lam=0.1)
+        eta = pm.Exponential(f"_eta_{name}", lam=1)
   #      cov = eta ** 2 * pm.gp.cov.ExpQuad(1, ls=ell)
 
         cov = eta ** 2 * pm.gp.cov.Matern32(1, ls=ell)

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -300,11 +300,12 @@ class BaseDelayedSaturatedMMM(MMM):
                 print(is_positive)
 
                 if prior_type == "tvp":
-                    length = dimensions.get(config.get("dims", [None, None])[1], 1)
-                 #   if length > 1:
+                    try:
+                        length = dimensions.get(config.get("dims", [None, None])[1], 1)
+                    except IndexError:
+                        length = 1
+
                     priors[param] = self.create_tvp_priors(param, config, length, positive=is_positive)
-                #    else:
-                 #       priors[param] = self.gp_wrapper(name=param, X=np.arange(len(self.X[self.date_column]))[:, None], positive=is_positive)
                     continue
 
                 dist_func = getattr(pm, prior_type, None)

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -300,7 +300,7 @@ class BaseDelayedSaturatedMMM(MMM):
                 continue
 
             if prior_type:
-                dist_func = getattr(pm, prior_type, None).
+                dist_func = getattr(pm, prior_type, None)
                 if dist_func is None: raise ValueError(f"Invalid distribution type {prior_type}")
             
                 # Remove the 'type' key and create a new prior.

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -335,7 +335,7 @@ class BaseDelayedSaturatedMMM(MMM):
 
         return likelihood_func(name="likelihood", mu=mu, observed=target_, dims=dims, **sub_priors)
 
-    def create_tvp_priors(self, param, config, length, positive=False):
+    def create_tvp_priors(self, param, config, positive=False):
         dims = config.get("dims", None)  # Extracting dims from the config
         print(dims)
         params = pm.find_constrained_prior(pm.InverseGamma, 0.5, 2, init_guess={"alpha": 2, "beta": 1}, mass=0.95)

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -287,7 +287,8 @@ class BaseDelayedSaturatedMMM(MMM):
     
         for param, config in model_config.items():
             if param == "likelihood": continue
-            prior_type, dim = config.get("type"), config.get("dims")[0]
+            prior_type = config.get("type")
+            dim = config.get("dims")[0]
             print(prior_type)
             length = dimensions.get(dim, 1)
         

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -235,6 +235,11 @@ class BaseDelayedSaturatedMMM(MMM):
                     dims=("date", "control"),
                 )
 
+                print("Shape of control_data_:", control_data_.eval().shape)
+                print("Shape of control_data_:", control_data_.eval().shape)
+
+
+
                 control_contributions = pm.Deterministic(
                     name="control_contributions",
                     var=control_data_ * gamma_control,

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -188,7 +188,7 @@ class BaseDelayedSaturatedMMM(MMM):
             )
 
             #Building the priors
-            priors = self.create_priors_from_config(self.model_config)
+            priors = self.create_priors_from_config(self.model_config, idata)
 
             #Specifying the variables
             intercept = priors['intercept']

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -310,11 +310,6 @@ class BaseDelayedSaturatedMMM(MMM):
 
         return priors
 
-
-
-
-
-
     def create_likelihood(self, model_config, target_, mu):
         likelihood_config = model_config.get("likelihood", {})
         likelihood_type = likelihood_config.get("type")
@@ -380,7 +375,7 @@ class BaseDelayedSaturatedMMM(MMM):
                 "type": "Normal",
                 "dims": ("date",),
                 "params": {
-                    "sigma": {"type": "HalfNormal", "sigma": 1},
+                    "sigma": {"type": "HalfNormal", "sigma": 1, 'dims': ('date',)},
                 }
             },
             "gamma_fourier": {"mu": 0, "b": 1, "dims": "fourier_mode"},

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -341,7 +341,8 @@ class BaseDelayedSaturatedMMM(MMM):
     def create_tvp_priors(self, param, config, length, positive=False):
         dims = config.get("dims", None)  # Extracting dims from the config
         gp_list = [self.gp_wrapper(name=f"{param}_{i}", X=np.arange(len(self.X[self.date_column]))[:, None], positive=positive) for i in range(length)]
-        concatenated_gp = pt.concatenate(gp_list, axis=0)
+        concatenated_gp = pt.concatenate(gp_list, axis=1)
+        print("Concatenated shape:", concatenated_gp.shape.eval())
         return pm.Deterministic(f"{param}", concatenated_gp, dims=dims)
 
 

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -340,9 +340,9 @@ class BaseDelayedSaturatedMMM(MMM):
 
     def create_tvp_priors(self, param, config, length, positive=False):
         dims = config.get("dims", None)  # Extracting dims from the config
+        print(dims)
         gp_list = [self.gp_wrapper(name=f"{param}_{i}", X=np.arange(len(self.X[self.date_column]))[:, None], positive=positive) for i in range(length)]
         stacked_gp = pt.stack(gp_list, axis=1)
-        print("stacked shape:", stacked_gp.shape.eval())
         return pm.Deterministic(f"{param}", stacked_gp, dims=dims)
 
 

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -303,12 +303,11 @@ class BaseDelayedSaturatedMMM(MMM):
 
 
                 if prior_type == "tvp":
-                    try:
-                        length = dimensions.get(config.get("dims", [None, None])[1], 1)
-                    except IndexError:
-                        print("indexerror so building it diffeent way")
+                    if param in ["intercept", "lam", "alpha", "sigma"]:
                         priors[param] = self.gp_wrapper(name=param, X=np.arange(len(self.X[self.date_column]))[:, None], mean=0, positive=is_positive, **kwargs)
                         continue
+                    try:
+                        length = dimensions.get(config.get("dims", [None, None])[1], 1)
 
                     priors[param] = self.create_tvp_priors(param, config, length, positive=is_positive)
                     continue

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -344,7 +344,7 @@ class BaseDelayedSaturatedMMM(MMM):
         cov = eta ** 2 * pm.gp.cov.ExpQuad(1, ls=ell)
         
         gp = pm.gp.HSGP(m=[20], c=1.3, cov_func=cov)
-        f_raw = gp.prior(f"{param}_tvp_raw", X=np.arange(len(self.X[self.date_column]))[:, None], dims=dims)
+        f_raw = gp.prior(f"{param}_tvp_raw", X=np.tile(np.arange(len(self.X[self.date_column])), (5, 1)).T, dims=dims)
         print(f_raw.shape.eval())
 
         if positive:

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -346,7 +346,7 @@ class BaseDelayedSaturatedMMM(MMM):
     def gp_wrapper(self, name, X, mean=0, **kwargs):
         return self.gp_coeff(X, name, mean=mean, **kwargs)
 
-    def gp_coeff(self, X, name, dim, mean=0.0):
+    def gp_coeff(self, X, name, mean=0.0):
 
         lower, upper = 0.5, 2
         local_ell_params = pm.find_constrained_prior(

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -358,11 +358,11 @@ class BaseDelayedSaturatedMMM(MMM):
 
     def gp_coeff(self, X, name, mean=0.0, positive=False, config=None):
         params = pm.find_constrained_prior(pm.Gamma, 8, 12, init_guess={"alpha": 12, "beta": 1}, mass=0.75)
-        ell = pm.InverseGamma(f"ell_{name}", **params)
-        eta = pm.Exponential(f"_eta_{name}", lam=1 / 0.5)
+        ell = pm.Gamma(f"ell_{name}", **params)
+        eta = pm.Exponential(f"_eta_{name}", lam=10)
         cov = eta ** 2 * pm.gp.cov.ExpQuad(1, ls=ell)
     
-        gp = pm.gp.HSGP(m=[40], c=2, cov_func=cov)
+        gp = pm.gp.HSGP(m=[200], c=2, cov_func=cov)
         f_raw = gp.prior(f"{name}_tvp_raw", X=X)
     
 

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -377,7 +377,7 @@ class BaseDelayedSaturatedMMM(MMM):
             offset_prior = 0
 
         if positive:
-            f_output = pm.Deterministic(f"{name}", (pt.exp(f_raw) - 1) + offset_prior, dims=("date"))
+            f_output = pm.Deterministic(f"{name}", (pt.exp(f_raw)) + offset_prior, dims=("date"))
         else:
             f_output = pm.Deterministic(f"{name}", f_raw + offset_prior, dims=("date"))
     

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -374,6 +374,8 @@ class BaseDelayedSaturatedMMM(MMM):
             offset_type = offset_config.get('type')
             offset_params = {k: v for k, v in offset_config.items() if k != 'type'}
             offset_prior = getattr(pm, offset_type)(name=f"{name}_offset", **offset_params)
+        else: 
+            offset_prior = 0
 
         if positive:
             f_output = pm.Deterministic(f"{name}", (pt.exp(f_raw) - 1) + offset_prior, dims=("date"))

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -288,6 +288,7 @@ class BaseDelayedSaturatedMMM(MMM):
         for param, config in model_config.items():
             if param == "likelihood": continue
             prior_type, dim = config.get("type"), config.get("dims")[0]
+            print(prior_type)
             length = dimensions.get(dim, 1)
         
             if prior_type == "tvp":

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -213,6 +213,11 @@ class BaseDelayedSaturatedMMM(MMM):
                 var=logistic_saturation(x=channel_adstock, lam=lam),
                 dims=("date", "channel"),
             )
+
+            #Debug for shape error of channel contributions
+            print("Shape of channel_adstock_saturated:", channel_adstock_saturated.shape.eval())
+            print("Shape of beta_channel:", beta_channel.shape.eval())
+
             channel_contributions = pm.Deterministic(
                 name="channel_contributions",
                 var=channel_adstock_saturated * beta_channel,

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -357,7 +357,7 @@ class BaseDelayedSaturatedMMM(MMM):
         gp = pm.gp.HSGP(m=[20], c=1.3, cov_func=cov)
         f_raw = gp.prior(f"{name}_tvp_raw", X=X)
     
-        f_output = pm.Deterministic(f"{name}", pm.math.log1pexp(f_raw) if positive else f_raw, dims=("date"))
+        f_output = pm.Deterministic(f"{name}", pm.math.exp(f_raw) if positive else f_raw, dims=("date"))
     
         return f_output
 

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -188,7 +188,7 @@ class BaseDelayedSaturatedMMM(MMM):
             )
 
             #Building the priors
-            priors = self.create_priors_from_config(self.model_config, idata)
+            priors = self.create_priors_from_config(self.model_config)
 
             #Specifying the variables
             intercept = priors['intercept']
@@ -284,11 +284,11 @@ class BaseDelayedSaturatedMMM(MMM):
     def create_tvp_priors(self, param, config, length):
         return [self.gp_wrapper(name=f"{param}_{i}", X=np.arange(len(self.X[self.date_column]))[:, None]) for i in range(length)]
 
-    def create_priors_from_config(self, model_config, idata):
+    def create_priors_from_config(self, model_config):
         priors = {}
         dimensions = {
-            "channel": len(idata.attrs["channel_columns"]),
-            "control": len(idata.attrs["control_columns"]),
+            "channel": len(self.channel_columns),
+            "control": len(self.control_columns),
         }
         stacked_priors = {"channel": [], "control": []}
 

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -357,7 +357,7 @@ class BaseDelayedSaturatedMMM(MMM):
         return self.gp_coeff(X, name, config=config, positive=positive, **kwargs)
 
     def gp_coeff(self, X, name, mean=0.0, positive=False, config=None):
-        params = pm.find_constrained_prior(pm.InverseGamma, 8, 12, init_guess={"alpha": 1, "beta": 1}, mass=0.90)
+        params = pm.find_constrained_prior(pm.InverseGamma, 8, 12, init_guess={"alpha": 1, "beta": 5}, mass=0.80)
         ell = pm.InverseGamma(f"ell_{name}", **params)
         eta = pm.Exponential(f"_eta_{name}", lam=1 / 0.5)
         cov = eta ** 2 * pm.gp.cov.ExpQuad(1, ls=ell)

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -357,7 +357,7 @@ class BaseDelayedSaturatedMMM(MMM):
         return self.gp_coeff(X, name, config=config, positive=positive, **kwargs)
 
     def gp_coeff(self, X, name, mean=0.0, positive=False, config=None):
-        params = pm.find_constrained_prior(pm.InverseGamma, 8, 12, init_guess={"alpha": 1, "beta": 5}, mass=0.80)
+        params = pm.find_constrained_prior(pm.Gamma, 8, 12, init_guess={"alpha": 12, "beta": 1}, mass=0.75)
         ell = pm.InverseGamma(f"ell_{name}", **params)
         eta = pm.Exponential(f"_eta_{name}", lam=1 / 0.5)
         cov = eta ** 2 * pm.gp.cov.ExpQuad(1, ls=ell)

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -8,6 +8,7 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 import pymc as pm
+import pytensor.tensor as pt
 import seaborn as sns
 from xarray import DataArray
 

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -301,10 +301,10 @@ class BaseDelayedSaturatedMMM(MMM):
 
                 if prior_type == "tvp":
                     length = dimensions.get(config.get("dims", [None, None])[1], 1)
-                    if length > 1:
-                        priors[param] = self.create_tvp_priors(param, config, length, positive=is_positive)
-                    else:
-                        priors[param] = self.gp_wrapper(name=param, X=np.arange(len(self.X[self.date_column]))[:, None], positive=is_positive)
+                 #   if length > 1:
+                    priors[param] = self.create_tvp_priors(param, config, length, positive=is_positive)
+                #    else:
+                 #       priors[param] = self.gp_wrapper(name=param, X=np.arange(len(self.X[self.date_column]))[:, None], positive=is_positive)
                     continue
 
                 dist_func = getattr(pm, prior_type, None)

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -293,13 +293,14 @@ class BaseDelayedSaturatedMMM(MMM):
 
             prior_type = config.get("type")
             if prior_type is not None:
-                length = dimensions.get(config.get("dims", [None, None])[1], 1)
+               
 
                 # Check if this parameter should be positive
                 is_positive = param in positive_params
                 print(is_positive)
 
                 if prior_type == "tvp":
+                    length = dimensions.get(config.get("dims", [None, None])[1], 1)
                     if length > 1:
                         priors[param] = self.create_tvp_priors(param, config, length, positive=is_positive)
                     else:

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -358,7 +358,7 @@ class BaseDelayedSaturatedMMM(MMM):
         f_raw = gp.prior(f"{name}_tvp_raw", X=X)
     
         if positive:
-            f_output = pm.Deterministic(f"{name}", pt.exp(pt.log(f_raw), dims=("date"))
+            f_output = pm.Deterministic(f"{name}", pt.exp(pt.log(f_raw), dims=("date")))
         else:
             f_output = pm.Deterministic(f"{name}", f_raw, dims=("date"))
     

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -301,7 +301,7 @@ class BaseDelayedSaturatedMMM(MMM):
                 if prior_type == "tvp":
                         print("making tvp priors")
                         priors[param] = self.create_tvp_priors(param, config, positive=is_positive)
-                    continue
+                        continue
 
                 dist_func = getattr(pm, prior_type, None)
                 if not dist_func: raise ValueError(f"Invalid distribution type {prior_type}")

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -314,7 +314,9 @@ class BaseDelayedSaturatedMMM(MMM):
 
         for dim, priors_list in stacked_priors.items():
             if priors_list:
-                priors[f"{dim}_stacked"] = pm.math.stack(priors_list, axis=1)
+                new_key = f"beta_{dim}" if dim == "channel" else f"gamma_{dim}"
+                priors[new_key] = pm.math.stack(priors_list, axis=1)
+
 
         return priors
 

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -236,9 +236,7 @@ class BaseDelayedSaturatedMMM(MMM):
                 )
 
                 print("Shape of control_data_:", control_data_.eval().shape)
-                print("Shape of control_data_:", control_data_.eval().shape)
-
-
+                print("Shape of gamma_control:", gamma_control.eval().shape)
 
                 control_contributions = pm.Deterministic(
                     name="control_contributions",

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -301,16 +301,15 @@ class BaseDelayedSaturatedMMM(MMM):
                 if 'positive' in config:
                     is_positive = config.get('positive')
 
-
                 if prior_type == "tvp":
                     if param in ["intercept", "lam", "alpha", "sigma"]:
                         priors[param] = self.gp_wrapper(name=param, X=np.arange(len(self.X[self.date_column]))[:, None], mean=0, positive=is_positive, **kwargs)
                         continue
-                    try:
-                        length = dimensions.get(config.get("dims", [None, None])[1], 1)
 
+                    length = dimensions.get(config.get("dims", [None, None])[1], 1)
                     priors[param] = self.create_tvp_priors(param, config, length, positive=is_positive)
                     continue
+
 
                 dist_func = getattr(pm, prior_type, None)
                 if not dist_func: raise ValueError(f"Invalid distribution type {prior_type}")


### PR DESCRIPTION
Essentially 3 things:

1. Flexibility in prior selection to anything in the PyMC API (this is a duplicate as I believe there's already a PR for this )
2. Flexibility in likelihood
3. HSGP prior for model coefficients, intercept, alpha etc 

Some inefficient functions can be deleted e.g GP_wrapper can be edited out of the code



<!-- readthedocs-preview pymc-marketing start -->
----
:books: Documentation preview :books:: https://pymc-marketing--415.org.readthedocs.build/en/415/

<!-- readthedocs-preview pymc-marketing end -->