### PR TITLE
Restrict scipy<1.13.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     # NOTE: Keep minimum pymc version in sync with ci.yml `OLDEST_PYMC_VERSION`
     "pymc>=5.10.4",
     "scikit-learn>=1.1.1",
-    "scipy<1.13.0"
+    "scipy<1.13.0",
     "seaborn>=0.12.2",
     "xarray",
     "xarray-einstats>=0.5.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     # NOTE: Keep minimum pymc version in sync with ci.yml `OLDEST_PYMC_VERSION`
     "pymc>=5.10.4",
     "scikit-learn>=1.1.1",
+    "scipy==1.13.0"
     "seaborn>=0.12.2",
     "xarray",
     "xarray-einstats>=0.5.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     # NOTE: Keep minimum pymc version in sync with ci.yml `OLDEST_PYMC_VERSION`
     "pymc>=5.10.4",
     "scikit-learn>=1.1.1",
-    "scipy==1.13.0"
+    "scipy<1.13.0"
     "seaborn>=0.12.2",
     "xarray",
     "xarray-einstats>=0.5.1",


### PR DESCRIPTION
Scipy 1.13.0 was released on the 2nd of April 2024. Some tests are failing, and I want to test if it is due to the last release.

I suggest we pin this for now and create an issue to make it compatible.

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--608.org.readthedocs.build/en/608/

<!-- readthedocs-preview pymc-marketing end -->