### PR TITLE
Deprecate to/from_json of Prior class in favor of to/from_dict

### DIFF
--- a/docs/source/notebooks/general/model_configuration.ipynb
+++ b/docs/source/notebooks/general/model_configuration.ipynb
@@ -2112,7 +2112,7 @@
    "source": [
     "### Serialization\n",
     "\n",
-    "The `to_json` and `from_json` methods can be helpful for storage of the distributions."
+    "The `to_dict` and `from_dict` methods can be helpful for storage of the distributions."
    ]
   },
   {
@@ -2142,7 +2142,7 @@
     }
    ],
    "source": [
-    "variable_2d_dict = variable_2d.to_json()\n",
+    "variable_2d_dict = variable_2d.to_dict()\n",
     "variable_2d_dict"
    ]
   },
@@ -2315,7 +2315,7 @@
     }
    ],
    "source": [
-    "Prior.from_json(variable_2d_dict).to_graph()"
+    "Prior.from_dict(variable_2d_dict).to_graph()"
    ]
   },
   {
@@ -2332,7 +2332,7 @@
     " \n",
     "### Backwards compatibility\n",
     "\n",
-    "The `from_json` method will create a `Prior` instance from the previous format.\n",
+    "The `from_dict` method will create a `Prior` instance from the previous format.\n",
     "\n",
     "For instance, take this previous configuration: "
    ]
@@ -2367,7 +2367,7 @@
    "id": "d63987c0-2525-4b12-8415-cd62dd66265f",
    "metadata": {},
    "source": [
-    "This can be parsed with the `Prior.from_json` constructor for each key. Much more consise too!"
+    "This can be parsed with the `Prior.from_dict` constructor for each key. Much more consise too!"
    ]
   },
   {
@@ -2390,7 +2390,7 @@
    ],
    "source": [
     "new_model_config = {\n",
-    "    name: Prior.from_json(key) for name, key in old_model_config.items()\n",
+    "    name: Prior.from_dict(key) for name, key in old_model_config.items()\n",
     "}\n",
     "\n",
     "new_model_config"
@@ -2414,7 +2414,7 @@
     }
    ],
    "source": [
-    "new_model_config[\"alpha\"].to_json()"
+    "new_model_config[\"alpha\"].to_dict()"
    ]
   },
   {

--- a/pymc_marketing/customer_choice/mv_its.py
+++ b/pymc_marketing/customer_choice/mv_its.py
@@ -219,9 +219,9 @@ class MVITS(ModelBuilder):
     @property
     def _serializable_model_config(self) -> dict[str, int | float | dict]:  # type: ignore
         result: dict[str, int | float | dict] = {
-            "intercept": self.model_config["intercept"].to_json(),
-            "likelihood": self.model_config["likelihood"].to_json(),
-            "market_distribution": self.model_config["market_distribution"].to_json(),
+            "intercept": self.model_config["intercept"].to_dict(),
+            "likelihood": self.model_config["likelihood"].to_dict(),
+            "market_distribution": self.model_config["market_distribution"].to_dict(),
         }
 
         return result

--- a/pymc_marketing/mmm/components/base.py
+++ b/pymc_marketing/mmm/components/base.py
@@ -579,9 +579,6 @@ class Transformation:
 
 
 def _serialize_value(value: Any) -> Any:
-    if isinstance(value, Prior):
-        return value.to_json()
-
     if hasattr(value, "to_dict"):
         return value.to_dict()
 

--- a/pymc_marketing/mmm/fourier.py
+++ b/pymc_marketing/mmm/fourier.py
@@ -321,7 +321,7 @@ class FourierBase(BaseModel):
 
         Parameters
         ----------
-        prior : Prior
+        prior : VariableFactory | Prior
             The prior distribution to serialize.
 
         Returns
@@ -330,9 +330,6 @@ class FourierBase(BaseModel):
             The serialized prior distribution.
 
         """
-        if hasattr(prior, "to_dict"):
-            return prior.to_dict()
-
         return prior.to_dict()
 
     @property

--- a/pymc_marketing/mmm/fourier.py
+++ b/pymc_marketing/mmm/fourier.py
@@ -333,7 +333,7 @@ class FourierBase(BaseModel):
         if hasattr(prior, "to_dict"):
             return prior.to_dict()
 
-        return prior.to_json()
+        return prior.to_dict()
 
     @property
     def nodes(self) -> list[str]:

--- a/pymc_marketing/mmm/hsgp.py
+++ b/pymc_marketing/mmm/hsgp.py
@@ -319,7 +319,7 @@ class HSGPBase(BaseModel):
         data = self.model_dump()
 
         def handle_prior(value):
-            return value if not hasattr(value, "to_json") else value.to_json()
+            return value if not hasattr(value, "to_dict") else value.to_dict()
 
         return {key: handle_prior(value) for key, value in data.items()}
 
@@ -770,7 +770,7 @@ class HSGP(HSGPBase):
         """
         for key in ["eta", "ls"]:
             if isinstance(data[key], dict):
-                data[key] = Prior.from_json(data[key])
+                data[key] = Prior.from_dict(data[key])
 
         return cls(**data)
 
@@ -1002,6 +1002,6 @@ class HSGPPeriodic(HSGPBase):
         """
         for key in ["scale", "ls"]:
             if isinstance(data[key], dict):
-                data[key] = Prior.from_json(data[key])
+                data[key] = Prior.from_dict(data[key])
 
         return cls(**data)

--- a/pymc_marketing/model_builder.py
+++ b/pymc_marketing/model_builder.py
@@ -29,7 +29,6 @@ import xarray as xr
 from pymc.util import RandomState
 
 from pymc_marketing.hsgp_kwargs import HSGPKwargs
-from pymc_marketing.prior import Prior
 from pymc_marketing.utils import from_netcdf
 
 # If scikit-learn is available, use its data validator
@@ -353,8 +352,8 @@ class ModelBuilder(ABC):
         """
 
         def default(x):
-            if isinstance(x, Prior):
-                return x.to_json()
+            if hasattr(x, "to_dict"):
+                return x.to_dict()
             elif isinstance(x, HSGPKwargs):
                 return x.model_dump(mode="json")
             return x.__dict__

--- a/pymc_marketing/prior.py
+++ b/pymc_marketing/prior.py
@@ -97,6 +97,7 @@ Create a prior with a custom transform function by registering it with
 from __future__ import annotations
 
 import copy
+import warnings
 from collections.abc import Callable
 from inspect import signature
 from typing import Any, Protocol, runtime_checkable
@@ -641,8 +642,10 @@ class Prior:
 
         return getattr(pz, self.distribution)(**self.parameters)
 
-    def to_json(self) -> dict[str, Any]:
-        """Convert the prior to the previous dictionary format.
+    def to_dict(self) -> dict[str, Any]:
+        """Convert the prior to dictionary format.
+
+        This is equivalent to the older PyMC-Marketing dictionary format.
 
         Returns
         -------
@@ -659,7 +662,7 @@ class Prior:
 
             dist = Prior("Normal", mu=0, sigma=1)
 
-            dist.to_json()
+            dist.to_dict()
             # {"dist": "Normal", "kwargs": {"mu": 0, "sigma": 1}}
 
         Convert a hierarchical prior to the dictionary format.
@@ -673,7 +676,7 @@ class Prior:
                 dims="channel",
             )
 
-            dist.to_json()
+            dist.to_dict()
             # {
             #     "dist": "Normal",
             #     "kwargs": {
@@ -684,14 +687,14 @@ class Prior:
             # }
 
         """
-        json: dict[str, Any] = {
+        data: dict[str, Any] = {
             "dist": self.distribution,
         }
         if self.parameters:
 
             def handle_value(value):
                 if isinstance(value, Prior):
-                    return value.to_json()
+                    return value.to_dict()
 
                 if isinstance(value, pt.TensorVariable):
                     value = value.eval()
@@ -704,27 +707,45 @@ class Prior:
 
                 return value
 
-            json["kwargs"] = {
+            data["kwargs"] = {
                 param: handle_value(value) for param, value in self.parameters.items()
             }
         if not self.centered:
-            json["centered"] = False
+            data["centered"] = False
 
         if self.dims:
-            json["dims"] = self.dims
+            data["dims"] = self.dims
 
         if self.transform:
-            json["transform"] = self.transform
+            data["transform"] = self.transform
 
-        return json
+        return data
+
+    def to_json(self) -> dict[str, Any]:
+        """Convert the prior to dictionary format.
+
+        Deprecated in favor of :function:`pymc_marketing.prior.Prior.to_dict`.
+
+        Returns
+        -------
+        dict[str, Any]
+            The dictionary format of the prior.
+
+        """
+        warnings.warn(
+            "The `to_json` method is deprecated in favor of `to_dict`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.to_dict()
 
     @classmethod
-    def from_json(cls, json) -> Prior:
+    def from_dict(cls, data) -> Prior:
         """Create a Prior from the dictionary format.
 
         Parameters
         ----------
-        json : dict[str, Any]
+        data : dict[str, Any]
             The dictionary format of the prior.
 
         Returns
@@ -740,25 +761,25 @@ class Prior:
 
             from pymc_marketing.prior import Prior
 
-            json = {
+            data = {
                 "dist": "Normal",
                 "kwargs": {"mu": 0, "sigma": 1},
             }
 
-            dist = Prior.from_json(json)
+            dist = Prior.from_dict(data)
             dist
             # Prior("Normal", mu=0, sigma=1)
 
         """
-        if not isinstance(json, dict):
+        if not isinstance(data, dict):
             msg = (
                 "Must be a dictionary representation of a prior distribution. "
-                f"Not of type: {type(json)}"
+                f"Not of type: {type(data)}"
             )
             raise ValueError(msg)
 
-        dist = json["dist"]
-        kwargs = json.get("kwargs", {})
+        dist = data["dist"]
+        kwargs = data.get("kwargs", {})
 
         def handle_value(value):
             if isinstance(value, dict):
@@ -770,13 +791,37 @@ class Prior:
             return value
 
         kwargs = {param: handle_value(value) for param, value in kwargs.items()}
-        centered = json.get("centered", True)
-        dims = json.get("dims")
+        centered = data.get("centered", True)
+        dims = data.get("dims")
         if isinstance(dims, list):
             dims = tuple(dims)
-        transform = json.get("transform")
+        transform = data.get("transform")
 
         return cls(dist, dims=dims, centered=centered, transform=transform, **kwargs)
+
+    @classmethod
+    def from_json(cls, json) -> Prior:
+        """Create a Prior from the dictionary format.
+
+        Deprecated in favor of :function:`pymc_marketing.prior.Prior.from_dict`.
+
+        Parameters
+        ----------
+        json : dict[str, Any]
+            The dictionary format of the prior.
+
+        Returns
+        -------
+        Prior
+            The prior distribution.
+
+        """
+        warnings.warn(
+            "The `from_json` method is deprecated in favor of `from_dict`",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return cls.from_dict(json)
 
     def constrain(
         self, lower: float, upper: float, mass: float = 0.95, kwargs=None
@@ -1133,7 +1178,7 @@ class Censored:
         return {
             "class": "Censored",
             "data": {
-                "dist": self.distribution.to_json(),
+                "dist": self.distribution.to_dict(),
                 "lower": handle_value(self.lower),
                 "upper": handle_value(self.upper),
             },
@@ -1144,7 +1189,7 @@ class Censored:
         """Create a censored distribution from a dictionary."""
         data = data["data"]
         return cls(  # type: ignore
-            distribution=Prior.from_json(data["dist"]),
+            distribution=Prior.from_dict(data["dist"]),
             lower=data["lower"],
             upper=data["upper"],
         )
@@ -1295,5 +1340,5 @@ def _is_censored_type(data: dict) -> bool:
     return data.keys() == {"class", "data"} and data["class"] == "Censored"
 
 
-register_deserialization(is_type=_is_prior_type, deserialize=Prior.from_json)
+register_deserialization(is_type=_is_prior_type, deserialize=Prior.from_dict)
 register_deserialization(is_type=_is_censored_type, deserialize=Censored.from_dict)

--- a/tests/mmm/components/test_adstock.py
+++ b/tests/mmm/components/test_adstock.py
@@ -153,7 +153,7 @@ def test_adstock_from_dict_without_priors(adstock, deserialize_func) -> None:
 
     adstock = deserialize_func(data)
     assert adstock.default_priors == {
-        k: Prior.from_json(v) for k, v in adstock.to_dict()["priors"].items()
+        k: Prior.from_dict(v) for k, v in adstock.to_dict()["priors"].items()
     }
 
 

--- a/tests/mmm/components/test_saturation.py
+++ b/tests/mmm/components/test_saturation.py
@@ -243,7 +243,7 @@ def test_saturation_from_dict_without_priors(saturation) -> None:
 
     saturation = saturation_from_dict(data)
     assert saturation.default_priors == {
-        k: Prior.from_json(v) for k, v in saturation.to_dict()["priors"].items()
+        k: Prior.from_dict(v) for k, v in saturation.to_dict()["priors"].items()
     }
 
 

--- a/tests/test_prior.py
+++ b/tests/test_prior.py
@@ -1009,3 +1009,18 @@ def test_censored_logp(mu) -> None:
 
     point = {}
     np.testing.assert_allclose(logp(point), expected_logp(point))
+
+
+def test_to_json_deprecation() -> None:
+    match = "The `to_json` method is deprecated"
+    with pytest.warns(DeprecationWarning, match=match):
+        Prior("Normal").to_json()
+
+
+def test_from_json_deprecation() -> None:
+    data = {
+        "dist": "Normal",
+    }
+    match = "The `from_json` method is deprecated"
+    with pytest.warns(DeprecationWarning, match=match):
+        Prior.from_json(data)

--- a/tests/test_prior.py
+++ b/tests/test_prior.py
@@ -311,8 +311,8 @@ def test_transform() -> None:
         assert fast_eval(model[var_name]).shape == dim
 
 
-def test_to_json(large_var) -> None:
-    data = large_var.to_json()
+def test_to_dict(large_var) -> None:
+    data = large_var.to_dict()
 
     assert data == {
         "dist": "Normal",
@@ -347,9 +347,9 @@ def test_to_json(large_var) -> None:
     }
 
 
-def test_to_json_numpy() -> None:
+def test_to_dict_numpy() -> None:
     var = Prior("Normal", mu=np.array([0, 10, 20]), dims="channel")
-    assert var.to_json() == {
+    assert var.to_dict() == {
         "dist": "Normal",
         "kwargs": {
             "mu": [0, 10, 20],
@@ -358,8 +358,8 @@ def test_to_json_numpy() -> None:
     }
 
 
-def test_json_round_trip(large_var) -> None:
-    assert Prior.from_json(large_var.to_json()) == large_var
+def test_dict_round_trip(large_var) -> None:
+    assert Prior.from_dict(large_var.to_dict()) == large_var
 
 
 def test_constrain_with_transform_error() -> None:
@@ -433,7 +433,7 @@ def mmm_default_model_config():
 
 def test_backwards_compat(mmm_default_model_config) -> None:
     result = {
-        param: Prior.from_json(value)
+        param: Prior.from_dict(value)
         for param, value in mmm_default_model_config.items()
     }
     assert result == {
@@ -479,7 +479,7 @@ def test_to_graph() -> None:
     assert isinstance(G, Digraph)
 
 
-def test_from_json_list() -> None:
+def test_from_dict_list() -> None:
     data = {
         "dist": "Normal",
         "kwargs": {
@@ -489,13 +489,13 @@ def test_from_json_list() -> None:
         "dims": "channel",
     }
 
-    var = Prior.from_json(data)
+    var = Prior.from_dict(data)
     assert var.dims == ("channel",)
     assert isinstance(var["mu"], np.ndarray)
     np.testing.assert_array_equal(var["mu"], [0, 1, 2])
 
 
-def test_from_json_list_dims() -> None:
+def test_from_dict_list_dims() -> None:
     data = {
         "dist": "Normal",
         "kwargs": {
@@ -505,14 +505,14 @@ def test_from_json_list_dims() -> None:
         "dims": ["channel", "geo"],
     }
 
-    var = Prior.from_json(data)
+    var = Prior.from_dict(data)
     assert var.dims == ("channel", "geo")
 
 
-def test_to_json_transform() -> None:
+def test_to_dict_transform() -> None:
     dist = Prior("Normal", transform="sigmoid")
 
-    data = dist.to_json()
+    data = dist.to_dict()
     assert data == {
         "dist": "Normal",
         "transform": "sigmoid",
@@ -655,7 +655,7 @@ def test_serialize_with_pytensor() -> None:
     sigma = pt.arange(1, 4)
     dist = Prior("Normal", mu=0, sigma=sigma)
 
-    assert dist.to_json() == {
+    assert dist.to_dict() == {
         "dist": "Normal",
         "kwargs": {
             "mu": 0,
@@ -809,7 +809,7 @@ def test_censored_to_dict() -> None:
     data = censored_normal.to_dict()
     assert data == {
         "class": "Censored",
-        "data": {"dist": normal.to_json(), "lower": 0, "upper": float("inf")},
+        "data": {"dist": normal.to_dict(), "lower": 0, "upper": float("inf")},
     }
 
 
@@ -850,7 +850,7 @@ def test_create_prior_with_arbitrary_serializable(arbitrary_serialized_data) -> 
         dims=("channel", "geo"),
     )
 
-    assert dist.to_json() == {
+    assert dist.to_dict() == {
         "dist": "Normal",
         "kwargs": {
             "mu": arbitrary_serialized_data,
@@ -898,7 +898,7 @@ def test_censored_with_tensor_variable() -> None:
     assert censored_normal.to_dict() == {
         "class": "Censored",
         "data": {
-            "dist": normal.to_json(),
+            "dist": normal.to_dict(),
             "lower": [0, 1, 2],
             "upper": float("inf"),
         },


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

The `to/from_json` methods are replaced with `to/from_dict` methods which has become a more standard method name.

They are a drop in replacement.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Modules affected
<!--- Please list the modules that are affected by this PR by typing an `x` in the boxes below: -->
- [ ] MMM
- [ ] CLV
- [ ] Customer Choice
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1338.org.readthedocs.build/en/1338/

<!-- readthedocs-preview pymc-marketing end -->