### PR TITLE
Add scale preserving saturation function

### DIFF
--- a/pymc_marketing/mmm/transformers.py
+++ b/pymc_marketing/mmm/transformers.py
@@ -312,14 +312,14 @@ def scale_preserving_logistic_saturation(x, m: Union[npt.NDArray[np.float_], flo
     """Scale preserving logistic transformation.
 
     This single-parameter saturation function maps its input to the range
-    `[0, m]`, where \( f(x) \leq x \) for all x. It can be interpreted as mapping
+    :math:`[0, m]`, where :math:`f(x) \leq x` for all :math:`x`. It can be interpreted as mapping
     from spend to "effective spend".
 
     Properties:
     * Transformed values are on similar scale as input values. This enables
       one to specify coefficient priors in units of channel ROI, without
       transformation.
-    * Intuitive parameter interpretation: `m` is the "maximum achievable effect".
+    * Intuitive parameter interpretation: :math:`m` is the "maximum achievable effect".
     * Slope of curve never exceeds 1. Thus "effective spend" <= "actual spend".
 
     .. math::

--- a/pymc_marketing/mmm/transformers.py
+++ b/pymc_marketing/mmm/transformers.py
@@ -316,10 +316,9 @@ def scale_preserving_logistic_saturation(x, m: Union[npt.NDArray[np.float_], flo
     from spend to "effective spend".
 
     Properties:
-    * Transformed values are on similar scale as input values. This enables
-      one to specify coefficient priors in units of channel ROI, without
-      transformation.
-    * Intuitive parameter interpretation: :math:`m` is the "maximum achievable effect".
+    
+    * Output is on scale with input values. Simplifies prior specification.
+    * Intuitive parameter interpretation: `m` is the "maximum achievable effect".
     * Slope of curve never exceeds 1. Thus "effective spend" <= "actual spend".
 
     .. math::

--- a/pymc_marketing/mmm/transformers.py
+++ b/pymc_marketing/mmm/transformers.py
@@ -308,22 +308,22 @@ def logistic_saturation(x, lam: Union[npt.NDArray[np.float_], float] = 0.5):
     return (1 - pt.exp(-lam * x)) / (1 + pt.exp(-lam * x))
 
 
-def asymptotic_logistic_saturation(x, lam: Union[npt.NDArray[np.float_], float]):
-    """Logistic transformation with max slope 1 and asymptote at `lam`.
+def scale_preserving_logistic_saturation(x, L: Union[npt.NDArray[np.float_], float]):
+    """Scale preserving logistic transformation.
 
     This single-parameter saturation function maps its input to the range
-    `[0, lam]`, where f(x) <= x for all x. It can be interpreted as mapping
+    `[0, L]`, where f(x) <= x for all x. It can be interpreted as mapping
     from spend to "effective spend".
 
-    Features:
+    Properties:
     * Transformed values are on similar scale as input values. This enables
       one to specify coefficient priors in units of channel ROI, without
       transformation.
-    * Intuitive parameter interpretation: `lam` is the "maximum achievable effect".
-    * Because the slope never exceeds 1, "effective spend" <= "actual spend".
+    * Intuitive parameter interpretation: `L` is the "maximum achievable effect".
+    * Slope of curve never exceeds 1. Thus "effective spend" <= "actual spend".
 
     .. math::
-        f(x) = \lambda \left( \frac{1 - e^{-\frac{2}{\lambda} x}}{1 + e^{-\frac{2}{\lambda} x}} \right)
+        f(x) = L \left( \frac{1 - e^{-\frac{2}{L} x}}{1 + e^{-\frac{2}{L} x}} \right)
 
     .. plot::
         :context: close-figs
@@ -331,14 +331,14 @@ def asymptotic_logistic_saturation(x, lam: Union[npt.NDArray[np.float_], float])
         import matplotlib.pyplot as plt
         import numpy as np
         import arviz as az
-        from pymc_marketing.mmm.transformers import asymptotic_logistic_function
+        from pymc_marketing.mmm.transformers import scale_preserving_logistic_saturation
         plt.style.use('arviz-darkgrid')
-        lam = np.array([500, 1000, 2000, 4000, 8000])
+        L = np.array([500, 1000, 2000, 4000, 8000])
         x = np.linspace(0, 10000, 400)
         ax = plt.subplot(111)
-        for l in lam:
-            y = asymptotic_logistic_function(x, lam=l).eval()
-            plt.plot(x, y, label=f'lam = {l}')
+        for l in L:
+            y = scale_preserving_logistic_saturation(x, L=l).eval()
+            plt.plot(x, y, label=f'L = {l}')
         plt.xlabel('x', fontsize=12)
         plt.ylabel('f(x)', fontsize=12)
         box = ax.get_position()
@@ -350,7 +350,7 @@ def asymptotic_logistic_saturation(x, lam: Union[npt.NDArray[np.float_], float])
     ----------
     x : tensor
         Input tensor.
-    lam : float or array-like
+    L : float or array-like
         Saturation parameter, characterizing the asymptote of the function value.
 
     Returns
@@ -358,9 +358,9 @@ def asymptotic_logistic_saturation(x, lam: Union[npt.NDArray[np.float_], float])
     tensor
         Transformed tensor.
     """  # noqa: W605
-    if lam == 0:
+    if L == 0:
         return pt.zeros_like(x)
-    return lam * (1 - pt.exp(-2 / lam * x)) / (1 + pt.exp(-2 / lam * x))
+    return L * (1 - pt.exp(-2 / L * x)) / (1 + pt.exp(-2 / L * x))
 
 
 class TanhSaturationParameters(NamedTuple):

--- a/pymc_marketing/mmm/transformers.py
+++ b/pymc_marketing/mmm/transformers.py
@@ -308,22 +308,22 @@ def logistic_saturation(x, lam: Union[npt.NDArray[np.float_], float] = 0.5):
     return (1 - pt.exp(-lam * x)) / (1 + pt.exp(-lam * x))
 
 
-def scale_preserving_logistic_saturation(x, L: Union[npt.NDArray[np.float_], float]):
+def scale_preserving_logistic_saturation(x, m: Union[npt.NDArray[np.float_], float]):
     """Scale preserving logistic transformation.
 
     This single-parameter saturation function maps its input to the range
-    `[0, L]`, where f(x) <= x for all x. It can be interpreted as mapping
+    `[0, m]`, where f(x) <= x for all x. It can be interpreted as mapping
     from spend to "effective spend".
 
     Properties:
     * Transformed values are on similar scale as input values. This enables
       one to specify coefficient priors in units of channel ROI, without
       transformation.
-    * Intuitive parameter interpretation: `L` is the "maximum achievable effect".
+    * Intuitive parameter interpretation: `m` is the "maximum achievable effect".
     * Slope of curve never exceeds 1. Thus "effective spend" <= "actual spend".
 
     .. math::
-        f(x) = L \left( \frac{1 - e^{-\frac{2}{L} x}}{1 + e^{-\frac{2}{L} x}} \right)
+        f(x) = m \left( \frac{1 - e^{-\frac{2}{m} x}}{1 + e^{-\frac{2}{m} x}} \right)
 
     .. plot::
         :context: close-figs
@@ -333,12 +333,12 @@ def scale_preserving_logistic_saturation(x, L: Union[npt.NDArray[np.float_], flo
         import arviz as az
         from pymc_marketing.mmm.transformers import scale_preserving_logistic_saturation
         plt.style.use('arviz-darkgrid')
-        L = np.array([500, 1000, 2000, 4000, 8000])
+        m = np.array([500, 1000, 2000, 4000, 8000])
         x = np.linspace(0, 10000, 400)
         ax = plt.subplot(111)
-        for l in L:
-            y = scale_preserving_logistic_saturation(x, L=l).eval()
-            plt.plot(x, y, label=f'L = {l}')
+        for l in m:
+            y = scale_preserving_logistic_saturation(x, m=l).eval()
+            plt.plot(x, y, label=f'm = {l}')
         plt.xlabel('x', fontsize=12)
         plt.ylabel('f(x)', fontsize=12)
         box = ax.get_position()
@@ -350,7 +350,7 @@ def scale_preserving_logistic_saturation(x, L: Union[npt.NDArray[np.float_], flo
     ----------
     x : tensor
         Input tensor.
-    L : float or array-like
+    m : float or array-like
         Saturation parameter, characterizing the asymptote of the function value.
 
     Returns
@@ -358,9 +358,9 @@ def scale_preserving_logistic_saturation(x, L: Union[npt.NDArray[np.float_], flo
     tensor
         Transformed tensor.
     """  # noqa: W605
-    if L == 0:
+    if m == 0:
         return pt.zeros_like(x)
-    return L * (1 - pt.exp(-2 / L * x)) / (1 + pt.exp(-2 / L * x))
+    return m * (1 - pt.exp(-2 / m * x)) / (1 + pt.exp(-2 / m * x))
 
 
 class TanhSaturationParameters(NamedTuple):

--- a/pymc_marketing/mmm/transformers.py
+++ b/pymc_marketing/mmm/transformers.py
@@ -312,7 +312,7 @@ def scale_preserving_logistic_saturation(x, m: Union[npt.NDArray[np.float_], flo
     """Scale preserving logistic transformation.
 
     This single-parameter saturation function maps its input to the range
-    `[0, m]`, where f(x) <= x for all x. It can be interpreted as mapping
+    `[0, m]`, where \( f(x) \leq x \) for all x. It can be interpreted as mapping
     from spend to "effective spend".
 
     Properties:
@@ -323,7 +323,7 @@ def scale_preserving_logistic_saturation(x, m: Union[npt.NDArray[np.float_], flo
     * Slope of curve never exceeds 1. Thus "effective spend" <= "actual spend".
 
     .. math::
-        f(x) = m \left( \frac{1 - e^{-\frac{2}{m} x}}{1 + e^{-\frac{2}{m} x}} \right)
+        f(x) = m \\left( \\frac{1 - e^{-\\frac{2}{m} x}}{1 + e^{-\\frac{2}{m} x}} \\right)
 
     .. plot::
         :context: close-figs

--- a/pymc_marketing/mmm/transformers.py
+++ b/pymc_marketing/mmm/transformers.py
@@ -309,19 +309,18 @@ def logistic_saturation(x, lam: Union[npt.NDArray[np.float_], float] = 0.5):
 
 
 def asymptotic_logistic_saturation(x, lam: Union[npt.NDArray[np.float_], float]):
-    """Asymptotic logistic transformation.
+    """Logistic transformation with max slope 1 and asymptote at `lam`.
 
-    This function represents a special type of logistic function where 
-    the `lam` characterizes its asymptote and the maximum slope is 1.
+    This single-parameter saturation function maps its input to the range
+    `[0, lam]`, where f(x) <= x for all x. It can be interpreted as mapping
+    from spend to "effective spend".
 
-    This is useful for multiple reasons:
-    * The function transforms spend into "effective spend", which is on
-      the same scale but has a saturation point. This means that channel
-      priors can be specified in units of spend relative to the KPI (e.g.
-      ROAS) without transformation.
-    * `lam` is intuitively interpreted as the "maximum effective spend".
-    * Since the slope never exceeds 1, "effective spend" is always less
-      than or equal to actual spend.
+    Features:
+    * Transformed values are on similar scale as input values. This enables
+      one to specify coefficient priors in units of channel ROI, without
+      transformation.
+    * Intuitive parameter interpretation: `lam` is the "maximum achievable effect".
+    * Because the slope never exceeds 1, "effective spend" <= "actual spend".
 
     .. math::
         f(x) = \lambda \left( \frac{1 - e^{-\frac{2}{\lambda} x}}{1 + e^{-\frac{2}{\lambda} x}} \right)
@@ -338,7 +337,7 @@ def asymptotic_logistic_saturation(x, lam: Union[npt.NDArray[np.float_], float])
         x = np.linspace(0, 10000, 400)
         ax = plt.subplot(111)
         for l in lam:
-            y = asymptotic_logistic_function(x, lam=l)
+            y = asymptotic_logistic_function(x, lam=l).eval()
             plt.plot(x, y, label=f'lam = {l}')
         plt.xlabel('x', fontsize=12)
         plt.ylabel('f(x)', fontsize=12)
@@ -352,7 +351,7 @@ def asymptotic_logistic_saturation(x, lam: Union[npt.NDArray[np.float_], float])
     x : tensor
         Input tensor.
     lam : float or array-like
-        Saturation parameter, characterizing the asymptote of the function.
+        Saturation parameter, characterizing the asymptote of the function value.
 
     Returns
     -------

--- a/pymc_marketing/mmm/transformers.py
+++ b/pymc_marketing/mmm/transformers.py
@@ -316,7 +316,7 @@ def scale_preserving_logistic_saturation(x, m: Union[npt.NDArray[np.float_], flo
     from spend to "effective spend".
 
     Properties:
-    
+
     * Output is on scale with input values. Simplifies prior specification.
     * Intuitive parameter interpretation: `m` is the "maximum achievable effect".
     * Slope of curve never exceeds 1. Thus "effective spend" <= "actual spend".

--- a/tests/mmm/test_transformers.py
+++ b/tests/mmm/test_transformers.py
@@ -7,11 +7,11 @@ from pytensor.tensor.variable import TensorVariable
 from pymc_marketing.mmm.transformers import (
     ConvMode,
     TanhSaturationParameters,
+    asymptotic_logistic_saturation,
     batched_convolution,
     delayed_adstock,
     geometric_adstock,
     logistic_saturation,
-    asymptotic_logistic_saturation,
     tanh_saturation,
     tanh_saturation_baselined,
 )
@@ -220,7 +220,9 @@ class TestSaturationTransformers:
         # When lam == max(x), f(max(x)) is max(x) * 0.76
         x = np.ones(shape=(100))
         y = asymptotic_logistic_saturation(x=x, lam=1)
-        np.testing.assert_array_almost_equal(x=np.ones(shape=(100)) * 0.761594, y=y.eval(), decimal=3)
+        np.testing.assert_array_almost_equal(
+            x=np.ones(shape=(100)) * 0.761594, y=y.eval(), decimal=3
+        )
 
     @pytest.mark.parametrize(
         "x",

--- a/tests/mmm/test_transformers.py
+++ b/tests/mmm/test_transformers.py
@@ -216,8 +216,11 @@ class TestSaturationTransformers:
         y = scale_preserving_logistic_saturation(x=x, m=0.0)
         np.testing.assert_array_almost_equal(x=np.zeros(shape=(100)), y=y.eval())
 
-    def test_scale_preserving_logistic_saturation_m_max_x(self):
-        # When m == max(x), f(max(x)) is max(x) * 0.76
+    def test_scale_preserving_logistic_saturation_m_eq_x(self):
+        # At x = m, the saturation f(x), reduces to
+        #     f(x) = m * (1 - exp(-2)) / (1 + exp(-2))
+        #          = m * 0.761594...
+        # This test asserts that this is the case
         x = np.ones(shape=(100))
         y = scale_preserving_logistic_saturation(x=x, m=1)
         np.testing.assert_array_almost_equal(

--- a/tests/mmm/test_transformers.py
+++ b/tests/mmm/test_transformers.py
@@ -210,16 +210,16 @@ class TestSaturationTransformers:
         assert y_eval.max() <= 1
         assert y_eval.min() >= 0
 
-    def test_scale_preserving_logistic_saturation_L_zero(self):
+    def test_scale_preserving_logistic_saturation_m_zero(self):
         # All values should be zero
         x = np.ones(shape=(100))
-        y = scale_preserving_logistic_saturation(x=x, L=0.0)
+        y = scale_preserving_logistic_saturation(x=x, m=0.0)
         np.testing.assert_array_almost_equal(x=np.zeros(shape=(100)), y=y.eval())
 
-    def test_scale_preserving_logistic_saturation_L_max_x(self):
-        # When L == max(x), f(max(x)) is max(x) * 0.76
+    def test_scale_preserving_logistic_saturation_m_max_x(self):
+        # When m == max(x), f(max(x)) is max(x) * 0.76
         x = np.ones(shape=(100))
-        y = scale_preserving_logistic_saturation(x=x, L=1)
+        y = scale_preserving_logistic_saturation(x=x, m=1)
         np.testing.assert_array_almost_equal(
             x=np.ones(shape=(100)) * 0.761594, y=y.eval(), decimal=3
         )
@@ -232,13 +232,13 @@ class TestSaturationTransformers:
             np.linspace(start=200, stop=1000, num=50),
         ],
     )
-    def test_scale_preserving_logistic_saturation_L_large(self, x):
+    def test_scale_preserving_logistic_saturation_m_large(self, x):
         # When asymptote is large, f(x) = x
-        y = scale_preserving_logistic_saturation(x=x, L=1e9)
+        y = scale_preserving_logistic_saturation(x=x, m=1e9)
         np.testing.assert_array_almost_equal(x=x, y=y.eval(), decimal=0)
 
     @pytest.mark.parametrize(
-        "x, L",
+        "x, m",
         [
             (np.ones(shape=(100)), 30),
             (np.linspace(start=0.0, stop=1.0, num=50), 90),
@@ -246,17 +246,17 @@ class TestSaturationTransformers:
             (np.zeros(shape=(100)), 200),
         ],
     )
-    def test_scale_preserving_logistic_saturation_bounds(self, x, L):
-        # Check that the values are within the range [0, L]
-        y = scale_preserving_logistic_saturation(x=x, L=L)
-        assert y.eval().max() <= L
+    def test_scale_preserving_logistic_saturation_bounds(self, x, m):
+        # Check that the values are within the range [0, m]
+        y = scale_preserving_logistic_saturation(x=x, m=m)
+        assert y.eval().max() <= m
         assert y.eval().min() >= 0
 
-    @pytest.mark.parametrize("L", [10, 100, 1000])
-    def test_scale_preserving_logistic_saturation_slope(self, L):
+    @pytest.mark.parametrize("m", [10, 100, 1000])
+    def test_scale_preserving_logistic_saturation_slope(self, m):
         # Check that slope < 1
         x = np.linspace(0, 10, 100)
-        y = scale_preserving_logistic_saturation(x, L=L).eval()
+        y = scale_preserving_logistic_saturation(x, m=m).eval()
         dy_dx = np.diff(y) / np.diff(x)
         assert np.all(dy_dx <= 1)
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Scale preserving saturation function (with max slope 1)

Saturation function with **single interpretable** parameter and **nice properties**:

$$ f(x) = m \left( \frac{1 - e^{-\frac{2}{m} x}}{1 + e^{-\frac{2}{m} x}} \right) $$

![764b9192-bfc6-4c31-91e8-72e8d8a732e4](https://github.com/pymc-labs/pymc-marketing/assets/6390218/c72d538d-1b18-4e7c-870e-907d4ffe597b)

The function maps $x$ into the range $\[0, m\]$, where $m$ is the asymptote (function value in $x=\inf$). As such it can be interpreted as mapping from *actual spend* to *effective spend*. Since the slope never exceeds one, it is guaranteed that effective is always less than actual spend—which resonates well with our understanding of how spend saturation works in the real world.

### Benefits
* Single easy-to-interpret parameter.
* Since *effective spend* is on the same (or very similar) scale as *spend*, it is **not necessary to transform** coefficient priors. They can simply be the expected channel ROI in units of `[return] / [investment]`.
* Unsaturated case supported, by letting $m \gg \max(\text{spend}_{\text{channel}})$ in which case $f(x) ≈ x$.

### Origins

I don't know if this is a common function used somewhere. Maybe someone reviewing this has seen it before? GPT4 could not suggest a source. I came up with it by trial and error.

## Description
PR adds a new spend saturation function, as well as tests. The saturation function has two desirable properties:
* Slope never exceeds 1
* `m` parameter is the asymptote

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [X] Included tests that prove the fix is effective or that the new feature works
- [X] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Modules affected
<!--- Please list the modules that are affected by this PR by typing an `x` in the boxes below: -->
- [X] MMM
- [ ] CLV
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [X] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--503.org.readthedocs.build/en/503/

<!-- readthedocs-preview pymc-marketing end -->