### PR TITLE
Add support for pre-commit-ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,15 @@
+ci:
+  autofix_commit_msg: |
+    [pre-commit.ci] auto fixes from pre-commit.com hooks
+
+    for more information, see https://pre-commit.ci
+  autofix_prs: true
+  autoupdate_branch: ""
+  autoupdate_commit_msg: "[pre-commit.ci] pre-commit autoupdate"
+  autoupdate_schedule: weekly
+  skip: []
+  submodules: false
+
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.1.11


### PR DESCRIPTION
Motivated by https://github.com/pymc-labs/pymc-marketing/pull/473

I suggest adding support for pre-commit-ci to automate the revision updates and potentially improve the dev experience by auto-fixing PRs. See docs: https://pre-commit.ci/. I added the defaults explicitly to have more control over the actions.

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--476.org.readthedocs.build/en/476/

<!-- readthedocs-preview pymc-marketing end -->