### PR TITLE
1271 predictions=true for sample posterior predictive throws error

### DIFF
--- a/pymc_marketing/mmm/mmm.py
+++ b/pymc_marketing/mmm/mmm.py
@@ -1930,9 +1930,9 @@ class MMM(
                 self.idata.extend(post_pred, join="right")  # type: ignore
 
         group = (
-            "posterior_predictive"
+            "predictions"
             if sample_posterior_predictive_kwargs.get("predictions", False)
-            else "predictions"
+            else "posterior_predictive"
         )
         posterior_predictive_samples = az.extract(post_pred, group, combined=combined)
 

--- a/pymc_marketing/mmm/mmm.py
+++ b/pymc_marketing/mmm/mmm.py
@@ -1929,9 +1929,12 @@ class MMM(
             if extend_idata:
                 self.idata.extend(post_pred, join="right")  # type: ignore
 
-        posterior_predictive_samples = az.extract(
-            post_pred, "posterior_predictive", combined=combined
+        group = (
+            "posterior_predictive"
+            if sample_posterior_predictive_kwargs.get("predictions", False)
+            else "predictions"
         )
+        posterior_predictive_samples = az.extract(post_pred, group, combined=combined)
 
         if include_last_observations:
             posterior_predictive_samples = posterior_predictive_samples.isel(

--- a/tests/mmm/test_mmm.py
+++ b/tests/mmm/test_mmm.py
@@ -898,6 +898,30 @@ def test_new_data_sample_posterior_predictive_method(
 
 
 @pytest.mark.parametrize(
+    "predictions",
+    [True, False],
+)
+def test_sample_posterior_predictive_with_prediction_kwarg(
+    generate_data,
+    mmm_fitted,
+    predictions: bool,
+) -> None:
+    new_dates = pd.date_range("2022-01-01", "2022-03-01", freq="W-MON")
+    X_pred = generate_data(new_dates)
+
+    predictions = mmm_fitted.sample_posterior_predictive(
+        X_pred=X_pred,
+        extend_idata=False,
+        combined=True,
+        predictions=predictions,
+    )
+    pd.testing.assert_index_equal(
+        pd.DatetimeIndex(predictions.coords["date"]),
+        new_dates,
+    )
+
+
+@pytest.mark.parametrize(
     "model_name", ["mmm_fitted", "mmm_fitted_with_fourier_features"]
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

The extracted group is conditional on the kwargs if `predictions=True`

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Modules affected
<!--- Please list the modules that are affected by this PR by typing an `x` in the boxes below: -->
- [x] MMM
- [ ] CLV
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->