### PR TITLE
Move `fit_result` to `model_builder.py` and remove redundancies from CLV and MMM

### DIFF
--- a/pymc_marketing/clv/models/basic.py
+++ b/pymc_marketing/clv/models/basic.py
@@ -26,7 +26,6 @@ from pydantic import ConfigDict, InstanceOf, validate_call
 from pymc.backends import NDArray
 from pymc.backends.base import MultiTrace
 from pymc.model.core import Model
-from xarray import Dataset
 
 from pymc_marketing.model_builder import ModelBuilder
 from pymc_marketing.model_config import ModelConfig, parse_model_config
@@ -255,23 +254,6 @@ class CLVModel(ModelBuilder):
     @property
     def _serializable_model_config(self) -> dict:
         return self.model_config
-
-    @property
-    def fit_result(self) -> Dataset:
-        """Get the fit result."""
-        if self.idata is None or "posterior" not in self.idata:
-            raise RuntimeError("The model hasn't been fit yet, call .fit() first")
-        return self.idata["posterior"]
-
-    @fit_result.setter
-    def fit_result(self, res: az.InferenceData) -> None:
-        if self.idata is None:
-            self.idata = res
-        elif "posterior" in self.idata:
-            warnings.warn("Overriding pre-existing fit_result", stacklevel=1)
-            self.idata.posterior = res
-        else:
-            self.idata.posterior = res
 
     def fit_summary(self, **kwargs):
         """Compute the summary of the fit result."""

--- a/pymc_marketing/mmm/base.py
+++ b/pymc_marketing/mmm/base.py
@@ -271,13 +271,6 @@ class MMMModelBuilder(ModelBuilder):
             identity_transformer = FunctionTransformer()
             return Pipeline(steps=[("scaler", identity_transformer)])
 
-    @property
-    def fit_result(self) -> Dataset:
-        """Get the posterior data."""
-        if self.idata is None or "posterior" not in self.idata:
-            raise RuntimeError("The model hasn't been fit yet, call .fit() first")
-        return self.idata["posterior"]
-
     def _get_group_predictive_data(
         self,
         group: Literal["prior_predictive", "posterior_predictive"],

--- a/pymc_marketing/model_builder.py
+++ b/pymc_marketing/model_builder.py
@@ -72,16 +72,7 @@ def create_idata_accessor(value: str, message: str):
 
         return self.idata[value]
 
-    def setter(self, res: az.InferenceData) -> None:
-        if self.idata is None:
-            self.idata = res
-        elif "posterior" in self.idata:
-            warnings.warn("Overriding pre-existing fit_result", stacklevel=1)
-            self.idata.posterior = res
-        else:
-            self.idata.posterior = res
-
-    return property(accessor, setter)
+    return property(accessor)
 
 
 def create_sample_kwargs(
@@ -693,6 +684,42 @@ class ModelBuilder(ABC):
         self.set_idata_attrs(self.idata)
         return self.idata  # type: ignore
 
+    @property
+    def fit_result(self) -> xr.Dataset:
+        """Get the posterior fit_result.
+
+        Returns
+        -------
+        InferenceData object.
+
+        """
+        return create_idata_accessor(
+            "posterior", "The model hasn't been fit yet, call .fit() first"
+        ).__get__(self)
+
+    @fit_result.setter
+    def fit_result(self, res: az.InferenceData) -> None:
+        """Create a setter method to overwrite the pre-existing fit_result.
+
+        Parameters
+        ----------
+        res : az.InferenceData
+            The inferencedata object to be set
+
+        Returns
+        -------
+        property
+            The property setter for the InferenceData object.
+
+        """
+        if self.idata is None:
+            self.idata = res
+        elif "posterior" in self.idata:
+            warnings.warn("Overriding pre-existing fit_result", stacklevel=1)
+            self.idata.posterior = res
+        else:
+            self.idata.posterior = res
+
     def predict(
         self,
         X_pred: np.ndarray | pd.DataFrame | pd.Series,
@@ -968,9 +995,7 @@ class ModelBuilder(ABC):
     posterior = create_idata_accessor(
         "posterior", "The model hasn't been fit yet, call .fit() first"
     )
-    fit_result = create_idata_accessor(
-        "posterior", "The model hasn't been fit yet, call .fit() first"
-    )
+
     posterior_predictive = create_idata_accessor(
         "posterior_predictive",
         "The model hasn't been fit yet, call .sample_posterior_predictive() first",

--- a/pymc_marketing/model_builder.py
+++ b/pymc_marketing/model_builder.py
@@ -72,7 +72,16 @@ def create_idata_accessor(value: str, message: str):
 
         return self.idata[value]
 
-    return property(accessor)
+    def setter(self, res: az.InferenceData) -> None:
+        if self.idata is None:
+            self.idata = res
+        elif "posterior" in self.idata:
+            warnings.warn("Overriding pre-existing fit_result", stacklevel=1)
+            self.idata.posterior = res
+        else:
+            self.idata.posterior = res
+
+    return property(accessor, setter)
 
 
 def create_sample_kwargs(
@@ -957,6 +966,9 @@ class ModelBuilder(ABC):
         "The model hasn't been sampled yet, call .sample_prior_predictive() first",
     )
     posterior = create_idata_accessor(
+        "posterior", "The model hasn't been fit yet, call .fit() first"
+    )
+    fit_result = create_idata_accessor(
         "posterior", "The model hasn't been fit yet, call .fit() first"
     )
     posterior_predictive = create_idata_accessor(

--- a/tests/clv/models/test_basic.py
+++ b/tests/clv/models/test_basic.py
@@ -153,20 +153,6 @@ class TestCLVModel:
         model = CLVModelTest()
         assert model.sampler_config == {}
 
-    def test_set_fit_result(self):
-        model = CLVModelTest()
-        model.build_model()
-        model.idata = None
-        fake_fit = pm.sample_prior_predictive(
-            samples=50, model=model.model, random_seed=1234
-        )
-        fake_fit.add_groups(dict(posterior=fake_fit.prior))
-        model.fit_result = fake_fit
-        with pytest.warns(UserWarning, match="Overriding pre-existing fit_result"):
-            model.fit_result = fake_fit
-        model.idata = None
-        model.fit_result = fake_fit
-
     def test_fit_summary_for_mcmc(self, mocker):
         model = CLVModelTest()
 

--- a/tests/clv/models/test_basic.py
+++ b/tests/clv/models/test_basic.py
@@ -132,11 +132,6 @@ class TestCLVModel:
         ):
             model.fit(fit_method="wrong_method")
 
-    def test_fit_result_error(self):
-        model = CLVModelTest()
-        with pytest.raises(RuntimeError, match="The model hasn't been fit yet"):
-            model.fit_result
-
     def test_load(self, mocker):
         model = CLVModelTest()
 

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -275,7 +275,7 @@ def test_fit_result_error():
         model.fit_result
 
 
-def test_set_fit_result():
+def test_set_fit_result(toy_X, toy_y):
     model = ModelBuilderTest()
     model.build_model(X=toy_X, y=toy_y)
     model.idata = None

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -269,6 +269,12 @@ def test_fit_dup_Y(toy_X, toy_y):
         model_builder.fit(X=toy_X, chains=1, draws=100, tune=100)
 
 
+def test_fit_result_error(self):
+    model = ModelBuilderTest()
+    with pytest.raises(RuntimeError, match="The model hasn't been fit yet"):
+        model.fit_result
+
+
 def test_set_fit_result(self):
     model = ModelBuilderTest()
     model.build_model()

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -269,13 +269,13 @@ def test_fit_dup_Y(toy_X, toy_y):
         model_builder.fit(X=toy_X, chains=1, draws=100, tune=100)
 
 
-def test_fit_result_error(self):
+def test_fit_result_error():
     model = ModelBuilderTest()
     with pytest.raises(RuntimeError, match="The model hasn't been fit yet"):
         model.fit_result
 
 
-def test_set_fit_result(self):
+def test_set_fit_result():
     model = ModelBuilderTest()
     model.build_model()
     model.idata = None

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -277,7 +277,7 @@ def test_fit_result_error():
 
 def test_set_fit_result():
     model = ModelBuilderTest()
-    model.build_model()
+    model.build_model(X=toy_X, y=toy_y)
     model.idata = None
     fake_fit = pm.sample_prior_predictive(
         samples=50, model=model.model, random_seed=1234

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -269,6 +269,21 @@ def test_fit_dup_Y(toy_X, toy_y):
         model_builder.fit(X=toy_X, chains=1, draws=100, tune=100)
 
 
+def test_set_fit_result(self):
+    model = ModelBuilderTest()
+    model.build_model()
+    model.idata = None
+    fake_fit = pm.sample_prior_predictive(
+        samples=50, model=model.model, random_seed=1234
+    )
+    fake_fit.add_groups(dict(posterior=fake_fit.prior))
+    model.fit_result = fake_fit
+    with pytest.warns(UserWarning, match="Overriding pre-existing fit_result"):
+        model.fit_result = fake_fit
+    model.idata = None
+    model.fit_result = fake_fit
+
+
 @pytest.mark.skipif(
     sys.platform == "win32",
     reason="Permissions for temp files not granted on windows CI.",


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

Have made the following changes:
1. Add `fit_result` similar to posterior in the `model_builder` since it is still used across many files
2. Added a property() setter to tackle the setter function in the `basic.py` in CLV
3.  Removed `fit_result` from MMM and CLV base 

Submitting a draft PR and appreciate any feedback. 

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [x] Related to #1333 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Modules affected
<!--- Please list the modules that are affected by this PR by typing an `x` in the boxes below: -->
- [x] MMM
- [x] CLV
- [ ] Customer Choice
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1344.org.readthedocs.build/en/1344/

<!-- readthedocs-preview pymc-marketing end -->