### PR TITLE
Check for incompatible dims in MediaTranform

### DIFF
--- a/pymc_marketing/mmm/media_transformation.py
+++ b/pymc_marketing/mmm/media_transformation.py
@@ -92,6 +92,7 @@ Apply the media transformation to media data in PyMC model:
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import cast
 
 import pymc as pm
 import pytensor.tensor as pt
@@ -144,6 +145,21 @@ class MediaTransformation:
             else (self.saturation, self.adstock)
         )
         self.dims = self.dims or ()
+
+        self._check_compatible_dims()
+
+    def _check_compatible_dims(self):
+        self.dims = cast(Dims, self.dims)
+
+        if not set(self.adstock.combined_dims).issubset(self.dims):
+            raise ValueError(
+                f"Adstock dimensions {self.adstock.combined_dims} are not a subset of {self.dims}"
+            )
+
+        if not set(self.saturation.combined_dims).issubset(self.dims):
+            raise ValueError(
+                f"Saturation dimensions {self.saturation.combined_dims} are not a subset of {self.dims}"
+            )
 
     def __call__(self, x):
         """Apply adstock and saturation transformation to media data.

--- a/tests/mmm/test_media_transformation.py
+++ b/tests/mmm/test_media_transformation.py
@@ -59,6 +59,7 @@ def create_media_config_list():
                             online_dims
                         ),
                         adstock_first=True,
+                        dims=online_dims,
                     ),
                 ),
                 MediaConfig(
@@ -72,6 +73,7 @@ def create_media_config_list():
                             offline_dims
                         ),
                         adstock_first=False,
+                        dims=offline_dims,
                     ),
                 ),
             ]

--- a/tests/mmm/test_media_transformation.py
+++ b/tests/mmm/test_media_transformation.py
@@ -142,3 +142,23 @@ def test_apply_media_transformation(
     for rv in expected_free_RVs:
         expected_dims = offline_dims if rv.startswith("offline") else online_dims
         assert actual_dims[rv] == expected_dims
+
+
+@pytest.mark.parametrize(
+    "adstock_dims, saturation_dims",
+    [
+        ((), "media"),
+        ("media", ()),
+        ("media", "media"),
+    ],
+)
+def test_incompatible_dims_raise(adstock_dims, saturation_dims) -> None:
+    adstock = GeometricAdstock(l_max=10).set_dims_for_all_priors(adstock_dims)
+    saturation = LogisticSaturation().set_dims_for_all_priors(saturation_dims)
+    with pytest.raises(ValueError):
+        MediaTransformation(
+            adstock=adstock,
+            saturation=saturation,
+            adstock_first=True,
+            dims=(),
+        )


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

Incompatible dims were allowed which would cause an error while sampling. This checks it at an earlier stage

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1502.org.readthedocs.build/en/1502/

<!-- readthedocs-preview pymc-marketing end -->