### PR TITLE
Correcting HSGP to be link to model graph

### DIFF
--- a/pymc_marketing/mmm/hsgp.py
+++ b/pymc_marketing/mmm/hsgp.py
@@ -625,7 +625,7 @@ class HSGP(HSGPBase):
     @classmethod
     def parameterize_from_data(
         cls,
-        X: np.ndarray,
+        X: TensorLike | np.ndarray,
         dims: Dims,
         X_mid: float | None = None,
         eta_mass: float = 0.05,
@@ -650,11 +650,25 @@ class HSGP(HSGPBase):
                 upper=ls_upper,
                 mass=ls_mass,
             )
-        X = pt.as_tensor_variable(X).eval()
+
+        numeric_X = None
+        if isinstance(X, np.ndarray):
+            numeric_X = np.asarray(X)
+        elif isinstance(X, TensorVariable):
+            numeric_X = X.get_value(borrow=False)  # current numeric data
+        else:
+            raise ValueError(
+                "X must be a NumPy array (or list) or a pm.Data/pm.MutableData. "
+                "If it's a plain symbolic tensor, you must manually specify m, L."
+            )
+
+        numeric_X = np.asarray(numeric_X)
         if X_mid is None:
-            X_mid = float(X.mean())
+            X_mid = float(numeric_X.mean())
+
+        # 3. Use the standard approximation
         m, L = create_m_and_L_recommendations(
-            X,
+            numeric_X,  # numeric version
             X_mid,
             ls_lower=ls_lower,
             ls_upper=ls_upper,
@@ -666,7 +680,7 @@ class HSGP(HSGPBase):
             eta=eta,
             m=m,
             L=L,
-            X=X,
+            X=X,  # store the original reference (even if symbolic)
             X_mid=X_mid,
             cov_func=cov_func,
             dims=dims,

--- a/pymc_marketing/mmm/hsgp.py
+++ b/pymc_marketing/mmm/hsgp.py
@@ -658,7 +658,7 @@ class HSGP(HSGPBase):
             numeric_X = X.get_value(borrow=False)
         else:
             raise ValueError(
-                "X must be a NumPy array (or list) or a pm.Data/pm.MutableData. "
+                "X must be a NumPy array (or list) or a TensorVariable. "
                 "If it's a plain symbolic tensor, you must manually specify m, L."
             )
 

--- a/pymc_marketing/mmm/hsgp.py
+++ b/pymc_marketing/mmm/hsgp.py
@@ -655,7 +655,7 @@ class HSGP(HSGPBase):
         if isinstance(X, np.ndarray):
             numeric_X = np.asarray(X)
         elif isinstance(X, TensorVariable):
-            numeric_X = X.get_value(borrow=False)  # current numeric data
+            numeric_X = X.get_value(borrow=False)
         else:
             raise ValueError(
                 "X must be a NumPy array (or list) or a pm.Data/pm.MutableData. "
@@ -666,9 +666,8 @@ class HSGP(HSGPBase):
         if X_mid is None:
             X_mid = float(numeric_X.mean())
 
-        # 3. Use the standard approximation
         m, L = create_m_and_L_recommendations(
-            numeric_X,  # numeric version
+            numeric_X,
             X_mid,
             ls_lower=ls_lower,
             ls_upper=ls_upper,
@@ -680,7 +679,7 @@ class HSGP(HSGPBase):
             eta=eta,
             m=m,
             L=L,
-            X=X,  # store the original reference (even if symbolic)
+            X=X,
             X_mid=X_mid,
             cov_func=cov_func,
             dims=dims,


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->
Correcting HSGP to be link to model graph

Closes #1451 


## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #1451 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1452.org.readthedocs.build/en/1452/

<!-- readthedocs-preview pymc-marketing end -->