### PR TITLE
Register new media transformations automatically

### DIFF
--- a/pymc_marketing/mmm/components/adstock.py
+++ b/pymc_marketing/mmm/components/adstock.py
@@ -52,6 +52,8 @@ Plot the default priors for an adstock transformation:
 
 """
 
+from __future__ import annotations
+
 import numpy as np
 import xarray as xr
 from pydantic import Field, validate_call
@@ -60,6 +62,7 @@ from pymc_marketing.deserialize import deserialize, register_deserialization
 from pymc_marketing.mmm.components.base import (
     SupportedPrior,
     Transformation,
+    create_registration_meta,
 )
 from pymc_marketing.mmm.transformers import (
     ConvMode,
@@ -70,8 +73,12 @@ from pymc_marketing.mmm.transformers import (
 )
 from pymc_marketing.prior import Prior
 
+ADSTOCK_TRANSFORMATIONS: dict[str, type[AdstockTransformation]] = {}
 
-class AdstockTransformation(Transformation):
+AdstockRegistrationMeta: type[type] = create_registration_meta(ADSTOCK_TRANSFORMATIONS)
+
+
+class AdstockTransformation(Transformation, metaclass=AdstockRegistrationMeta):  # type: ignore
     """Subclass for all adstock functions.
 
     In order to use a custom saturation function, inherit from this class and define:
@@ -320,17 +327,6 @@ class WeibullCDFAdstock(AdstockTransformation):
         "lam": Prior("Gamma", mu=2, sigma=2.5),
         "k": Prior("Gamma", mu=2, sigma=2.5),
     }
-
-
-ADSTOCK_TRANSFORMATIONS: dict[str, type[AdstockTransformation]] = {
-    cls.lookup_name: cls  # type: ignore
-    for cls in [
-        GeometricAdstock,
-        DelayedAdstock,
-        WeibullPDFAdstock,
-        WeibullCDFAdstock,
-    ]
-}
 
 
 def register_adstock_transformation(cls: type[AdstockTransformation]) -> None:

--- a/pymc_marketing/mmm/components/base.py
+++ b/pymc_marketing/mmm/components/base.py
@@ -592,3 +592,47 @@ def _serialize_value(value: Any) -> Any:
         return value.tolist()
 
     return value
+
+
+class DuplicatedTransformationError(Exception):
+    """Exception when a transformation is duplicated."""
+
+    def __init__(self, name: str, lookup_name: str):
+        self.name = name
+        self.lookup_name = lookup_name
+        super().__init__(f"Duplicate {name}. The name {lookup_name!r} already exists.")
+
+
+def create_registration_meta(subclasses: dict[str, Any]) -> type[type]:
+    """Create a metaclass for registering subclasses.
+
+    Parameters
+    ----------
+    subclasses : dict[str, type[Transformation]]
+        The subclasses to register.
+
+    Returns
+    -------
+    type
+        The metaclass for registering subclasses.
+
+    """
+
+    class RegistrationMeta(type):
+        def __new__(cls, name, bases, attrs):
+            new_cls = super().__new__(cls, name, bases, attrs)
+
+            if "lookup_name" not in attrs:
+                return new_cls
+
+            base_name = bases[0].__name__
+
+            lookup_name = attrs["lookup_name"]
+            if lookup_name in subclasses:
+                raise DuplicatedTransformationError(base_name, lookup_name)
+
+            subclasses[lookup_name] = new_cls
+
+            return new_cls
+
+    return RegistrationMeta

--- a/pymc_marketing/mmm/components/saturation.py
+++ b/pymc_marketing/mmm/components/saturation.py
@@ -71,6 +71,8 @@ for saturation parameter of logistic saturation.
 
 """
 
+from __future__ import annotations
+
 import numpy as np
 import pytensor.tensor as pt
 import xarray as xr
@@ -79,6 +81,7 @@ from pydantic import Field, InstanceOf, validate_call
 from pymc_marketing.deserialize import deserialize, register_deserialization
 from pymc_marketing.mmm.components.base import (
     Transformation,
+    create_registration_meta,
 )
 from pymc_marketing.mmm.transformers import (
     hill_function,
@@ -92,8 +95,12 @@ from pymc_marketing.mmm.transformers import (
 )
 from pymc_marketing.prior import Prior
 
+SATURATION_TRANSFORMATIONS: dict[str, type[SaturationTransformation]] = {}
 
-class SaturationTransformation(Transformation):
+SaturationRegistrationMeta = create_registration_meta(SATURATION_TRANSFORMATIONS)
+
+
+class SaturationTransformation(Transformation, metaclass=SaturationRegistrationMeta):  # type: ignore
     """Subclass for all saturation transformations.
 
     In order to use a custom saturation transformation, subclass and define:
@@ -450,21 +457,6 @@ class RootSaturation(SaturationTransformation):
         "alpha": Prior("Beta", alpha=1, beta=2),
         "beta": Prior("Gamma", mu=1, sigma=1),
     }
-
-
-SATURATION_TRANSFORMATIONS: dict[str, type[SaturationTransformation]] = {
-    cls.lookup_name: cls
-    for cls in [
-        LogisticSaturation,
-        InverseScaledLogisticSaturation,
-        TanhSaturation,
-        TanhSaturationBaselined,
-        MichaelisMentenSaturation,
-        HillSaturation,
-        HillSaturationSigmoid,
-        RootSaturation,
-    ]
-}
 
 
 def register_saturation_transformation(cls: type[SaturationTransformation]) -> None:

--- a/tests/mmm/components/test_saturation.py
+++ b/tests/mmm/components/test_saturation.py
@@ -32,6 +32,7 @@ from pymc_marketing.mmm import (
     LogisticSaturation,
     MichaelisMentenSaturation,
     RootSaturation,
+    SaturationTransformation,
     TanhSaturation,
     TanhSaturationBaselined,
     saturation_from_dict,
@@ -287,3 +288,20 @@ def test_deserialization(
     assert isinstance(alpha, ArbitraryObject)
     assert alpha.msg == "hello"
     assert alpha.value == 1
+
+
+def test_deserialize_new_transformation() -> None:
+    class NewSaturation(SaturationTransformation):
+        lookup_name = "new_saturation"
+
+        def function(self, x):
+            return x
+
+        default_priors = {}
+
+    data = {
+        "lookup_name": "new_saturation",
+    }
+
+    instance = deserialize(data)
+    assert isinstance(instance, NewSaturation)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

Adstock and Saturation Transformations will be registry automatically when the class is created (**not instantiated**). This will allow for a more seamless experience when using the transformations in the future.


```python
from pymc_marketing.mmm import SaturationTransformation

# This registers the class with other saturation transformations
class Identity(SaturationTransformation):
    lookup_name: str = "identity"

    def function(self, x): 
        return x

    default_priors = {}
```

That makes the class available for serialization and deserialization (i.e. what is done in MMM load method)

```python
from pymc_marketing.deserialize import deserialize

data = {"lookup_name": "identity"}
saturation_transformation = deserialize(data)

assert isinstance(saturation_transformation, Identity)
```

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #1319
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Modules affected
<!--- Please list the modules that are affected by this PR by typing an `x` in the boxes below: -->
- [x] MMM
- [ ] CLV
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1320.org.readthedocs.build/en/1320/

<!-- readthedocs-preview pymc-marketing end -->