### PR TITLE
lower bound xarray

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "pymc>=5.13.0,<5.16.0",
     "scikit-learn>=1.1.1",
     "seaborn>=0.12.2",
-    "xarray",
+    "xarray>=2024.1.0",
     "xarray-einstats>=0.5.1",
 ]
 


### PR DESCRIPTION
From a fresh environment, I was seeing that older versions of `xarray` do not have the `on_missing_core_dim` parameter for  https://docs.xarray.dev/en/stable/generated/xarray.apply_ufunc.html

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1025.org.readthedocs.build/en/1025/

<!-- readthedocs-preview pymc-marketing end -->