### PR TITLE
Add PR auto labeling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -24,7 +24,7 @@ CLV:
 streamlit:
   - changed-files:
     - any-glob-to-any-file:
-      - streamlit/*
+      - streamlit/**
 
 tests:
   - changed-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,19 +1,19 @@
 docs:
   - changed-files:
-  - any-glob-to-any-file:
-    - docs/source/**
+    - any-glob-to-any-file:
+      - docs/source/**
 
 MMM:
   - changed-files:
-  - any-glob-to-any-file:
-    - docs/source/notebooks/mmm/*
-    - pymc_marketing/mmm/**
+    - any-glob-to-any-file:
+      - docs/source/notebooks/mmm/*
+      - pymc_marketing/mmm/**
 
 CLV:
   - changed-files:
-  - any-glob-to-any-file:
-    - docs/source/notebooks/clv/*
-    - pymc_marketing/clv/**
+    - any-glob-to-any-file:
+      - docs/source/notebooks/clv/*
+      - pymc_marketing/clv/**
 
 "Prior class":
   - changed-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,37 @@
+docs:
+  - changed-files:
+  - any-glob-to-any-file:
+    - docs/source/**
+
+MMM:
+  - changed-files:
+  - any-glob-to-any-file:
+    - docs/source/notebooks/mmm/*
+    - pymc_marketing/mmm/**
+
+CLV:
+  - changed-files:
+  - any-glob-to-any-file:
+    - docs/source/notebooks/clv/*
+    - pymc_marketing/clv/**
+
+"Prior class":
+  - changed-files:
+    - any-glob-to-any-file:
+      - pymc_marketing/prior.py
+
+
+streamlit:
+  - changed-files:
+    - any-glob-to-any-file:
+      - streamlit/*
+
+tests:
+  - changed-files:
+    - any-glob-to-any-file:
+      - tests/**
+
+mlflow:
+  - changed-files:
+    - any-glob-to-any-file:
+      - pymc_marketing/mlflow.py

--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5


### PR DESCRIPTION
Uses the action [here](https://github.com/actions/labeler) in order to label PRs. This should update as the PRs update.

Related to #1087 


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1111.org.readthedocs.build/en/1111/

<!-- readthedocs-preview pymc-marketing end -->