### PR TITLE
[FIX] Wrong legend in the posterior predictive plot then we set gradient=True

### DIFF
--- a/pymc_marketing/mmm/base.py
+++ b/pymc_marketing/mmm/base.py
@@ -558,6 +558,7 @@ class MMMModelBuilder(ModelBuilder):
                     hdi_prob=hdi_prob,
                     alpha=alpha,
                 )
+
         if add_mean:
             ax = self._add_mean_to_plot(
                 ax=ax, group=group, original_scale=original_scale, color="blue"

--- a/pymc_marketing/mmm/base.py
+++ b/pymc_marketing/mmm/base.py
@@ -548,7 +548,7 @@ class MMMModelBuilder(ModelBuilder):
         if hdi_list is None:
             hdi_list = [0.94, 0.5]
 
-        if hdi_list:
+        if hdi_list and not add_gradient:
             alpha_list = np.linspace(0.2, 0.4, len(hdi_list))
             for hdi_prob, alpha in zip(hdi_list, alpha_list, strict=True):
                 ax = self._add_hdi_to_plot(
@@ -558,7 +558,6 @@ class MMMModelBuilder(ModelBuilder):
                     hdi_prob=hdi_prob,
                     alpha=alpha,
                 )
-
         if add_mean:
             ax = self._add_mean_to_plot(
                 ax=ax, group=group, original_scale=original_scale, color="blue"


### PR DESCRIPTION
Fix wrong legend.

### Before 

![image](https://github.com/user-attachments/assets/402d7ae6-30ca-43c2-abf2-d6042dd42f5d)


### After

![image](https://github.com/user-attachments/assets/9ef14a9a-14f4-49cd-b574-5867a2ddf2fb)

(see example notebook diff)

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1212.org.readthedocs.build/en/1212/

<!-- readthedocs-preview pymc-marketing end -->