### PR TITLE
Drop python 3.9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        config: [ {python-version: "3.10", oldest-pymc: false}, {python-version: "3.11", oldest-pymc: true}]
+        config: [ {python-version: "3.10", oldest-pymc: false}, {python-version: "3.12", oldest-pymc: true}]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        config: [ {python-version: "3.10", oldest-pymc: false}, {python-version: "3.12", oldest-pymc: true}]
+        config: [ {python-version: "3.10", oldest-pymc: false}, {python-version: "3.11", oldest-pymc: true}]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        config: [ {python-version: "3.9", oldest-pymc: false}, {python-version: "3.11", oldest-pymc: true}]
+        config: [ {python-version: "3.10", oldest-pymc: false}, {python-version: "3.11", oldest-pymc: true}]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Build the sdist and the wheel
         run: |
           pip install build
@@ -62,7 +62,7 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Test pip install from test.pypi
         run: |
           python -m venv venv-test-pypi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["setuptools>=61.0"]
 [project]
 name = "pymc-marketing"
 description = "Marketing Statistical Models in PyMC"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 readme = "README.md"
 license = { file = "LICENSE" }
 dynamic = ["version"]
@@ -38,11 +38,7 @@ docs = [
     "sphinx-design",
 ]
 lint = ["mypy", "pandas-stubs", "pre-commit>=2.19.0", "ruff>=0.1.4"]
-test = [
-    "lifetimes==0.11.3",
-    "pytest==7.0.1",
-    "pytest-cov==3.0.0",
-]
+test = ["lifetimes==0.11.3", "pytest==7.0.1", "pytest-cov==3.0.0"]
 
 [tool.setuptools]
 packages = [


### PR DESCRIPTION
After the arviz release, the test kept failing because arviz 0.18.0 does not support Python 3.9 (https://github.com/arviz-devs/arviz/pull/2315/files#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7). 

Hence, we are also dropping the support for python 3.9.

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--615.org.readthedocs.build/en/615/

<!-- readthedocs-preview pymc-marketing end -->