### PR TITLE
1325 invalid way of calling first element of pdseries

### DIFF
--- a/pymc_marketing/mmm/tvp.py
+++ b/pymc_marketing/mmm/tvp.py
@@ -234,10 +234,27 @@ def create_time_varying_gp_multiplier(
 
 
 def infer_time_index(
-    date_series_new: pd.Series, date_series: pd.Series, time_resolution: int
+    date_series_new: pd.Series,
+    date_series: pd.Series,
+    time_resolution: int,
 ) -> npt.NDArray[np.int_]:
     """Infer the time-index given a new dataset.
 
     Infers the time-indices by calculating the number of days since the first date in the dataset.
+
+    Parameters
+    ----------
+    date_series_new : pd.Series
+        New date series.
+    date_series : pd.Series
+        Original date series.
+    time_resolution : int
+        Resolution of time points in days.
+
+    Returns
+    -------
+    np.ndarray
+        Time index.
+
     """
-    return (date_series_new - date_series[0]).dt.days.values // time_resolution
+    return (date_series_new - date_series.iloc[0]).dt.days.values // time_resolution


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

This uses `iloc` over empty bracket slicing

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1433.org.readthedocs.build/en/1433/

<!-- readthedocs-preview pymc-marketing end -->