### PR TITLE
Fix minor latex rendering issue

### DIFF
--- a/pymc_marketing/mmm/transformers.py
+++ b/pymc_marketing/mmm/transformers.py
@@ -501,7 +501,7 @@ def inverse_scaled_logistic_saturation(
     when using default value for eps.
 
     .. math::
-        f(x) = \\frac{1 - e^{-x*\epsilon/\lambda}}{1 + e^{-x*\epsilon/\lambda}}
+        f(x) = \frac{1 - e^{-x*\epsilon/\lambda}}{1 + e^{-x*\epsilon/\lambda}}
 
     .. plot::
         :context: close-figs


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixes a minor rendering issue in the latex equation of `inverse_scaled_logistic_saturation` 



<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1449.org.readthedocs.build/en/1449/

<!-- readthedocs-preview pymc-marketing end -->