### PR TITLE
add support for select channels and overlay charts

### DIFF
--- a/pymc_marketing/mmm/base.py
+++ b/pymc_marketing/mmm/base.py
@@ -1,3 +1,4 @@
+from itertools import repeat
 import warnings
 from inspect import (
     getattr_static,
@@ -715,6 +716,7 @@ class BaseMMM(ModelBuilder):
         color_index: int,
         xlim_max: int,
         method: str = "sigmoid",
+        label: str = "Fit Curve",
     ) -> None:
         """
         Plot the curve fit for the given channel based on the estimation of the parameters.
@@ -815,7 +817,7 @@ class BaseMMM(ModelBuilder):
         ax.fill_between(
             x_fit, y_fit_lower, y_fit_upper, color=f"C{color_index}", alpha=0.25
         )
-        ax.plot(x_fit, y_fit, color=f"C{color_index}", label="Fit Curve", alpha=0.6)
+        ax.plot(x_fit, y_fit, color=f"C{color_index}", label=label, alpha=0.6)
         ax.plot(
             x_inflection,
             y_inflection,
@@ -936,7 +938,12 @@ class BaseMMM(ModelBuilder):
         }
 
     def plot_direct_contribution_curves(
-        self, show_fit: bool = False, xlim_max=None, method: str = "sigmoid"
+        self,
+        show_fit: bool = False,
+        xlim_max=None,
+        method: str = "sigmoid",
+        channels: Optional[List[str]] = None,
+        same_axis: bool = False,
     ) -> plt.Figure:
         """
         Plots the direct contribution curves for each marketing channel. The term "direct" refers to the fact
@@ -951,35 +958,71 @@ class BaseMMM(ModelBuilder):
             The maximum value to be plot on the X-axis. If not provided, the maximum value in the data will be used.
         method : str, optional
             The method used to fit the contribution & spent non-linear relationship. It can be either 'sigmoid' or 'michaelis-menten'. Defaults to 'sigmoid'.
+        channels : List[str], optional
+            A list of channels to plot. If not provided, all channels will be plotted.
+        same_axis : bool, optional
+            If True, all channels will be plotted on the same axis. Defaults to False.
 
         Returns
         -------
         plt.Figure
             A matplotlib Figure object with the direct contribution curves.
         """
+        channels_to_plot = self.channel_columns if channels is None else channels
+
+        if not all(channel in self.channel_columns for channel in channels_to_plot):
+            raise ValueError(
+                "The provided channels must be a subset of the available channels."
+            )
+
         channel_contributions = self.compute_channel_contribution_original_scale().mean(
             ["chain", "draw"]
         )
 
+        if same_axis:
+            nrows = 1
+            figsize = (12, 4)
+
+            def label_func(channel):
+                return f"{channel} Data Points"
+
+            def legend_title_func(channel):
+                return "Legend"
+        else:
+            nrows = len(channels_to_plot)
+            figsize = (12, 4 * len(channels_to_plot))
+
+            def label_func(channel):
+                return "Data Points"
+
+            def legend_title_func(channel):
+                return f"{channel} Legend"
+
         fig, axes = plt.subplots(
-            nrows=self.n_channel,
+            nrows=nrows,
             ncols=1,
             sharex=False,
             sharey=False,
-            figsize=(12, 4 * self.n_channel),
+            figsize=figsize,
             layout="constrained",
         )
 
-        for i, channel in enumerate(self.channel_columns):
-            ax = axes[i]
+        axes_channels = (
+            zip(repeat(axes), channels_to_plot)
+            if same_axis
+            else zip(np.ravel(axes), channels_to_plot)
+        )
 
+        for i, (ax, channel) in enumerate(axes_channels):
             if self.X is not None:
-                x = self.X[self.channel_columns].to_numpy()[:, i]
+                x = self.X[channels].to_numpy()[:, i]
                 y = channel_contributions.sel(channel=channel).to_numpy()
 
-                ax.scatter(x, y, label="Data Points", color=f"C{i}")
+                label = label_func(channel)
+                ax.scatter(x, y, label=label, color=f"C{i}")
 
                 if show_fit:
+                    label = f"{channel} Fit Curve" if same_axis else "Fit Curve"
                     self._plot_response_curve_fit(
                         x=x,
                         ax=ax,
@@ -987,12 +1030,14 @@ class BaseMMM(ModelBuilder):
                         color_index=i,
                         xlim_max=xlim_max,
                         method=method,
+                        label=label,
                     )
 
+                title = legend_title_func(channel)
                 ax.legend(
                     loc="upper left",
                     facecolor="white",
-                    title=f"{channel} Legend",
+                    title=title,
                     fontsize="small",
                 )
 

--- a/pymc_marketing/mmm/base.py
+++ b/pymc_marketing/mmm/base.py
@@ -943,7 +943,7 @@ class BaseMMM(ModelBuilder):
         xlim_max=None,
         method: str = "sigmoid",
         channels: Optional[List[str]] = None,
-        same_axis: bool = False,
+        same_axes: bool = False,
     ) -> plt.Figure:
         """
         Plots the direct contribution curves for each marketing channel. The term "direct" refers to the fact
@@ -960,8 +960,8 @@ class BaseMMM(ModelBuilder):
             The method used to fit the contribution & spent non-linear relationship. It can be either 'sigmoid' or 'michaelis-menten'. Defaults to 'sigmoid'.
         channels : List[str], optional
             A list of channels to plot. If not provided, all channels will be plotted.
-        same_axis : bool, optional
-            If True, all channels will be plotted on the same axis. Defaults to False.
+        same_axes : bool, optional
+            If True, all channels will be plotted on the same axes. Defaults to False.
 
         Returns
         -------
@@ -979,7 +979,7 @@ class BaseMMM(ModelBuilder):
             ["chain", "draw"]
         )
 
-        if same_axis:
+        if same_axes:
             nrows = 1
             figsize = (12, 4)
 
@@ -1009,7 +1009,7 @@ class BaseMMM(ModelBuilder):
 
         axes_channels = (
             zip(repeat(axes), channels_to_plot)
-            if same_axis
+            if same_axes
             else zip(np.ravel(axes), channels_to_plot)
         )
 
@@ -1022,7 +1022,7 @@ class BaseMMM(ModelBuilder):
                 ax.scatter(x, y, label=label, color=f"C{i}")
 
                 if show_fit:
-                    label = f"{channel} Fit Curve" if same_axis else "Fit Curve"
+                    label = f"{channel} Fit Curve" if same_axes else "Fit Curve"
                     self._plot_response_curve_fit(
                         x=x,
                         ax=ax,

--- a/pymc_marketing/mmm/base.py
+++ b/pymc_marketing/mmm/base.py
@@ -971,9 +971,13 @@ class BaseMMM(ModelBuilder):
         channels_to_plot = self.channel_columns if channels is None else channels
 
         if not all(channel in self.channel_columns for channel in channels_to_plot):
+            unknown_channels = set(channels_to_plot) - set(self.channel_columns)
             raise ValueError(
-                "The provided channels must be a subset of the available channels."
+                f"The provided channels must be a subset of the available channels. Got {unknown_channels}"
             )
+
+        if len(channels_to_plot) != len(set(channels_to_plot)):
+            raise ValueError("The provided channels must be unique.")
 
         channel_contributions = self.compute_channel_contribution_original_scale().mean(
             ["chain", "draw"]
@@ -1015,7 +1019,7 @@ class BaseMMM(ModelBuilder):
 
         for i, (ax, channel) in enumerate(axes_channels):
             if self.X is not None:
-                x = self.X[channels].to_numpy()[:, i]
+                x = self.X[channels_to_plot].to_numpy()[:, i]
                 y = channel_contributions.sel(channel=channel).to_numpy()
 
                 label = label_func(channel)

--- a/tests/mmm/test_plotting.py
+++ b/tests/mmm/test_plotting.py
@@ -93,6 +93,8 @@ class TestBasePlotting:
             ("plot_components_contributions", {}),
             ("plot_channel_parameter", {"param_name": "alpha"}),
             ("plot_direct_contribution_curves", {}),
+            ("plot_direct_contribution_curves", {"same_axes": True}),
+            ("plot_direct_contribution_curves", {"channels": ["channel_2"]}),
             ("plot_channel_contribution_share_hdi", {"hdi_prob": 0.95}),
             ("plot_grouped_contribution_breakdown_over_time", {}),
             (
@@ -109,3 +111,15 @@ class TestBasePlotting:
         func = plotting_mmm.__getattribute__(func_plot_name)
         assert isinstance(func(**kwargs_plot), plt.Figure)
         plt.close("all")
+
+    @pytest.mark.parametrize(
+        "channels, match",
+        [
+            (["invalid_channel"], "subset"),
+            (["channel_1", "channel_1"], "unique"),
+            ([], "Number of rows must be a positive"),
+        ],
+    )
+    def test_plot_direct_contribution_curves_error(self, plotting_mmm, channels, match):
+        with pytest.raises(ValueError, match=match):
+            plotting_mmm.plot_direct_contribution_curves(channels=channels)


### PR DESCRIPTION
Creating two new arguments
- `channels` : Addressing #412 where `channels` is now an argument that can limit which channels are being plotted
- `same_axes` : if true, all channels selected will be on the same axes. (I've found this helpful to comparing channels)

This can lead to figures like: 

<img width="1189" alt="Screenshot 2023-12-05 at 19 51 42" src="https://github.com/pymc-labs/pymc-marketing/assets/57733339/2fa57139-65c6-44f1-8521-9e1a428d99e9">



Compared to the visual before which is still the default behavior

<!-- readthedocs-preview pymc-marketing start -->
----
:books: Documentation preview :books:: https://pymc-marketing--455.org.readthedocs.build/en/455/

<!-- readthedocs-preview pymc-marketing end -->