### PR TITLE
Add convolution modes

### DIFF
--- a/pymc_marketing/mmm/transformers.py
+++ b/pymc_marketing/mmm/transformers.py
@@ -25,6 +25,8 @@ def batched_convolution(x, w, axis: int = 0, mode: ConvMode = ConvMode.Before):
         to use in the convolution.
     axis : int
         The axis of ``x`` along witch to apply the convolution
+    mode : (ConvMode, optional): The mode of the convolution. Determines how the convolution is applied at the boundaries of x. Defaults to ConvMode.Before.
+
 
     Returns
     -------

--- a/pymc_marketing/mmm/transformers.py
+++ b/pymc_marketing/mmm/transformers.py
@@ -76,7 +76,8 @@ def batched_convolution(x, w, axis: int = 0, mode: ConvMode = ConvMode.Before):
     elif mode == ConvMode.Before:
         window = slice(None, -l_max + 1)
     elif mode == ConvMode.Overlap:
-        window = slice(l_max // 2, -(l_max // 2))
+        # Handle even and odd l_max differently if l_max is odd then we can split evenly otherwise we drop from the end
+        window = slice((l_max // 2) - (1 if l_max % 2 == 0 else 0), -(l_max // 2))
     else:
         raise ValueError("Wrong Mode")
 

--- a/pymc_marketing/mmm/transformers.py
+++ b/pymc_marketing/mmm/transformers.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Union
 
 import numpy as np
@@ -6,7 +7,13 @@ import pytensor.tensor as pt
 from pytensor.tensor.random.utils import params_broadcast_shapes
 
 
-def batched_convolution(x, w, axis: int = 0):
+class ConvMode(Enum):
+    After = "After"
+    Before = "Before"
+    Overlap = "Overlap"
+
+
+def batched_convolution(x, w, axis: int = 0, mode: ConvMode = ConvMode.Before):
     """Apply a 1D convolution in a vectorized way across multiple batch dimensions.
 
     Parameters
@@ -43,22 +50,39 @@ def batched_convolution(x, w, axis: int = 0):
     # The last dimension of x is the "time" axis, which doesn't get broadcast
     # The last dimension of w is the number of time steps that go into the convolution
     x_shape, w_shape = params_broadcast_shapes([x.shape, w.shape], [1, 1])
+
     x = pt.broadcast_to(x, x_shape)
     w = pt.broadcast_to(w, w_shape)
     x_time = x.shape[-1]
-    shape = (*x.shape, w.shape[-1])
     # Make a tensor with x at the different time lags needed for the convolution
+    x_shape = list(x.shape)
+    # Add the size of the kernel to the time axis
+    x_shape[-1] = x_shape[-1] + w.shape[-1] - 1
+    shape = [*x_shape, w.shape[-1]]
     padded_x = pt.zeros(shape, dtype=x.dtype)
-    if l_max is not None:
-        for i in range(l_max):
-            padded_x = pt.set_subtensor(
-                padded_x[..., i:x_time, i], x[..., : x_time - i]
-            )
-    else:  # pragma: no cover
+
+    if l_max is None:  # pragma: no cover
         raise NotImplementedError(
             "At the moment, convolving with weight arrays that don't have a concrete shape "
             "at compile time is not supported."
         )
+    # The window is the slice of the padded array that corresponds to the original x
+    if l_max <= 1:
+        window = slice(None)
+    elif mode == ConvMode.After:
+        window = slice(l_max - 1, None)
+    elif mode == ConvMode.Before:
+        window = slice(None, -l_max + 1)
+    elif mode == ConvMode.Overlap:
+        window = slice(l_max // 2, -(l_max // 2))
+    else:
+        raise ValueError("Wrong Mode")
+
+    for i in range(l_max):
+        padded_x = pt.set_subtensor(padded_x[..., i : x_time + i, i], x)
+
+    padded_x = padded_x[..., window, :]
+
     # The convolution is treated as an element-wise product, that then gets reduced
     # along the dimension that represents the convolution time lags
     conv = pt.sum(padded_x * w[..., None, :], axis=-1)

--- a/tests/mmm/test_transformers.py
+++ b/tests/mmm/test_transformers.py
@@ -5,6 +5,7 @@ import pytest
 from pytensor.tensor.var import TensorVariable
 
 from pymc_marketing.mmm.transformers import (
+    ConvMode,
     batched_convolution,
     delayed_adstock,
     geometric_adstock,
@@ -51,9 +52,10 @@ def convolution_axis(request):
     return request.param
 
 
-def test_batched_convolution(convolution_inputs, convolution_axis):
+@pytest.mark.parametrize("mode", [ConvMode.After, ConvMode.Before, ConvMode.Overlap])
+def test_batched_convolution(convolution_inputs, convolution_axis, mode):
     x, w, x_val, w_val = convolution_inputs
-    y = batched_convolution(x, w, convolution_axis)
+    y = batched_convolution(x, w, convolution_axis, mode)
     if x_val is None:
         y_val = y.eval()
         expected_shape = getattr(x, "value", x).shape
@@ -65,8 +67,22 @@ def test_batched_convolution(convolution_inputs, convolution_axis):
     x_val = np.moveaxis(
         x_val if x_val is not None else getattr(x, "value", x), convolution_axis, 0
     )
-    assert np.allclose(y_val[0], x_val[0])
-    assert np.allclose(y_val[1:], x_val[1:] + x_val[:-1])
+    mode_assertions = {
+        ConvMode.Before: lambda: (
+            np.allclose(y_val[0], x_val[0]),
+            np.allclose(y_val[1:], x_val[1:] + x_val[:-1]),
+        ),
+        ConvMode.After: lambda: (
+            np.allclose(y_val[-1], x_val[-1]),
+            np.allclose(y_val[:-1], x_val[1:] + x_val[:-1]),
+        ),
+        ConvMode.Overlap: lambda: (
+            np.allclose(y_val[0], x_val[0]),
+            np.allclose(y_val[1:-1], x_val[1:-1] + x_val[:-2]),
+        ),
+    }
+
+    assert all(mode_assertions[mode]())
 
 
 def test_batched_convolution_broadcasting():


### PR DESCRIPTION
Add different modes to model interactions (build-up, decay, symmetric build-up decay)
Those modes correspond to different offsets for the convolution:
- Before (build-up)
<img width="318" alt="image" src="https://github.com/pymc-labs/pymc-marketing/assets/33545649/ed68b2fd-1b79-42db-9f37-7b65c55139fa">

- After (decay)
<img width="318" alt="image" src="https://github.com/pymc-labs/pymc-marketing/assets/33545649/090e84b1-0dc5-4c9b-ba98-1e4ca306cb8e">

- Overlap (build-up and decay)
  * With overlap we have two cases when the kernel is even we drop the excess from the end
  <img width="318" alt="image" src="https://github.com/pymc-labs/pymc-marketing/assets/33545649/9c0b5c84-5d23-4d38-8f9c-0dd44bc30f88">
  
  * When the kernel is odd we will have symmetric build-up and decay:
  <img width="369" alt="image" src="https://github.com/pymc-labs/pymc-marketing/assets/33545649/485b0d06-9598-4533-a8aa-e5e707811554">
