### PR TITLE
Add WeeklyFourier

### DIFF
--- a/pymc_marketing/constants.py
+++ b/pymc_marketing/constants.py
@@ -15,3 +15,4 @@
 
 DAYS_IN_YEAR: float = 365.25
 DAYS_IN_MONTH: float = DAYS_IN_YEAR / 12
+DAYS_IN_WEEK: int = 7

--- a/pymc_marketing/mmm/__init__.py
+++ b/pymc_marketing/mmm/__init__.py
@@ -35,7 +35,7 @@ from pymc_marketing.mmm.components.saturation import (
     TanhSaturationBaselined,
     saturation_from_dict,
 )
-from pymc_marketing.mmm.fourier import MonthlyFourier, YearlyFourier
+from pymc_marketing.mmm.fourier import MonthlyFourier, WeeklyFourier, YearlyFourier
 from pymc_marketing.mmm.hsgp import (
     HSGP,
     CovFunc,
@@ -85,6 +85,7 @@ __all__ = [
     "SaturationTransformation",
     "TanhSaturation",
     "TanhSaturationBaselined",
+    "WeeklyFourier",
     "WeibullCDFAdstock",
     "WeibullPDFAdstock",
     "YearlyFourier",

--- a/pymc_marketing/mmm/fourier.py
+++ b/pymc_marketing/mmm/fourier.py
@@ -866,7 +866,7 @@ class MonthlyFourier(FourierBase):
 
 
 class WeeklyFourier(FourierBase):
-    """Monthly fourier seasonality.
+    """Weekly fourier seasonality.
 
     .. plot::
         :context: close-figs

--- a/pymc_marketing/mmm/fourier.py
+++ b/pymc_marketing/mmm/fourier.py
@@ -912,7 +912,7 @@ class WeeklyFourier(FourierBase):
     days_in_period: float = DAYS_IN_WEEK
 
     def _get_default_start_date(self) -> datetime.datetime:
-        """Get the default start date for monthly seasonality.
+        """Get the default start date for weekly seasonality.
 
         Returns the first day of the current month.
         """

--- a/pymc_marketing/mmm/fourier.py
+++ b/pymc_marketing/mmm/fourier.py
@@ -875,12 +875,12 @@ class WeeklyFourier(FourierBase):
         import matplotlib.pyplot as plt
         import numpy as np
 
-        from pymc_marketing.mmm import MonthlyFourier
+        from pymc_marketing.mmm import WeeklyFourier
         from pymc_marketing.prior import Prior
 
         az.style.use("arviz-white")
 
-        seed = sum(map(ord, "Monthly"))
+        seed = sum(map(ord, "Weekly"))
         rng = np.random.default_rng(seed)
 
         mu = np.array([0, 0, 0.5, 0])

--- a/tests/mmm/test_fourier.py
+++ b/tests/mmm/test_fourier.py
@@ -34,24 +34,51 @@ from pymc_marketing.mmm.fourier import (
 from pymc_marketing.prior import Prior
 
 
-def test_prior_without_dims() -> None:
+@pytest.mark.parametrize(
+    argnames="seasonality",
+    argvalues=[YearlyFourier, MonthlyFourier, WeeklyFourier],
+    ids=[
+        "yearly",
+        "monthly",
+        "weekly",
+    ],
+)
+def test_prior_without_dims(seasonality) -> None:
     prior = Prior("Normal")
-    yearly = YearlyFourier(n_order=2, prior=prior)
+    periodicity = seasonality(n_order=2, prior=prior)
 
-    assert yearly.prior.dims == (yearly.prefix,)
+    assert periodicity.prior.dims == (periodicity.prefix,)
     assert prior.dims == ()
 
 
-def test_prior_doesnt_have_prefix() -> None:
+@pytest.mark.parametrize(
+    argnames="seasonality",
+    argvalues=[YearlyFourier, MonthlyFourier, WeeklyFourier],
+    ids=[
+        "yearly",
+        "monthly",
+        "weekly",
+    ],
+)
+def test_prior_doesnt_have_prefix(seasonality) -> None:
     prior = Prior("Normal", dims="hierarchy")
     with pytest.raises(ValueError, match="Prior distribution must have"):
-        YearlyFourier(n_order=2, prior=prior)
+        seasonality(n_order=2, prior=prior)
 
 
-def test_nodes() -> None:
-    yearly = YearlyFourier(n_order=2)
+@pytest.mark.parametrize(
+    argnames="seasonality",
+    argvalues=[YearlyFourier, MonthlyFourier, WeeklyFourier],
+    ids=[
+        "yearly",
+        "monthly",
+        "weekly",
+    ],
+)
+def test_nodes(seasonality) -> None:
+    periodicity = seasonality(n_order=2)
 
-    assert yearly.nodes == ["sin_1", "sin_2", "cos_1", "cos_2"]
+    assert periodicity.nodes == ["sin_1", "sin_2", "cos_1", "cos_2"]
 
 
 @pytest.mark.parametrize(
@@ -65,13 +92,13 @@ def test_nodes() -> None:
 )
 def test_sample_prior(seasonality) -> None:
     n_order = 2
-    yearly = seasonality(n_order=n_order)
-    prior = yearly.sample_prior(samples=10)
+    periodicity = seasonality(n_order=n_order)
+    prior = periodicity.sample_prior(samples=10)
 
     assert prior.sizes == {
         "chain": 1,
         "draw": 10,
-        yearly.prefix: n_order * 2,
+        periodicity.prefix: n_order * 2,
     }
 
 
@@ -172,59 +199,95 @@ def mock_parameters() -> xr.Dataset:
     )
 
 
-def test_sample_curve_additional_dims(mock_parameters) -> None:
-    yearly = YearlyFourier(n_order=2)
-    curve = yearly.sample_curve(mock_parameters)
+@pytest.mark.parametrize(
+    argnames="seasonality",
+    argvalues=[YearlyFourier, MonthlyFourier, WeeklyFourier],
+    ids=[
+        "yearly",
+        "monthly",
+        "weekly",
+    ],
+)
+def test_sample_curve_additional_dims(mock_parameters, seasonality) -> None:
+    periodicity = seasonality(n_order=2)
+    curve = periodicity.sample_curve(mock_parameters)
 
     assert curve.sizes == {
         "chain": 1,
         "draw": 250,
-        "day": 367,
+        "day": np.ceil(periodicity.days_in_period) + 1,
     }
 
 
-def test_additional_dimension() -> None:
+@pytest.mark.parametrize(
+    argnames="seasonality",
+    argvalues=[YearlyFourier, MonthlyFourier, WeeklyFourier],
+    ids=[
+        "yearly",
+        "monthly",
+        "weekly",
+    ],
+)
+def test_additional_dimension(seasonality) -> None:
     prior = Prior("Normal", dims=("fourier", "additional_dim", "yet_another_dim"))
-    yearly = YearlyFourier(n_order=2, prior=prior)
+    periodicity = YearlyFourier(n_order=2, prior=prior)
 
     coords = {
         "additional_dim": range(2),
         "yet_another_dim": range(3),
     }
-    prior = yearly.sample_prior(samples=10, coords=coords)
-    curve = yearly.sample_curve(prior)
+    prior = periodicity.sample_prior(samples=10, coords=coords)
+    curve = periodicity.sample_curve(prior)
 
     assert curve.sizes == {
         "chain": 1,
         "draw": 10,
         "additional_dim": 2,
         "yet_another_dim": 3,
-        "day": 367,
+        "day": np.ceil(periodicity.days_in_period) + 1,
     }
 
 
-def test_plot_curve() -> None:
+@pytest.mark.parametrize(
+    argnames="seasonality",
+    argvalues=[YearlyFourier, MonthlyFourier, WeeklyFourier],
+    ids=[
+        "yearly",
+        "monthly",
+        "weekly",
+    ],
+)
+def test_plot_curve(seasonality) -> None:
     prior = Prior("Normal", dims=("fourier", "additional_dim"))
-    yearly = YearlyFourier(n_order=2, prior=prior)
+    periodicity = seasonality(n_order=2, prior=prior)
 
     coords = {"additional_dim": range(4)}
-    prior = yearly.sample_prior(samples=10, coords=coords)
-    curve = yearly.sample_curve(prior)
+    prior = periodicity.sample_prior(samples=10, coords=coords)
+    curve = periodicity.sample_curve(prior)
 
     subplot_kwargs = {"ncols": 2}
-    fig, axes = yearly.plot_curve(curve, subplot_kwargs=subplot_kwargs)
+    fig, axes = periodicity.plot_curve(curve, subplot_kwargs=subplot_kwargs)
 
     assert isinstance(fig, plt.Figure)
     assert axes.shape == (2, 2)
 
 
 @pytest.mark.parametrize("n_order", [0, -1, -100])
-def test_bad_negative_order(n_order) -> None:
+@pytest.mark.parametrize(
+    argnames="seasonality",
+    argvalues=[YearlyFourier, MonthlyFourier, WeeklyFourier],
+    ids=[
+        "yearly",
+        "monthly",
+        "weekly",
+    ],
+)
+def test_bad_negative_order(n_order, seasonality) -> None:
     with pytest.raises(
         ValueError,
-        match="1 validation error for YearlyFourier\\nn_order\\n  Input should be greater than 0",
+        match=f"1 validation error for {seasonality.__name__}\\nn_order\\n  Input should be greater than 0",
     ):
-        YearlyFourier(n_order=n_order)
+        seasonality(n_order=n_order)
 
 
 @pytest.mark.parametrize(
@@ -232,12 +295,21 @@ def test_bad_negative_order(n_order) -> None:
     argvalues=[2.5, 100.001, "m", None],
     ids=["neg_float", "neg_float_2", "str", "None"],
 )
-def test_bad_non_integer_order(n_order) -> None:
+@pytest.mark.parametrize(
+    argnames="seasonality",
+    argvalues=[YearlyFourier, MonthlyFourier, WeeklyFourier],
+    ids=[
+        "yearly",
+        "monthly",
+        "weekly",
+    ],
+)
+def test_bad_non_integer_order(n_order, seasonality) -> None:
     with pytest.raises(
         ValueError,
-        match="1 validation error for YearlyFourier\nn_order\n  Input should be a valid integer",
+        match=f"1 validation error for {seasonality.__name__}\nn_order\n  Input should be a valid integer",
     ):
-        YearlyFourier(n_order=n_order)
+        seasonality(n_order=n_order)
 
 
 @pytest.mark.parametrize(
@@ -248,7 +320,16 @@ def test_bad_non_integer_order(n_order) -> None:
         (np.ones(shape=1), 1, (1, 1 * 2)),
     ],
 )
-def test_fourier_modes_shape(periods, n_order, expected_shape) -> None:
+@pytest.mark.parametrize(
+    argnames="seasonality",
+    argvalues=[YearlyFourier, MonthlyFourier, WeeklyFourier],
+    ids=[
+        "yearly",
+        "monthly",
+        "weekly",
+    ],
+)
+def test_fourier_modes_shape(periods, n_order, expected_shape, seasonality) -> None:
     result = generate_fourier_modes(periods, n_order)
     assert result.eval().shape == expected_shape
 
@@ -306,9 +387,18 @@ def test_fourier_modes_pythagoras(periods, n_order):
     assert (abs(norm - 1) < 1e-10).all()
 
 
-def test_apply_result_callback() -> None:
+@pytest.mark.parametrize(
+    argnames="seasonality",
+    argvalues=[YearlyFourier, MonthlyFourier, WeeklyFourier],
+    ids=[
+        "yearly",
+        "monthly",
+        "weekly",
+    ],
+)
+def test_apply_result_callback(seasonality) -> None:
     n_order = 3
-    fourier = YearlyFourier(n_order=n_order)
+    fourier = seasonality(n_order=n_order)
 
     def result_callback(x):
         pm.Deterministic(
@@ -328,21 +418,48 @@ def test_apply_result_callback() -> None:
     assert model["components"].eval().shape == (365, n_order * 2)
 
 
-def test_error_with_prefix_and_variable_name() -> None:
+@pytest.mark.parametrize(
+    argnames="seasonality",
+    argvalues=[YearlyFourier, MonthlyFourier, WeeklyFourier],
+    ids=[
+        "yearly",
+        "monthly",
+        "weekly",
+    ],
+)
+def test_error_with_prefix_and_variable_name(seasonality) -> None:
     name = "variable_name"
     with pytest.raises(ValueError, match="Variable name cannot"):
-        YearlyFourier(n_order=2, prefix=name, variable_name=name)
+        seasonality(n_order=2, prefix=name, variable_name=name)
 
 
-def test_change_name() -> None:
+@pytest.mark.parametrize(
+    argnames="seasonality",
+    argvalues=[YearlyFourier, MonthlyFourier, WeeklyFourier],
+    ids=[
+        "yearly",
+        "monthly",
+        "weekly",
+    ],
+)
+def test_change_name(seasonality) -> None:
     variable_name = "variable_name"
-    fourier = YearlyFourier(n_order=2, variable_name=variable_name)
+    fourier = seasonality(n_order=2, variable_name=variable_name)
     prior = fourier.sample_prior(samples=10)
     assert variable_name in prior
 
 
-def test_serialization_to_json() -> None:
-    fourier = YearlyFourier(n_order=2)
+@pytest.mark.parametrize(
+    argnames="seasonality",
+    argvalues=[YearlyFourier, MonthlyFourier, WeeklyFourier],
+    ids=[
+        "yearly",
+        "monthly",
+        "weekly",
+    ],
+)
+def test_serialization_to_json(seasonality) -> None:
+    fourier = seasonality(n_order=2)
     fourier.model_dump_json()
 
 
@@ -364,89 +481,65 @@ def weekly_fourier() -> WeeklyFourier:
     return WeeklyFourier(n_order=2, prior=prior)
 
 
-def test_get_default_start_date_none_yearly(yearly_fourier: YearlyFourier):
+@pytest.mark.parametrize(
+    argnames="seasonality",
+    argvalues=[YearlyFourier, MonthlyFourier, WeeklyFourier],
+    ids=[
+        "yearly",
+        "monthly",
+        "weekly",
+    ],
+)
+def test_get_default_start_date_none(seasonality):
     current_year = datetime.datetime.now().year
     expected_start_date = datetime.datetime(year=current_year, month=1, day=1)
-    actual_start_date = yearly_fourier.get_default_start_date()
+    actual_start_date = seasonality.get_default_start_date()
     assert actual_start_date == expected_start_date
 
 
-def test_get_default_start_date_none_monthly(monthly_fourier: MonthlyFourier):
-    now = datetime.datetime.now()
-    expected_start_date = datetime.datetime(year=now.year, month=now.month, day=1)
-    actual_start_date = monthly_fourier.get_default_start_date()
-    assert actual_start_date == expected_start_date
-
-
-def test_get_default_start_date_none_weekly(weekly_fourier: WeeklyFourier):
-    now = datetime.datetime.now()
-    expected_start_date = datetime.datetime.fromisocalendar(
-        year=now.year, week=now.isocalendar().week, day=1
-    )
-    actual_start_date = weekly_fourier.get_default_start_date()
-    assert actual_start_date == expected_start_date
-
-
-def test_get_default_start_date_str_yearly(yearly_fourier: YearlyFourier):
+@pytest.mark.parametrize(
+    argnames="seasonality",
+    argvalues=[YearlyFourier, MonthlyFourier, WeeklyFourier],
+    ids=[
+        "yearly",
+        "monthly",
+        "weekly",
+    ],
+)
+def test_get_default_start_date_str(seasonality):
     start_date_str = "2023-02-01"
-    actual_start_date = yearly_fourier.get_default_start_date(start_date=start_date_str)
+    actual_start_date = seasonality.get_default_start_date(start_date=start_date_str)
     assert actual_start_date == start_date_str
 
 
-def test_get_default_start_date_datetime_yearly(yearly_fourier: YearlyFourier):
+@pytest.mark.parametrize(
+    argnames="seasonality",
+    argvalues=[yearly_fourier, monthly_fourier, weekly_fourier],
+    ids=[
+        "yearly",
+        "monthly",
+        "weekly",
+    ],
+)
+def test_get_default_start_date_datetime(seasonality):
     start_date_dt = datetime.datetime(2023, 3, 1)
-    actual_start_date = yearly_fourier.get_default_start_date(start_date=start_date_dt)
+    actual_start_date = seasonality.get_default_start_date(start_date=start_date_dt)
     assert actual_start_date == start_date_dt
 
 
-def test_get_default_start_date_invalid_type_yearly(yearly_fourier: YearlyFourier):
+@pytest.mark.parametrize(
+    argnames="seasonality",
+    argvalues=[YearlyFourier, MonthlyFourier, WeeklyFourier],
+    ids=[
+        "yearly",
+        "monthly",
+        "weekly",
+    ],
+)
+def test_get_default_start_date_invalid_type(seasonality):
     invalid_start_date = 12345  # Invalid type again
     with pytest.raises(TypeError) as exc_info:
-        yearly_fourier.get_default_start_date(start_date=invalid_start_date)
-    assert "start_date must be a datetime.datetime object, a string, or None" in str(
-        exc_info.value
-    )
-
-
-def test_get_default_start_date_str_monthly(monthly_fourier: MonthlyFourier):
-    start_date_str = "2023-06-15"
-    actual_start_date = monthly_fourier.get_default_start_date(
-        start_date=start_date_str
-    )
-    assert actual_start_date == start_date_str
-
-
-def test_get_default_start_date_datetime_monthly(monthly_fourier: MonthlyFourier):
-    start_date_dt = datetime.datetime(2023, 7, 1)
-    actual_start_date = monthly_fourier.get_default_start_date(start_date=start_date_dt)
-    assert actual_start_date == start_date_dt
-
-
-def test_get_default_start_date_invalid_type_monthly(monthly_fourier: MonthlyFourier):
-    invalid_start_date = [2023, 1, 1]
-    with pytest.raises(TypeError) as exc_info:
-        monthly_fourier.get_default_start_date(start_date=invalid_start_date)
-    assert "start_date must be a datetime.datetime object, a string, or None" in str(
-        exc_info.value
-    )
-
-
-def test_get_default_start_date_str_weekly(weekly_fourier: WeeklyFourier):
-    start_date_str = "2023-06-15"
-    actual_start_date = weekly_fourier.get_default_start_date(start_date=start_date_str)
-    assert actual_start_date == start_date_str
-
-
-def test_get_default_start_date_datetime_weekly(weekly_fourier: WeeklyFourier):
-    start_date_dt = datetime.datetime(2023, 7, 1)
-    actual_start_date = weekly_fourier.get_default_start_date(start_date=start_date_dt)
-    assert actual_start_date == start_date_dt
-
-
-def test_get_default_start_date_invalid_type_weekly(weekly_fourier: WeeklyFourier):
-    invalid_start_date = [2023, 1, 1]
-    with pytest.raises(TypeError) as exc_info:
-        weekly_fourier.get_default_start_date(start_date=invalid_start_date)
+        seasonality.get_default_start_date(start_date=invalid_start_date)
     assert "start_date must be a datetime.datetime object, a string, or None" in str(
         exc_info.value
     )
@@ -469,9 +562,18 @@ class ArbitraryCode:
         return pm.Normal(name, dims=self.dims)
 
 
-def test_fourier_arbitrary_prior() -> None:
+@pytest.mark.parametrize(
+    argnames="seasonality",
+    argvalues=[YearlyFourier, MonthlyFourier, WeeklyFourier],
+    ids=[
+        "yearly",
+        "monthly",
+        "weekly",
+    ],
+)
+def test_fourier_arbitrary_prior(seasonality) -> None:
     prior = ArbitraryCode(dims=("fourier",))
-    fourier = YearlyFourier(n_order=4, prior=prior)
+    fourier = seasonality(n_order=4, prior=prior)
 
     x = np.arange(10)
     with pm.Model():
@@ -480,7 +582,16 @@ def test_fourier_arbitrary_prior() -> None:
     assert y.eval().shape == (10,)
 
 
-def test_fourier_dims_modified() -> None:
+@pytest.mark.parametrize(
+    argnames="seasonality",
+    argvalues=[YearlyFourier, MonthlyFourier, WeeklyFourier],
+    ids=[
+        "yearly",
+        "monthly",
+        "weekly",
+    ],
+)
+def test_fourier_dims_modified(seasonality) -> None:
     prior = ArbitraryCode(dims=())
     YearlyFourier(n_order=4, prior=prior)
     assert prior.dims == "fourier"

--- a/tests/mmm/test_fourier.py
+++ b/tests/mmm/test_fourier.py
@@ -481,65 +481,89 @@ def weekly_fourier() -> WeeklyFourier:
     return WeeklyFourier(n_order=2, prior=prior)
 
 
-@pytest.mark.parametrize(
-    argnames="seasonality",
-    argvalues=[YearlyFourier, MonthlyFourier, WeeklyFourier],
-    ids=[
-        "yearly",
-        "monthly",
-        "weekly",
-    ],
-)
-def test_get_default_start_date_none(seasonality):
+def test_get_default_start_date_none_yearly(yearly_fourier: YearlyFourier):
     current_year = datetime.datetime.now().year
     expected_start_date = datetime.datetime(year=current_year, month=1, day=1)
-    actual_start_date = seasonality.get_default_start_date()
+    actual_start_date = yearly_fourier.get_default_start_date()
     assert actual_start_date == expected_start_date
 
 
-@pytest.mark.parametrize(
-    argnames="seasonality",
-    argvalues=[YearlyFourier, MonthlyFourier, WeeklyFourier],
-    ids=[
-        "yearly",
-        "monthly",
-        "weekly",
-    ],
-)
-def test_get_default_start_date_str(seasonality):
+def test_get_default_start_date_none_monthly(monthly_fourier: MonthlyFourier):
+    now = datetime.datetime.now()
+    expected_start_date = datetime.datetime(year=now.year, month=now.month, day=1)
+    actual_start_date = monthly_fourier.get_default_start_date()
+    assert actual_start_date == expected_start_date
+
+
+def test_get_default_start_date_none_weekly(weekly_fourier: WeeklyFourier):
+    now = datetime.datetime.now()
+    expected_start_date = datetime.datetime.fromisocalendar(
+        year=now.year, week=now.isocalendar().week, day=1
+    )
+    actual_start_date = weekly_fourier.get_default_start_date()
+    assert actual_start_date == expected_start_date
+
+
+def test_get_default_start_date_str_yearly(yearly_fourier: YearlyFourier):
     start_date_str = "2023-02-01"
-    actual_start_date = seasonality.get_default_start_date(start_date=start_date_str)
+    actual_start_date = yearly_fourier.get_default_start_date(start_date=start_date_str)
     assert actual_start_date == start_date_str
 
 
-@pytest.mark.parametrize(
-    argnames="seasonality",
-    argvalues=[yearly_fourier, monthly_fourier, weekly_fourier],
-    ids=[
-        "yearly",
-        "monthly",
-        "weekly",
-    ],
-)
-def test_get_default_start_date_datetime(seasonality):
+def test_get_default_start_date_datetime_yearly(yearly_fourier: YearlyFourier):
     start_date_dt = datetime.datetime(2023, 3, 1)
-    actual_start_date = seasonality.get_default_start_date(start_date=start_date_dt)
+    actual_start_date = yearly_fourier.get_default_start_date(start_date=start_date_dt)
     assert actual_start_date == start_date_dt
 
 
-@pytest.mark.parametrize(
-    argnames="seasonality",
-    argvalues=[YearlyFourier, MonthlyFourier, WeeklyFourier],
-    ids=[
-        "yearly",
-        "monthly",
-        "weekly",
-    ],
-)
-def test_get_default_start_date_invalid_type(seasonality):
+def test_get_default_start_date_invalid_type_yearly(yearly_fourier: YearlyFourier):
     invalid_start_date = 12345  # Invalid type again
     with pytest.raises(TypeError) as exc_info:
-        seasonality.get_default_start_date(start_date=invalid_start_date)
+        yearly_fourier.get_default_start_date(start_date=invalid_start_date)
+    assert "start_date must be a datetime.datetime object, a string, or None" in str(
+        exc_info.value
+    )
+
+
+def test_get_default_start_date_str_monthly(monthly_fourier: MonthlyFourier):
+    start_date_str = "2023-06-15"
+    actual_start_date = monthly_fourier.get_default_start_date(
+        start_date=start_date_str
+    )
+    assert actual_start_date == start_date_str
+
+
+def test_get_default_start_date_datetime_monthly(monthly_fourier: MonthlyFourier):
+    start_date_dt = datetime.datetime(2023, 7, 1)
+    actual_start_date = monthly_fourier.get_default_start_date(start_date=start_date_dt)
+    assert actual_start_date == start_date_dt
+
+
+def test_get_default_start_date_invalid_type_monthly(monthly_fourier: MonthlyFourier):
+    invalid_start_date = [2023, 1, 1]
+    with pytest.raises(TypeError) as exc_info:
+        monthly_fourier.get_default_start_date(start_date=invalid_start_date)
+    assert "start_date must be a datetime.datetime object, a string, or None" in str(
+        exc_info.value
+    )
+
+
+def test_get_default_start_date_str_weekly(weekly_fourier: WeeklyFourier):
+    start_date_str = "2023-06-15"
+    actual_start_date = weekly_fourier.get_default_start_date(start_date=start_date_str)
+    assert actual_start_date == start_date_str
+
+
+def test_get_default_start_date_datetime_weekly(weekly_fourier: WeeklyFourier):
+    start_date_dt = datetime.datetime(2023, 7, 1)
+    actual_start_date = weekly_fourier.get_default_start_date(start_date=start_date_dt)
+    assert actual_start_date == start_date_dt
+
+
+def test_get_default_start_date_invalid_type_weekly(weekly_fourier: WeeklyFourier):
+    invalid_start_date = [2023, 1, 1]
+    with pytest.raises(TypeError) as exc_info:
+        weekly_fourier.get_default_start_date(start_date=invalid_start_date)
     assert "start_date must be a datetime.datetime object, a string, or None" in str(
         exc_info.value
     )

--- a/tests/mmm/test_fourier.py
+++ b/tests/mmm/test_fourier.py
@@ -160,9 +160,9 @@ def test_sample_curve_same_size(seasonality) -> None:
     periodicity = seasonality(n_order=n_order)
     prior = periodicity.sample_prior(samples=10)
     curve_without_dates = periodicity.sample_curve(prior, use_dates=False)
-    curve_with_dates = periodicity.sample_curve(prior, use_dates=False)
+    curve_with_dates = periodicity.sample_curve(prior, use_dates=True)
 
-    assert curve_without_dates.sizes == curve_with_dates.sizes
+    assert curve_without_dates.shape == curve_with_dates.shape
 
 
 def create_mock_variable(coords):


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->
* Introduces `WeeklyFourier` 
* Fixes `sample_curve`. Now returns same sizes when called with `use_dates: bool = True | False` [see `test_sample_curve_same_size`]
* Parametrizes some tests so they are now run on the 3 different Fourier classes.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [x] Related to #1442 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1443.org.readthedocs.build/en/1443/

<!-- readthedocs-preview pymc-marketing end -->