### PR TITLE
Change filter to "success"

### DIFF
--- a/.github/workflows/slow-tests-issue.yml
+++ b/.github/workflows/slow-tests-issue.yml
@@ -2,6 +2,7 @@
 name: Slow Tests Issue Body
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 */6 * * *'
 

--- a/scripts/slowest_tests/update-slowest-times-issue.sh
+++ b/scripts/slowest_tests/update-slowest-times-issue.sh
@@ -7,7 +7,7 @@ repo=pymc-marketing
 issue_number=1158
 title="Speed up test times :rocket:"
 workflow=Test
-latest_id=$(gh run list --workflow $workflow --status completed --limit 1 --json databaseId --jq '.[0].databaseId')
+latest_id=$(gh run list --workflow $workflow --status success --limit 1 --json databaseId --jq '.[0].databaseId')
 jobs=$(gh api /repos/$owner/$repo/actions/runs/$latest_id/jobs --jq '.jobs | map({name: .name, run_id: .run_id, id: .id})')
 
 all_times=""
@@ -18,6 +18,7 @@ echo "$jobs" | jq -c '.[]' | while read -r job; do
 
     echo "Processing job: $name (ID: $id, Run ID: $run_id)"
     times=$(gh run view --job $id --log | python extract-slow-tests.py)
+    echo $times
 
     top="<details><summary>$name</summary>\n\n\n\`\`\`"
     bottom="\`\`\`\n\n</details>"


### PR DESCRIPTION

Follow up to #1160 which picked up a failure


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1167.org.readthedocs.build/en/1167/

<!-- readthedocs-preview pymc-marketing end -->