### PR TITLE
Add Weibull CDF and PDF Adstock Transformations

### DIFF
--- a/pymc_marketing/mmm/transformers.py
+++ b/pymc_marketing/mmm/transformers.py
@@ -14,7 +14,8 @@ class ConvMode(Enum):
     Overlap = "Overlap"
 
 
-class WeibullType(Enum):
+class WeibullType(str, Enum):
+    # TODO: use StrEnum when we upgrade to python 3.11
     PDF = "PDF"
     CDF = "CDF"
 
@@ -272,7 +273,7 @@ def weibull_adstock(
     k=1,
     l_max: int = 12,
     axis: int = 0,
-    type: WeibullType = WeibullType.PDF,
+    type: WeibullType | str = WeibullType.PDF,
 ):
     R"""Weibull Adstocking Transformation.
 

--- a/pymc_marketing/mmm/transformers.py
+++ b/pymc_marketing/mmm/transformers.py
@@ -273,7 +273,7 @@ def weibull_adstock(
     k=1,
     l_max: int = 12,
     axis: int = 0,
-    type: WeibullType | str = WeibullType.PDF,
+    type: Union[WeibullType, str] = WeibullType.PDF,
 ):
     R"""Weibull Adstocking Transformation.
 

--- a/pymc_marketing/mmm/transformers.py
+++ b/pymc_marketing/mmm/transformers.py
@@ -337,7 +337,7 @@ def weibull_adstock(
         Shape parameter of the Weibull distribution. Must be positive.
     l_max : int, by default 12
         Maximum duration of carryover effect.
-    type : WeibullType, by default WeibullType.PDF
+    type : WeibullType or str, by default WeibullType.PDF
         Type of Weibull adstock transformation to be applied (PDF or CDF).
 
     Returns

--- a/pymc_marketing/mmm/transformers.py
+++ b/pymc_marketing/mmm/transformers.py
@@ -362,23 +362,6 @@ def weibull_adstock(
         raise ValueError(f"Wrong WeibullType: {type}, expected of WeibullType")
     return batched_convolution(x, w, axis=axis)
 
-    # lam = pt.as_tensor(lam)
-    # k = pt.as_tensor(k)
-    # t = pt.arange(l_max, dtype=x.dtype) + 1
-
-    # if type == WeibullType.PDF:
-    #     w = pt.exp(pm.Weibull.logp(t, k, lam))
-    #     w = (w - pt.min(w, axis=-1)) / (pt.max(w, axis=-1) - pt.min(w, axis=-1))
-    # elif type == WeibullType.CDF:
-    #     w = 1 - pt.exp(pm.Weibull.logcdf(t, k, lam))
-    #     shape = (*w.shape[:-1], w.shape[-1] + 1)
-    #     padded_w = pt.ones(shape, dtype=w.dtype)
-    #     padded_w = pt.set_subtensor(padded_w[..., 1:], w)
-    #     w = pt.cumprod(padded_w, axis=-1)
-    # else:
-    #     raise ValueError(f"Wrong WeibullType: {type}, expected of WeibullType")
-    # return batched_convolution(x, w, axis=axis)
-
 
 def logistic_saturation(x, lam: Union[npt.NDArray[np.float_], float] = 0.5):
     """Logistic saturation transformation.

--- a/pymc_marketing/mmm/transformers.py
+++ b/pymc_marketing/mmm/transformers.py
@@ -277,6 +277,7 @@ def weibull_adstock(
     R"""Weibull Adstocking Transformation.
 
     This transformation is similar to geometric adstock transformation but has more degrees of freedom, adding more flexibility.
+
     .. plot::
         :context: close-figs
         import matplotlib.pyplot as plt
@@ -311,7 +312,6 @@ def weibull_adstock(
                         adstock,
                         label=f"Scale={scale}",
                         linestyle="-",
-                        alpha=0.5
                     )
 
         fig.legend(

--- a/pymc_marketing/mmm/transformers.py
+++ b/pymc_marketing/mmm/transformers.py
@@ -281,6 +281,7 @@ def weibull_adstock(
 
     .. plot::
         :context: close-figs
+
         import matplotlib.pyplot as plt
         import numpy as np
         import arviz as az

--- a/tests/mmm/test_transformers.py
+++ b/tests/mmm/test_transformers.py
@@ -2,15 +2,18 @@ import numpy as np
 import pytensor
 import pytensor.tensor as pt
 import pytest
+import scipy as sp
 from pytensor.tensor.var import TensorVariable
 
 from pymc_marketing.mmm.transformers import (
     ConvMode,
+    WeibullType,
     batched_convolution,
     delayed_adstock,
     geometric_adstock,
     logistic_saturation,
     tanh_saturation,
+    weibull_adstock,
 )
 
 
@@ -160,6 +163,86 @@ class TestsAdstockTransformers:
 
         y_tensors = [
             delayed_adstock(x=x[:, i], alpha=alpha[i], theta=theta[i], l_max=12)
+            for i in range(x.shape[1])
+        ]
+        ys = np.concatenate([y_t.eval()[..., None] for y_t in y_tensors], axis=1)
+        assert y.shape == x.shape
+        np.testing.assert_almost_equal(actual=y, desired=ys, decimal=12)
+
+    def test_weibull_adstock_output_type(self):
+        x = np.ones(shape=(100))
+        y = weibull_adstock(x=x, lam=1, k=1, l_max=7, type=WeibullType.PDF)
+        assert isinstance(y, TensorVariable)
+        assert isinstance(y.eval(), np.ndarray)
+
+    def test_weibull_adstock_x_zero(self):
+        x = np.zeros(shape=(100))
+        y = weibull_adstock(x=x, lam=1, k=1, l_max=4, type=WeibullType.PDF)
+        np.testing.assert_array_equal(x=x, y=y.eval())
+
+    @pytest.mark.parametrize(
+        "x, lam, k, l_max",
+        [
+            (np.ones(shape=(100)), 0.3, 0.5, 10),
+            (np.ones(shape=(100)), 0.7, 1, 100),
+            (np.zeros(shape=(100)), 0.2, 0.2, 5),
+            (np.ones(shape=(100)), 0.5, 0.8, 7),
+            (np.linspace(start=0.0, stop=1.0, num=50), 0.8, 1.5, 3),
+            (np.linspace(start=0.0, stop=1.0, num=50), 0.8, 1, 50),
+        ],
+    )
+    def test_weibull_pdf_adstock(self, x, lam, k, l_max):
+        y = weibull_adstock(x=x, lam=lam, k=k, l_max=l_max, type=WeibullType.PDF).eval()
+
+        assert np.all(np.isfinite(y))
+        w = sp.stats.weibull_min.pdf(np.arange(l_max) + 1, c=k, scale=lam)
+        w = (w - np.min(w)) / (np.max(w) - np.min(w))
+        sp_y = batched_convolution(x, w).eval()
+
+        np.testing.assert_almost_equal(y, sp_y)
+
+    @pytest.mark.parametrize(
+        "x, lam, k, l_max",
+        [
+            (np.ones(shape=(100)), 0.3, 0.5, 10),
+            (np.ones(shape=(100)), 0.7, 1, 100),
+            (np.zeros(shape=(100)), 0.2, 0.2, 5),
+            (np.ones(shape=(100)), 0.5, 0.8, 7),
+            (np.linspace(start=0.0, stop=1.0, num=50), 0.8, 1.5, 3),
+            (np.linspace(start=0.0, stop=1.0, num=50), 0.8, 1, 50),
+        ],
+    )
+    def test_weibull_cdf_adsotck(self, x, lam, k, l_max):
+        y = weibull_adstock(x=x, lam=lam, k=k, l_max=l_max, type=WeibullType.CDF).eval()
+
+        assert np.all(np.isfinite(y))
+        w = 1 - sp.stats.weibull_min.cdf(np.arange(l_max) + 1, c=k, scale=lam)
+        w = sp.cumprod(np.concatenate([[1], w]))
+        sp_y = batched_convolution(x, w).eval()
+        np.testing.assert_almost_equal(y, sp_y)
+
+    @pytest.mark.parametrize(
+        "type",
+        [
+            WeibullType.PDF,
+            WeibullType.CDF,
+        ],
+    )
+    def test_weibull_adstock_vectorized(self, type, dummy_design_matrix):
+        x = dummy_design_matrix.copy()
+        x_tensor = pt.as_tensor_variable(x)
+        lam = [0.9, 0.33, 0.5, 0.1, 1.0]
+        lam_tensor = pt.as_tensor_variable(lam)
+        k = [0.8, 0.2, 0.6, 0.4, 1.0]
+        k_tensor = pt.as_tensor_variable(k)
+        y = weibull_adstock(
+            x=x_tensor, lam=lam_tensor, k=k_tensor, l_max=12, type=type
+        ).eval()
+
+        y_tensors = [
+            weibull_adstock(
+                x=x_tensor[:, i], lam=lam_tensor[i], k=k_tensor[i], l_max=12, type=type
+            )
             for i in range(x.shape[1])
         ]
         ys = np.concatenate([y_t.eval()[..., None] for y_t in y_tensors], axis=1)

--- a/tests/mmm/test_transformers.py
+++ b/tests/mmm/test_transformers.py
@@ -212,7 +212,7 @@ class TestsAdstockTransformers:
 
         assert np.all(np.isfinite(y))
         w = 1 - sp.stats.weibull_min.cdf(np.arange(l_max) + 1, c=k, scale=lam)
-        w = sp.cumprod(np.concatenate([[1], w]))
+        w = np.cumprod(np.concatenate([[1], w]))
         sp_y = batched_convolution(x, w).eval()
         np.testing.assert_almost_equal(y, sp_y)
 


### PR DESCRIPTION
## Description
This pull request add the `weibull_adstock function`, providing support for both Weibull CDF and PDF adstock transformations.

<img width="1208" alt="image" src="https://github.com/pymc-labs/pymc-marketing/assets/33545649/71fad253-3ac0-46d9-88a2-e601833f01ac">


## Related Issue
- [x] Closes #447

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)

## Modules affected
- [x] MMM
- [ ] CLV


## Type of change
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):



<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--499.org.readthedocs.build/en/499/

<!-- readthedocs-preview pymc-marketing end -->