### PR TITLE
Add url health job from streamlit app

### DIFF
--- a/.github/workflows/streamlit_url_health.yml
+++ b/.github/workflows/streamlit_url_health.yml
@@ -7,19 +7,19 @@ on:
 
 jobs:
 
-  build:
+    build:
 
-    runs-on: ubuntu-latest
+        runs-on: ubuntu-latest
 
-    steps:
-      - name: Check the deployed service URL
-        uses: jtalk/url-health-check-action@v4
-        with:
-          # Check the following URLs one by one sequentially
-          url: https://pymc-marketing-app.streamlit.app/
-          # Follow redirects, or just report success on 3xx status codes
-          follow-redirect: no # Optional, defaults to "no"
-          # Fail this action after this many failed attempts
-          max-attempts: 3 # Optional, defaults to 1
-          # Delay between retries
-          retry-delay: 5s # Optional, only applicable to max-attempts > 1
+        steps:
+        - name: Check the deployed service URL
+          uses: jtalk/url-health-check-action@v4
+          with:
+            # Check the following URLs one by one sequentially
+            url: https://pymc-marketing-app.streamlit.app/
+            # Follow redirects, or just report success on 3xx status codes
+            follow-redirect: false # Optional, defaults to false
+            # Fail this action after this many failed attempts
+            max-attempts: 3 # Optional, defaults to 1
+            # Delay between retries
+            retry-delay: 5s # Optional, only applicable to max-attempts > 1

--- a/.github/workflows/streamlit_url_health.yml
+++ b/.github/workflows/streamlit_url_health.yml
@@ -1,0 +1,25 @@
+name: URL Health
+
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '0 */6 * * *'
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check the deployed service URL
+        uses: jtalk/url-health-check-action@v4
+        with:
+          # Check the following URLs one by one sequentially
+          url: https://pymc-marketing-app.streamlit.app/
+          # Follow redirects, or just report success on 3xx status codes
+          follow-redirect: no # Optional, defaults to "no"
+          # Fail this action after this many failed attempts
+          max-attempts: 3 # Optional, defaults to 1
+          # Delay between retries
+          retry-delay: 5s # Optional, only applicable to max-attempts > 1


### PR DESCRIPTION
Closes https://github.com/pymc-labs/pymc-marketing/issues/890

It uses https://github.com/Jtalk/url-health-check-action. I have used this GitHub action for my own website, see https://github.com/juanitorduz/juanitorduz.github.io/blob/master/.github/workflows/url_health.yml

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--902.org.readthedocs.build/en/902/

<!-- readthedocs-preview pymc-marketing end -->