### PR TITLE
Add Adstock & saturation visuals to docstrings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx_autodoc_typehints",
     # extensions provided by other packages
-    # "matplotlib.sphinxext.plot_directive",  # needed to plot in docstrings
+    "matplotlib.sphinxext.plot_directive",  # needed to plot in docstrings
     "myst_nb",
     "notfound.extension",
     "sphinx_copybutton",

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -495,15 +495,10 @@ class BaseDelayedSaturatedMMM(MMM):
         new_channel_data: Optional[np.ndarray] = None
         coords = {"date": X[self.date_column].to_numpy()}
 
-        if isinstance(X, pd.DataFrame):
-            try:
-                new_channel_data = X[self.channel_columns].to_numpy()
-            except KeyError as e:
-                raise RuntimeError("New data must contain channel_data!", e)
-        elif isinstance(X, np.ndarray):
-            new_channel_data = X
-        else:
-            raise TypeError("X must be either a pandas DataFrame or a numpy array")
+        try:
+            new_channel_data = X[self.channel_columns].to_numpy()
+        except KeyError as e:
+            raise RuntimeError("New data must contain channel_data!", e)
 
         def identity(x):
             return x

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -539,7 +539,8 @@ class BaseDelayedSaturatedMMM(MMM):
             else:
                 raise TypeError("y must be either a pandas Series or a numpy array")
         else:
-            data["target"] = np.zeros(X.shape[0])
+            dtype = self.preprocessed_data["y"].dtype  # type: ignore
+            data["target"] = np.zeros(X.shape[0], dtype=dtype)  # type: ignore
 
         with self.model:
             pm.set_data(data, coords=coords)

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -517,7 +517,7 @@ class BaseDelayedSaturatedMMM(MMM):
             "channel_data": channel_transformation(new_channel_data)
         }
 
-        if hasattr(self, "control_columns"):
+        if self.control_columns is not None:
             control_data = X[self.control_columns].to_numpy()
             control_transformation = (
                 identity

--- a/pymc_marketing/mmm/transformers.py
+++ b/pymc_marketing/mmm/transformers.py
@@ -69,7 +69,7 @@ def batched_convolution(x, w, axis: int = 0):
 def geometric_adstock(
     x, alpha: float = 0.0, l_max: int = 12, normalize: bool = False, axis: int = 0
 ):
-    """Geometric adstock transformation.
+    R"""Geometric adstock transformation.
 
     Adstock with geometric decay assumes advertising effect peaks at the same
     time period as ad exposure. The cumulative media effect is a weighted average
@@ -83,6 +83,7 @@ def geometric_adstock(
         import matplotlib.pyplot as plt
         import numpy as np
         import arviz as az
+        from pymc_marketing.mmm.transformers import geometric_adstock
         plt.style.use('arviz-darkgrid')
         l_max = 12
         params = [
@@ -98,7 +99,7 @@ def geometric_adstock(
         x = np.arange(len(spend))
         for a, normalize in params:
             y = geometric_adstock(spend, alpha=a, l_max=l_max, normalize=normalize).eval()
-            plt.plot(x, y, label=f'$\\alpha$ = {a}, normalize = {normalize}')
+            plt.plot(x, y, label=f'alpha = {a}, normalize = {normalize}')
         plt.xlabel('time since spend', fontsize=12)
         plt.title(f'Geometric Adstock with l_max = {l_max}', fontsize=14)
         plt.ylabel('f(time since spend)', fontsize=12)
@@ -152,6 +153,7 @@ def delayed_adstock(
         import matplotlib.pyplot as plt
         import numpy as np
         import arviz as az
+        from pymc_marketing.mmm.transformers import delayed_adstock
         plt.style.use('arviz-darkgrid')
         params = [
             (0.25, 0, False),
@@ -165,7 +167,7 @@ def delayed_adstock(
         ax = plt.subplot(111)
         for a, t, normalize in params:
             y = delayed_adstock(spend, alpha=a, theta=t, normalize=normalize).eval()
-            plt.plot(x, y, label=f'$\\alpha$ = {a}, $\\theta$ = {t}, normalize = {normalize}')
+            plt.plot(x, y, label=f'alpha = {a}, theta$ = {t}, normalize = {normalize}')
         plt.xlabel('time since spend', fontsize=12)
         plt.ylabel('f(time since spend)', fontsize=12)
         plt.legend()
@@ -215,13 +217,14 @@ def logistic_saturation(x, lam: Union[npt.NDArray[np.float_], float] = 0.5):
         import matplotlib.pyplot as plt
         import numpy as np
         import arviz as az
+        from pymc_marketing.mmm.transformers import logistic_saturation
         plt.style.use('arviz-darkgrid')
         lam = np.array([0.25, 0.5, 1, 2, 4])
         x = np.linspace(0, 5, 100)
         ax = plt.subplot(111)
         for l in lam:
             y = logistic_saturation(x, lam=l).eval()
-            plt.plot(x, y, label=f'$\lambda$ = {l}')
+            plt.plot(x, y, label=f'lam = {l}')
         plt.xlabel('spend', fontsize=12)
         plt.ylabel('f(spend)', fontsize=12)
         plt.legend()
@@ -243,11 +246,11 @@ def logistic_saturation(x, lam: Union[npt.NDArray[np.float_], float] = 0.5):
 
 
 def tanh_saturation(x, b: float = 0.5, c: float = 0.5):
-    """Tanh saturation transformation.
+    R"""Tanh saturation transformation.
 
     .. math::
 
-        f(x) = b \\tanh \\left( \\frac{x}{bc} \\right)
+        f(x) = b \tanh \left( \frac{x}{bc} \right)
 
     .. plot::
         :context: close-figs
@@ -255,6 +258,7 @@ def tanh_saturation(x, b: float = 0.5, c: float = 0.5):
         import matplotlib.pyplot as plt
         import numpy as np
         import arviz as az
+        from pymc_marketing.mmm.transformers import tanh_saturation
         plt.style.use('arviz-darkgrid')
         params = [
             (0.75, 0.25),

--- a/pymc_marketing/mmm/transformers.py
+++ b/pymc_marketing/mmm/transformers.py
@@ -77,6 +77,35 @@ def geometric_adstock(
     periods (e.g. weeks). `l_max` is the maximum duration of carryover effect.
 
 
+    .. plot::
+        :context: close-figs
+
+        import matplotlib.pyplot as plt
+        import numpy as np
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
+        l_max = 12
+        params = [
+            (0.01, False),
+            (0.5, False),
+            (0.9, False),
+            (0.5, True),
+            (0.9, True),
+        ]
+        spend = np.zeros(15)
+        spend[0] = 1
+        ax = plt.subplot(111)
+        x = np.arange(len(spend))
+        for a, normalize in params:
+            y = geometric_adstock(spend, alpha=a, l_max=l_max, normalize=normalize).eval()
+            plt.plot(x, y, label=f'$\\alpha$ = {a}, normalize = {normalize}')
+        plt.xlabel('time since spend', fontsize=12)
+        plt.title(f'Geometric Adstock with l_max = {l_max}', fontsize=14)
+        plt.ylabel('f(time since spend)', fontsize=12)
+        plt.legend()
+        plt.show()
+
+
     Parameters
     ----------
     x : tensor
@@ -117,6 +146,31 @@ def delayed_adstock(
     This transformation is similar to geometric adstock transformation, but it
     allows for a delayed peak of the effect. The peak is assumed to occur at `theta`.
 
+    .. plot::
+        :context: close-figs
+
+        import matplotlib.pyplot as plt
+        import numpy as np
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
+        params = [
+            (0.25, 0, False),
+            (0.25, 5, False),
+            (0.75, 5, False),
+            (0.75, 5, True)
+        ]
+        spend = np.zeros(15)
+        spend[0] = 1
+        x = np.arange(len(spend))
+        ax = plt.subplot(111)
+        for a, t, normalize in params:
+            y = delayed_adstock(spend, alpha=a, theta=t, normalize=normalize).eval()
+            plt.plot(x, y, label=f'$\\alpha$ = {a}, $\\theta$ = {t}, normalize = {normalize}')
+        plt.xlabel('time since spend', fontsize=12)
+        plt.ylabel('f(time since spend)', fontsize=12)
+        plt.legend()
+        plt.show()
+
     Parameters
     ----------
     x : tensor
@@ -150,6 +204,29 @@ def delayed_adstock(
 
 def logistic_saturation(x, lam: Union[npt.NDArray[np.float_], float] = 0.5):
     """Logistic saturation transformation.
+
+    .. math::
+
+        f(x) = \\frac{1 - e^{-\lambda x}}{1 + e^{-\lambda x}}
+
+    .. plot::
+        :context: close-figs
+
+        import matplotlib.pyplot as plt
+        import numpy as np
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
+        lam = np.array([0.25, 0.5, 1, 2, 4])
+        x = np.linspace(0, 5, 100)
+        ax = plt.subplot(111)
+        for l in lam:
+            y = logistic_saturation(x, lam=l).eval()
+            plt.plot(x, y, label=f'$\lambda$ = {l}')
+        plt.xlabel('spend', fontsize=12)
+        plt.ylabel('f(spend)', fontsize=12)
+        plt.legend()
+        plt.show()
+
     Parameters
     ----------
     x : tensor
@@ -167,6 +244,34 @@ def logistic_saturation(x, lam: Union[npt.NDArray[np.float_], float] = 0.5):
 
 def tanh_saturation(x, b: float = 0.5, c: float = 0.5):
     """Tanh saturation transformation.
+
+    .. math::
+
+        f(x) = b \\tanh \\left( \\frac{x}{bc} \\right)
+
+    .. plot::
+        :context: close-figs
+
+        import matplotlib.pyplot as plt
+        import numpy as np
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
+        params = [
+            (0.75, 0.25),
+            (0.75, 1.5),
+            (1, 0.25),
+            (1, 1),
+            (1, 1.5),
+        ]
+        x = np.linspace(0, 5, 100)
+        ax = plt.subplot(111)
+        for b, c in params:
+            y = tanh_saturation(x, b=b, c=c).eval()
+            plt.plot(x, y, label=f'b = {b}, c = {c}')
+        plt.xlabel('spend', fontsize=12)
+        plt.ylabel('f(spend)', fontsize=12)
+        plt.legend()
+        plt.show()
 
     Parameters
     ----------

--- a/tests/mmm/test_delayed_saturated_mmm.py
+++ b/tests/mmm/test_delayed_saturated_mmm.py
@@ -527,6 +527,10 @@ class TestDelayedSaturatedMMM:
         ):
             mmm_fitted.predict_posterior(X_pred=new_X)
 
-        mmm_fitted.sample_posterior_predictive(
-            X_pred=new_X, extend_idata=True, combined=True
+        posterior_predictive = mmm_fitted.sample_posterior_predictive(
+            X_pred=new_X, extend_idata=False, combined=True
         )
+        pd.testing.assert_index_equal(
+            pd.DatetimeIndex(posterior_predictive.coords["date"]), new_dates
+        )
+        assert posterior_predictive["likelihood"].shape[0] == new_dates.size

--- a/tests/mmm/test_delayed_saturated_mmm.py
+++ b/tests/mmm/test_delayed_saturated_mmm.py
@@ -448,7 +448,7 @@ class TestDelayedSaturatedMMM:
         with pytest.raises(TypeError):
             base_delayed_saturated_mmm._data_setter(toy_X, y_incorrect)
 
-        with pytest.raises(RuntimeError):
+        with pytest.raises(KeyError):
             X_wrong_df = pd.DataFrame(
                 {"column1": np.random.rand(135), "column2": np.random.rand(135)}
             )
@@ -459,12 +459,10 @@ class TestDelayedSaturatedMMM:
         except Exception as e:
             pytest.fail(f"_data_setter failed with error {e}")
 
-        try:
+        with pytest.raises(TypeError, match="X must be a pandas DataFrame"):
             base_delayed_saturated_mmm._data_setter(
                 X_correct_ndarray, y_correct_ndarray
             )
-        except Exception as e:
-            pytest.fail(f"_data_setter failed with error {e}")
 
     def test_save_load(self, mmm_fitted):
         model = mmm_fitted

--- a/tests/mmm/test_delayed_saturated_mmm.py
+++ b/tests/mmm/test_delayed_saturated_mmm.py
@@ -506,3 +506,29 @@ class TestDelayedSaturatedMMM:
         ):
             DelayedSaturatedMMM.load("test_model")
         os.remove("test_model")
+
+    def test_new_data_predictions(self, mmm_fitted: DelayedSaturatedMMM):
+        new_dates = pd.date_range(start="2021-11-01", end="2022-03-01", freq="W-MON")
+
+        n = new_dates.size
+        new_X = pd.DataFrame(
+            {
+                "date": new_dates,
+                "channel_1": rng.integers(low=0, high=400, size=n),
+                "channel_2": rng.integers(low=0, high=50, size=n),
+                "control_1": rng.gamma(shape=1000, scale=500, size=n),
+                "control_2": rng.gamma(shape=100, scale=5, size=n),
+                "other_column_1": rng.integers(low=0, high=100, size=n),
+                "other_column_2": rng.normal(loc=0, scale=1, size=n),
+            }
+        )
+
+        with pytest.raises(
+            TypeError,
+            match=r"The DType <class 'numpy.dtype\[datetime64\]'> could not be promoted by",
+        ):
+            mmm_fitted.predict_posterior(X_pred=new_X)
+
+        mmm_fitted.sample_posterior_predictive(
+            X_pred=new_X, extend_idata=True, combined=True
+        )


### PR DESCRIPTION
Thought adding some visuals to the docstring would give some context

Still an issue with the sphinx extension though 

<!-- readthedocs-preview pymc-marketing start -->
----
:books: Documentation preview :books:: https://pymc-marketing--449.org.readthedocs.build/en/449/

<!-- readthedocs-preview pymc-marketing end -->