### PR TITLE
Replaceable steps and ordering of channel contribution forward pass

### DIFF
--- a/pymc_marketing/mmm/forward_pass.py
+++ b/pymc_marketing/mmm/forward_pass.py
@@ -1,0 +1,112 @@
+from functools import wraps
+from typing import Callable, Union
+
+import pymc as pm
+
+from pymc_marketing.mmm.transformers import (
+    WeibullType,
+    geometric_adstock,
+    logistic_saturation,
+    scale_preserving_logistic_saturation,
+    tanh_saturation,
+    tanh_saturation_baselined,
+    weibull_adstock,
+)
+
+
+def wrap_as_deterministic(name, dims):
+    """Create a decorator that wraps a function as a PyMC Deterministic."""
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            return pm.Deterministic(name=name, var=func(*args, **kwargs), dims=dims)
+
+        return wrapper
+
+    return decorator
+
+
+def create_geometric_adstock_handler(l_max: int, normalize: bool, axis: int):
+    def handler(x, params):
+        return geometric_adstock(
+            x,
+            alpha=params["alpha"],
+            l_max=l_max,
+            normalize=normalize,
+            axis=axis,
+        )
+
+    return handler
+
+
+def logistic_saturation_handler(x, params):
+    return logistic_saturation(
+        x,
+        lam=params["lam"],
+    )
+
+
+def create_weibull_adstock_handler(
+    l_max: int, axis: int, type: Union[WeibullType, str]
+):
+    def handler(x, params):
+        return weibull_adstock(
+            x,
+            lam=params["lam"],
+            k=params["k"],
+            l_max=l_max,
+            axis=axis,
+            type=type,
+        )
+
+    return handler
+
+
+def scale_preserving_logistic_saturation_handler(x, params):
+    return scale_preserving_logistic_saturation(
+        x,
+        m=params["m"],
+    )
+
+
+def tanh_saturation_handler(x, params):
+    return tanh_saturation(
+        x,
+        b=params["b"],
+        c=params["c"],
+    )
+
+
+def create_tanh_saturation_baselined_handler(x0):
+    def handler(x, params):
+        return tanh_saturation_baselined(
+            x,
+            x0=x0,
+            gain0=params["gain0"],
+            r=params["r"],
+        )
+
+    return handler
+
+
+def create_multiply_handler(name: str):
+    def multiply(x, params):
+        return x * params[name]
+
+    return multiply
+
+
+def apply_forward_pass(x, steps, params):
+    """Apply a sequence of transformations to variable x."""
+    for step in steps:
+        x = step(x, params)
+
+    return x
+
+
+def create_forward_pass(forward_pass_steps, params) -> Callable:
+    def forward_pass(x):
+        return apply_forward_pass(x, forward_pass_steps, params)
+
+    return forward_pass


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description

This is an attempt to generalize the forward pass of the mmm in order to make the steps more flexible and open to: 
- different adstocks and saturations functions
- change of order of steps (saw this in a few discussions)

The implementation is done so by adding in:
- `forward_pass` method which is supports general forward pass
- `forward_pass_params` : names of the variable required for the forward pass. All of these have to be keys in the current `model_config` property of the model
- `forward_pass_steps` : the order to the steps defined by callables

Each forward_pass_steps are all callables that take two arguments. **Having the same argument signature is key to generalize the steps!**


I've defined a few based on the transformation functions, but they can be defined by the user as well

```python
def forward_pass_step(x: TensorVariable, params: dict[str, TensorVariable]) -> TensorVariable:
    """Forward pass step
    
    Args: 
        x: data from first or previous step of forward_pass_step
        params: dict[str, TensorVariable]

    Returns: 
        TensorVariable
            Result data to be used in the next step
    """
````

The default behavior is what was available before but can now be extended

# Examples

## Change the order of steps

The default ordering is adstock, saturation, multiply (by beta for each channel). However, that can be changed now.

```python
adstock, saturation, multiply = mmm.forward_pass_steps
mmm.forward_pass_steps = [saturation, adstock, multiply]
```

For a more verbose way of doing this, we can redefine the steps: 

```python
from pymc_marketing.mmm.forward_pass import (
    create_geometric_adstock_handler, 
    logistic_saturation_handler, 
    create_multiply_handler, 
)

# All of these are functions with the signature (x, params)
# adstock and multiply are functions that return functions with that signature
saturation = logistic_saturation_handler
adstock = create_geometric_adstock_handler(l_max=adstock_max_lag, normalize=True, axis=0)
multiply = create_multiply_handler("beta_channel")

mmm = ...
mmm.forward_pass_steps = [
    # This is usually second step!
    saturation, 
    adstock, 
    multiply, 
]
mmm.fit(X, y)
```

## Change the adstock function

1. Create a handler that has the signature defined above (x, params)
2. Make sure that each variable forward_pass_params is in the model_config. If not define
3. Override the forward_pass_steps do the desired

This might look like this

```python
from pymc_marketing.mmm.forward_pass import scale_preserving_saturation_handler

saturation = scale_preserving_saturation_handler
mmm.forward_pass_steps[1] = saturation

mmm.forward_pass_params = [
    # For the default geometric_adstock
    "lam"
    # For the replaced saturation
    "m", 
    # For the default scaling at end
    "beta_channel", 
]
# Same format as before. (Just an example)
mmm.model_config["m"] = {"dist": "HalfNormal", "kwargs": {"sigma": 2.5}}
```
## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Modules affected
<!--- Please list the modules that are affected by this PR by typing an `x` in the boxes below: -->
- [x] MMM
- [ ] CLV
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
