### PR TITLE
`json.loads` with python types bug

### DIFF
--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -647,12 +647,12 @@ class BaseMMM(BaseValidateMMM):
             "adstock_max_lag": json.loads(attrs["adstock_max_lag"]),
             "adstock": json.loads(attrs.get("adstock", "geometric")),
             "saturation": json.loads(attrs.get("saturation", "logistic")),
-            "adstock_first": json.loads(attrs.get("adstock_first", True)),
+            "adstock_first": json.loads(attrs.get("adstock_first", "true")),
             "yearly_seasonality": json.loads(attrs["yearly_seasonality"]),
             "time_varying_intercept": json.loads(
-                attrs.get("time_varying_intercept", False)
+                attrs.get("time_varying_intercept", "false")
             ),
-            "time_varying_media": json.loads(attrs.get("time_varying_media", False)),
+            "time_varying_media": json.loads(attrs.get("time_varying_media", "false")),
             "validate_data": json.loads(attrs["validate_data"]),
             "sampler_config": json.loads(attrs["sampler_config"]),
         }

--- a/pymc_marketing/mmm/delayed_saturated_mmm.py
+++ b/pymc_marketing/mmm/delayed_saturated_mmm.py
@@ -645,8 +645,8 @@ class BaseMMM(BaseValidateMMM):
             "control_columns": json.loads(attrs["control_columns"]),
             "channel_columns": json.loads(attrs["channel_columns"]),
             "adstock_max_lag": json.loads(attrs["adstock_max_lag"]),
-            "adstock": json.loads(attrs.get("adstock", "geometric")),
-            "saturation": json.loads(attrs.get("saturation", "logistic")),
+            "adstock": json.loads(attrs.get("adstock", '"geometric"')),
+            "saturation": json.loads(attrs.get("saturation", '"logistic"')),
             "adstock_first": json.loads(attrs.get("adstock_first", "true")),
             "yearly_seasonality": json.loads(attrs["yearly_seasonality"]),
             "time_varying_intercept": json.loads(

--- a/tests/mmm/test_delayed_saturated_mmm.py
+++ b/tests/mmm/test_delayed_saturated_mmm.py
@@ -1115,3 +1115,30 @@ def test_save_load_with_tvp(
 
     # clean up
     os.remove(file)
+
+
+def test_missing_attrs_to_defaults(toy_X, toy_y) -> None:
+    mmm = MMM(
+        date_column="date",
+        channel_columns=["channel_1", "channel_2"],
+        control_columns=["control_1", "control_2"],
+        adstock=GeometricAdstock(l_max=4),
+        saturation=LogisticSaturation(),
+        adstock_first=False,
+    )
+    mmm = mock_fit(mmm, toy_X, toy_y)
+    mmm.idata.attrs.pop("adstock")
+    mmm.idata.attrs.pop("saturation")
+    mmm.idata.attrs.pop("adstock_first")
+
+    file = "tmp-model"
+    mmm.save(file)
+
+    loaded_mmm = MMM.load(file)
+    assert loaded_mmm.adstock.lookup_name == "geometric"
+    assert loaded_mmm.saturation.lookup_name == "logistic"
+    # Falsely loaded
+    assert loaded_mmm.adstock_first
+
+    # clean up
+    os.remove(file)

--- a/tests/mmm/test_delayed_saturated_mmm.py
+++ b/tests/mmm/test_delayed_saturated_mmm.py
@@ -1125,18 +1125,35 @@ def test_missing_attrs_to_defaults(toy_X, toy_y) -> None:
         adstock=GeometricAdstock(l_max=4),
         saturation=LogisticSaturation(),
         adstock_first=False,
+        time_varying_intercept=False,
+        time_varying_media=False,
     )
     mmm = mock_fit(mmm, toy_X, toy_y)
     mmm.idata.attrs.pop("adstock")
     mmm.idata.attrs.pop("saturation")
     mmm.idata.attrs.pop("adstock_first")
+    mmm.idata.attrs.pop("time_varying_intercept")
+    mmm.idata.attrs.pop("time_varying_media")
 
     file = "tmp-model"
     mmm.save(file)
 
     loaded_mmm = MMM.load(file)
+
+    attrs = loaded_mmm.idata.attrs
+    for key in [
+        "adstock",
+        "saturation",
+        "adstock_first",
+        "time_varying_intercept",
+        "time_varying_media",
+    ]:
+        assert key not in attrs
+
     assert loaded_mmm.adstock.lookup_name == "geometric"
     assert loaded_mmm.saturation.lookup_name == "logistic"
+    assert not loaded_mmm.time_varying_intercept
+    assert not loaded_mmm.time_varying_media
     # Falsely loaded
     assert loaded_mmm.adstock_first
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

`json.loads` doesn't support boolean types. The values would "true" and "false" if they existed

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Modules affected
<!--- Please list the modules that are affected by this PR by typing an `x` in the boxes below: -->
- [ ] MMM
- [ ] CLV
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--881.org.readthedocs.build/en/881/

<!-- readthedocs-preview pymc-marketing end -->