### PR TITLE
support xarray in ModelBuilder

### DIFF
--- a/pymc_marketing/clv/models/basic.py
+++ b/pymc_marketing/clv/models/basic.py
@@ -273,10 +273,6 @@ class CLVModel(ModelBuilder):
         """Output variable of the model."""
         pass
 
-    def _generate_and_preprocess_model_data(self, *args, **kwargs):
-        """Generate and preprocess model data."""
-        pass
-
     def _data_setter(self):
         """Set the data for the model."""
         pass

--- a/pymc_marketing/model_builder.py
+++ b/pymc_marketing/model_builder.py
@@ -661,7 +661,6 @@ class ModelBuilder(ABC):
         X: pd.DataFrame,
         y: pd.Series | np.ndarray | None = None,
         progressbar: bool | None = None,
-        predictor_names: list[str] | None = None,
         random_seed: RandomState | None = None,
         **kwargs: Any,
     ) -> az.InferenceData:
@@ -677,10 +676,6 @@ class ModelBuilder(ABC):
             The target values (real numbers). If scikit-learn is available, array-like, otherwise array.
         progressbar : bool, optional
             Specifies whether the fit progress bar should be displayed. Defaults to True.
-        predictor_names : Optional[List[str]] = None,
-            Allows for custom naming of predictors when given in a form of a 2D array.
-            Allows for naming of predictors when given in a form of np.ndarray, if not provided
-            the predictors will be named like predictor1, predictor2...
         random_seed : Optional[RandomState]
             Provides sampler with initial random seed for obtaining reproducible samples.
         **kwargs : Any
@@ -702,8 +697,6 @@ class ModelBuilder(ABC):
         if isinstance(y, pd.Series) and not X.index.equals(y.index):
             raise ValueError("Index of X and y must match.")
 
-        if predictor_names is None:
-            predictor_names = []
         if y is None:
             y = np.zeros(X.shape[0])
 

--- a/pymc_marketing/model_builder.py
+++ b/pymc_marketing/model_builder.py
@@ -207,7 +207,7 @@ class ModelBuilder(ABC):
     @abstractmethod
     def _data_setter(
         self,
-        X: np.ndarray | pd.DataFrame | xr.Dataset,
+        X: np.ndarray | pd.DataFrame | xr.Dataset | xr.DataArray,
         y: np.ndarray | pd.Series | xr.DataArray | None = None,
     ) -> None:
         """Set new data in the model.

--- a/pymc_marketing/model_builder.py
+++ b/pymc_marketing/model_builder.py
@@ -307,7 +307,7 @@ class ModelBuilder(ABC):
     @abstractmethod
     def build_model(
         self,
-        X: pd.DataFrame | xr.Dataset,
+        X: pd.DataFrame | xr.Dataset | xr.DataArray,
         y: pd.Series | np.ndarray | xr.DataArray,
         **kwargs,
     ) -> None:
@@ -623,7 +623,11 @@ class ModelBuilder(ABC):
             )
             raise DifferentModelError(error_msg) from e
 
-    def create_fit_data(self, X, y) -> xr.Dataset:
+    def create_fit_data(
+        self,
+        X: pd.DataFrame | xr.Dataset | xr.DataArray,
+        y: np.ndarray | pd.Series | xr.DataArray,
+    ) -> xr.Dataset:
         """Create the fit_data group based on the input data."""
         if isinstance(y, np.ndarray):
             y = pd.Series(y, index=X.index, name=self.output_var)
@@ -637,11 +641,11 @@ class ModelBuilder(ABC):
         if isinstance(y, pd.Series):
             y = y.to_xarray()
 
-        return X.merge(y)
+        return xr.merge([X, y])
 
     def fit(
         self,
-        X: pd.DataFrame | xr.Dataset,
+        X: pd.DataFrame | xr.Dataset | xr.DataArray,
         y: pd.Series | xr.DataArray | np.ndarray | None = None,
         progressbar: bool | None = None,
         random_seed: RandomState | None = None,

--- a/pymc_marketing/model_builder.py
+++ b/pymc_marketing/model_builder.py
@@ -625,8 +625,12 @@ class ModelBuilder(ABC):
 
     def create_fit_data(self, X, y) -> xr.Dataset:
         """Create the fit_data group based on the input data."""
+        if isinstance(y, np.ndarray):
+            y = pd.Series(y, index=X.index, name=self.output_var)
+
         X_df = pd.DataFrame(X, columns=X.columns)
         combined_data = pd.concat([X_df, y], axis=1)
+
         if not all(combined_data.columns):
             raise ValueError("All columns must have non-empty names")
 

--- a/pymc_marketing/model_builder.py
+++ b/pymc_marketing/model_builder.py
@@ -628,6 +628,9 @@ class ModelBuilder(ABC):
         if isinstance(y, np.ndarray):
             y = pd.Series(y, index=X.index, name=self.output_var)
 
+        if y.name is None:
+            y.name = self.output_var
+
         X_df = pd.DataFrame(X, columns=X.columns)
         combined_data = pd.concat([X_df, y], axis=1)
 

--- a/pymc_marketing/model_builder.py
+++ b/pymc_marketing/model_builder.py
@@ -631,13 +631,13 @@ class ModelBuilder(ABC):
         if y.name is None:
             y.name = self.output_var
 
-        X_df = pd.DataFrame(X, columns=X.columns)
-        combined_data = pd.concat([X_df, y], axis=1)
+        if isinstance(X, pd.DataFrame):
+            X = X.to_xarray()
 
-        if not all(combined_data.columns):
-            raise ValueError("All columns must have non-empty names")
+        if isinstance(y, pd.Series):
+            y = y.to_xarray()
 
-        return combined_data.to_xarray()
+        return X.merge(y)
 
     def fit(
         self,

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -1,4 +1,4 @@
-#   Copyright 2025 - 2025 The PyMC Labs Developers
+#   Copyright 2022 - 2025 The PyMC Labs Developers
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -11,33 +11,6 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-#   Copyright 2022 - 2025 The PyMC Labs Developer
-#
-#   Licensed under the Apache License, Version 2.0 (the "License");
-#   you may not use this file except in compliance with the License.
-#   You may obtain a copy of the License at
-#
-#       http://www.apache.org/licenses/LICENSE-2.0
-#
-#   Unless required by applicable law or agreed to in writing, software
-#   distributed under the License is distributed on an "AS IS" BASIS,
-#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#   See the License for the specific language governing permissions and
-#   limitations under the License.
-#   Copyright 2023 The PyMC Developers
-#
-#   Licensed under the Apache License, Version 2.0 (the "License");
-#   you may not use this file except in compliance with the License.
-#   You may obtain a copy of the License at
-#
-#       http://www.apache.org/licenses/LICENSE-2.0
-#
-#   Unless required by applicable law or agreed to in writing, software
-#   distributed under the License is distributed on an "AS IS" BASIS,
-#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#   See the License for the specific language governing permissions and
-#   limitations under the License.
-
 import hashlib
 import json
 import sys


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

Expanding the support of the ModelBuilder to include xarray types

The `create_fit_data` method in the ModelBuilder class acts to generate the data that will be used to fit the model. There will be a base implementation. However, the user can override this method without touching `fit` directly.

The `_generate_and_process_model_data` is no longer required method of the ModelBuilder class. The `build_model` method can do this directly or the user has the ability to make custom methods which can act similarly.


## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1459.org.readthedocs.build/en/1459/

<!-- readthedocs-preview pymc-marketing end -->