### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,14 @@ on:
     branches: [main]
 
 env:
-  OLDEST_PYMC_VERSION: "5.10.4"
+  OLDEST_PYMC_VERSION: "5.12.0"
 
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        config: [ {python-version: "3.10", oldest-pymc: false}, {python-version: "3.11", oldest-pymc: true}]
+        config: [ {python-version: "3.10", oldest-pymc: false}, {python-version: "3.12", oldest-pymc: true}]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
 - pandas
 - pip
 # NOTE: Keep minimum pymc version in sync with ci.yml `OLDEST_PYMC_VERSION`
-- pymc>=5.10.4
+- pymc>=5.12.0
 - scikit-learn>=1.1.1
 - seaborn>=0.12.2
 - xarray


### PR DESCRIPTION
The 5.12 PyMC release provides support for Python 12. As we dropped support for Python 3.9, it seems reasonable to do it sooner rather than later.

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--618.org.readthedocs.build/en/618/

<!-- readthedocs-preview pymc-marketing end -->