### PR TITLE
add GH discussions link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Explore these topics further by watching our video on [Bayesian Marketing Mix Mo
 
 ### Community Resources
 
+- [PyMC-Marketing Discussions](https://github.com/pymc-labs/pymc-marketing/discussions)
 - [Bayesian discord server](https://discord.gg/swztKRaVKe)
 - [PyMC discourse](https://discourse.pymc.io/)
 


### PR DESCRIPTION
We have github discussions, but the README only linked to the Bayesian discord and the PyMC discourse. I added a link to [the PyMC-Marketing github discussions page](https://github.com/pymc-labs/pymc-marketing/discussions).