### PR TITLE
Remove parameter methods

### DIFF
--- a/pymc_marketing/model_builder.py
+++ b/pymc_marketing/model_builder.py
@@ -947,18 +947,6 @@ class ModelBuilder(ABC):
 
         return az.extract(post_pred, variable_name, combined=combined)
 
-    def get_params(self, deep=True):
-        """Get all the model parameters needed to instantiate a copy of the model, not including training data."""
-        return {
-            "model_config": self.model_config,
-            "sampler_config": self.sampler_config,
-        }
-
-    def set_params(self, **params):
-        """Set all the model parameters needed to instantiate the model, not including training data."""
-        self.model_config = params["model_config"]
-        self.sampler_config = params["sampler_config"]
-
     @property
     @abstractmethod
     def _serializable_model_config(self) -> dict[str, int | float | dict]:


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

Removes the two methods from the `ModelBuilder` class:

- `get_params`
- `set_params`

Not used anywhere and not needed so removing them.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #1453 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->