### PR TITLE
Fix bug in predictive methods of ParetoNBD model with covariates

### DIFF
--- a/pymc_marketing/clv/models/pareto_nbd.py
+++ b/pymc_marketing/clv/models/pareto_nbd.py
@@ -384,10 +384,13 @@ class ParetoNBDModel(CLVModel):
             must_be_unique=["customer_id"],
         )
 
+        customer_id = data["customer_id"]
+        model_coords = self.model.coords  # type: ignore
         if self.purchase_covariate_cols:
             purchase_xarray = xarray.DataArray(
                 data[self.purchase_covariate_cols],
                 dims=["customer_id", "purchase_covariate"],
+                coords=[customer_id, list(model_coords["purchase_covariate"])],
             )
             alpha_scale = self.fit_result["alpha_scale"]
             purchase_coefficient = self.fit_result["purchase_coefficient"]
@@ -404,6 +407,7 @@ class ParetoNBDModel(CLVModel):
             dropout_xarray = xarray.DataArray(
                 data[self.dropout_covariate_cols],
                 dims=["customer_id", "dropout_covariate"],
+                coords=[customer_id, list(model_coords["dropout_covariate"])],
             )
             beta_scale = self.fit_result["beta_scale"]
             dropout_coefficient = self.fit_result["dropout_coefficient"]

--- a/pymc_marketing/clv/models/pareto_nbd.py
+++ b/pymc_marketing/clv/models/pareto_nbd.py
@@ -915,7 +915,6 @@ class ParetoNBDModel(CLVModel):
         data: pd.DataFrame, optional
             DataFrame containing the following columns:
                 * `customer_id`: unique customer identifier
-                * `T`: time between the first purchase and the end of the observation period.
                 * covariates: Purchase and dropout covariate columns if original model had any.
             If not provided, the method will use the fit dataset.
         random_seed: RandomState, optional
@@ -934,7 +933,7 @@ class ParetoNBDModel(CLVModel):
 
     def distribution_new_customer_purchase_rate(
         self,
-        data,
+        data: Optional[pd.DataFrame] = None,
         *,
         random_seed: Optional[RandomState] = None,
     ) -> xarray.Dataset:
@@ -945,6 +944,11 @@ class ParetoNBDModel(CLVModel):
 
         Parameters
         ----------
+        data: pd.DataFrame, optional
+            DataFrame containing the following columns:
+                * `customer_id`: unique customer identifier
+                * covariates: Purchase and dropout covariate columns if original model had any.
+            If not provided, the method will use the fit dataset.
         random_seed : RandomState, optional
             Random state to use for sampling.
 
@@ -961,7 +965,7 @@ class ParetoNBDModel(CLVModel):
 
     def distribution_new_customer_recency_frequency(
         self,
-        data,
+        data: Optional[pd.DataFrame] = None,
         *,
         T: Optional[Union[int, np.ndarray, pd.Series]] = None,
         random_seed: Optional[RandomState] = None,

--- a/tests/clv/models/test_pareto_nbd.py
+++ b/tests/clv/models/test_pareto_nbd.py
@@ -485,12 +485,20 @@ class TestParetoNBDModelWithCovariates:
         new_data = self.data.assign(
             purchase_cov1=1.0,
             dropout_cov=1.0,
+            customer_id=self.data["customer_id"] + 1,
         )
         different_vars = model._extract_predictive_variables(data=new_data)
-        different_alpha = different_vars["alpha"]
-        different_beta = different_vars["beta"]
 
+        different_alpha = different_vars["alpha"]
+        assert np.all(
+            different_alpha.customer_id.values == alpha_model.customer_id.values + 1
+        )
         assert not np.allclose(alpha_model, different_alpha)
+
+        different_beta = different_vars["beta"]
+        assert np.all(
+            different_beta.customer_id.values == beta_model.customer_id.values + 1
+        )
         assert not np.allclose(beta_model, different_beta)
 
     def test_logp(self):


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->
* Fixed a bug with aligning coords of customer_id in predictive methods (only revelant for model with covariates)
* Make `data` optional in some methods (missed in #545)


## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Modules affected
<!--- Please list the modules that are affected by this PR by typing an `x` in the boxes below: -->
- [ ] MMM
- [x] CLV
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--589.org.readthedocs.build/en/589/

<!-- readthedocs-preview pymc-marketing end -->