### PR TITLE
Makefile to include ruff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,12 @@ init:
 
 lint:
 	pip install .[lint]
-	isort .
-	black .
+	ruff . --fix
+	mypy .
 
 check_lint:
 	pip install .[lint]
-	flake8 .
-	isort --check-only .
-	black --diff --check --fast .
+	ruff .
 	mypy .
 
 test:


### PR DESCRIPTION
Remove flake8, isort and black from Makefile and use ruff instead

<!-- readthedocs-preview pymc-marketing start -->
----
:books: Documentation preview :books:: https://pymc-marketing--438.org.readthedocs.build/en/438/

<!-- readthedocs-preview pymc-marketing end -->