### PR TITLE
scaling should be done before hdi computation posterior predictive

### DIFF
--- a/pymc_marketing/mmm/base.py
+++ b/pymc_marketing/mmm/base.py
@@ -404,15 +404,17 @@ class MMMModelBuilder(ModelBuilder):
         else:
             fig = ax.figure
 
+        if original_scale:
+            posterior_predictive_data = apply_sklearn_transformer_across_dim(
+                data=posterior_predictive_data,
+                func=self.get_target_transformer().inverse_transform,
+                dim_name="date",
+            )
+
         for hdi_prob, alpha in zip((0.94, 0.50), (0.2, 0.4), strict=True):
             likelihood_hdi: DataArray = az.hdi(
                 ary=posterior_predictive_data, hdi_prob=hdi_prob
             )[self.output_var]
-
-            if original_scale:
-                likelihood_hdi = self.get_target_transformer().inverse_transform(
-                    likelihood_hdi
-                )
 
             ax.fill_between(
                 x=posterior_predictive_data.date,


### PR DESCRIPTION
The scaling step  should be done before  the hdi computation in the posterior predictive plot. Tested locally in mmm notebook ✅ 

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--970.org.readthedocs.build/en/970/

<!-- readthedocs-preview pymc-marketing end -->