### PR TITLE
use stages in pre-commit hoks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,8 +33,7 @@ repos:
     hooks:
       - id: no-commit-to-branch
         args: [--branch, main]
-        skip:
-        - merge
+        stages: [pre-commit, pre-merge-commit, pre-push, manual]
       - id: debug-statements
       - id: trailing-whitespace
       - id: end-of-file-fixer


### PR DESCRIPTION
Followup of https://github.com/pymc-labs/pymc-marketing/pull/1489 using the docs https://pre-commit.com/#confining-hooks-to-run-at-certain-stages. I am actively omitting `merge-commit` 🤞 .

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1493.org.readthedocs.build/en/1493/

<!-- readthedocs-preview pymc-marketing end -->