### PR TITLE
typo mmm roas nb

### DIFF
--- a/docs/source/notebooks/mmm/mmm_roas.ipynb
+++ b/docs/source/notebooks/mmm/mmm_roas.ipynb
@@ -814,7 +814,7 @@
    "metadata": {},
    "source": [
     "## Lift Test Model\n",
-    "i\n",
+    "\n",
     "Now we fit a model with some lift tests. We will use the same model configuration as before, but we free the priors of the beta channel coefficients as these are included in the saturation function parametrization. In general, we expect lift tests priors or associated custom likelihoods to be better than the cost share prior."
    ]
   },


### PR DESCRIPTION
Small typo from https://github.com/pymc-labs/pymc-marketing/pull/916

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--923.org.readthedocs.build/en/923/

<!-- readthedocs-preview pymc-marketing end -->