### PR TITLE
action to label when a PR is from a bot

### DIFF
--- a/.github/workflows/bot-prs.yml
+++ b/.github/workflows/bot-prs.yml
@@ -2,7 +2,9 @@ name: Bot PRs
 
 on:
   pull_request:
-    types: [opened]
+
+permissions:
+  pull-requests: write
 
 jobs:
   label-no-releasenotes:
@@ -13,8 +15,9 @@ jobs:
         run: |
           number=${{ github.event.pull_request.number }}
           is_bot=$(gh pr view $number --json author --jq '.author.is_bot')
-          if [[ $is_bot == "true" ]]; then
-            gh pr edit $number --add-label "no releasenotes"
-          fi
+          # if [[ $is_bot == "true" ]]; then
+          #   gh pr edit $number --add-label "no releasenotes"
+          # fi
+          gh pr edit $number --add-label "no releasenotes"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/bot-prs.yml
+++ b/.github/workflows/bot-prs.yml
@@ -2,6 +2,7 @@ name: Bot PRs
 
 on:
   pull_request:
+    types: [opened]
 
 jobs:
   label-no-releasenotes:

--- a/.github/workflows/bot-prs.yml
+++ b/.github/workflows/bot-prs.yml
@@ -2,12 +2,12 @@ name: Bot PRs
 
 on:
   pull_request:
-    types: [opened]
 
 jobs:
   label-no-releasenotes:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Label no releasenotes
         run: |
           number=${{ github.event.pull_request.number }}

--- a/.github/workflows/bot-prs.yml
+++ b/.github/workflows/bot-prs.yml
@@ -2,6 +2,7 @@ name: Bot PRs
 
 on:
   pull_request:
+    types: [opened]
 
 permissions:
   pull-requests: write
@@ -15,9 +16,8 @@ jobs:
         run: |
           number=${{ github.event.pull_request.number }}
           is_bot=$(gh pr view $number --json author --jq '.author.is_bot')
-          # if [[ $is_bot == "true" ]]; then
-          #   gh pr edit $number --add-label "no releasenotes"
-          # fi
-          gh pr edit $number --add-label "no releasenotes"
+          if [[ $is_bot == "true" ]]; then
+            gh pr edit $number --add-label "no releasenotes"
+          fi
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/bot-prs.yml
+++ b/.github/workflows/bot-prs.yml
@@ -1,0 +1,19 @@
+name: Bot PRs
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  label-no-releasenotes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label no releasenotes
+        run: |
+          number=${{ github.event.pull_request.number }}
+          is_bot=$(gh pr view $number --json author --jq '.author.is_bot')
+          if [[ $is_bot == "true" ]]; then
+            gh pr edit $number --add-label "no releasenotes"
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

Check for PRs from bots and label with "no releasenotes"

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1520.org.readthedocs.build/en/1520/

<!-- readthedocs-preview pymc-marketing end -->