### PR TITLE
Add `load_from_idata` method

### DIFF
--- a/tests/mmm/test_mmm.py
+++ b/tests/mmm/test_mmm.py
@@ -31,6 +31,7 @@ from pymc_marketing.mmm.components.saturation import (
     register_saturation_transformation,
 )
 from pymc_marketing.mmm.mmm import MMM, BaseMMM
+from pymc_marketing.model_builder import DifferentModelError
 from pymc_marketing.prior import Prior
 
 seed: int = sum(map(ord, "pymc_marketing"))
@@ -783,10 +784,10 @@ class TestMMM:
 
         error_msg = (
             "The file 'test_model' does not "
-            "contain an inference data of the "
+            "contain an InferenceData of the "
             "same model or configuration as 'MMM'"
         )
-        with pytest.raises(ValueError, match=error_msg):
+        with pytest.raises(DifferentModelError, match=error_msg):
             MMM.load("test_model")
         os.remove("test_model")
 


### PR DESCRIPTION
This adds `load_from_idata` classmethod to allow loading from arbitrary InferenceData objects


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1379.org.readthedocs.build/en/1379/

<!-- readthedocs-preview pymc-marketing end -->