### PR TITLE
Reuse fixtures in slow MMM tests

### DIFF
--- a/tests/mmm/test_delayed_saturated_mmm.py
+++ b/tests/mmm/test_delayed_saturated_mmm.py
@@ -17,7 +17,7 @@ seed: int = sum(map(ord, "pymc_marketing"))
 rng: np.random.Generator = np.random.default_rng(seed=seed)
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="module")
 def generate_data():
     def _generate_data(date_data: pd.DatetimeIndex) -> pd.DataFrame:
         n: int = date_data.size
@@ -37,7 +37,7 @@ def generate_data():
     return _generate_data
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="module")
 def toy_X(generate_data) -> pd.DataFrame:
     date_data: pd.DatetimeIndex = pd.date_range(
         start="2019-06-01", end="2021-12-31", freq="W-MON"
@@ -80,12 +80,12 @@ def model_config_requiring_serialization() -> Dict:
     return model_config
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="module")
 def toy_y(toy_X: pd.DataFrame) -> pd.Series:
     return pd.Series(data=rng.integers(low=0, high=100, size=toy_X.shape[0]))
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="module")
 def mmm() -> DelayedSaturatedMMM:
     return DelayedSaturatedMMM(
         date_column="date",
@@ -95,7 +95,7 @@ def mmm() -> DelayedSaturatedMMM:
     )
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="module")
 def mmm_with_fourier_features() -> DelayedSaturatedMMM:
     return DelayedSaturatedMMM(
         date_column="date",
@@ -106,7 +106,7 @@ def mmm_with_fourier_features() -> DelayedSaturatedMMM:
     )
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="module")
 def mmm_fitted(
     mmm: DelayedSaturatedMMM, toy_X: pd.DataFrame, toy_y: pd.Series
 ) -> DelayedSaturatedMMM:
@@ -114,7 +114,7 @@ def mmm_fitted(
     return mmm
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="module")
 def mmm_fitted_with_fourier_features(
     mmm_with_fourier_features: DelayedSaturatedMMM,
     toy_X: pd.DataFrame,

--- a/tests/mmm/test_delayed_saturated_mmm.py
+++ b/tests/mmm/test_delayed_saturated_mmm.py
@@ -106,29 +106,24 @@ def mmm_with_fourier_features() -> DelayedSaturatedMMM:
     )
 
 
-def mmm_with_prior_as_posterior(
-    mmm: DelayedSaturatedMMM, X: pd.DataFrame
-) -> DelayedSaturatedMMM:
-    mmm.sample_prior_predictive(X, samples=2000, extend_idata=True, random_seed=rng)
-    mmm.idata.add_groups({"posterior": mmm.idata.prior})
-
-    return mmm
-
-
 @pytest.fixture(scope="module")
 def mmm_fitted(
-    mmm: DelayedSaturatedMMM,
-    toy_X: pd.DataFrame,
+    mmm: DelayedSaturatedMMM, toy_X: pd.DataFrame, toy_y: pd.Series
 ) -> DelayedSaturatedMMM:
-    return mmm_with_prior_as_posterior(mmm, toy_X)
+    mmm.fit(X=toy_X, y=toy_y, target_accept=0.8, draws=3, chains=2)
+    return mmm
 
 
 @pytest.fixture(scope="module")
 def mmm_fitted_with_fourier_features(
     mmm_with_fourier_features: DelayedSaturatedMMM,
     toy_X: pd.DataFrame,
+    toy_y: pd.Series,
 ) -> DelayedSaturatedMMM:
-    return mmm_with_prior_as_posterior(mmm_with_fourier_features, toy_X)
+    mmm_with_fourier_features.fit(
+        X=toy_X, y=toy_y, target_accept=0.8, draws=3, chains=2
+    )
+    return mmm_with_fourier_features
 
 
 class TestDelayedSaturatedMMM:

--- a/tests/mmm/test_delayed_saturated_mmm.py
+++ b/tests/mmm/test_delayed_saturated_mmm.py
@@ -106,24 +106,29 @@ def mmm_with_fourier_features() -> DelayedSaturatedMMM:
     )
 
 
+def mmm_with_prior_as_posterior(
+    mmm: DelayedSaturatedMMM, X: pd.DataFrame
+) -> DelayedSaturatedMMM:
+    mmm.sample_prior_predictive(X, samples=2000, extend_idata=True, random_seed=rng)
+    mmm.idata.add_groups({"posterior": mmm.idata.prior})
+
+    return mmm
+
+
 @pytest.fixture(scope="module")
 def mmm_fitted(
-    mmm: DelayedSaturatedMMM, toy_X: pd.DataFrame, toy_y: pd.Series
+    mmm: DelayedSaturatedMMM,
+    toy_X: pd.DataFrame,
 ) -> DelayedSaturatedMMM:
-    mmm.fit(X=toy_X, y=toy_y, target_accept=0.8, draws=3, chains=2)
-    return mmm
+    return mmm_with_prior_as_posterior(mmm, toy_X)
 
 
 @pytest.fixture(scope="module")
 def mmm_fitted_with_fourier_features(
     mmm_with_fourier_features: DelayedSaturatedMMM,
     toy_X: pd.DataFrame,
-    toy_y: pd.Series,
 ) -> DelayedSaturatedMMM:
-    mmm_with_fourier_features.fit(
-        X=toy_X, y=toy_y, target_accept=0.8, draws=3, chains=2
-    )
-    return mmm_with_fourier_features
+    return mmm_with_prior_as_posterior(mmm_with_fourier_features, toy_X)
 
 
 class TestDelayedSaturatedMMM:


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

Modify the scope of the fixture from class to module in order to reuse on the out of sample tests

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #514 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Modules affected
<!--- Please list the modules that are affected by this PR by typing an `x` in the boxes below: -->
- [x] MMM
- [ ] CLV
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--515.org.readthedocs.build/en/515/

<!-- readthedocs-preview pymc-marketing end -->