### PR TITLE
Add isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,7 @@ repos:
     rev: v0.1.11
     hooks:
       - id: ruff
+        args: ["--fix", "--show-source"]
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.8.0

--- a/pymc_marketing/mmm/base.py
+++ b/pymc_marketing/mmm/base.py
@@ -1,4 +1,3 @@
-from itertools import repeat
 import warnings
 from inspect import (
     getattr_static,
@@ -7,6 +6,7 @@ from inspect import (
     ismemberdescriptor,
     ismethoddescriptor,
 )
+from itertools import repeat
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import arviz as az

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,9 @@ repository = "https://github.com/pymc-labs/pymc-marketing"
 #documentation = ""
 #changelog = ""
 
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F", "I"]
+
 [tool.pytest.ini_options]
 addopts = [
     "-v",

--- a/tests/mmm/test_delayed_saturated_mmm.py
+++ b/tests/mmm/test_delayed_saturated_mmm.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Optional, Dict
+from typing import Dict, List, Optional
 
 import arviz as az
 import numpy as np
@@ -7,7 +7,6 @@ import pandas as pd
 import pymc as pm
 import pytest
 from matplotlib import pyplot as plt
-
 
 from pymc_marketing.mmm.delayed_saturated_mmm import (
     BaseDelayedSaturatedMMM,


### PR DESCRIPTION
I just realized `isort` was not in the default ruff config 🤦 . Sorry!

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--480.org.readthedocs.build/en/480/

<!-- readthedocs-preview pymc-marketing end -->