### PR TITLE
Break ModelBuilder into smaller classes

### DIFF
--- a/pymc_marketing/customer_choice/mv_its.py
+++ b/pymc_marketing/customer_choice/mv_its.py
@@ -26,14 +26,14 @@ from matplotlib.axes import Axes
 from typing_extensions import Self
 from xarray import DataArray
 
-from pymc_marketing.model_builder import ModelBuilder, create_idata_accessor
+from pymc_marketing.model_builder import RegressionModelBuilder, create_idata_accessor
 from pymc_marketing.model_config import parse_model_config
 from pymc_marketing.prior import Prior
 
 HDI_ALPHA = 0.5
 
 
-class MVITS(ModelBuilder):
+class MVITS(RegressionModelBuilder):
     """Multivariate Interrupted Time Series class.
 
     Class to perform a multivariate interrupted time series analysis with the

--- a/pymc_marketing/mmm/base.py
+++ b/pymc_marketing/mmm/base.py
@@ -45,14 +45,14 @@ from pymc_marketing.mmm.validating import (
     ValidateDateColumn,
     ValidateTargetColumn,
 )
-from pymc_marketing.model_builder import ModelBuilder
+from pymc_marketing.model_builder import RegressionModelBuilder
 
 __all__ = ["BaseValidateMMM", "MMMModelBuilder"]
 
 from pydantic import Field, validate_call
 
 
-class MMMModelBuilder(ModelBuilder):
+class MMMModelBuilder(RegressionModelBuilder):
     """Base class for Marketing Mix Models (MMM)."""
 
     model: pm.Model

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -24,7 +24,7 @@ import pymc as pm
 import pytest
 import xarray as xr
 
-from pymc_marketing.model_builder import ModelBuilder, create_sample_kwargs
+from pymc_marketing.model_builder import RegressionModelBuilder, create_sample_kwargs
 
 
 @pytest.fixture(scope="module")
@@ -84,7 +84,7 @@ def not_fitted_model_instance():
     )
 
 
-class ModelBuilderTest(ModelBuilder):
+class ModelBuilderTest(RegressionModelBuilder):
     def __init__(self, model_config=None, sampler_config=None, test_parameter=None):
         self.test_parameter = test_parameter
         super().__init__(model_config=model_config, sampler_config=sampler_config)
@@ -182,6 +182,7 @@ def test_save_load(fitted_model_instance):
     rng = np.random.default_rng(42)
     temp = tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", delete=False)
     fitted_model_instance.save(temp.name)
+
     test_builder2 = ModelBuilderTest.load(temp.name)
 
     assert fitted_model_instance.idata.groups() == test_builder2.idata.groups()
@@ -197,7 +198,9 @@ def test_save_load(fitted_model_instance):
     temp.close()
 
 
-def test_initial_build_and_fit(fitted_model_instance, check_idata=True) -> ModelBuilder:
+def test_initial_build_and_fit(
+    fitted_model_instance, check_idata=True
+) -> RegressionModelBuilder:
     if check_idata:
         assert fitted_model_instance.idata is not None
         assert "posterior" in fitted_model_instance.idata.groups()
@@ -395,7 +398,7 @@ def test_second_fit(toy_X, toy_y):
     assert id_before != id_after
 
 
-class InsufficientModel(ModelBuilder):
+class InsufficientModel(RegressionModelBuilder):
     def __init__(
         self, model_config=None, sampler_config=None, new_parameter=None
     ) -> None:
@@ -643,7 +646,7 @@ def test_X_pred_prior_deprecation(fitted_model_instance, toy_X, toy_y) -> None:
     assert isinstance(fitted_model_instance.prior_predictive, xr.Dataset)
 
 
-class XarrayModel(ModelBuilder):
+class XarrayModel(RegressionModelBuilder):
     """Multivariate Regression model."""
 
     def build_model(self, X, y, **kwargs):


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

Splitting the original ModelBuilder into base class which then supports ModelBuilder and RegressionModelBuilder

Work in progress. Likely very broken at the moment

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->
