### PR TITLE
Add basis bumps effect to MMM model

### DIFF
--- a/pymc_marketing/clv/distributions.py
+++ b/pymc_marketing/clv/distributions.py
@@ -783,7 +783,9 @@ class ModifiedBetaGeoNBDRV(RandomVariable):
             t = 0  # recency
             n = 0  # frequency
 
-            churn = p  # MBG/NBD customer active with probability p at time 0
+            churn = (
+                rng.random() < p
+            )  # MBG/NBD customer active with probability p at time 0
             wait = rng.exponential(scale=1 / lam)
 
             while t + wait < T and not churn:

--- a/pymc_marketing/mmm/components/base.py
+++ b/pymc_marketing/mmm/components/base.py
@@ -318,6 +318,11 @@ class Transformation:
             for parameter in self.default_priors.keys()
         }
 
+    @property
+    def combined_dims(self) -> tuple[str, ...]:
+        """Get the combined dims for all the parameters."""
+        return tuple(self._infer_output_core_dims())
+
     def _infer_output_core_dims(self) -> tuple[str, ...]:
         parameter_dims = sorted(
             [

--- a/pymc_marketing/mmm/events.py
+++ b/pymc_marketing/mmm/events.py
@@ -92,7 +92,11 @@ This module provides event transformations for use in Marketing Mix Models.
 
 """
 
+from typing import cast
+
 import numpy as np
+import numpy.typing as npt
+import pandas as pd
 import pymc as pm
 import pytensor.tensor as pt
 import xarray as xr
@@ -229,3 +233,33 @@ class GaussianBasis(Basis):
     default_priors = {
         "sigma": Prior("Gamma", mu=7, sigma=1),
     }
+
+
+def days_from_reference(
+    dates: pd.Series | pd.DatetimeIndex,
+    reference_date: str | pd.Timestamp,
+) -> npt.NDArray[np.int64]:
+    """Calculate the difference in days between dates and a reference date.
+
+    Parameters
+    ----------
+    dates : pd.Series | pd.DatetimeIndex
+        Dates to calculate the difference from the reference date.
+    reference_date : str | pd.Timestamp
+        Reference date.
+
+    Returns
+    -------
+    np.ndarray
+        Difference in days between dates and the reference date.
+
+    """
+    reference_date = cast(pd.Timestamp, pd.to_datetime(reference_date))
+    dates = pd.to_datetime(dates)
+
+    diff = dates - reference_date
+
+    if isinstance(diff, pd.Series):
+        diff = diff.dt  # type: ignore
+
+    return diff.days.to_numpy()  # type: ignore

--- a/pymc_marketing/mmm/multidimensional.py
+++ b/pymc_marketing/mmm/multidimensional.py
@@ -258,6 +258,11 @@ class MMM(ModelBuilder):
         This must be called before building the model.
 
         """
+        if not set((prefix, self.dims)).issubset(set(effect.dims)):
+            raise ValueError(
+                f"Event effect dims {effect.dims} must contain {prefix} and {self.dims}"
+            )
+
         event_effect = create_event_mu_effect(df_events, prefix, effect)
         self.mu_effects.append(event_effect)
 

--- a/pymc_marketing/mmm/multidimensional.py
+++ b/pymc_marketing/mmm/multidimensional.py
@@ -65,7 +65,7 @@ class MuEffect(Protocol):
         """Create the additive effect in the model."""
 
 
-def create_event_effect(
+def create_event_mu_effect(
     df_events: pd.DataFrame,
     prefix: str,
     effect: EventEffect,
@@ -79,6 +79,8 @@ def create_event_effect(
         ["start_date", "end_date", "name"]
     ).tolist():
         raise ValueError(f"Columns {missing_columns} are missing in df_events.")
+
+    effect.basis.prefix = prefix
 
     class Effect:
         def create_data(self, mmm: MMM) -> None:
@@ -256,7 +258,7 @@ class MMM(ModelBuilder):
         This must be called before building the model.
 
         """
-        event_effect = create_event_effect(df_events, prefix, effect)
+        event_effect = create_event_mu_effect(df_events, prefix, effect)
         self.mu_effects.append(event_effect)
 
     @property

--- a/pymc_marketing/mmm/multidimensional.py
+++ b/pymc_marketing/mmm/multidimensional.py
@@ -315,7 +315,7 @@ class MMM(ModelBuilder):
             If the event effect dimensions do not contain the prefix and model dimensions.
 
         """
-        if not set((prefix, self.dims)).issubset(set(effect.dims)):
+        if not set(effect.dims).issubset((prefix, self.dims)):
             raise ValueError(
                 f"Event effect dims {effect.dims} must contain {prefix} and {self.dims}"
             )

--- a/tests/mmm/test_events.py
+++ b/tests/mmm/test_events.py
@@ -437,3 +437,22 @@ def test_days_from_reference(dates_constructor, reference_constructor):
     )
 
     np.testing.assert_allclose(result, np.arange(-4, 6))
+
+
+@pytest.mark.parametrize(
+    "sigma_dims, effect_dims",
+    [
+        pytest.param("something else", "event", id="basis_not_subset"),
+        pytest.param("event", "something else", id="effect_not_subset"),
+    ],
+)
+def test_event_effect_dim_validation(sigma_dims, effect_dims) -> None:
+    basis = GaussianBasis(
+        priors={
+            "sigma": Prior("HalfNormal", dims=sigma_dims),
+        }
+    )
+    effect_size = Prior("Normal", dims=effect_dims)
+
+    with pytest.raises(ValueError):
+        EventEffect(basis=basis, effect_size=effect_size, dims="event")

--- a/tests/mmm/test_multidimensional.py
+++ b/tests/mmm/test_multidimensional.py
@@ -511,7 +511,11 @@ def mock_mmm():
 
 @pytest.fixture
 def create_event_effect() -> Callable[[str], EventEffect]:
-    def create(prefix: str = "holiday"):
+    def create(
+        prefix: str = "holiday",
+        sigma_dims: str | None = None,
+        effect_size: Prior | None = None,
+    ):
         basis = GaussianBasis()
         return EventEffect(
             basis=basis,


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

The API 

```python
mmm = MMM(...)

mmm.add_events(df_holidays, prefix="holiday", effect=...)
mmm.add_events(df_weekends, prefix="weekend", effect=...)
mmm.add_events(df_earning_calls, prefix="earning_call", effect=...)
mmm.build_model(X, y)
```

TODO: 

- [x] Handle out of sample predictions
- [x] Relax the EventEffect requiring dims / make assumptions since it will be duplicated in the effect


## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->