### PR TITLE
Point to zsh in action

### DIFF
--- a/.github/workflows/slow-tests-issue.yml
+++ b/.github/workflows/slow-tests-issue.yml
@@ -13,6 +13,8 @@ jobs:
   update-comment:
     runs-on: ubuntu-latest
     steps:
+      - name: Install ZSH
+        run: sudo apt-get update && sudo apt-get install -y zsh
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Set up Python
@@ -21,6 +23,7 @@ jobs:
           python-version: "3.11"
       - name: Trigger the script
         working-directory: scripts/slowest_tests
+        shell: zsh {0}
         run: source update-slowest-times-issue.sh
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/scripts/slowest_tests/update-slowest-times-issue.sh
+++ b/scripts/slowest_tests/update-slowest-times-issue.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/zsh
 
 DRY_RUN=false
 


### PR DESCRIPTION
I'm using zsh and having success with that locally. So, switch the shell there for the action


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1171.org.readthedocs.build/en/1171/

<!-- readthedocs-preview pymc-marketing end -->