### PR TITLE
Fix `_create_synth_dataset` when MMM has no controls

### DIFF
--- a/pymc_marketing/mmm/mmm.py
+++ b/pymc_marketing/mmm/mmm.py
@@ -2165,7 +2165,7 @@ class MMM(
         if controls is not None:
             _controls: list[str] = controls
         else:
-            controls = []
+            _controls = []
 
         last_date = pd.to_datetime(df[date_column]).max()
         new_dates = []

--- a/tests/mmm/test_mmm.py
+++ b/tests/mmm/test_mmm.py
@@ -117,6 +117,16 @@ def mmm() -> MMM:
 
 
 @pytest.fixture(scope="module")
+def mmm_no_controls() -> MMM:
+    return MMM(
+        date_column="date",
+        channel_columns=["channel_1", "channel_2"],
+        adstock=GeometricAdstock(l_max=4),
+        saturation=LogisticSaturation(),
+    )
+
+
+@pytest.fixture(scope="module")
 def mmm_with_fourier_features() -> MMM:
     return MMM(
         date_column="date",
@@ -137,6 +147,17 @@ def mmm_fitted(
 ) -> MMM:
     mmm.fit(X=toy_X, y=toy_y)
     return mmm
+
+
+@pytest.fixture(scope="module")
+def mmm_fitted_no_controls(
+    mmm_no_controls: MMM,
+    toy_X: pd.DataFrame,
+    toy_y: pd.Series,
+    mock_pymc_sample,
+) -> MMM:
+    mmm_no_controls.fit(X=toy_X, y=toy_y)
+    return mmm_no_controls
 
 
 @pytest.fixture(scope="module")
@@ -1596,6 +1617,83 @@ def test_create_synth_dataset(
 
     # Check channel values are non-negative (since they represent spend)
     for channel in mmm_fitted.channel_columns:
+        assert (synth_df[channel] >= 0).all()
+
+    # Check target variable exists and has reasonable values
+    assert "y" in synth_df.columns
+    assert not synth_df["y"].isna().any()
+
+
+@pytest.mark.parametrize(
+    argnames="noise_level", argvalues=[0.01, 0.05], ids=["low_noise", "high_noise"]
+)
+@pytest.mark.parametrize(
+    argnames="granularity",
+    argvalues=["weekly", "monthly", "quarterly", "yearly"],
+    ids=["weekly", "monthly", "quarterly", "yearly"],
+)
+@pytest.mark.parametrize(
+    argnames="time_length",
+    argvalues=[8, 12, 16, 20],
+    ids=["time_length_8", "time_length_12", "time_length_16", "time_length_20"],
+)
+@pytest.mark.parametrize(
+    argnames="lag", argvalues=[2, 4, 6, 8], ids=["lag_2", "lag_4", "lag_6", "lag_8"]
+)
+def test_create_synth_dataset_no_controls(
+    mmm_fitted_no_controls: MMM,
+    toy_X: pd.DataFrame,
+    noise_level: float,
+    granularity: str,
+    time_length: int,
+    lag: int,
+) -> None:
+    """Test the _create_synth_dataset method of MMM class."""
+
+    # Create a simple allocation strategy
+    channels = mmm_fitted_no_controls.channel_columns
+    allocation_strategy = xr.DataArray(
+        data=np.ones(len(channels)),
+        dims=["channel"],
+        coords={"channel": channels},
+    )
+
+    # Generate synthetic dataset
+    synth_df = mmm_fitted_no_controls._create_synth_dataset(
+        df=toy_X,
+        date_column=mmm_fitted_no_controls.date_column,
+        channels=mmm_fitted_no_controls.channel_columns,
+        controls=mmm_fitted_no_controls.control_columns,
+        target_col="y",
+        allocation_strategy=allocation_strategy,
+        time_granularity=granularity,
+        time_length=time_length,
+        lag=lag,
+        noise_level=noise_level,
+    )
+
+    # Test output properties
+    assert isinstance(synth_df, pd.DataFrame)
+    assert len(synth_df) == time_length
+
+    # Check required columns exist
+    required_columns = {
+        mmm_fitted_no_controls.date_column,
+        *mmm_fitted_no_controls.channel_columns,
+        "y",
+    }
+    if mmm_fitted_no_controls.control_columns:
+        required_columns.update(mmm_fitted_no_controls.control_columns)
+    assert all(col in synth_df.columns for col in required_columns)
+
+    # Check date properties
+    assert pd.api.types.is_datetime64_any_dtype(
+        synth_df[mmm_fitted_no_controls.date_column]
+    )
+    assert len(synth_df[mmm_fitted_no_controls.date_column].unique()) == time_length
+
+    # Check channel values are non-negative (since they represent spend)
+    for channel in mmm_fitted_no_controls.channel_columns:
         assert (synth_df[channel] >= 0).all()
 
     # Check target variable exists and has reasonable values


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->
`
`MMM._create_synth_dataset` does not work in MMMs without controls. 

Note the underscore difference.

Before:
```
        if controls is not None:
            _controls: list[str] = controls
        else:
            controls = []
```

After: 
```
        if controls is not None:
            _controls: list[str] = controls
        else:
            _controls = [] 
```

Added a test and fixtures to test the method in MMMs without controls in the future. 


## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [x] Included tests that prove the fix is effective or that the new feature works

<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->
