### PR TITLE
Prior Parameter Distribution and Transform Visuals + Adstock Weighting and Contribution Visuals (Draft)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.1.4
+    rev: v0.1.11
     hooks:
       - id: ruff
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.2.0
+    rev: v1.8.0
     hooks:
       - id: mypy
         args: [--ignore-missing-imports]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
+  - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.1.11
     hooks:
       - id: ruff

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx_autodoc_typehints",
     # extensions provided by other packages
-    # "matplotlib.sphinxext.plot_directive",  # needed to plot in docstrings
+    "matplotlib.sphinxext.plot_directive",  # needed to plot in docstrings
     "myst_nb",
     "notfound.extension",
     "sphinx_copybutton",

--- a/pymc_marketing/clv/utils.py
+++ b/pymc_marketing/clv/utils.py
@@ -79,7 +79,12 @@ def customer_lifetime_value(
             x = x.squeeze(dims_to_squeeze)
         return x
 
-    steps = np.arange(1, time + 1)
+    if discount_rate == 0.0:
+        # no discount rate: just compute a single time step from 0 to `time`
+        steps = np.arange(time, time + 1)
+    else:
+        steps = np.arange(1, time + 1)
+
     factor = {"W": 4.345, "M": 1.0, "D": 30, "H": 30 * 24}[freq]
 
     # Monetary value can be passed as a DataArray, with entries per chain and draw or as a simple vector

--- a/pymc_marketing/mmm/base.py
+++ b/pymc_marketing/mmm/base.py
@@ -20,11 +20,6 @@ from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import FunctionTransformer
 from xarray import DataArray, Dataset
 
-<<<<<<< HEAD
-from pymc_marketing.mmm.transformers import geometric_adstock
-from pymc_marketing.mmm.budget_optimizer import budget_allocator
-=======
->>>>>>> 9f7066f (update to plots)
 from pymc_marketing.mmm.transformers import geometric_adstock
 from pymc_marketing.mmm.budget_optimizer import budget_allocator
 from pymc_marketing.mmm.utils import (
@@ -1055,9 +1050,9 @@ class BaseMMM(ModelBuilder):
 
         fig.suptitle("Direct response curves", fontsize=16)
         return fig
-    
+
     def compute_adstocked_channels(
-            self, 
+            self,
             channels : List[str],
             adstock_params : List[str] = ['alpha', 'lam'],
             adstock_func : Any = geometric_adstock,
@@ -1066,8 +1061,6 @@ class BaseMMM(ModelBuilder):
             axis : Optional[int] = 0,
         ):
             assert hasattr(self, 'fit_result'), 'Fit the model before calling this function'
-<<<<<<< HEAD
-=======
 
             x = self.X[channels].to_numpy()
             adstock_kwargs = {
@@ -1083,11 +1076,12 @@ class BaseMMM(ModelBuilder):
             for channel in channels:
                 idx = self.channel_columns.index(channel)
                 self.X[f'{channel}_adstocked'] = adstock[:, idx]
-    
+
+
     def plot_adstocked_contribution_curves(
-            self, 
-            show_fit : bool = True, 
-            xlim_max=None, 
+            self,
+            show_fit : bool = True,
+            xlim_max=None,
             adstock_params : List[str] = ['alpha'],
             adstock_func : Any = geometric_adstock,
             method: str = "sigmoid",
@@ -1107,7 +1101,7 @@ class BaseMMM(ModelBuilder):
             The maximum value to be plot on the X-axis. If not provided, the maximum value in the data will be used.
         method : str, optional
             The method used to fit the contribution & spent non-linear relationship. It can be either 'sigmoid' or 'michaelis-menten'. Defaults to 'sigmoid'.
-        
+
         Returns
         -------
         plt.Figure
@@ -1168,7 +1162,7 @@ class BaseMMM(ModelBuilder):
             normalize=normalize,
             axis=axis,
         )
-            
+
         for i, (ax, channel) in enumerate(axes_channels):
             if self.X is not None:
                 x = self.X[f'{channel}_adstocked'].to_numpy()
@@ -1201,145 +1195,7 @@ class BaseMMM(ModelBuilder):
 
         fig.suptitle("Adstocked response curves", fontsize=16)
         return fig
-       
-<<<<<<< HEAD
->>>>>>> fbf3164 (improved visuals for mmm)
 
-            x = self.X[channels].to_numpy()
-            adstock_kwargs = {
-                param : self.fit_result[param].to_numpy()
-                for param in adstock_params
-            }
-            adstock_kwargs['x'] = x
-            adstock_kwargs['l_max'] = self.adstock_max_lag if hasattr(self, 'adstock_max_lag') else l_max
-            adstock_kwargs['normalize'] = normalize
-            adstock_kwargs['axis'] = axis
-            adstock = adstock_func(**adstock_kwargs).eval().mean(axis=(0,1))
-
-            for channel in channels:
-                idx = self.channel_columns.index(channel)
-                self.X[f'{channel}_adstocked'] = adstock[:, idx]
-    
-    def plot_adstocked_contribution_curves(
-            self, 
-            show_fit : bool = True, 
-            xlim_max=None, 
-            adstock_params : List[str] = ['alpha'],
-            adstock_func : Any = geometric_adstock,
-            method: str = "sigmoid",
-            channels: Optional[List[str]] = None,
-            normalize: bool = True,
-            axis : Optional[int] = 0,
-            same_axes: bool = False,
-    ) -> plt.Figure:
-        """
-        Plots the adstocked contribution curves for each marketing channel.
-
-        Parameters
-        ----------
-        show_fit : bool
-            If True, the function will also plot the curve fit based on the specified method. Defaults to False.
-        xlim_max : int, optional
-            The maximum value to be plot on the X-axis. If not provided, the maximum value in the data will be used.
-        method : str, optional
-            The method used to fit the contribution & spent non-linear relationship. It can be either 'sigmoid' or 'michaelis-menten'. Defaults to 'sigmoid'.
-        
-        Returns
-        -------
-        plt.Figure
-            A matplotlib Figure object with the adsotcked contribution curves.
-        """
-        channels_to_plot = self.channel_columns if channels is None else channels
-
-        if not all(channel in self.channel_columns for channel in channels_to_plot):
-            unknown_channels = set(channels_to_plot) - set(self.channel_columns)
-            raise ValueError(
-                f"The provided channels must be a subset of the available channels. Got {unknown_channels}"
-            )
-
-        if len(channels_to_plot) != len(set(channels_to_plot)):
-            raise ValueError("The provided channels must be unique.")
-
-        channel_contributions = self.compute_channel_contribution_original_scale().mean(
-            ["chain", "draw"]
-        )
-
-        if same_axes:
-            nrows = 1
-            figsize = (12, 4)
-
-            def label_func(channel):
-                return f"{channel} Data Points"
-
-            def legend_title_func(channel):
-                return "Legend"
-        else:
-            nrows = len(channels_to_plot)
-            figsize = (12, 4 * len(channels_to_plot))
-
-            def label_func(channel):
-                return "Data Points"
-
-            def legend_title_func(channel):
-                return f"{channel} Legend"
-
-        fig, axes = plt.subplots(
-            nrows=nrows,
-            ncols=1,
-            sharex=False,
-            sharey=False,
-            figsize=figsize,
-            layout="constrained",
-        )
-
-        axes_channels = (
-            zip(repeat(axes), channels_to_plot)
-            if same_axes
-            else zip(np.ravel(axes), channels_to_plot)
-        )
-        self.compute_adstocked_channels(
-            channels=channels_to_plot,
-            adstock_params=adstock_params,
-            adstock_func=adstock_func,
-            normalize=normalize,
-            axis=axis,
-        )
-            
-        for i, (ax, channel) in enumerate(axes_channels):
-            if self.X is not None:
-                x = self.X[f'{channel}_adstocked'].to_numpy()
-                y = channel_contributions.sel(channel=channel).to_numpy()
-
-                label = label_func(channel)
-                ax.scatter(x, y, label=label, color=f"C{i}")
-
-                if show_fit:
-                    label = f"{channel} Fit Curve" if same_axes else "Fit Curve"
-                    self._plot_response_curve_fit(
-                        x=x,
-                        ax=ax,
-                        channel=channel,
-                        color_index=i,
-                        xlim_max=xlim_max,
-                        method=method,
-                        label=label,
-                    )
-
-                title = legend_title_func(channel)
-                ax.legend(
-                    loc="upper left",
-                    facecolor="white",
-                    title=title,
-                    fontsize="small",
-                )
-
-                ax.set(xlabel="Mean Adstock Spend", ylabel="Contribution")
-
-        fig.suptitle("Adstocked response curves", fontsize=16)
-        return fig
-       
-=======
->>>>>>> 9f7066f (update to plots)
     def _get_distribution(self, dist: Dict) -> Callable:
         """
         Retrieve a PyMC distribution callable based on the provided dictionary.
@@ -1557,3 +1413,4 @@ class BaseMMM(ModelBuilder):
 
 class MMM(BaseMMM, ValidateTargetColumn, ValidateDateColumn, ValidateChannelColumns):
     pass
+

--- a/pymc_marketing/mmm/base.py
+++ b/pymc_marketing/mmm/base.py
@@ -20,9 +20,13 @@ from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import FunctionTransformer
 from xarray import DataArray, Dataset
 
+<<<<<<< HEAD
 from pymc_marketing.mmm.transformers import geometric_adstock
 from pymc_marketing.mmm.budget_optimizer import budget_allocator
+=======
+>>>>>>> 9f7066f (update to plots)
 from pymc_marketing.mmm.transformers import geometric_adstock
+from pymc_marketing.mmm.budget_optimizer import budget_allocator
 from pymc_marketing.mmm.utils import (
     estimate_menten_parameters,
     estimate_sigmoid_parameters,
@@ -1071,7 +1075,7 @@ class BaseMMM(ModelBuilder):
                 for param in adstock_params
             }
             adstock_kwargs['x'] = x
-            adstock_kwargs['max_lag'] = self.adstock_max_lag if hasattr(self, 'adstock_max_lag') else l_max
+            adstock_kwargs['l_max'] = self.adstock_max_lag if hasattr(self, 'adstock_max_lag') else l_max
             adstock_kwargs['normalize'] = normalize
             adstock_kwargs['axis'] = axis
             adstock = adstock_func(**adstock_kwargs).eval().mean(axis=(0,1))
@@ -1084,7 +1088,7 @@ class BaseMMM(ModelBuilder):
             self, 
             show_fit : bool = True, 
             xlim_max=None, 
-            adstock_params : List[str] = ['alpha', 'lam'],
+            adstock_params : List[str] = ['alpha'],
             adstock_func : Any = geometric_adstock,
             method: str = "sigmoid",
             channels: Optional[List[str]] = None,
@@ -1198,6 +1202,7 @@ class BaseMMM(ModelBuilder):
         fig.suptitle("Adstocked response curves", fontsize=16)
         return fig
        
+<<<<<<< HEAD
 >>>>>>> fbf3164 (improved visuals for mmm)
 
             x = self.X[channels].to_numpy()
@@ -1333,6 +1338,8 @@ class BaseMMM(ModelBuilder):
         fig.suptitle("Adstocked response curves", fontsize=16)
         return fig
        
+=======
+>>>>>>> 9f7066f (update to plots)
     def _get_distribution(self, dist: Dict) -> Callable:
         """
         Retrieve a PyMC distribution callable based on the provided dictionary.

--- a/pymc_marketing/mmm/base.py
+++ b/pymc_marketing/mmm/base.py
@@ -22,6 +22,7 @@ from xarray import DataArray, Dataset
 
 from pymc_marketing.mmm.transformers import geometric_adstock
 from pymc_marketing.mmm.budget_optimizer import budget_allocator
+from pymc_marketing.mmm.transformers import geometric_adstock
 from pymc_marketing.mmm.utils import (
     estimate_menten_parameters,
     estimate_sigmoid_parameters,
@@ -1061,6 +1062,143 @@ class BaseMMM(ModelBuilder):
             axis : Optional[int] = 0,
         ):
             assert hasattr(self, 'fit_result'), 'Fit the model before calling this function'
+<<<<<<< HEAD
+=======
+
+            x = self.X[channels].to_numpy()
+            adstock_kwargs = {
+                param : self.fit_result[param].to_numpy()
+                for param in adstock_params
+            }
+            adstock_kwargs['x'] = x
+            adstock_kwargs['max_lag'] = self.adstock_max_lag if hasattr(self, 'adstock_max_lag') else l_max
+            adstock_kwargs['normalize'] = normalize
+            adstock_kwargs['axis'] = axis
+            adstock = adstock_func(**adstock_kwargs).eval().mean(axis=(0,1))
+
+            for channel in channels:
+                idx = self.channel_columns.index(channel)
+                self.X[f'{channel}_adstocked'] = adstock[:, idx]
+    
+    def plot_adstocked_contribution_curves(
+            self, 
+            show_fit : bool = True, 
+            xlim_max=None, 
+            adstock_params : List[str] = ['alpha', 'lam'],
+            adstock_func : Any = geometric_adstock,
+            method: str = "sigmoid",
+            channels: Optional[List[str]] = None,
+            normalize: bool = True,
+            axis : Optional[int] = 0,
+            same_axes: bool = False,
+    ) -> plt.Figure:
+        """
+        Plots the adstocked contribution curves for each marketing channel.
+
+        Parameters
+        ----------
+        show_fit : bool
+            If True, the function will also plot the curve fit based on the specified method. Defaults to False.
+        xlim_max : int, optional
+            The maximum value to be plot on the X-axis. If not provided, the maximum value in the data will be used.
+        method : str, optional
+            The method used to fit the contribution & spent non-linear relationship. It can be either 'sigmoid' or 'michaelis-menten'. Defaults to 'sigmoid'.
+        
+        Returns
+        -------
+        plt.Figure
+            A matplotlib Figure object with the adsotcked contribution curves.
+        """
+        channels_to_plot = self.channel_columns if channels is None else channels
+
+        if not all(channel in self.channel_columns for channel in channels_to_plot):
+            unknown_channels = set(channels_to_plot) - set(self.channel_columns)
+            raise ValueError(
+                f"The provided channels must be a subset of the available channels. Got {unknown_channels}"
+            )
+
+        if len(channels_to_plot) != len(set(channels_to_plot)):
+            raise ValueError("The provided channels must be unique.")
+
+        channel_contributions = self.compute_channel_contribution_original_scale().mean(
+            ["chain", "draw"]
+        )
+
+        if same_axes:
+            nrows = 1
+            figsize = (12, 4)
+
+            def label_func(channel):
+                return f"{channel} Data Points"
+
+            def legend_title_func(channel):
+                return "Legend"
+        else:
+            nrows = len(channels_to_plot)
+            figsize = (12, 4 * len(channels_to_plot))
+
+            def label_func(channel):
+                return "Data Points"
+
+            def legend_title_func(channel):
+                return f"{channel} Legend"
+
+        fig, axes = plt.subplots(
+            nrows=nrows,
+            ncols=1,
+            sharex=False,
+            sharey=False,
+            figsize=figsize,
+            layout="constrained",
+        )
+
+        axes_channels = (
+            zip(repeat(axes), channels_to_plot)
+            if same_axes
+            else zip(np.ravel(axes), channels_to_plot)
+        )
+        self.compute_adstocked_channels(
+            channels=channels_to_plot,
+            adstock_params=adstock_params,
+            adstock_func=adstock_func,
+            normalize=normalize,
+            axis=axis,
+        )
+            
+        for i, (ax, channel) in enumerate(axes_channels):
+            if self.X is not None:
+                x = self.X[f'{channel}_adstocked'].to_numpy()
+                y = channel_contributions.sel(channel=channel).to_numpy()
+
+                label = label_func(channel)
+                ax.scatter(x, y, label=label, color=f"C{i}")
+
+                if show_fit:
+                    label = f"{channel} Fit Curve" if same_axes else "Fit Curve"
+                    self._plot_response_curve_fit(
+                        x=x,
+                        ax=ax,
+                        channel=channel,
+                        color_index=i,
+                        xlim_max=xlim_max,
+                        method=method,
+                        label=label,
+                    )
+
+                title = legend_title_func(channel)
+                ax.legend(
+                    loc="upper left",
+                    facecolor="white",
+                    title=title,
+                    fontsize="small",
+                )
+
+                ax.set(xlabel="Mean Adstock Spend", ylabel="Contribution")
+
+        fig.suptitle("Adstocked response curves", fontsize=16)
+        return fig
+       
+>>>>>>> fbf3164 (improved visuals for mmm)
 
             x = self.X[channels].to_numpy()
             adstock_kwargs = {

--- a/pymc_marketing/mmm/base.py
+++ b/pymc_marketing/mmm/base.py
@@ -20,8 +20,8 @@ from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import FunctionTransformer
 from xarray import DataArray, Dataset
 
-from pymc_marketing.mmm.budget_optimizer import budget_allocator
 from pymc_marketing.mmm.transformers import geometric_adstock
+from pymc_marketing.mmm.budget_optimizer import budget_allocator
 from pymc_marketing.mmm.utils import (
     estimate_menten_parameters,
     estimate_sigmoid_parameters,
@@ -1068,7 +1068,7 @@ class BaseMMM(ModelBuilder):
                 for param in adstock_params
             }
             adstock_kwargs['x'] = x
-            adstock_kwargs['max_lag'] = self.adstock_max_lag if hasattr(self, 'adstock_max_lag') else l_max
+            adstock_kwargs['l_max'] = self.adstock_max_lag if hasattr(self, 'adstock_max_lag') else l_max
             adstock_kwargs['normalize'] = normalize
             adstock_kwargs['axis'] = axis
             adstock = adstock_func(**adstock_kwargs).eval().mean(axis=(0,1))
@@ -1081,7 +1081,7 @@ class BaseMMM(ModelBuilder):
             self, 
             show_fit : bool = True, 
             xlim_max=None, 
-            adstock_params : List[str] = ['alpha', 'lam'],
+            adstock_params : List[str] = ['alpha'],
             adstock_func : Any = geometric_adstock,
             method: str = "sigmoid",
             channels: Optional[List[str]] = None,
@@ -1195,7 +1195,6 @@ class BaseMMM(ModelBuilder):
         fig.suptitle("Adstocked response curves", fontsize=16)
         return fig
        
-
     def _get_distribution(self, dist: Dict) -> Callable:
         """
         Retrieve a PyMC distribution callable based on the provided dictionary.

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -892,8 +892,6 @@ class DelayedSaturatedMMM(
             The maximum lag for the adstock transformation, by default 12
         normalize : bool, optional
             Whether to normalize the weights, by default True
-        axis : int, optional
-            The axis to apply the transformation, by default 0
 
         Returns
         -------

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -892,7 +892,7 @@ class DelayedSaturatedMMM(
             The maximum lag for the adstock transformation, by default 12
         normalize : bool, optional
             Whether to normalize the weights, by default True
-     
+
         Returns
         -------
         Union[float, np.ndarray]

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -849,7 +849,6 @@ class DelayedSaturatedMMM(
         ax = ax.flatten() if len(col_names) > 1 else [ax]     
         cmap = plt.get_cmap('tab10')
         
-        
         def channel_sample(samples, col):
             """Filter parameter index by column index"""
             # index is 0 if channles have shared priors, otherwise index is column index

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -892,6 +892,8 @@ class DelayedSaturatedMMM(
             The maximum lag for the adstock transformation, by default 12
         normalize : bool, optional
             Whether to normalize the weights, by default True
+        axis : int, optional
+            The axis to apply the transformation, by default 0
 
         Returns
         -------

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -892,9 +892,7 @@ class DelayedSaturatedMMM(
             The maximum lag for the adstock transformation, by default 12
         normalize : bool, optional
             Whether to normalize the weights, by default True
-        axis : int, optional
-            The axis to apply the transformation, by default 0
-
+     
         Returns
         -------
         Union[float, np.ndarray]

--- a/pymc_marketing/mmm/transformers.py
+++ b/pymc_marketing/mmm/transformers.py
@@ -4,6 +4,7 @@ import numpy.typing as npt
 import pytensor.tensor as pt
 from pytensor.tensor.random.utils import params_broadcast_shapes
 
+<<<<<<< HEAD
 
 class ConvMode(Enum):
     After = "After"
@@ -37,6 +38,10 @@ def batched_convolution(x, w, axis: int = 0, mode: ConvMode = ConvMode.Before):
         ax.set_position([box.x0, box.y0, box.width * 0.8, box.height])
         ax.legend(loc='center left', bbox_to_anchor=(1, 0.5))
         plt.show()
+=======
+def batched_convolution(x, w, axis: int = 0):
+    """Apply a 1D convolution in a vectorized way across multiple batch dimensions.
+>>>>>>> 9f7066f (update to plots)
 
     Parameters
     ----------

--- a/pymc_marketing/mmm/transformers.py
+++ b/pymc_marketing/mmm/transformers.py
@@ -4,8 +4,15 @@ import numpy.typing as npt
 import pytensor.tensor as pt
 from pytensor.tensor.random.utils import params_broadcast_shapes
 
-def batched_convolution(x, w, axis: int = 0):
-    """Apply a 1D convolution in a vectorized way across multiple batch dimensions.
+
+class ConvMode(Enum):
+    After = "After"
+    Before = "Before"
+    Overlap = "Overlap"
+
+
+def batched_convolution(x, w, axis: int = 0, mode: ConvMode = ConvMode.Before):
+    R"""Apply a 1D convolution in a vectorized way across multiple batch dimensions.
 
     .. plot::
         :context: close-figs
@@ -21,12 +28,14 @@ def batched_convolution(x, w, axis: int = 0):
         ax = plt.subplot(111)
         for mode in [ConvMode.Before, ConvMode.Overlap, ConvMode.After]:
             y = batched_convolution(spends, w, mode=mode).eval()
-            suffix = " (default)" if mode == ConvMode.Before else ""
-            plt.plot(x, y, label=f'mode = {mode}{suffix}')
+            suffix = "\n(default)" if mode == ConvMode.Before else ""
+            plt.plot(x, y, label=f'{mode.value}{suffix}')
         plt.xlabel('time since spend', fontsize=12)
         plt.ylabel('f(time since spend)', fontsize=12)
         plt.title(f"1 spend at time 0 and {w = }", fontsize=14)
-        plt.legend()
+        box = ax.get_position()
+        ax.set_position([box.x0, box.y0, box.width * 0.8, box.height])
+        ax.legend(loc='center left', bbox_to_anchor=(1, 0.5))
         plt.show()
 
     Parameters
@@ -122,11 +131,13 @@ def geometric_adstock(
         x = np.arange(len(spend))
         for a, normalize in params:
             y = geometric_adstock(spend, alpha=a, l_max=l_max, normalize=normalize).eval()
-            plt.plot(x, y, label=f'alpha = {a}, normalize = {normalize}')
+            plt.plot(x, y, label=f'alpha = {a}\nnormalize = {normalize}')
         plt.xlabel('time since spend', fontsize=12)
         plt.title(f'Geometric Adstock with l_max = {l_max}', fontsize=14)
         plt.ylabel('f(time since spend)', fontsize=12)
-        plt.legend()
+        box = ax.get_position()
+        ax.set_position([box.x0, box.y0, box.width * 0.65, box.height])
+        ax.legend(loc='center left', bbox_to_anchor=(1, 0.5))
         plt.show()
 
     Parameters
@@ -167,7 +178,7 @@ def delayed_adstock(
     normalize: bool = False,
     axis: int = 0,
 ):
-    """Delayed adstock transformation.
+    R"""Delayed adstock transformation.
 
     This transformation is similar to geometric adstock transformation, but it
     allows for a delayed peak of the effect. The peak is assumed to occur at `theta`.
@@ -192,10 +203,12 @@ def delayed_adstock(
         ax = plt.subplot(111)
         for a, t, normalize in params:
             y = delayed_adstock(spend, alpha=a, theta=t, normalize=normalize).eval()
-            plt.plot(x, y, label=f'alpha = {a}, theta = {t}, normalize = {normalize}')
+            plt.plot(x, y, label=f'alpha = {a}\ntheta = {t}\nnormalize = {normalize}')
         plt.xlabel('time since spend', fontsize=12)
         plt.ylabel('f(time since spend)', fontsize=12)
-        plt.legend()
+        box = ax.get_position()
+        ax.set_position([box.x0, box.y0, box.width * 0.65, box.height])
+        ax.legend(loc='center left', bbox_to_anchor=(1, 0.5))
         plt.show()
 
     Parameters
@@ -254,7 +267,9 @@ def logistic_saturation(x, lam: Union[npt.NDArray[np.float_], float] = 0.5):
             plt.plot(x, y, label=f'lam = {l}')
         plt.xlabel('spend', fontsize=12)
         plt.ylabel('f(spend)', fontsize=12)
-        plt.legend()
+        box = ax.get_position()
+        ax.set_position([box.x0, box.y0, box.width * 0.8, box.height])
+        ax.legend(loc='center left', bbox_to_anchor=(1, 0.5))
         plt.show()
 
     Parameters
@@ -297,10 +312,13 @@ def tanh_saturation(x, b: float = 0.5, c: float = 0.5):
         ax = plt.subplot(111)
         for b, c in params:
             y = tanh_saturation(x, b=b, c=c).eval()
-            plt.plot(x, y, label=f'b = {b}, c = {c}')
+            plt.plot(x, y, label=f'b = {b}\nc = {c}')
         plt.xlabel('spend', fontsize=12)
         plt.ylabel('f(spend)', fontsize=12)
-        plt.legend()
+        box = ax.get_position()
+        ax.set_position([box.x0, box.y0, box.width * 0.8, box.height])
+        ax.legend(loc='center left', bbox_to_anchor=(1, 0.5))
+        # plt.legend()
         plt.show()
 
     Parameters

--- a/pymc_marketing/mmm/transformers.py
+++ b/pymc_marketing/mmm/transformers.py
@@ -7,6 +7,28 @@ from pytensor.tensor.random.utils import params_broadcast_shapes
 def batched_convolution(x, w, axis: int = 0):
     """Apply a 1D convolution in a vectorized way across multiple batch dimensions.
 
+    .. plot::
+        :context: close-figs
+
+        import matplotlib.pyplot as plt
+        import numpy as np
+        import arviz as az
+        from pymc_marketing.mmm.transformers import batched_convolution, ConvMode
+        plt.style.use('arviz-darkgrid')
+        spends = np.array([0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0])
+        w = np.array([0.75, 0.25, 0.125, 0.125])
+        x = np.arange(-5, 6)
+        ax = plt.subplot(111)
+        for mode in [ConvMode.Before, ConvMode.Overlap, ConvMode.After]:
+            y = batched_convolution(spends, w, mode=mode).eval()
+            suffix = " (default)" if mode == ConvMode.Before else ""
+            plt.plot(x, y, label=f'mode = {mode}{suffix}')
+        plt.xlabel('time since spend', fontsize=12)
+        plt.ylabel('f(time since spend)', fontsize=12)
+        plt.title(f"1 spend at time 0 and {w = }", fontsize=14)
+        plt.legend()
+        plt.show()
+
     Parameters
     ----------
     x :
@@ -71,13 +93,41 @@ def geometric_adstock(
     normalize: bool = False, 
     axis: int = 0, 
 ):
-    """Geometric adstock transformation.
+    R"""Geometric adstock transformation.
 
     Adstock with geometric decay assumes advertising effect peaks at the same
     time period as ad exposure. The cumulative media effect is a weighted average
     of media spend in the current time-period (e.g. week) and previous `l_max` - 1
     periods (e.g. weeks). `l_max` is the maximum duration of carryover effect.
 
+    .. plot::
+        :context: close-figs
+
+        import matplotlib.pyplot as plt
+        import numpy as np
+        import arviz as az
+        from pymc_marketing.mmm.transformers import geometric_adstock
+        plt.style.use('arviz-darkgrid')
+        l_max = 12
+        params = [
+            (0.01, False),
+            (0.5, False),
+            (0.9, False),
+            (0.5, True),
+            (0.9, True),
+        ]
+        spend = np.zeros(15)
+        spend[0] = 1
+        ax = plt.subplot(111)
+        x = np.arange(len(spend))
+        for a, normalize in params:
+            y = geometric_adstock(spend, alpha=a, l_max=l_max, normalize=normalize).eval()
+            plt.plot(x, y, label=f'alpha = {a}, normalize = {normalize}')
+        plt.xlabel('time since spend', fontsize=12)
+        plt.title(f'Geometric Adstock with l_max = {l_max}', fontsize=14)
+        plt.ylabel('f(time since spend)', fontsize=12)
+        plt.legend()
+        plt.show()
 
     Parameters
     ----------
@@ -122,6 +172,32 @@ def delayed_adstock(
     This transformation is similar to geometric adstock transformation, but it
     allows for a delayed peak of the effect. The peak is assumed to occur at `theta`.
 
+    .. plot::
+        :context: close-figs
+
+        import matplotlib.pyplot as plt
+        import numpy as np
+        import arviz as az
+        from pymc_marketing.mmm.transformers import delayed_adstock
+        plt.style.use('arviz-darkgrid')
+        params = [
+            (0.25, 0, False),
+            (0.25, 5, False),
+            (0.75, 5, False),
+            (0.75, 5, True)
+        ]
+        spend = np.zeros(15)
+        spend[0] = 1
+        x = np.arange(len(spend))
+        ax = plt.subplot(111)
+        for a, t, normalize in params:
+            y = delayed_adstock(spend, alpha=a, theta=t, normalize=normalize).eval()
+            plt.plot(x, y, label=f'alpha = {a}, theta = {t}, normalize = {normalize}')
+        plt.xlabel('time since spend', fontsize=12)
+        plt.ylabel('f(time since spend)', fontsize=12)
+        plt.legend()
+        plt.show()
+
     Parameters
     ----------
     x : tensor
@@ -158,6 +234,29 @@ def delayed_adstock(
 
 def logistic_saturation(x, lam: Union[npt.NDArray[np.float_], float] = 0.5):
     """Logistic saturation transformation.
+
+    .. math::
+        f(x) = \\frac{1 - e^{-\lambda x}}{1 + e^{-\lambda x}}
+
+    .. plot::
+        :context: close-figs
+
+        import matplotlib.pyplot as plt
+        import numpy as np
+        import arviz as az
+        from pymc_marketing.mmm.transformers import logistic_saturation
+        plt.style.use('arviz-darkgrid')
+        lam = np.array([0.25, 0.5, 1, 2, 4])
+        x = np.linspace(0, 5, 100)
+        ax = plt.subplot(111)
+        for l in lam:
+            y = logistic_saturation(x, lam=l).eval()
+            plt.plot(x, y, label=f'lam = {l}')
+        plt.xlabel('spend', fontsize=12)
+        plt.ylabel('f(spend)', fontsize=12)
+        plt.legend()
+        plt.show()
+
     Parameters
     ----------
     x : tensor
@@ -174,7 +273,35 @@ def logistic_saturation(x, lam: Union[npt.NDArray[np.float_], float] = 0.5):
 
 
 def tanh_saturation(x, b: float = 0.5, c: float = 0.5):
-    """Tanh saturation transformation.
+    R"""Tanh saturation transformation.
+
+    .. math::
+        f(x) = b \tanh \left( \frac{x}{bc} \right)
+
+    .. plot::
+        :context: close-figs
+
+        import matplotlib.pyplot as plt
+        import numpy as np
+        import arviz as az
+        from pymc_marketing.mmm.transformers import tanh_saturation
+        plt.style.use('arviz-darkgrid')
+        params = [
+            (0.75, 0.25),
+            (0.75, 1.5),
+            (1, 0.25),
+            (1, 1),
+            (1, 1.5),
+        ]
+        x = np.linspace(0, 5, 100)
+        ax = plt.subplot(111)
+        for b, c in params:
+            y = tanh_saturation(x, b=b, c=c).eval()
+            plt.plot(x, y, label=f'b = {b}, c = {c}')
+        plt.xlabel('spend', fontsize=12)
+        plt.ylabel('f(spend)', fontsize=12)
+        plt.legend()
+        plt.show()
 
     Parameters
     ----------


### PR DESCRIPTION
## Description
Additional functionalities serving to help the users specify their priors. This includes functions to:
1. Explore the priors across channels
2. See the effect of the adstock- and saturation transforms across channels
3. Compare the adstocked contribution with the direct contribution curve

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
   (some functions in `delayed_saturated_mmm.py` might need to be checked.
- [ ] Included tests that prove the fix is effective or that the new feature works
   (have done some here, but not an exhaustive list of tests)
- [ ] Added necessary documentation (docstrings and/or example notebooks)
   (only modified the `mmm_example.ipynb` file to show functionality. Would either need a prior predictive notebook or create an additional section in the file with more detailed description and appriopriate headers + placement.
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes) 
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

Sorry, but the commits are a bit all over the place 🙈 

## Modules affected
- [x] MMM
- [ ] CLV

## Type of change
- [x] New feature / enhancement
- [ ] Bug fix
- [x] Documentation (A maybe here)
- [ ] Maintenance
- [ ] Other (please specify):


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--477.org.readthedocs.build/en/477/

<!-- readthedocs-preview pymc-marketing end -->