### PR TITLE
Remove .flake8 file

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,8 +1,0 @@
-[flake8]
-max-line-length = 88
-extend-ignore = E203, E501
-per-file-ignores = */__init__.py:F401,F403
-
-# flake8 does not support pyproject.toml
-# https://github.com/PyCQA/flake8/issues/234
-# https://stackoverflow.com/questions/64482562/specify-per-file-ignores-with-pyproject-toml-and-flake8


### PR DESCRIPTION
Leftover from https://github.com/pymc-labs/pymc-marketing/pull/424 (sorry!)

<!-- readthedocs-preview pymc-marketing start -->
----
:books: Documentation preview :books:: https://pymc-marketing--425.org.readthedocs.build/en/425/

<!-- readthedocs-preview pymc-marketing end -->