### PR TITLE
Add GitHub token to env

### DIFF
--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -36,3 +36,5 @@ jobs:
           ' --jq '.data.repository.pullRequest.closingIssuesReferences.nodes | map(.labels.nodes | map(.name)) | flatten | unique | join(",")')
 
         gh pr edit $pr_number --add-label "$labels"
+      env:
+        GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Following this [failure](https://github.com/pymc-labs/pymc-marketing/actions/runs/11498821358/job/32005445760)

@juanitorduz


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1117.org.readthedocs.build/en/1117/

<!-- readthedocs-preview pymc-marketing end -->