### PR TITLE
Raise informative error when including target in `X`

### DIFF
--- a/pymc_marketing/model_builder.py
+++ b/pymc_marketing/model_builder.py
@@ -548,6 +548,8 @@ class ModelBuilder(ABC):
         self._generate_and_preprocess_model_data(X, y_df.values.flatten())
         if self.X is None or self.y is None:
             raise ValueError("X and y must be set before calling build_model!")
+        if self.output_var in X.columns:
+            raise ValueError(f"X includes a column named '{self.output_var}', which conflicts with the target variable.")
 
         if not hasattr(self, "model"):
             self.build_model(self.X, self.y)

--- a/pymc_marketing/model_builder.py
+++ b/pymc_marketing/model_builder.py
@@ -549,7 +549,9 @@ class ModelBuilder(ABC):
         if self.X is None or self.y is None:
             raise ValueError("X and y must be set before calling build_model!")
         if self.output_var in X.columns:
-            raise ValueError(f"X includes a column named '{self.output_var}', which conflicts with the target variable.")
+            raise ValueError(
+                f"X includes a column named '{self.output_var}', which conflicts with the target variable."
+            )
 
         if not hasattr(self, "model"):
             self.build_model(self.X, self.y)

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -256,6 +256,14 @@ def test_fit_no_t(toy_X):
     assert "posterior" in model_builder.idata.groups()
 
 
+@pytest.mark.xfail
+def test_fit_no_t(toy_X):
+    # create redundant target column in X
+    toy_X = pd.concat((toy_X, toy_y), axis=1)
+    model_builder = ModelBuilderTest()
+    model_builder.fit(X=toy_X, chains=1, draws=100, tune=100)
+
+
 @pytest.mark.skipif(
     sys.platform == "win32",
     reason="Permissions for temp files not granted on windows CI.",

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -257,7 +257,7 @@ def test_fit_no_t(toy_X):
 
 
 @pytest.mark.xfail
-def test_fit_no_t(toy_X):
+def test_fit_dup_Y(toy_X):
     # create redundant target column in X
     toy_X = pd.concat((toy_X, toy_y), axis=1)
     model_builder = ModelBuilderTest()


### PR DESCRIPTION
Raise informative error when including target in `X`

## Description
As described in https://github.com/pymc-labs/pymc-marketing/issues/452, calling `fit()` with an `X` dataframe that includes a column that shared a name with the target raises a mysterious error despite sampling successfully.  This PR fixes this, raising a more meaningful error and prevents sampling.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [X] Closes https://github.com/pymc-labs/pymc-marketing/issues/452
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [X] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [X] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Modules affected
<!--- Please list the modules that are affected by this PR by typing an `x` in the boxes below: -->
- [x] MMM
- [ ] CLV
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [X] Other (please specify): enhancement
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--962.org.readthedocs.build/en/962/

<!-- readthedocs-preview pymc-marketing end -->