### PR TITLE
Remove unnecessary NonImplemented errors from abstract methods

### DIFF
--- a/pymc_marketing/model_builder.py
+++ b/pymc_marketing/model_builder.py
@@ -130,8 +130,6 @@ class ModelBuilder(ABC):
 
         """
 
-        raise NotImplementedError
-
     @property
     @abstractmethod
     def output_var(self):
@@ -143,7 +141,6 @@ class ModelBuilder(ABC):
         output_var : str
             Name of the output variable of the model.
         """
-        raise NotImplementedError
 
     @property
     @abstractmethod
@@ -172,7 +169,6 @@ class ModelBuilder(ABC):
         model_config : dict
             A set of default parameters for predictor distributions that allow to save and recreate the model.
         """
-        raise NotImplementedError
 
     @property
     @abstractmethod
@@ -196,7 +192,6 @@ class ModelBuilder(ABC):
         sampler_config : dict
             A set of default settings for used by model in fit process.
         """
-        raise NotImplementedError
 
     @abstractmethod
     def _generate_and_preprocess_model_data(
@@ -229,7 +224,6 @@ class ModelBuilder(ABC):
         None
 
         """
-        raise NotImplementedError
 
     @abstractmethod
     def build_model(
@@ -270,7 +264,6 @@ class ModelBuilder(ABC):
         NotImplementedError
             This is an abstract method and must be implemented in a subclass.
         """
-        raise NotImplementedError
 
     def set_idata_attrs(self, idata=None):
         """

--- a/pymc_marketing/model_builder.py
+++ b/pymc_marketing/model_builder.py
@@ -258,11 +258,6 @@ class ModelBuilder(ABC):
         Returns
         -------
         None
-
-        Raises
-        ------
-        NotImplementedError
-            This is an abstract method and must be implemented in a subclass.
         """
 
     def set_idata_attrs(self, idata=None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,3 +89,6 @@ addopts = [
 ]
 filterwarnings = ["ignore::DeprecationWarning:bokeh.core.property.primitive:37"]
 testpaths = "tests"
+
+[tool.coverage.report]
+exclude_lines = ["raise NotImplementedError"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,3 @@ addopts = [
 ]
 filterwarnings = ["ignore::DeprecationWarning:bokeh.core.property.primitive:37"]
 testpaths = "tests"
-
-[tool.coverage.report]
-exclude_lines = ["raise NotImplementedError"]


### PR DESCRIPTION
We want to have a more precise metric of code coverage.

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--662.org.readthedocs.build/en/662/

<!-- readthedocs-preview pymc-marketing end -->