### PR TITLE
Allow for extra columns in df_events

### DIFF
--- a/pymc_marketing/mmm/multidimensional.py
+++ b/pymc_marketing/mmm/multidimensional.py
@@ -95,9 +95,9 @@ def create_event_mu_effect(
         The event effect which is used in the MMM.
 
     """
-    if missing_columns := df_events.columns.difference(
-        ["start_date", "end_date", "name"]
-    ).tolist():
+    if missing_columns := set(["start_date", "end_date", "name"]).difference(
+        df_events.columns,
+    ):
         raise ValueError(f"Columns {missing_columns} are missing in df_events.")
 
     effect.basis.prefix = prefix

--- a/tests/mmm/test_multidimensional.py
+++ b/tests/mmm/test_multidimensional.py
@@ -388,7 +388,7 @@ def df_events() -> pd.DataFrame:
             "end_date": ["2025-01-02", "2024-12-31"],
             "name": ["New Years", "Christmas Holiday"],
         }
-    )
+    ).assign(random_column="random_value", another_extra_column="extra_value")
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

An error would raise if there were extra columns in the df_events. This swaps the order of the check

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1501.org.readthedocs.build/en/1501/

<!-- readthedocs-preview pymc-marketing end -->