### PR TITLE
Fix latex in plot legends for `matplotlib>=3.8.1`

### DIFF
--- a/pymc_marketing/mmm/base.py
+++ b/pymc_marketing/mmm/base.py
@@ -270,7 +270,7 @@ class BaseMMM(ModelBuilder):
                 y2=likelihood_hdi_94[:, 1],
                 color="C0",
                 alpha=0.2,
-                label="94% HDI",
+                label=r"$94\%$ HDI",
             )
 
             ax.fill_between(
@@ -279,7 +279,7 @@ class BaseMMM(ModelBuilder):
                 y2=likelihood_hdi_50[:, 1],
                 color="C0",
                 alpha=0.3,
-                label="50% HDI",
+                label=r"$50\%$ HDI",
             )
 
             ax.plot(
@@ -323,7 +323,7 @@ class BaseMMM(ModelBuilder):
                 y2=likelihood_hdi_94[:, 1],
                 color="C0",
                 alpha=0.2,
-                label="94% HDI",
+                label="$94\%$ HDI",
             )
 
             ax.fill_between(
@@ -332,7 +332,7 @@ class BaseMMM(ModelBuilder):
                 y2=likelihood_hdi_50[:, 1],
                 color="C0",
                 alpha=0.3,
-                label="50% HDI",
+                label="$50\%$ HDI",
             )
 
             target_to_plot: np.ndarray = np.asarray(
@@ -405,7 +405,7 @@ class BaseMMM(ModelBuilder):
                     y2=hdi.isel(hdi=1),
                     color=f"C{i}",
                     alpha=0.25,
-                    label=f"$94 %$ HDI ({var_contribution})",
+                    label=f"$94\%$ HDI ({var_contribution})",
                 )
                 ax.plot(
                     np.asarray(self.X[self.date_column]),
@@ -432,7 +432,7 @@ class BaseMMM(ModelBuilder):
                 y2=intercept_hdi[:, 1],
                 color=f"C{i + 1}",
                 alpha=0.25,
-                label="$94 %$ HDI (intercept)",
+                label="$94\%$ HDI (intercept)",
             )
             ax.plot(
                 np.asarray(self.X[self.date_column]),

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -656,7 +656,7 @@ class DelayedSaturatedMMM(
                 y1=hdi_contribution[:, 0],
                 y2=hdi_contribution[:, 1],
                 color=f"C{i}",
-                label=f"{channel} $94%$ HDI contribution",
+                label=f"{channel} $94\%$ HDI contribution",
                 alpha=0.4,
             )
 


### PR DESCRIPTION
Closes https://github.com/pymc-labs/pymc-marketing/issues/387

Update MMM example notebook accordingly (it runs end-to-end). I tested with matplotlib 3.8.1 and 3.7.3 ✅ 

<!-- readthedocs-preview pymc-marketing start -->
----
:books: Documentation preview :books:: https://pymc-marketing--426.org.readthedocs.build/en/426/

<!-- readthedocs-preview pymc-marketing end -->