### PR TITLE
Remove "All checks" job which hangs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,13 +60,3 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }} # use token for more robust uploads
           name: "test_slow"
           fail_ci_if_error: false
-
-  all:
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    name: All checks
-    needs: [ test, test_slow ]
-    steps:
-      - name: Confirm checks passed
-        if: ${{ (needs.test.result != 'success' || needs.test_slow.result != 'success') }}
-        run: exit 1


### PR DESCRIPTION
@juanitorduz, I am just removing this because it hangs in the actions shown in PRs which don't have the tests running. I believe that both "test" and "test_slow" will run still. What are your thoughts?


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1154.org.readthedocs.build/en/1154/

<!-- readthedocs-preview pymc-marketing end -->