### PR TITLE
bring pre-commit action back

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,13 @@ env:
 
 
 jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.1
+
   test:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Related to https://github.com/pymc-labs/pymc-marketing/issues/1476

this is a short-term solution so that PRs are not blocked (see https://github.com/pre-commit/action)