### PR TITLE
Sync PyMC Olderst version independencies and CI.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "numpy>=1.17",
     "pandas",
     # NOTE: Keep minimum pymc version in sync with ci.yml `OLDEST_PYMC_VERSION`
-    "pymc>=5.10.4",
+    "pymc>=5.12.0",
     "scikit-learn>=1.1.1",
     "seaborn>=0.12.2",
     "xarray",


### PR DESCRIPTION
Relates to https://github.com/pymc-labs/pymc-marketing/issues/669

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--671.org.readthedocs.build/en/671/

<!-- readthedocs-preview pymc-marketing end -->