### PR TITLE
Create inverse_scaled_logistic_saturation and the corresponding class

### DIFF
--- a/pymc_marketing/mmm/__init__.py
+++ b/pymc_marketing/mmm/__init__.py
@@ -23,6 +23,7 @@ from pymc_marketing.mmm.components.adstock import (
 )
 from pymc_marketing.mmm.components.saturation import (
     HillSaturation,
+    InverseScaledLogisticSaturation,
     LogisticSaturation,
     MichaelisMentenSaturation,
     SaturationTransformation,
@@ -45,6 +46,7 @@ __all__ = [
     "GeometricAdstock",
     "HillSaturation",
     "LogisticSaturation",
+    "InverseScaledLogisticSaturation",
     "MMM",
     "MMMModelBuilder",
     "MichaelisMentenSaturation",

--- a/pymc_marketing/mmm/components/saturation.py
+++ b/pymc_marketing/mmm/components/saturation.py
@@ -76,6 +76,7 @@ from pydantic import Field, InstanceOf, validate_call
 from pymc_marketing.mmm.components.base import Transformation
 from pymc_marketing.mmm.transformers import (
     hill_saturation,
+    inverse_scaled_logistic_saturation,
     logistic_saturation,
     michaelis_menten,
     tanh_saturation,
@@ -194,6 +195,39 @@ class LogisticSaturation(SaturationTransformation):
 
     def function(self, x, lam, beta):
         return beta * logistic_saturation(x, lam)
+
+    default_priors = {
+        "lam": Prior("Gamma", alpha=3, beta=1),
+        "beta": Prior("HalfNormal", sigma=2),
+    }
+
+
+class InverseScaledLogisticSaturation(SaturationTransformation):
+    """Wrapper around inverse scaled logistic saturation function.
+
+    For more information, see :func:`pymc_marketing.mmm.transformers.inverse_scaled_logistic_saturation`.
+
+    .. plot::
+        :context: close-figs
+
+        import matplotlib.pyplot as plt
+        import numpy as np
+        from pymc_marketing.mmm import InverseScaledLogisticSaturation
+
+        rng = np.random.default_rng(0)
+
+        adstock = InverseScaledLogisticSaturation()
+        prior = adstock.sample_prior(random_seed=rng)
+        curve = adstock.sample_curve(prior)
+        adstock.plot_curve(curve, sample_kwargs={"rng": rng})
+        plt.show()
+
+    """
+
+    lookup_name = "inverse_scaled_logistic"
+
+    def function(self, x, lam, beta):
+        return beta * inverse_scaled_logistic_saturation(x, lam)
 
     default_priors = {
         "lam": Prior("Gamma", alpha=3, beta=1),
@@ -339,6 +373,7 @@ SATURATION_TRANSFORMATIONS: dict[str, type[SaturationTransformation]] = {
     cls.lookup_name: cls
     for cls in [
         LogisticSaturation,
+        InverseScaledLogisticSaturation,
         TanhSaturation,
         TanhSaturationBaselined,
         MichaelisMentenSaturation,

--- a/pymc_marketing/mmm/components/saturation.py
+++ b/pymc_marketing/mmm/components/saturation.py
@@ -230,7 +230,7 @@ class InverseScaledLogisticSaturation(SaturationTransformation):
         return beta * inverse_scaled_logistic_saturation(x, lam)
 
     default_priors = {
-        "lam": Prior("Gamma", alpha=3, beta=1),
+        "lam": Prior("Gamma", alpha=0.3, beta=0.6),
         "beta": Prior("HalfNormal", sigma=2),
     }
 

--- a/pymc_marketing/mmm/components/saturation.py
+++ b/pymc_marketing/mmm/components/saturation.py
@@ -230,7 +230,7 @@ class InverseScaledLogisticSaturation(SaturationTransformation):
         return beta * inverse_scaled_logistic_saturation(x, lam)
 
     default_priors = {
-        "lam": Prior("Gamma", alpha=0.3, beta=0.6),
+        "lam": Prior("Gamma", alpha=0.5, beta=1),
         "beta": Prior("HalfNormal", sigma=2),
     }
 

--- a/pymc_marketing/mmm/transformers.py
+++ b/pymc_marketing/mmm/transformers.py
@@ -482,6 +482,9 @@ def inverse_scaled_logistic_saturation(
     x, lam: npt.NDArray[np.float64] | float = 0.5, eps: float = np.log(3)
 ):
     """Inverse scaled logistic saturation transformation.
+        It offers a more intuitive alternative to logistic_saturation,
+        allowing for lambda to be interpreted as the half saturation point,
+        when using default values for lam and eps.
 
     .. math::
         f(x) = \\frac{1 - e^{-x*\epsilon/\lambda}}{1 + e^{-x*\epsilon/\lambda}}
@@ -514,7 +517,7 @@ def inverse_scaled_logistic_saturation(
     lam : float or array-like, optional, by default 0.5
         Saturation parameter.
     eps : float or array-like, optional, by default ln(3)
-        Scaling parameter.
+        Scaling parameter. ln(3) results in halfway saturation for lam = 0.5
 
     Returns
     -------

--- a/pymc_marketing/mmm/transformers.py
+++ b/pymc_marketing/mmm/transformers.py
@@ -517,7 +517,7 @@ def inverse_scaled_logistic_saturation(
     lam : float or array-like, optional, by default 0.5
         Saturation parameter.
     eps : float or array-like, optional, by default ln(3)
-        Scaling parameter. ln(3) results in halfway saturation
+        Scaling parameter. ln(3) results in halfway saturation at lam
 
     Returns
     -------

--- a/pymc_marketing/mmm/transformers.py
+++ b/pymc_marketing/mmm/transformers.py
@@ -478,6 +478,52 @@ def logistic_saturation(x, lam: npt.NDArray[np.float64] | float = 0.5):
     return (1 - pt.exp(-lam * x)) / (1 + pt.exp(-lam * x))
 
 
+def inverse_scaled_logistic_saturation(
+    x, lam: npt.NDArray[np.float64] | float = 0.5, eps: float = np.log(3)
+):
+    """Inverse scaled logistic saturation transformation.
+
+    .. math::
+        f(x) = \\frac{1 - e^{-x*\epsilon/\lambda}}{1 + e^{-x*\epsilon/\lambda}}
+
+    .. plot::
+        :context: close-figs
+
+        import matplotlib.pyplot as plt
+        import numpy as np
+        import arviz as az
+        from pymc_marketing.mmm.transformers import inverse_scaled_logistic_saturation
+        plt.style.use('arviz-darkgrid')
+        lam = np.array([0.25, 0.5, 1, 2, 4])
+        x = np.linspace(0, 5, 100)
+        ax = plt.subplot(111)
+        for l in lam:
+            y = inverse_scaled_logistic_saturation(x, lam=l).eval()
+            plt.plot(x, y, label=f'lam = {l}')
+        plt.xlabel('spend', fontsize=12)
+        plt.ylabel('f(spend)', fontsize=12)
+        box = ax.get_position()
+        ax.set_position([box.x0, box.y0, box.width * 0.8, box.height])
+        ax.legend(loc='center left', bbox_to_anchor=(1, 0.5))
+        plt.show()
+
+    Parameters
+    ----------
+    x : tensor
+        Input tensor.
+    lam : float or array-like, optional, by default 0.5
+        Saturation parameter.
+    eps : float or array-like, optional, by default ln(3)
+        Scaling parameter.
+
+    Returns
+    -------
+    tensor
+        Transformed tensor.
+    """  # noqa: W605
+    return logistic_saturation(x, eps / lam)
+
+
 class TanhSaturationParameters(NamedTuple):
     """Container for tanh saturation parameters.
 

--- a/pymc_marketing/mmm/transformers.py
+++ b/pymc_marketing/mmm/transformers.py
@@ -517,7 +517,7 @@ def inverse_scaled_logistic_saturation(
     lam : float or array-like, optional, by default 0.5
         Saturation parameter.
     eps : float or array-like, optional, by default ln(3)
-        Scaling parameter. ln(3) results in halfway saturation for lam = 0.5
+        Scaling parameter. ln(3) results in halfway saturation
 
     Returns
     -------

--- a/pymc_marketing/mmm/transformers.py
+++ b/pymc_marketing/mmm/transformers.py
@@ -483,8 +483,8 @@ def inverse_scaled_logistic_saturation(
 ):
     """Inverse scaled logistic saturation transformation.
         It offers a more intuitive alternative to logistic_saturation,
-        allowing for lambda to be interpreted as the half saturation point,
-        when using default values for lam and eps.
+        allowing for lambda to be interpreted as the half saturation point
+        when using default value for eps.
 
     .. math::
         f(x) = \\frac{1 - e^{-x*\epsilon/\lambda}}{1 + e^{-x*\epsilon/\lambda}}

--- a/tests/mmm/components/test_saturation.py
+++ b/tests/mmm/components/test_saturation.py
@@ -22,6 +22,7 @@ from pydantic import ValidationError
 
 from pymc_marketing.mmm.components.saturation import (
     HillSaturation,
+    InverseScaledLogisticSaturation,
     LogisticSaturation,
     MichaelisMentenSaturation,
     TanhSaturation,
@@ -40,6 +41,7 @@ def model() -> pm.Model:
 def saturation_functions():
     return [
         LogisticSaturation(),
+        InverseScaledLogisticSaturation(),
         TanhSaturation(),
         TanhSaturationBaselined(),
         MichaelisMentenSaturation(),
@@ -93,6 +95,7 @@ def test_support_for_lift_test_integrations(saturation) -> None:
 @pytest.mark.parametrize(
     "name, saturation_cls",
     [
+        ("inverse_scaled_logistic", InverseScaledLogisticSaturation),
         ("logistic", LogisticSaturation),
         ("tanh", TanhSaturation),
         ("tanh_baselined", TanhSaturationBaselined),

--- a/tests/mmm/test_transformers.py
+++ b/tests/mmm/test_transformers.py
@@ -346,7 +346,7 @@ class TestSaturationTransformers:
 
     def test_inverse_scaled_logistic_saturation_lam_half(self):
         x = np.array([0.5] * 100)
-        y = inverse_scaled_logistic_saturation(x=x, lam=0.5, eps=np.ln(3))
+        y = inverse_scaled_logistic_saturation(x=x, lam=0.5, eps=np.log(3))
         expected = np.array([0.5] * 100)
         np.testing.assert_almost_equal(
             y.eval(),
@@ -355,9 +355,12 @@ class TestSaturationTransformers:
             err_msg="The function does not behave as expected at lambda 0.5.",
         )
 
-    def test_inverse_scaled_logistic_saturation_min_max_value(self, x, lam):
+    def test_inverse_scaled_logistic_saturation_min_max_value(self):
         x = np.array([0, 1, 100, 500, 5000])
-        lam = np.array([...])[:, None]
+        lam = np.array([0.01, 0.25, 0.75, 1.5, 5.0, 10.0, 15.0])[:, None]
+        x = pt.as_tensor_variable(x)
+        lam = pt.as_tensor_variable(lam)
+
         y = inverse_scaled_logistic_saturation(x=x, lam=lam)
         y_eval = y.eval()
         assert y_eval.max() <= 1

--- a/tests/mmm/test_transformers.py
+++ b/tests/mmm/test_transformers.py
@@ -355,16 +355,9 @@ class TestSaturationTransformers:
             err_msg="The function does not behave as expected at lambda 0.5.",
         )
 
-    @pytest.mark.parametrize(
-        "x, lam",
-        [
-            (np.ones(shape=(100)), 0.5),
-            (np.linspace(start=0.0, stop=1.0, num=50), 10),
-            (np.linspace(start=200, stop=1000, num=50), 0.001),
-            (np.zeros(shape=(100)), 1),
-        ],
-    )
     def test_inverse_scaled_logistic_saturation_min_max_value(self, x, lam):
+        x = np.array([0, 1, 100, 500, 5000])
+        lam = np.array([...])[:, None]
         y = inverse_scaled_logistic_saturation(x=x, lam=lam)
         y_eval = y.eval()
         assert y_eval.max() <= 1

--- a/tests/mmm/test_transformers.py
+++ b/tests/mmm/test_transformers.py
@@ -345,14 +345,14 @@ class TestSaturationTransformers:
         assert y_eval.min() >= 0
 
     def test_inverse_scaled_logistic_saturation_lam_half(self):
-        x = np.array([0.5] * 100)
-        y = inverse_scaled_logistic_saturation(x=x, lam=0.5, eps=np.log(3))
-        expected = np.array([0.5] * 100)
+        x = np.array([0.01, 0.1, 0.5, 1, 100])
+        y = inverse_scaled_logistic_saturation(x=x, lam=x)
+        expected = np.array([0.5] * len(x))
         np.testing.assert_almost_equal(
             y.eval(),
             expected,
             decimal=5,
-            err_msg="The function does not behave as expected at lambda 0.5.",
+            err_msg="The function does not behave as expected at the default value for eps",
         )
 
     def test_inverse_scaled_logistic_saturation_min_max_value(self):

--- a/tests/mmm/test_transformers.py
+++ b/tests/mmm/test_transformers.py
@@ -358,8 +358,6 @@ class TestSaturationTransformers:
     def test_inverse_scaled_logistic_saturation_min_max_value(self):
         x = np.array([0, 1, 100, 500, 5000])
         lam = np.array([0.01, 0.25, 0.75, 1.5, 5.0, 10.0, 15.0])[:, None]
-        x = pt.as_tensor_variable(x)
-        lam = pt.as_tensor_variable(lam)
 
         y = inverse_scaled_logistic_saturation(x=x, lam=lam)
         y_eval = y.eval()

--- a/tests/mmm/test_transformers.py
+++ b/tests/mmm/test_transformers.py
@@ -28,6 +28,7 @@ from pymc_marketing.mmm.transformers import (
     delayed_adstock,
     geometric_adstock,
     hill_saturation,
+    inverse_scaled_logistic_saturation,
     logistic_saturation,
     michaelis_menten,
     tanh_saturation,
@@ -339,6 +340,32 @@ class TestSaturationTransformers:
     )
     def test_logistic_saturation_min_max_value(self, x, lam):
         y = logistic_saturation(x=x, lam=lam)
+        y_eval = y.eval()
+        assert y_eval.max() <= 1
+        assert y_eval.min() >= 0
+
+    def test_inverse_scaled_logistic_saturation_lam_half(self):
+        x = np.array([0.5] * 100)
+        y = inverse_scaled_logistic_saturation(x=x, lam=0.5, eps=np.ln(3))
+        expected = np.array([0.5] * 100)
+        np.testing.assert_almost_equal(
+            y.eval(),
+            expected,
+            decimal=5,
+            err_msg="The function does not behave as expected at lambda 0.5.",
+        )
+
+    @pytest.mark.parametrize(
+        "x, lam",
+        [
+            (np.ones(shape=(100)), 0.5),
+            (np.linspace(start=0.0, stop=1.0, num=50), 10),
+            (np.linspace(start=200, stop=1000, num=50), 0.001),
+            (np.zeros(shape=(100)), 1),
+        ],
+    )
+    def test_inverse_scaled_logistic_saturation_min_max_value(self, x, lam):
+        y = inverse_scaled_logistic_saturation(x=x, lam=lam)
         y_eval = y.eval()
         assert y_eval.max() <= 1
         assert y_eval.min() >= 0


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
Offer a more intuitive alternative to `logistic_saturation`, where we use
$$f(x,λ)=\frac{1−e^{−xln⁡(3)/λ}}{1+e^{−xln⁡(3)/λ}}$$

Instead of the original:
$$f(x,λ)=\frac{1−e^{−xλ}}{1+e^{−xλ}}$$

Allowing for lambda to be interpreted as the half saturation point.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [x] Related to #220 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Modules affected
<!--- Please list the modules that are affected by this PR by typing an `x` in the boxes below: -->
- [x] MMM
- [ ] CLV
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--827.org.readthedocs.build/en/827/

<!-- readthedocs-preview pymc-marketing end -->