### PR TITLE
Fix mismatched customer count in CLV Quickstart guide

### DIFF
--- a/docs/source/notebooks/clv/clv_quickstart.ipynb
+++ b/docs/source/notebooks/clv/clv_quickstart.ipynb
@@ -708,7 +708,7 @@
    "id": "49313fc3",
    "metadata": {},
    "source": [
-    "Having fit the model, we can ask what is the expected number of purchases for our customers in the next period. Let's look at the five more promising customers."
+    "Having fit the model, we can ask what is the expected number of purchases for our customers in the next period. Let's look at the four more promising customers."
    ]
   },
   {


### PR DESCRIPTION
## Overview
This Pull Request corrects a discrepancy in the CLV quickstart guide documentation. The guide currently states to look at the "five more promising customers," while the associated code snippet is actually designed to display the top four customers.

## Details
The specific line in the documentation that has been updated is:

- Before: Let's look at the **five** more promising customers.
- After: Let's look at the **four** more promising customers.

The corresponding code that illustrates this operation is:

```python
sdata.sort_values(by="expected_purchases").tail(4)
```

As the code correctly fetches the top four customers, no changes to the code were required—only the textual description needed to be updated to reflect the actual behavior of the code.

## Additional Information
Please find attached a screenshot which demonstrates the code's output prior to the documentation correction. 
![image](https://github.com/pymc-labs/pymc-marketing/assets/8223210/896047c3-6172-4ffd-863d-3c35eb4ee21f)


<!-- readthedocs-preview pymc-marketing start -->
----
:books: Documentation preview :books:: https://pymc-marketing--419.org.readthedocs.build/en/419/

<!-- readthedocs-preview pymc-marketing end -->