### PR TITLE
Remove `combined` flag from `apply_sklearn_transformer_across_dim`

### DIFF
--- a/pymc_marketing/mmm/mmm.py
+++ b/pymc_marketing/mmm/mmm.py
@@ -1403,7 +1403,6 @@ class MMM(
                 data=channel_contributions,
                 func=self.get_target_transformer().inverse_transform,
                 dim_name="time_since_spend",
-                combined=False,
             )
 
         return channel_contributions
@@ -1882,7 +1881,6 @@ class MMM(
                 data=posterior_predictive_samples,
                 func=self.get_target_transformer().inverse_transform,
                 dim_name="date",
-                combined=combined,
             )
 
         return posterior_predictive_samples

--- a/pymc_marketing/mmm/utils.py
+++ b/pymc_marketing/mmm/utils.py
@@ -227,6 +227,7 @@ def apply_sklearn_transformer_across_dim(
             input_core_dims=[[dim_name, "_"]],
             output_core_dims=[[dim_name, "_"]],
             vectorize=True,
+            on_missing_core_dim="copy",
         )
         .squeeze(dim="_")
         .transpose(*dims)

--- a/pymc_marketing/mmm/utils.py
+++ b/pymc_marketing/mmm/utils.py
@@ -218,6 +218,7 @@ def apply_sklearn_transformer_across_dim(
     """
     # These are lost during the ufunc
     attrs = data.attrs
+    # Cache dims to restore them after the ufunc
     dims = data.dims
 
     data = (

--- a/tests/mmm/test_utils.py
+++ b/tests/mmm/test_utils.py
@@ -123,11 +123,12 @@ def create_mock_mmm_return_data():
     def _create_mock_mm_return_data(combined: bool) -> xr.DataArray:
         dates = pd.date_range(start="2020-01-01", end="2020-01-31", freq="W-MON")
         data = xr.DataArray(
-            np.ones(shape=(1, 3, len(dates))),
+            np.ones(shape=(1, 3, len(dates), 2)),
             coords={
                 "chain": [1],
                 "draw": [1, 2, 3],
                 "date": dates,
+                "channel": ["channel1", "channel2"],
             },
         )
 
@@ -149,25 +150,9 @@ def test_apply_sklearn_function_across_dim(
         data,
         mock_method,
         dim_name="date",
-        combined=combined,
     )
 
     xr.testing.assert_allclose(result, data * 2)
-
-
-def test_apply_sklearn_function_across_dim_error(
-    mock_method,
-    create_mock_mmm_return_data,
-) -> None:
-    data = create_mock_mmm_return_data(combined=False)
-
-    with pytest.raises(ValueError, match="x must be 2-dimensional"):
-        apply_sklearn_transformer_across_dim(
-            data,
-            mock_method,
-            dim_name="date",
-            combined=True,
-        )
 
 
 @pytest.mark.parametrize("constructor", [pd.Series, np.array])


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->
Fix issue with `apply_sklearn_transformer_across_dim` when called with `combined=True`, and original data had extra dimensions (e.g. `channel`)

## Description
<!--- Describe your changes in detail -->
The issue is related to `xr.apply_ufunc` [moving or transposing core dimensions to the end of the array](https://tutorial.xarray.dev/advanced/apply_ufunc/core-dimensions.html#core-dimensions).

* Now the dimensions are cached at the beginning of the util function, and the result of the transformation is transposed back to the original shape.
* Extended relevant test with extra `channel` dimension, which is the problematic one. These dimensions are defined to the right of `date`, and `xr.apply_ufunc` shuffles dimensions.
* Remove `test_apply_sklearn_function_across_dim_error`. Now the transoformation is applied correctly in this previously faulty case.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [x] Related to #982 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Modules affected
<!--- Please list the modules that are affected by this PR by typing an `x` in the boxes below: -->
- [x] MMM
- [ ] CLV
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1010.org.readthedocs.build/en/1010/

<!-- readthedocs-preview pymc-marketing end -->