### PR TITLE
ignore license revision

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Added license to python scripts
+0e8ac45eaa0ee11287f1a87ab5bff7acf067c6d2


### PR DESCRIPTION
Following up with https://github.com/pymc-labs/pymc-marketing/pull/673 I do not want to ruin the git history :)

See [here](https://www.stefanjudis.com/today-i-learned/how-to-exclude-commits-from-git-blame/) to make `git blame` adopt this:

```bask
git config blame.ignoreRevsFile .git-blame-ignore-revs
```

Here is the output of `git log` from `main`

```
commit 0e8ac45eaa0ee11287f1a87ab5bff7acf067c6d2 (HEAD -> main, origin/main, origin/HEAD)
Author: Juan Orduz <juanitorduz@gmail.com>
Date:   Sun May 5 23:13:41 2024 +0200

    add license (#673)

commit 5f54d8e50c73c994c0b5112ad4c06566a6a9c6db
Author: Juan Orduz <juanitorduz@gmail.com>
Date:   Sun May 5 17:44:37 2024 +0200

    Update pyproject.toml (#671)

commit fc37560b76923eb111994a5199e6c15ee5c9cf56
Author: Juan Orduz <juanitorduz@gmail.com>
Date:   Fri May 3 11:25:34 2024 +0200

    [Try] Fix compressed images in docs. (#667)

commit 19bbf6ddc391ba27aea6ae4a1b0e5704736a21f2
Author: Juan Orduz <juanitorduz@gmail.com>
Date:   Thu May 2 22:29:06 2024 +0200
```

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--674.org.readthedocs.build/en/674/

<!-- readthedocs-preview pymc-marketing end -->