### PR TITLE
Fix some ParetoNBDModel docstring typos

### DIFF
--- a/pymc_marketing/clv/models/pareto_nbd.py
+++ b/pymc_marketing/clv/models/pareto_nbd.py
@@ -68,7 +68,7 @@ class ParetoNBDModel(CLVModel):
     """Pareto Negative Binomial Model (Pareto/NBD).
 
     Model for continuous, non-contractual customers, first introduced by Schmittlein et al. [1]_,
-    with additional derivations and predictive methods by Hardie & Fader [2]_ [3]_ [4]_.
+    with additional derivations and predictive methods by Hardie & Fader [2]_ [3]_ [4]_ [5]_.
 
     The Pareto/NBD model assumes the time duration a customer is active follows a Gamma distribution,
     and time between purchases is also Gamma-distributed while the customer is still active.

--- a/pymc_marketing/clv/models/pareto_nbd.py
+++ b/pymc_marketing/clv/models/pareto_nbd.py
@@ -67,7 +67,7 @@ pytensor.compile.optdb["specialize"].register(
 class ParetoNBDModel(CLVModel):
     """Pareto Negative Binomial Model (Pareto/NBD).
 
-    Model for continuous, non-contractual customers, first introduced by Schmittlein, et al. [1]_,
+    Model for continuous, non-contractual customers, first introduced by Schmittlein et al. [1]_,
     with additional derivations and predictive methods by Hardie & Fader [2]_ [3]_ [4]_.
 
     The Pareto/NBD model assumes the time duration a customer is active follows a Gamma distribution,

--- a/pymc_marketing/clv/models/pareto_nbd.py
+++ b/pymc_marketing/clv/models/pareto_nbd.py
@@ -96,7 +96,7 @@ class ParetoNBDModel(CLVModel):
             * `purchase_covariates_prior`: Coefficients for purchase rate covariates; defaults to `Normal(0, 3)`
             * `dropout_covariates_prior`: Coefficients for dropout covariates; defaults to `Normal.dist(0, 3)`
             * `purchase_covariate_cols`: List containing column names of covariates for customer purchase rates.
-            * `dropout_covariate_cols:`: List containing column names of covariates for customer dropouts.
+            * `dropout_covariate_cols`: List containing column names of covariates for customer dropouts.
 
         If not provided, the model will use default priors specified in the `default_model_config` class attribute.
     sampler_config: dict, optional


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->
Fixed some typos in the docstring for the `ParetoNBDModel` class

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Related to #727 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Modules affected
<!--- Please list the modules that are affected by this PR by typing an `x` in the boxes below: -->
- [ ] MMM
- [x] CLV
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [x] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--731.org.readthedocs.build/en/731/

<!-- readthedocs-preview pymc-marketing end -->