### PR TITLE
solved mypy error in base.py

### DIFF
--- a/pymc_marketing/mmm/base.py
+++ b/pymc_marketing/mmm/base.py
@@ -549,7 +549,7 @@ class MMMModelBuilder(ModelBuilder):
             hdi_list = [0.94, 0.5]
 
         if hdi_list and not add_gradient:
-            alpha_list = np.linspace(0.2, 0.4, len(hdi_list))
+            alpha_list = np.linspace(0.2, 0.4, len(hdi_list), dtype=float)
             for hdi_prob, alpha in zip(hdi_list, alpha_list, strict=True):
                 ax = self._add_hdi_to_plot(
                     ax=ax,


### PR DESCRIPTION
solved mypy error in base.py

## Description
`_add_hdi_to_plot` expects `alpha` input param to be of type `float`. Pylance reports that it is the correct type but mypy does not. Added `dtype=float` to preceeding `np.linspace` call and now mypy no longer reports that error.

## Related Issue
- [ ] Related to #1262

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] If you are a pro: each commit corresponds to a [relevant logical change]

## Modules affected
- [x] MMM
- [ ] CLV

## Type of change
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1285.org.readthedocs.build/en/1285/

<!-- readthedocs-preview pymc-marketing end -->