### PR TITLE
Allow non-Prior parameters in Prior and media transformations

### DIFF
--- a/pymc_marketing/mmm/components/adstock.py
+++ b/pymc_marketing/mmm/components/adstock.py
@@ -54,9 +54,13 @@ Plot the default priors for an adstock transformation:
 
 import numpy as np
 import xarray as xr
-from pydantic import Field, InstanceOf, validate_call
+from pydantic import Field, validate_call
 
-from pymc_marketing.mmm.components.base import Transformation
+from pymc_marketing.mmm.components.base import (
+    SupportedPrior,
+    Transformation,
+    _deserialize,
+)
 from pymc_marketing.mmm.transformers import (
     ConvMode,
     WeibullType,
@@ -92,7 +96,7 @@ class AdstockTransformation(Transformation):
             True, description="Whether to normalize the adstock values."
         ),
         mode: ConvMode = Field(ConvMode.After, description="Convolution mode."),
-        priors: dict[str, InstanceOf[Prior]] | None = Field(
+        priors: dict[str, SupportedPrior] | None = Field(
             default=None, description="Priors for the parameters."
         ),
         prefix: str | None = Field(None, description="Prefix for the parameters."),
@@ -341,5 +345,6 @@ def adstock_from_dict(data: dict) -> AdstockTransformation:
     cls = ADSTOCK_TRANSFORMATIONS[lookup_name]
 
     if "priors" in data:
-        data["priors"] = {k: Prior.from_json(v) for k, v in data["priors"].items()}
+        data["priors"] = {k: _deserialize(v) for k, v in data["priors"].items()}
+
     return cls(**data)

--- a/pymc_marketing/mmm/components/base.py
+++ b/pymc_marketing/mmm/components/base.py
@@ -44,12 +44,14 @@ from pymc_marketing.plot import (
     plot_hdi,
     plot_samples,
 )
-from pymc_marketing.prior import DimHandler, Prior, create_dim_handler
+from pymc_marketing.prior import DimHandler, Prior, VariableFactory, create_dim_handler
 
 # "x" for saturation, "time since exposure" for adstock
 NON_GRID_NAMES: frozenset[str] = frozenset({"x", "time since exposure"})
 
-SupportedPrior = InstanceOf[Prior] | float | InstanceOf[TensorVariable]
+SupportedPrior = (
+    InstanceOf[Prior] | float | InstanceOf[TensorVariable] | VariableFactory
+)
 
 
 class ParameterPriorException(Exception):
@@ -104,7 +106,7 @@ class Transformation:
 
     Parameters
     ----------
-    priors : dict[str, Prior], optional
+    priors : dict[str, Prior | float | TensorVariable | VariableFactory], optional
         Dictionary with the priors for the parameters of the function. The keys should be the
         parameter names and the values the priors. If not provided, it will use the default
         priors from the subclass.
@@ -121,7 +123,8 @@ class Transformation:
 
     def __init__(
         self,
-        priors: Prior | float | TensorVariable | None = None,
+        priors: dict[str, Prior | float | TensorVariable | VariableFactory]
+        | None = None,
         prefix: str | None = None,
     ) -> None:
         self._checks()

--- a/pymc_marketing/mmm/components/base.py
+++ b/pymc_marketing/mmm/components/base.py
@@ -50,7 +50,7 @@ from pymc_marketing.prior import DimHandler, Prior, VariableFactory, create_dim_
 NON_GRID_NAMES: frozenset[str] = frozenset({"x", "time since exposure"})
 
 SupportedPrior = (
-    InstanceOf[Prior] | float | InstanceOf[TensorVariable] | VariableFactory
+    InstanceOf[Prior] | float | InstanceOf[TensorVariable] | InstanceOf[VariableFactory]
 )
 
 
@@ -586,7 +586,7 @@ def _serialize_value(value: Any) -> Any:
         return value.to_dict()
 
     if isinstance(value, TensorVariable):
-        return value.eval()
+        value = value.eval()
 
     if isinstance(value, np.ndarray):
         return value.tolist()

--- a/pymc_marketing/mmm/components/base.py
+++ b/pymc_marketing/mmm/components/base.py
@@ -310,6 +310,9 @@ class Transformation:
 
         def create_variable(parameter_name: str, variable_name: str) -> TensorVariable:
             dist = self.function_priors[parameter_name]
+            if not hasattr(dist, "create_variable"):
+                return dist
+
             var = dist.create_variable(variable_name)
             return dim_handler(var, dist.dims)
 

--- a/pymc_marketing/mmm/components/base.py
+++ b/pymc_marketing/mmm/components/base.py
@@ -32,6 +32,7 @@ import pymc as pm
 import xarray as xr
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
+from pydantic import InstanceOf
 from pymc.distributions.shape_utils import Dims
 from pytensor import tensor as pt
 from pytensor.tensor.variable import TensorVariable
@@ -47,6 +48,8 @@ from pymc_marketing.prior import DimHandler, Prior, create_dim_handler
 
 # "x" for saturation, "time since exposure" for adstock
 NON_GRID_NAMES: frozenset[str] = frozenset({"x", "time since exposure"})
+
+SupportedPrior = InstanceOf[Prior] | float | InstanceOf[TensorVariable]
 
 
 class ParameterPriorException(Exception):
@@ -117,7 +120,9 @@ class Transformation:
     lookup_name: str
 
     def __init__(
-        self, priors: dict[str, Prior] | None = None, prefix: str | None = None
+        self,
+        priors: Prior | float | TensorVariable | None = None,
+        prefix: str | None = None,
     ) -> None:
         self._checks()
         self.function_priors = priors  # type: ignore
@@ -164,7 +169,8 @@ class Transformation:
             "lookup_name": self.lookup_name,
             "prefix": self.prefix,
             "priors": {
-                key: value.to_json() for key, value in self.function_priors.items()
+                key: _serialize_value(value)
+                for key, value in self.function_priors.items()
             },
         }
 
@@ -184,7 +190,13 @@ class Transformation:
     def function_priors(self, priors: dict[str, Any | Prior] | None) -> None:
         priors = priors or {}
 
-        priors = parse_model_config(priors)
+        non_distributions = [
+            key
+            for key, value in priors.items()
+            if not isinstance(value, Prior) and not isinstance(value, dict)
+        ]
+
+        priors = parse_model_config(priors, non_distributions=non_distributions)
         self._function_priors = {**deepcopy(self.default_priors), **priors}
 
     def update_priors(self, priors: dict[str, Prior]) -> None:
@@ -405,7 +417,9 @@ class Transformation:
         x: pt.TensorLike,
         coords: dict[str, Any],
     ) -> xr.DataArray:
-        required_vars = list(self.variable_mapping.values())
+        required_vars = set(self.variable_mapping.values()).intersection(
+            parameters.data_vars.keys()
+        )
 
         keys = list(coords.keys())
         if len(keys) != 1:
@@ -559,3 +573,26 @@ class Transformation:
         """
         kwargs = self._create_distributions(dims=dims)
         return self.function(x, **kwargs)
+
+
+def _serialize_value(value: Any) -> Any:
+    if isinstance(value, Prior):
+        return value.to_json()
+
+    if hasattr(value, "to_dict"):
+        return value.to_dict()
+
+    if isinstance(value, TensorVariable):
+        return value.eval()
+
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+
+    return value
+
+
+def _deserialize(value):
+    try:
+        return Prior.from_json(value)
+    except Exception:
+        return value

--- a/pymc_marketing/mmm/components/saturation.py
+++ b/pymc_marketing/mmm/components/saturation.py
@@ -76,7 +76,10 @@ import pytensor.tensor as pt
 import xarray as xr
 from pydantic import Field, InstanceOf, validate_call
 
-from pymc_marketing.mmm.components.base import Transformation
+from pymc_marketing.mmm.components.base import (
+    Transformation,
+    _deserialize,
+)
 from pymc_marketing.mmm.transformers import (
     hill_function,
     hill_saturation_sigmoid,
@@ -480,6 +483,6 @@ def saturation_from_dict(data: dict) -> SaturationTransformation:
 
     if "priors" in data:
         data["priors"] = {
-            key: Prior.from_json(value) for key, value in data["priors"].items()
+            key: _deserialize(value) for key, value in data["priors"].items()
         }
     return cls(**data)

--- a/tests/mmm/components/test_base.py
+++ b/tests/mmm/components/test_base.py
@@ -16,6 +16,7 @@ import numpy as np
 import pymc as pm
 import pytest
 import xarray as xr
+from pytensor.tensor import TensorVariable
 
 from pymc_marketing.mmm.components.base import (
     MissingDataParameter,
@@ -353,3 +354,47 @@ def test_support_for_non_prior(new_transformation_class) -> None:
         "prefix": "new",
         "priors": {"a": 1, "b": 2},
     }
+
+
+class StandardNormal:
+    def __init__(self, dims: tuple[str, ...]) -> None:
+        self.dims = dims
+
+    def to_dict(self) -> dict:
+        return {
+            "type": "StandardNormal",
+            "dims": self.dims,
+        }
+
+    def create_variable(self, name: str) -> TensorVariable:
+        return pm.Normal(name, 0, 1, dims=self.dims)
+
+
+@pytest.fixture
+def new_transformation_with_custom(new_transformation_class):
+    return new_transformation_class(
+        priors={"a": StandardNormal(("channel",))},
+    )
+
+
+def test_support_customer_serialization(
+    new_transformation_with_custom,
+) -> None:
+    assert new_transformation_with_custom.to_dict() == {
+        "lookup_name": "new_transformation",
+        "prefix": "new",
+        "priors": {
+            "a": {"type": "StandardNormal", "dims": ("channel",)},
+            "b": {"dist": "HalfNormal", "kwargs": {"sigma": 1}},
+        },
+    }
+
+
+def test_support_customer_samples(
+    new_transformation_with_custom,
+) -> None:
+    coords = {"channel": ["C1", "C2", "C3"]}
+    priors = new_transformation_with_custom.sample_prior(coords=coords)
+
+    assert priors.data_vars.keys() == {"new_a", "new_b"}
+    assert priors["new_a"].sizes == {"chain": 1, "draw": 500, "channel": 3}

--- a/tests/mmm/components/test_base.py
+++ b/tests/mmm/components/test_base.py
@@ -341,3 +341,15 @@ def test_repr(new_transformation) -> None:
         "priors={'a': Prior(\"HalfNormal\", sigma=1), 'b': Prior(\"HalfNormal\", sigma=1)}"
         ")"
     )
+
+
+def test_support_for_non_prior(new_transformation_class) -> None:
+    instance = new_transformation_class(
+        priors={"a": 1, "b": 2},
+    )
+
+    assert instance.to_dict() == {
+        "lookup_name": "new_transformation",
+        "prefix": "new",
+        "priors": {"a": 1, "b": 2},
+    }

--- a/tests/mmm/components/test_base.py
+++ b/tests/mmm/components/test_base.py
@@ -14,6 +14,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import pymc as pm
+import pytensor.tensor as pt
 import pytest
 import xarray as xr
 from pytensor.tensor import TensorVariable
@@ -398,3 +399,21 @@ def test_support_customer_samples(
 
     assert priors.data_vars.keys() == {"new_a", "new_b"}
     assert priors["new_a"].sizes == {"chain": 1, "draw": 500, "channel": 3}
+
+
+def test_serialization(new_transformation_class) -> None:
+    instance = new_transformation_class(
+        priors={
+            "a": pt.as_tensor_variable([1, 2, 3]),
+            "b": np.array([1, 2, 3]),
+        }
+    )
+
+    assert instance.to_dict() == {
+        "lookup_name": "new_transformation",
+        "prefix": "new",
+        "priors": {
+            "a": [1, 2, 3],
+            "b": [1, 2, 3],
+        },
+    }


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

```python
import numpy as np
import pymc as pm

from pymc_marketing.mmm import GeometricAdstock

adstock = GeometricAdstock(l_max=12, priors={"alpha": 1.0})

X = np.random.randn(100)

with pm.Model() as model:
    adstocked_X = adstock.apply(X)
```
Some plotting will not be supported if there are no distribution parameters required

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Modules affected
<!--- Please list the modules that are affected by this PR by typing an `x` in the boxes below: -->
- [x] MMM
- [ ] CLV
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->