### PR TITLE
Use SoftPlusHSGP directly in MMM class

### DIFF
--- a/tests/mmm/test_hsgp.py
+++ b/tests/mmm/test_hsgp.py
@@ -27,6 +27,7 @@ from pymc_marketing.mmm.hsgp import (
     CovFunc,
     HSGPPeriodic,
     PeriodicCovFunc,
+    SoftPlusHSGP,
     approx_hsgp_hyperparams,
     create_complexity_penalizing_prior,
 )
@@ -347,3 +348,55 @@ def test_hsgp_with_shared_data():
 
         # prior should have a "f" variable
         assert "f" in prior.prior
+
+
+def test_soft_plus_hsgp_continous_with_new_data() -> None:
+    seed = sum(map(ord, "No jump from in-sample to out-of-sample"))
+    rng = np.random.default_rng(seed)
+    hsgp = SoftPlusHSGP(
+        m=10,
+        L=5,
+        dims="date",
+        ls=Prior("Exponential", lam=1),
+        eta=Prior("Exponential", lam=1),
+    )
+
+    n_points = 100
+    data = np.linspace(0, 10, n_points)
+
+    n_out_of_sample = 1
+    insample = data[: n_points - n_out_of_sample]
+    outsample = data[n_points - n_out_of_sample :]
+
+    prior_samples = 50
+
+    coords = {"date": insample}
+    with pm.Model(coords=coords) as model:
+        X = pm.Data("X", insample, dims="date")
+        hsgp.register_data(X).create_variable("f")
+
+        idata = pm.sample_prior_predictive(prior_samples, random_seed=rng)
+
+    # set posterior as prior for out of sample
+    idata["posterior"] = idata.prior
+
+    with model:
+        pm.set_data({"X": outsample}, coords={"date": outsample})
+
+        idata.extend(
+            pm.sample_posterior_predictive(
+                idata,
+                var_names=["f"],
+                random_seed=rng,
+            )
+        )
+
+    jump = idata.posterior_predictive["f"].isel(date=0) - idata.prior["f"].isel(date=-1)
+    diffs = idata.prior["f"].diff(dim="date")
+
+    q = 0.95
+    threshold = abs(diffs).quantile(q, dim="date")
+    stat = abs(jump) < threshold
+
+    # Approx 95% of the differences should be below the threshold
+    assert stat.mean().item() >= (q - 0.05)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

Use the `SoftPlusHSGP` which correctly handles the out of sample 

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1523.org.readthedocs.build/en/1523/

<!-- readthedocs-preview pymc-marketing end -->