### PR TITLE
Support MediaTransformation and MediaConfigList deserialization

### DIFF
--- a/tests/mmm/test_media_transformation.py
+++ b/tests/mmm/test_media_transformation.py
@@ -16,6 +16,7 @@ import pandas as pd
 import pymc as pm
 import pytest
 
+from pymc_marketing.deserialize import deserialize
 from pymc_marketing.mmm import GeometricAdstock, LogisticSaturation
 from pymc_marketing.mmm.media_transformation import (
     MediaConfig,
@@ -142,3 +143,35 @@ def test_apply_media_transformation(
     for rv in expected_free_RVs:
         expected_dims = offline_dims if rv.startswith("offline") else online_dims
         assert actual_dims[rv] == expected_dims
+
+
+def test_media_transformation_deserialize() -> None:
+    adstock = GeometricAdstock(l_max=10)
+    saturation = LogisticSaturation()
+    data = {
+        "adstock": adstock.to_dict(),
+        "saturation": saturation.to_dict(),
+        "adstock_first": True,
+    }
+
+    media_transformation = deserialize(data)
+    assert isinstance(media_transformation, MediaTransformation)
+
+
+def test_media_config_list_deserialize() -> None:
+    adstock = GeometricAdstock(l_max=10)
+    saturation = LogisticSaturation()
+    data = [
+        {
+            "name": "online",
+            "columns": ["Facebook", "Instagram", "YouTube", "TikTok"],
+            "media_transformation": {
+                "adstock": adstock.to_dict(),
+                "saturation": saturation.to_dict(),
+                "adstock_first": True,
+            },
+        }
+    ]
+
+    media_config_list = deserialize(data)
+    assert isinstance(media_config_list, MediaConfigList)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

Support for these two types in `pymc_marketing.deserialize.deserialize` function

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1504.org.readthedocs.build/en/1504/

<!-- readthedocs-preview pymc-marketing end -->