### PR TITLE
skip mypy in pre-commit ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 ci:
   autofix_prs: false
+  skip: [mypy]
 
 repos:
   - repo: https://github.com/lucianopaz/head_of_apache


### PR DESCRIPTION
Related to https://github.com/pymc-labs/pymc-marketing/issues/1476

MyPy takes too much and we can use the action in https://github.com/pymc-labs/pymc-marketing/pull/1477 to check for it.
We can still use pre-commit ci for auto fix and revision update.

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1480.org.readthedocs.build/en/1480/

<!-- readthedocs-preview pymc-marketing end -->