### PR TITLE
Raise error when two dims are not compatible

### DIFF
--- a/pymc_marketing/prior.py
+++ b/pymc_marketing/prior.py
@@ -110,7 +110,7 @@ from pymc.distributions.shape_utils import Dims
 
 
 class UnsupportedShapeError(Exception):
-    """Error for when the shape of the hierarchical variable is not supported."""
+    """Error for when the shapes from variables are not compatible."""
 
 
 class UnsupportedDistributionError(Exception):
@@ -168,6 +168,12 @@ def handle_dims(x: pt.TensorLike, dims: Dims, desired_dims: Dims) -> pt.TensorVa
 
     dims = dims if isinstance(dims, tuple) else (dims,)
     desired_dims = desired_dims if isinstance(desired_dims, tuple) else (desired_dims,)
+
+    if difference := set(dims).difference(desired_dims):
+        raise UnsupportedShapeError(
+            f"Desired dims {desired_dims} are not a subset of the given dims {dims}. "
+            f"{difference} is missing from the desired dims."
+        )
 
     aligned_dims = np.array(dims)[:, None] == np.array(desired_dims)
 

--- a/pymc_marketing/prior.py
+++ b/pymc_marketing/prior.py
@@ -171,7 +171,7 @@ def handle_dims(x: pt.TensorLike, dims: Dims, desired_dims: Dims) -> pt.TensorVa
 
     if difference := set(dims).difference(desired_dims):
         raise UnsupportedShapeError(
-            f"Desired dims {desired_dims} are not a subset of the given dims {dims}. "
+            f"Dims {dims} of data are not a subset of the desired dims {desired_dims}. "
             f"{difference} is missing from the desired dims."
         )
 

--- a/tests/test_prior.py
+++ b/tests/test_prior.py
@@ -648,6 +648,6 @@ def test_custom_transform_comes_first() -> None:
     ids=["no_incommon", "some_incommon"],
 )
 def test_handle_dims_with_impossible_dims(x, dims, desired_dims) -> None:
-    match = " are not a subset of the given dims "
+    match = " are not a subset of the desired dims "
     with pytest.raises(UnsupportedShapeError, match=match):
         handle_dims(x, dims, desired_dims)

--- a/tests/test_prior.py
+++ b/tests/test_prior.py
@@ -72,6 +72,20 @@ def test_handle_dims(x, dims, desired_dims, expected_fn) -> None:
     np.testing.assert_array_equal(result, expected_fn(x))
 
 
+@pytest.mark.parametrize(
+    "x, dims, desired_dims",
+    [
+        (np.ones(3), "channel", "something_else"),
+        (np.ones((3, 2)), ("a", "b"), ("a", "B")),
+    ],
+    ids=["no_incommon", "some_incommon"],
+)
+def test_handle_dims_with_impossible_dims(x, dims, desired_dims) -> None:
+    match = " are not a subset of the desired dims "
+    with pytest.raises(UnsupportedShapeError, match=match):
+        handle_dims(x, dims, desired_dims)
+
+
 def test_missing_transform() -> None:
     match = "Neither pytensor.tensor nor pymc.math have the function 'foo_bar'"
     with pytest.raises(UnknownTransformError, match=match):
@@ -637,17 +651,3 @@ def test_custom_transform_comes_first() -> None:
     )
 
     clear_custom_transforms()
-
-
-@pytest.mark.parametrize(
-    "x, dims, desired_dims",
-    [
-        (np.ones(3), "channel", "something_else"),
-        (np.ones((3, 2)), ("a", "b"), ("a", "B")),
-    ],
-    ids=["no_incommon", "some_incommon"],
-)
-def test_handle_dims_with_impossible_dims(x, dims, desired_dims) -> None:
-    match = " are not a subset of the desired dims "
-    with pytest.raises(UnsupportedShapeError, match=match):
-        handle_dims(x, dims, desired_dims)

--- a/tests/test_prior.py
+++ b/tests/test_prior.py
@@ -637,3 +637,17 @@ def test_custom_transform_comes_first() -> None:
     )
 
     clear_custom_transforms()
+
+
+@pytest.mark.parametrize(
+    "x, dims, desired_dims",
+    [
+        (np.ones(3), "channel", "something_else"),
+        (np.ones((3, 2)), ("a", "b"), ("a", "B")),
+    ],
+    ids=["no_incommon", "some_incommon"],
+)
+def test_handle_dims_with_impossible_dims(x, dims, desired_dims) -> None:
+    match = " are not a subset of the given dims "
+    with pytest.raises(UnsupportedShapeError, match=match):
+        handle_dims(x, dims, desired_dims)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

Bug fix for an earlier error. Closes #1248

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Modules affected
<!--- Please list the modules that are affected by this PR by typing an `x` in the boxes below: -->
- [ ] MMM
- [ ] CLV
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1249.org.readthedocs.build/en/1249/

<!-- readthedocs-preview pymc-marketing end -->