### PR TITLE
Automatic labeling of untouched issues

### DIFF
--- a/.github/workflows/label-blank-issue.yml
+++ b/.github/workflows/label-blank-issue.yml
@@ -1,0 +1,16 @@
+# Taken from scikit-learn repo
+# https://github.com/scikit-learn/scikit-learn/blob/main/.github/workflows/label-blank-issue.yml
+name: Labels Blank Issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  label-blank-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: andymckay/labeler@1.0.4
+        with:
+          add-labels: "Needs Triage"
+          ignore-if-labeled: true

--- a/.github/workflows/label-blank-issue.yml
+++ b/.github/workflows/label-blank-issue.yml
@@ -1,6 +1,6 @@
 # Taken from scikit-learn repo
 # https://github.com/scikit-learn/scikit-learn/blob/main/.github/workflows/label-blank-issue.yml
-name: Labels Blank Issues
+name: Label Blank Issue
 
 on:
   issues:


### PR DESCRIPTION
Liked this idea from scikit-learn. Idea is automatically label issues "Needs Triage" if they are not labeled. Once they are touched by someone, the label can be removed.

Any thoughts on this? There are a few more automation ideas I think that would be good.


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1086.org.readthedocs.build/en/1086/

<!-- readthedocs-preview pymc-marketing end -->