### PR TITLE
Pass arbitrary HSGP to MMM class

### DIFF
--- a/pymc_marketing/mmm/hsgp.py
+++ b/pymc_marketing/mmm/hsgp.py
@@ -154,7 +154,7 @@ def approx_hsgp_hyperparams(
     lengthscale_min, lengthscale_max = lengthscale_range
     if lengthscale_min >= lengthscale_max:
         raise ValueError(
-            "The boundaries are out of order. {lengthscale_min} should be less than {lengthscale_max}"
+            f"The boundaries are out of order. {lengthscale_min} should be less than {lengthscale_max}"
         )
 
     Xs = x - x_center
@@ -1005,3 +1005,14 @@ class HSGPPeriodic(HSGPBase):
                 data[key] = Prior.from_dict(data[key])
 
         return cls(**data)
+
+
+class SoftPlusHSGP(HSGP):
+    """HSGP with softplus transformation."""
+
+    def create_variable(self, name: str) -> TensorVariable:
+        """Create the variable."""
+        f = super().create_variable(f"{name}_raw")
+        f = pt.softplus(f)
+        centered_f = f - f.mean(axis=0) + 1
+        return pm.Deterministic(name, centered_f, dims=self.dims)

--- a/pymc_marketing/mmm/hsgp.py
+++ b/pymc_marketing/mmm/hsgp.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from enum import Enum
-from typing import Literal, cast
+from typing import Literal, Protocol, cast, runtime_checkable
 
 import numpy as np
 import numpy.typing as npt
@@ -34,6 +34,21 @@ from typing_extensions import Self
 
 from pymc_marketing.plot import SelToString, plot_curve
 from pymc_marketing.prior import Prior, create_dim_handler
+
+
+@runtime_checkable
+class HSGPLike(Protocol):
+    """Quacks like a HSGP."""
+
+    dims: tuple[str, ...]
+
+    def create_variable(self, name: str) -> TensorVariable:
+        """Create a variable."""
+        ...
+
+    def register_data(self, X: TensorLike) -> Self:
+        """Register the data."""
+        ...
 
 
 @validate_call

--- a/pymc_marketing/mmm/hsgp.py
+++ b/pymc_marketing/mmm/hsgp.py
@@ -50,6 +50,10 @@ class HSGPLike(Protocol):
         """Register the data."""
         ...
 
+    def to_dict(self) -> dict:
+        """Convert the object to a dictionary."""
+        ...
+
 
 @validate_call
 def create_complexity_penalizing_prior(

--- a/pymc_marketing/mmm/mmm.py
+++ b/pymc_marketing/mmm/mmm.py
@@ -372,8 +372,16 @@ class BaseMMM(BaseValidateMMM):
         attrs["channel_columns"] = json.dumps(self.channel_columns)
         attrs["validate_data"] = json.dumps(self.validate_data)
         attrs["yearly_seasonality"] = json.dumps(self.yearly_seasonality)
-        attrs["time_varying_intercept"] = json.dumps(self.time_varying_intercept)
-        attrs["time_varying_media"] = json.dumps(self.time_varying_media)
+        attrs["time_varying_intercept"] = json.dumps(
+            self.time_varying_intercept
+            if not isinstance(self.time_varying_intercept, HSGPLike)
+            else self.time_varying_intercept.to_dict()
+        )
+        attrs["time_varying_media"] = json.dumps(
+            self.time_varying_media
+            if not isinstance(self.time_varying_media, HSGPLike)
+            else self.time_varying_media.to_dict()
+        )
         attrs["dag"] = json.dumps(self.dag)
         attrs["treatment_nodes"] = json.dumps(self.treatment_nodes)
         attrs["outcome_node"] = json.dumps(self.outcome_node)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

WIP but the API would look like this:

```python
hsgp = SoftPlusHSGP.parameterize_from_data(
    np.arange(X.shape[0]),
    dims=("date", "channel"),
)

mmm = MMM(
    adstock=GeometricAdstock(l_max=8),
    saturation=LogisticSaturation(),
    date_column="date_week",
    channel_columns=["x1", "x2"],
    control_columns=[
        "event_1",
        "event_2",
        "t",
    ],
    time_varying_media=hsgp,
    yearly_seasonality=2,
)
mmm.fit(X, y)
```

Anything that follows the HSGPLike protocol can be used. This can be GPs or other time varying functions

```python
@runtime_checkable
class HSGPLike(Protocol):
    """Quacks like a HSGP."""

    dims: tuple[str, ...]

    def create_variable(self, name: str) -> TensorVariable:
        """Create a variable."""

    def register_data(self, X: TensorLike) -> Self:
        """Register the data."""
        ...
```

CC: @cetagostini

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1432.org.readthedocs.build/en/1432/

<!-- readthedocs-preview pymc-marketing end -->