### PR TITLE
load bug with y name different than `output_var`

### DIFF
--- a/pymc_marketing/model_builder.py
+++ b/pymc_marketing/model_builder.py
@@ -632,8 +632,7 @@ class ModelBuilder(ABC):
         if isinstance(y, np.ndarray):
             y = pd.Series(y, index=X.index, name=self.output_var)
 
-        if y.name is None:
-            y.name = self.output_var
+        y.name = self.output_var
 
         if isinstance(X, pd.DataFrame):
             X = X.to_xarray()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -147,7 +147,7 @@ def mock_sample(*args, **kwargs):
     return idata
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def mock_pymc_sample():
     original_sample = pm.sample
     pm.sample = mock_sample

--- a/tests/customer_choice/test_mv_its.py
+++ b/tests/customer_choice/test_mv_its.py
@@ -13,7 +13,6 @@
 #   limitations under the License.
 
 import re
-import warnings
 
 import numpy as np
 import pandas as pd
@@ -84,37 +83,9 @@ def test_plot_data(saturated_data):
     plt.close()
 
 
-def mock_fit(self, X, y, **kwargs):
-    self.idata.add_groups(
-        {
-            "posterior": self.idata.prior,
-        }
-    )
-
-    combined_data = pd.concat([X, y.rename(self.output_var)], axis=1)
-
-    if "fit_data" in self.idata:
-        del self.idata.fit_data
-
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            category=UserWarning,
-            message="The group fit_data is not defined in the InferenceData scheme",
-        )
-        self.idata.add_groups(fit_data=combined_data.to_xarray())  # type: ignore
-
-    return self
-
-
 @pytest.fixture(scope="module")
-def fit_model(module_mocker, saturated_data):
+def fit_model(saturated_data, mock_pymc_sample):
     model = MVITS(existing_sales=["competitor", "own"], saturated_market=True)
-
-    module_mocker.patch(
-        "pymc_marketing.customer_choice.mv_its.MVITS.fit",
-        mock_fit,
-    )
 
     model.sample(
         saturated_data.loc[:, ["competitor", "own"]],
@@ -151,13 +122,8 @@ def unsaturated_data_good():
 
 
 @pytest.fixture(scope="module")
-def unsaturated_model_bad(module_mocker, unsaturated_data_bad):
+def unsaturated_model_bad(unsaturated_data_bad, mock_pymc_sample):
     model = MVITS(existing_sales=["competitor", "own"], saturated_market=False)
-
-    module_mocker.patch(
-        "pymc_marketing.customer_choice.mv_its.MVITS.fit",
-        mock_fit,
-    )
 
     model.sample(
         unsaturated_data_bad.loc[:, ["competitor", "own"]],
@@ -169,13 +135,8 @@ def unsaturated_model_bad(module_mocker, unsaturated_data_bad):
 
 
 @pytest.fixture(scope="module")
-def unsaturated_model_good(module_mocker, unsaturated_data_good):
+def unsaturated_model_good(unsaturated_data_good, mock_pymc_sample):
     model = MVITS(existing_sales=["competitor", "own"], saturated_market=False)
-
-    module_mocker.patch(
-        "pymc_marketing.customer_choice.mv_its.MVITS.fit",
-        mock_fit,
-    )
 
     model.sample(
         unsaturated_data_good.loc[:, ["competitor", "own"]],
@@ -220,8 +181,11 @@ def test_save_load(fit_model, saturated_data) -> None:
     assert loaded.saturated_market == fit_model.saturated_market
     assert loaded.X.columns.name is None
     pd.testing.assert_frame_equal(loaded.X, fit_model.X, check_names=False)
-    assert loaded.y.name == fit_model.output_var
-    pd.testing.assert_series_equal(loaded.y.rename("new"), saturated_data["new"])
+    assert loaded.y.name == fit_model.y.name
+    pd.testing.assert_series_equal(
+        loaded.y,
+        saturated_data["new"].rename(fit_model.output_var),
+    )
 
 
 @pytest.mark.parametrize("variable", ["y", "mu"])

--- a/tests/mmm/test_base.py
+++ b/tests/mmm/test_base.py
@@ -314,7 +314,12 @@ def test_calling_prior_predictive_before_fit_raises_error(test_mmm, toy_X, toy_y
         test_mmm.prior_predictive
 
 
-def test_calling_fit_result_before_fit_raises_error(test_mmm, toy_X, toy_y):
+def test_calling_fit_result_before_fit_raises_error(
+    test_mmm,
+    toy_X,
+    toy_y,
+    mock_pymc_sample,
+):
     # Arrange
     test_mmm.idata = None
     with pytest.raises(

--- a/tests/mmm/test_mmm.py
+++ b/tests/mmm/test_mmm.py
@@ -149,6 +149,15 @@ def mmm_fitted_with_posterior_predictive(
 
 
 @pytest.fixture(scope="module")
+def mmm_fitted_with_prior_and_posterior_predictive(
+    mmm_fitted_with_posterior_predictive,
+    toy_X,
+):
+    _ = mmm_fitted_with_posterior_predictive.sample_prior_predictive(toy_X)
+    return mmm_fitted_with_posterior_predictive
+
+
+@pytest.fixture(scope="module")
 def mmm_fitted_with_fourier_features(
     mmm_with_fourier_features: MMM,
     toy_X: pd.DataFrame,
@@ -736,16 +745,17 @@ class TestMMM:
     )
     def test_get_group_predictive_data(
         self,
-        mmm_fitted_with_posterior_predictive: MMM,
+        mmm_fitted_with_prior_and_posterior_predictive: MMM,
         group: str,
         original_scale: bool,
     ):
-        dataset = mmm_fitted_with_posterior_predictive._get_group_predictive_data(
-            group=group, original_scale=original_scale
+        dataset = (
+            mmm_fitted_with_prior_and_posterior_predictive._get_group_predictive_data(
+                group=group,
+                original_scale=original_scale,
+            )
         )
         assert isinstance(dataset, xr.Dataset)
-        assert dataset.dims["chain"] == 1
-        assert dataset.dims["draw"] == 500
         assert dataset.dims["date"] == 135
         assert dataset["y"].dims == ("chain", "draw", "date")
 

--- a/tests/mmm/test_mmm.py
+++ b/tests/mmm/test_mmm.py
@@ -12,7 +12,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 import os
-import warnings
 
 import arviz as az
 import numpy as np
@@ -35,35 +34,6 @@ from pymc_marketing.prior import Prior
 
 seed: int = sum(map(ord, "pymc_marketing"))
 rng: np.random.Generator = np.random.default_rng(seed=seed)
-
-
-def mock_fit(model, X: pd.DataFrame, y: np.ndarray, **kwargs):
-    model.build_model(X=X, y=y)
-
-    with model.model:
-        idata = pm.sample_prior_predictive(random_seed=rng, **kwargs)
-
-    model.preprocess("X", X)
-    model.preprocess("y", y)
-
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            category=UserWarning,
-            message="The group fit_data is not defined in the InferenceData scheme",
-        )
-        idata.add_groups(
-            {
-                "posterior": idata.prior,
-                "fit_data": pd.concat(
-                    [X, pd.Series(y, index=X.index, name="y")], axis=1
-                ).to_xarray(),
-            }
-        )
-    model.idata = idata
-    model.set_idata_attrs(idata=idata)
-
-    return model
 
 
 @pytest.fixture(scope="module")
@@ -159,8 +129,14 @@ def mmm_with_fourier_features() -> MMM:
 
 
 @pytest.fixture(scope="module")
-def mmm_fitted(mmm: MMM, toy_X: pd.DataFrame, toy_y: pd.Series) -> MMM:
-    return mock_fit(mmm, toy_X, toy_y)
+def mmm_fitted(
+    mmm: MMM,
+    toy_X: pd.DataFrame,
+    toy_y: pd.Series,
+    mock_pymc_sample,
+) -> MMM:
+    mmm.fit(X=toy_X, y=toy_y)
+    return mmm
 
 
 @pytest.fixture(scope="module")
@@ -177,8 +153,10 @@ def mmm_fitted_with_fourier_features(
     mmm_with_fourier_features: MMM,
     toy_X: pd.DataFrame,
     toy_y: pd.Series,
+    mock_pymc_sample,
 ) -> MMM:
-    return mock_fit(mmm_with_fourier_features, toy_X, toy_y)
+    mmm_with_fourier_features.fit(X=toy_X, y=toy_y)
+    return mmm_with_fourier_features
 
 
 @pytest.mark.parametrize("media_transform", ["adstock", "saturation"])
@@ -195,7 +173,11 @@ def test_plotting_media_transform_workflow(mmm_fitted, media_transform) -> None:
 
 class TestMMM:
     def test_save_load_with_not_serializable_model_config(
-        self, model_config_requiring_serialization, toy_X, toy_y
+        self,
+        model_config_requiring_serialization,
+        toy_X,
+        toy_y,
+        mock_pymc_sample,
     ):
         def deep_equal(dict1, dict2):
             for key, value in dict1.items():
@@ -222,7 +204,7 @@ class TestMMM:
             adstock=adstock,
             saturation=saturation,
         )
-        model = mock_fit(model, toy_X, toy_y)
+        model.fit(toy_X, toy_y)
         model.save("test_save_load")
         model2 = MMM.load("test_save_load")
         assert model.date_column == model2.date_column
@@ -371,10 +353,7 @@ class TestMMM:
                 samples,
             )
 
-    def test_fit(self, toy_X: pd.DataFrame, toy_y: pd.Series) -> None:
-        draws: int = 500
-        chains: int = 1
-
+    def test_fit(self, toy_X: pd.DataFrame, toy_y: pd.Series, mock_pymc_sample) -> None:
         mmm = BaseMMM(
             date_column="date",
             channel_columns=["channel_1", "channel_2"],
@@ -389,25 +368,27 @@ class TestMMM:
         assert mmm.model_config is not None
         n_channel: int = len(mmm.channel_columns)
         n_control: int = len(mmm.control_columns)
-        mmm = mock_fit(mmm, toy_X, toy_y)
-        idata: az.InferenceData = mmm.fit_result
+        mmm.fit(X=toy_X, y=toy_y)
+        posterior: az.InferenceData = mmm.fit_result
+        chains = posterior.sizes["chain"]
+        draws = posterior.sizes["draw"]
         assert (
-            az.extract(data=idata, var_names=["intercept"], combined=True)
+            az.extract(data=posterior, var_names=["intercept"], combined=True)
             .to_numpy()
             .size
             == draws * chains
         )
         assert az.extract(
-            data=idata, var_names=["saturation_beta"], combined=True
+            data=posterior, var_names=["saturation_beta"], combined=True
         ).to_numpy().shape == (n_channel, draws * chains)
         assert az.extract(
-            data=idata, var_names=["adstock_alpha"], combined=True
+            data=posterior, var_names=["adstock_alpha"], combined=True
         ).to_numpy().shape == (n_channel, draws * chains)
         assert az.extract(
-            data=idata, var_names=["saturation_lam"], combined=True
+            data=posterior, var_names=["saturation_lam"], combined=True
         ).to_numpy().shape == (n_channel, draws * chains)
         assert az.extract(
-            data=idata, var_names=["gamma_control"], combined=True
+            data=posterior, var_names=["gamma_control"], combined=True
         ).to_numpy().shape == (
             n_channel,
             draws * chains,
@@ -439,7 +420,10 @@ class TestMMM:
         ]
 
     def test_mmm_serializes_and_deserializes_dag_and_nodes(
-        self, toy_X: pd.DataFrame, toy_y: pd.Series
+        self,
+        toy_X: pd.DataFrame,
+        toy_y: pd.Series,
+        mock_pymc_sample,
     ) -> None:
         dag = """
         digraph {
@@ -462,7 +446,7 @@ class TestMMM:
             outcome_node=outcome_node,
         )
 
-        mmm = mock_fit(mmm, toy_X, toy_y)
+        mmm.fit(X=toy_X, y=toy_y)
 
         # Save and reload the model
         mmm.save("test_model")
@@ -595,9 +579,11 @@ class TestMMM:
                 var_contribution=var_contribution, original_scale=original_scale
             )
         )
+        chains = ts_posterior.sizes["chain"]
+        draws = ts_posterior.sizes["draw"]
         assert ts_posterior.dims == ("chain", "draw", "date")
-        assert ts_posterior.chain.size == 1
-        assert ts_posterior.draw.size == 500
+        assert ts_posterior.chain.size == chains
+        assert ts_posterior.draw.size == draws
 
     @pytest.mark.parametrize(
         argnames="original_scale",
@@ -612,8 +598,8 @@ class TestMMM:
         errors = mmm_fitted_with_posterior_predictive.get_errors(
             original_scale=original_scale
         )
-        n_chains = 1
-        n_draws = 500
+        n_chains = errors.sizes["chain"]
+        n_draws = errors.sizes["draw"]
         assert isinstance(errors, xr.DataArray)
         assert errors.name == "errors"
         assert errors.shape == (
@@ -699,12 +685,12 @@ class TestMMM:
     ) -> None:
         n_channels = len(mmm_fitted.channel_columns)
         data_range = mmm_fitted.X.shape[0]
-        draws = 500
-        chains = 1
         grid_size = 2
         contributions = mmm_fitted.get_channel_contributions_forward_pass_grid(
             start=0, stop=1.5, num=grid_size
         )
+        draws = contributions.sizes["draw"]
+        chains = contributions.sizes["chain"]
         assert contributions.shape == (
             grid_size,
             chains,
@@ -763,14 +749,14 @@ class TestMMM:
         assert dataset.dims["date"] == 135
         assert dataset["y"].dims == ("chain", "draw", "date")
 
-    def test_data_setter(self, toy_X, toy_y):
+    def test_data_setter(self, toy_X, toy_y, mock_pymc_sample):
         base_delayed_saturated_mmm = BaseMMM(
             date_column="date",
             channel_columns=["channel_1", "channel_2"],
             adstock=GeometricAdstock(l_max=4),
             saturation=LogisticSaturation(),
         )
-        base_delayed_saturated_mmm = mock_fit(base_delayed_saturated_mmm, toy_X, toy_y)
+        base_delayed_saturated_mmm.fit(X=toy_X, y=toy_y)
 
         X_correct_ndarray = np.random.randint(low=0, high=100, size=(135, 2))
         y_correct_ndarray = np.random.randint(low=0, high=100, size=135)
@@ -829,7 +815,7 @@ class TestMMM:
         )
 
         # Check that the property returns the new value
-        DSMMM = mock_fit(DSMMM, toy_X, toy_y)
+        DSMMM.fit(toy_X, toy_y)
         DSMMM.save("test_model")
         # Apply the monkeypatch for the property
         monkeypatch.setattr(MMM, "id", property(mock_property))
@@ -1374,7 +1360,7 @@ def test_save_load_with_tvp(
         time_varying_intercept=time_varying_intercept,
         time_varying_media=time_varying_media,
     )
-    mmm = mock_fit(mmm, toy_X, toy_y)
+    mmm.fit(toy_X, toy_y)
 
     file = "tmp-model"
     mmm.save(file)
@@ -1416,7 +1402,8 @@ def mmm_with_media_config_fitted(
     toy_X: pd.DataFrame,
     toy_y: pd.Series,
 ) -> MMM:
-    return mock_fit(mmm_with_media_config, toy_X, toy_y)
+    mmm_with_media_config.fit(toy_X, toy_y)
+    return mmm_with_media_config
 
 
 def test_save_load_with_media_transformation(mmm_with_media_config_fitted) -> None:
@@ -1443,7 +1430,7 @@ def test_save_load_with_media_transformation(mmm_with_media_config_fitted) -> No
     os.remove(file)
 
 
-def test_missing_attrs_to_defaults(toy_X, toy_y) -> None:
+def test_missing_attrs_to_defaults(toy_X, toy_y, mock_pymc_sample) -> None:
     mmm = MMM(
         date_column="date",
         channel_columns=["channel_1", "channel_2"],
@@ -1454,7 +1441,7 @@ def test_missing_attrs_to_defaults(toy_X, toy_y) -> None:
         time_varying_intercept=False,
         time_varying_media=False,
     )
-    mmm = mock_fit(mmm, toy_X, toy_y)
+    mmm.fit(toy_X, toy_y)
     mmm.idata.attrs.pop("adstock_first")
     mmm.idata.attrs.pop("time_varying_intercept")
     mmm.idata.attrs.pop("time_varying_media")
@@ -1481,7 +1468,11 @@ def test_missing_attrs_to_defaults(toy_X, toy_y) -> None:
     os.remove(file)
 
 
-def test_channel_contributions_forward_pass_time_varying_media(toy_X, toy_y) -> None:
+def test_channel_contributions_forward_pass_time_varying_media(
+    toy_X,
+    toy_y,
+    mock_pymc_sample,
+) -> None:
     mmm = MMM(
         date_column="date",
         channel_columns=["channel_1", "channel_2"],
@@ -1490,7 +1481,7 @@ def test_channel_contributions_forward_pass_time_varying_media(toy_X, toy_y) -> 
         saturation=LogisticSaturation(),
         time_varying_media=True,
     )
-    mmm = mock_fit(mmm, toy_X, toy_y)
+    mmm.fit(toy_X, toy_y)
 
     posterior = mmm.fit_result
 

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -43,7 +43,7 @@ def toy_y(toy_X):
 
 
 @pytest.fixture(scope="module")
-def fitted_model_instance(toy_X, mock_pymc_sample):
+def fitted_model_instance(toy_X, toy_y, mock_pymc_sample):
     sampler_config = {
         "draws": 100,
         "tune": 100,
@@ -62,6 +62,7 @@ def fitted_model_instance(toy_X, mock_pymc_sample):
     )
     model.fit(
         toy_X,
+        toy_y,
         chains=1,
         draws=100,
         tune=100,

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -712,7 +712,7 @@ def xarray_y(xarray_X) -> xr.DataArray:
     )
     beta = xr.DataArray([1, 2], dims=["country"], coords={"country": ["A", "B"]})
 
-    return (alpha + beta * xarray_X["x"]).rename("output")
+    return (alpha + beta * xarray_X["x"]).rename("name other than output")
 
 
 @pytest.mark.parametrize("X_is_array", [False, True], ids=["DataArray", "Dataset"])


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

Found this while making the tests use mocked pm.sample

If y already has a name, then `load_from_idata` method would raise a KeyError

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1468.org.readthedocs.build/en/1468/

<!-- readthedocs-preview pymc-marketing end -->