### PR TITLE
Mute `Sampling: []` stdout when calling `get_channel_contributions_forward_pass_grid`

### DIFF
--- a/pymc_marketing/mmm/mmm.py
+++ b/pymc_marketing/mmm/mmm.py
@@ -14,6 +14,7 @@
 """Media Mix Model class."""
 
 import json
+import logging
 import warnings
 from typing import Annotated, Any, Literal
 
@@ -582,7 +583,9 @@ class BaseMMM(BaseValidateMMM):
         }
 
     def channel_contributions_forward_pass(
-        self, channel_data: npt.NDArray[np.float64]
+        self,
+        channel_data: npt.NDArray[np.float64],
+        disable_logger_stdout: bool | None = False,
     ) -> npt.NDArray[np.float64]:
         """Evaluate the channel contribution for a given channel data and a fitted model, ie. the forward pass.
 
@@ -590,6 +593,8 @@ class BaseMMM(BaseValidateMMM):
         ----------
         channel_data : array-like
             Input channel data. Result of all the preprocessing steps.
+        disable_logger_stdout : bool, optional
+            If True, suppress logger output to stdout
 
         Returns
         -------
@@ -597,6 +602,10 @@ class BaseMMM(BaseValidateMMM):
             Transformed channel data.
 
         """
+        if disable_logger_stdout:
+            logger = logging.getLogger("pymc.sampling.forward")
+            logger.propagate = False
+
         coords = {
             **self.model_coords,
         }
@@ -925,7 +934,9 @@ class MMM(
     version: str = "0.0.2"
 
     def channel_contributions_forward_pass(
-        self, channel_data: npt.NDArray[np.float64]
+        self,
+        channel_data: npt.NDArray[np.float64],
+        disable_logger_stdout: bool | None = False,
     ) -> npt.NDArray[np.float64]:
         """Evaluate the channel contribution for a given channel data and a fitted model, ie. the forward pass.
 
@@ -935,6 +946,8 @@ class MMM(
         ----------
         channel_data : array-like
             Input channel data. Result of all the preprocessing steps.
+        disable_logger_stdout : bool, optional
+            If True, suppress logger output to stdout
 
         Returns
         -------
@@ -943,7 +956,7 @@ class MMM(
 
         """
         channel_contribution_forward_pass = super().channel_contributions_forward_pass(
-            channel_data=channel_data
+            channel_data=channel_data, disable_logger_stdout=disable_logger_stdout
         )
         target_transformed_vectorized = np.vectorize(
             self.target_transformer.inverse_transform,
@@ -983,7 +996,7 @@ class MMM(
                 delta * self.preprocessed_data["X"][self.channel_columns].to_numpy()
             )
             channel_contribution_forward_pass = self.channel_contributions_forward_pass(
-                channel_data=channel_data
+                channel_data=channel_data, disable_logger_stdout=True
             )
             channel_contributions.append(channel_contribution_forward_pass)
         return DataArray(


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->
Mutes repetitive `Sampling: []` message displayed when calling `plot_channel_contributions_grid`

## Description
<!--- Describe your changes in detail -->
* Adds `disable_logger_stdout` flag, an `Optional[bool]`, to `channel_contributions_forward_pass`.
* When `True`, it disables the `pymc.sampling.forward` logger propagation [as suggested [here](https://discourse.pymc.io/t/stop-all-output-messages-to-console/1162/4)]
* In essence we are muting stdout from [this `logger.info` message](https://github.com/pymc-devs/pymc/blob/79fafb04bd5e26bf1e7057e80860107aa5939c1a/pymc/sampling/forward.py#L853)

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #896 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Modules affected
<!--- Please list the modules that are affected by this PR by typing an `x` in the boxes below: -->
- [x] MMM
- [ ] CLV
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1043.org.readthedocs.build/en/1043/

<!-- readthedocs-preview pymc-marketing end -->