### PR TITLE
Check for wrong media dims

### DIFF
--- a/pymc_marketing/mmm/multidimensional.py
+++ b/pymc_marketing/mmm/multidimensional.py
@@ -274,6 +274,8 @@ class MMM(ModelBuilder):
             self.adstock.update_priors({**self.default_model_config, **model_config})
             self.saturation.update_priors({**self.default_model_config, **model_config})
 
+        self._check_compatible_media_dims()
+
         self.date_column = date_column
         self.target_column = target_column
         self.channel_columns = channel_columns
@@ -290,6 +292,19 @@ class MMM(ModelBuilder):
             )
 
         self.mu_effects: list[MuEffect] = []
+
+    def _check_compatible_media_dims(self) -> None:
+        allowed_dims = set(self.dims).union({"channel"})
+
+        if not set(self.adstock.combined_dims).issubset(allowed_dims):
+            raise ValueError(
+                f"Adstock effect dims {self.adstock.combined_dims} must contain {allowed_dims}"
+            )
+
+        if not set(self.saturation.combined_dims).issubset(allowed_dims):
+            raise ValueError(
+                f"Saturation effect dims {self.saturation.combined_dims} must contain {allowed_dims}"
+            )
 
     @property
     def default_sampler_config(self) -> dict:

--- a/tests/mmm/test_multidimensional.py
+++ b/tests/mmm/test_multidimensional.py
@@ -523,3 +523,53 @@ def test_mmm_with_events(
     )
 
     assert less_effect_for_out_of_sample.to_pandas().all()
+
+
+@pytest.mark.parametrize(
+    "adstock, saturation, dims",
+    [
+        pytest.param(
+            GeometricAdstock(l_max=2).set_dims_for_all_priors("country"),
+            LogisticSaturation(),
+            (),
+            id="adstock",
+        ),
+        pytest.param(
+            GeometricAdstock(l_max=2),
+            LogisticSaturation().set_dims_for_all_priors("country"),
+            (),
+            id="saturation",
+        ),
+        pytest.param(
+            GeometricAdstock(l_max=2).set_dims_for_all_priors("media"),
+            LogisticSaturation(),
+            (),
+            id="adstock-wrong-media",
+        ),
+        pytest.param(
+            GeometricAdstock(l_max=2),
+            LogisticSaturation().set_dims_for_all_priors("media"),
+            (),
+            id="saturation-wrong-media",
+        ),
+        pytest.param(
+            GeometricAdstock(l_max=2),
+            LogisticSaturation().set_dims_for_all_priors(("media", "product")),
+            ("country",),
+            id="wrong-extra-dim",
+        ),
+    ],
+)
+def test_check_for_incompatible_dims(adstock, saturation, dims) -> None:
+    kwargs = dict(
+        date_column="date",
+        target_column="target",
+        channel_columns=["channel_1", "channel_2"],
+    )
+    with pytest.raises(ValueError):
+        MMM(
+            adstock=adstock,
+            saturation=saturation,
+            dims=dims,
+            **kwargs,  # type: ignore
+        )


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

Adds check for compatible dimensions in the saturation and adstock transformations passed to `MMM` class

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1505.org.readthedocs.build/en/1505/

<!-- readthedocs-preview pymc-marketing end -->