### PR TITLE
Enable transform `_sample_curve` to work with `VariableFactory`

### DIFF
--- a/pymc_marketing/mmm/components/base.py
+++ b/pymc_marketing/mmm/components/base.py
@@ -44,7 +44,7 @@ from pymc_marketing.plot import (
     plot_hdi,
     plot_samples,
 )
-from pymc_marketing.prior import DimHandler, Prior, VariableFactory, create_dim_handler
+from pymc_marketing.prior import Prior, VariableFactory, create_dim_handler
 
 # "x" for saturation, "time since exposure" for adstock
 NON_GRID_NAMES: frozenset[str] = frozenset({"x", "time since exposure"})
@@ -318,10 +318,22 @@ class Transformation:
             for parameter in self.default_priors.keys()
         }
 
+    def _infer_output_core_dims(self) -> tuple[str, ...]:
+        parameter_dims = sorted(
+            [
+                (dims,) if isinstance(dims, str) else dims
+                for dist in self.function_priors.values()
+                if (dims := getattr(dist, "dims", None)) is not None
+            ],
+            key=len,
+            reverse=True,
+        )
+        return tuple(list({str(dim): None for dims in parameter_dims for dim in dims}))
+
     def _create_distributions(
         self, dims: Dims | None = None
     ) -> dict[str, TensorVariable]:
-        dim_handler: DimHandler = create_dim_handler(dims)
+        dim_handler = create_dim_handler(dims or self._infer_output_core_dims())
 
         def create_variable(parameter_name: str, variable_name: str) -> TensorVariable:
             dist = self.function_priors[parameter_name]
@@ -420,9 +432,7 @@ class Transformation:
         x: pt.TensorLike,
         coords: dict[str, Any],
     ) -> xr.DataArray:
-        required_vars = set(self.variable_mapping.values()).intersection(
-            parameters.data_vars.keys()
-        )
+        output_core_dims = self._infer_output_core_dims()
 
         keys = list(coords.keys())
         if len(keys) != 1:
@@ -430,34 +440,29 @@ class Transformation:
             raise ValueError(msg)
         x_dim = keys[0]
 
-        function_parameters = parameters[required_vars]
-
-        parameter_coords = function_parameters.coords
-
-        additional_coords = {
-            coord: parameter_coords[coord].to_numpy()
-            for coord in parameter_coords.keys()
-            if coord not in {"chain", "draw"}
-        }
-
-        dims = tuple(additional_coords.keys())
         # Allow broadcasting
         x = np.expand_dims(
             x,
-            axis=tuple(range(1, len(dims) + 1)),
+            axis=tuple(range(1, len(output_core_dims) + 1)),
         )
 
-        coords.update(additional_coords)
+        coords.update(
+            {
+                dim: np.asarray(coord)
+                for dim, coord in parameters.coords.items()
+                if dim not in ["chain", "draw"]
+            }
+        )
 
         with pm.Model(coords=coords):
             pm.Deterministic(
                 var_name,
-                self.apply(x, dims=dims),
-                dims=(x_dim, *dims),
+                self.apply(x, dims=output_core_dims),
+                dims=(x_dim, *output_core_dims),
             )
 
             return pm.sample_posterior_predictive(
-                function_parameters,
+                parameters,
                 var_names=[var_name],
             ).posterior_predictive[var_name]
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
The core problem was that the transform's `_sample_curve` method created a `Model` instance that didn't have access to all of the required coordinate information. The secondary issue that I addressed was to automatically determine the expected core dimensions of the transformation's output. The way this used to work was very brittle because it relied on expecting the `function_parameters` to be stored in the `parameters` dataset. The method I used just relies on the meta information of the parameters' `dims`.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [X] Closes #1360 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [X] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [X] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [X] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Modules affected
<!--- Please list the modules that are affected by this PR by typing an `x` in the boxes below: -->
- [X] MMM
- [ ] CLV
- [ ] Customer Choice
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [X] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1362.org.readthedocs.build/en/1362/

<!-- readthedocs-preview pymc-marketing end -->