### PR TITLE
Fix parameterization in `_distribution_new_customers`

### DIFF
--- a/pymc_marketing/clv/models/beta_geo.py
+++ b/pymc_marketing/clv/models/beta_geo.py
@@ -372,7 +372,9 @@ class BetaGeoModel(CLVModel):
                 shape_kwargs = {}
 
             pm.Beta("population_dropout", alpha=a, beta=b, **shape_kwargs)
-            pm.Gamma("population_purchase_rate", alpha=r, beta=alpha, **shape_kwargs)
+            pm.Gamma(
+                "population_purchase_rate", alpha=r, beta=1 / alpha, **shape_kwargs
+            )
 
             return pm.sample_posterior_predictive(
                 self.fit_result,

--- a/tests/clv/models/test_beta_geo.py
+++ b/tests/clv/models/test_beta_geo.py
@@ -471,7 +471,7 @@ class TestBetaGeoModel:
 
         N = 1000
         p = pm.Beta.dist(self.a_true, self.b_true, size=N)
-        lam = pm.Gamma.dist(self.r_true, self.alpha_true, size=N)
+        lam = pm.Gamma.dist(self.r_true, 1 / self.alpha_true, size=N)
 
         rtol = 0.05
         np.testing.assert_allclose(


### PR DESCRIPTION
Address #328 

Wondering why there is discrepancy in the generative process in the top of the test class and what is required here. Also, this test doesn't confirm the validity 

TODO: 
- Add test to confirm @ColtAllen 's claim. Compare the rate to the scale of the observed data
- Is it good to add an example and a plot of this to one of the notebooks? visual confirmation of above

<!-- readthedocs-preview pymc-marketing start -->
----
:books: Documentation preview :books:: https://pymc-marketing--430.org.readthedocs.build/en/430/

<!-- readthedocs-preview pymc-marketing end -->