### PR TITLE
Docs update: make sure the right title shows up on Google

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,6 +11,7 @@ import pymc_marketing  # isort:skip
 project = "pymc-marketing"
 author = "PyMC Labs"
 copyright = f"2022, {author}"
+html_title = "Open Source Marketing Analytics Solution"
 
 # The master toctree document.
 master_doc = "index"


### PR DESCRIPTION
Explicitly set the HTML title. Otherwise the title in Google Searches becomes "Schedule a Free Strategy Consultation — pymc-marketing 0.9" which is not great.

I BELIEVE this will solve the problem which is that currently, when you Google "PyMC-Marketing", it shows up like:

<img width="1328" alt="Screenshot 2024-10-01 at 10 19 22" src="https://github.com/user-attachments/assets/6754c71e-12de-4ccb-a77d-dc84769f13bc">

That is not great. Should be:

<img width="620" alt="Screenshot 2024-10-01 at 11 13 48" src="https://github.com/user-attachments/assets/17be972d-f124-4611-844e-cd50c15ca11d">

When we merge this, it might take while for the change to show up on Google Searches too, so we need patience. But it needs to get fixed, it's not good for the funnel