### PR TITLE
Log model with only pm.Data for likelihood

### DIFF
--- a/pymc_marketing/mlflow.py
+++ b/pymc_marketing/mlflow.py
@@ -253,11 +253,15 @@ def log_metadata(model: Model, idata: az.InferenceData) -> None:
     """
     data_vars: list[TensorVariable] = model.data_vars
 
-    features = {
-        var.name: idata.constant_data[var.name].to_numpy()
-        for var in data_vars
-        if var.name in idata.constant_data
-    }
+    if "constant_data" in idata:
+        features = {
+            var.name: idata.constant_data[var.name].to_numpy()
+            for var in data_vars
+            if var.name in idata.constant_data
+        }
+    else:
+        features = {}
+
     targets = {
         var.name: idata.observed_data[var.name].to_numpy()
         for var in model.observed_RVs


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

Edge case for model where data for the likelihood uses pm.Data but nowhere else

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1423.org.readthedocs.build/en/1423/

<!-- readthedocs-preview pymc-marketing end -->