### PR TITLE
Remove scale_preserving_logistic_saturation function

### DIFF
--- a/pymc_marketing/mmm/transformers.py
+++ b/pymc_marketing/mmm/transformers.py
@@ -413,60 +413,6 @@ def logistic_saturation(x, lam: Union[npt.NDArray[np.float_], float] = 0.5):
     return (1 - pt.exp(-lam * x)) / (1 + pt.exp(-lam * x))
 
 
-def scale_preserving_logistic_saturation(x, m: Union[npt.NDArray[np.float_], float]):
-    """Scale preserving logistic transformation.
-
-    This single-parameter saturation function maps its input to the range
-    :math:`[0, m]`, where :math:`f(x) \leq x` for all :math:`x`. It can be interpreted as mapping
-    from spend to "effective spend".
-
-    Properties:
-
-    * Output is on scale with input values. Simplifies prior specification.
-    * Intuitive parameter interpretation: `m` is the "maximum achievable effect".
-    * Slope of curve never exceeds 1. Thus "effective spend" <= "actual spend".
-
-    .. math::
-        f(x) = m \\left( \\frac{1 - e^{-\\frac{2}{m} x}}{1 + e^{-\\frac{2}{m} x}} \\right)
-
-    .. plot::
-        :context: close-figs
-
-        import matplotlib.pyplot as plt
-        import numpy as np
-        import arviz as az
-        from pymc_marketing.mmm.transformers import scale_preserving_logistic_saturation
-        plt.style.use('arviz-darkgrid')
-        m = np.array([500, 1000, 2000, 4000, 8000])
-        x = np.linspace(0, 10000, 400)
-        ax = plt.subplot(111)
-        for l in m:
-            y = scale_preserving_logistic_saturation(x, m=l).eval()
-            plt.plot(x, y, label=f'm = {l}')
-        plt.xlabel('x', fontsize=12)
-        plt.ylabel('f(x)', fontsize=12)
-        box = ax.get_position()
-        ax.set_position([box.x0, box.y0, box.width * 0.8, box.height])
-        ax.legend(loc='center left', bbox_to_anchor=(1, 0.5))
-        plt.show()
-
-    Parameters
-    ----------
-    x : tensor
-        Input tensor.
-    m : float or array-like
-        Saturation parameter, characterizing the asymptote of the function value.
-
-    Returns
-    -------
-    tensor
-        Transformed tensor.
-    """  # noqa: W605
-    if m == 0:
-        return pt.zeros_like(x)
-    return m * (1 - pt.exp(-2 / m * x)) / (1 + pt.exp(-2 / m * x))
-
-
 class TanhSaturationParameters(NamedTuple):
     b: pt.TensorLike
     """Saturation.


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
Turns out that `scale_preserving_logistic_saturation` is equivalent to `tanh_saturation` where `c = 0`.

<img width="1026" alt="Screenshot 2024-03-11 at 09 00 43" src="https://github.com/pymc-labs/pymc-marketing/assets/6390218/75be4e43-10f1-47ae-8254-a3d11a221eaf">

## Description
This PR removes `scale_preserving_logistic_saturation` and it's tests.

## Modules affected
<!--- Please list the modules that are affected by this PR by typing an `x` in the boxes below: -->
- [x] MMM
- [ ] CLV
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [x] Other (please specify): Removal
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--585.org.readthedocs.build/en/585/

<!-- readthedocs-preview pymc-marketing end -->