### PR TITLE
Change Basis sample_curve defaults

### DIFF
--- a/pymc_marketing/mmm/events.py
+++ b/pymc_marketing/mmm/events.py
@@ -123,7 +123,7 @@ class Basis(Transformation, metaclass=BasisMeta):  # type: ignore[misc]
         parameters: InstanceOf[xr.Dataset] = Field(
             ..., description="Parameters of the saturation transformation."
         ),
-        days: int = Field(0, ge=0, description="Number of days around basis."),
+        days: int = Field(14, gt=0, description="Number of days around basis."),
     ) -> xr.DataArray:
         """Sample the curve of the saturation transformation given parameters.
 
@@ -132,7 +132,7 @@ class Basis(Transformation, metaclass=BasisMeta):  # type: ignore[misc]
         parameters : xr.Dataset
             Dataset with the parameters of the saturation transformation.
         days : int
-            Number of days around basis.
+            Number of days around basis. Default is 14 days or two weeks.
 
         Returns
         -------

--- a/pymc_marketing/mmm/events.py
+++ b/pymc_marketing/mmm/events.py
@@ -123,7 +123,11 @@ class Basis(Transformation, metaclass=BasisMeta):  # type: ignore[misc]
         parameters: InstanceOf[xr.Dataset] = Field(
             ..., description="Parameters of the saturation transformation."
         ),
-        days: int = Field(14, gt=0, description="Number of days around basis."),
+        days: int = Field(
+            14,
+            gt=0,
+            description="Number of days before and after the basis.",
+        ),
     ) -> xr.DataArray:
         """Sample the curve of the saturation transformation given parameters.
 
@@ -132,7 +136,8 @@ class Basis(Transformation, metaclass=BasisMeta):  # type: ignore[misc]
         parameters : xr.Dataset
             Dataset with the parameters of the saturation transformation.
         days : int
-            Number of days around basis. Default is 14 days or two weeks.
+            Number of days around basis. Default is 14 days or two weeks before and
+            after the basis for a total of 28 days.
 
         Returns
         -------

--- a/tests/mmm/test_events.py
+++ b/tests/mmm/test_events.py
@@ -151,10 +151,8 @@ def test_gaussian_basis_curve_sampling():
         },
     )
 
-    curve_0 = gaussian.sample_curve(parameters, days=0)
     curve_10 = gaussian.sample_curve(parameters, days=10)
 
-    assert isinstance(curve_0, xr.DataArray)
     assert isinstance(curve_10, xr.DataArray)
     assert len(curve_10.x) == 100  # Check default number of points
     assert curve_10.x.min() == -10  # Check range


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

This changes the default from 0 (doesn't work) to 14 days

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1500.org.readthedocs.build/en/1500/

<!-- readthedocs-preview pymc-marketing end -->