### PR TITLE
Fix the TVP example

### DIFF
--- a/pymc_marketing/mmm/tvp.py
+++ b/pymc_marketing/mmm/tvp.py
@@ -27,29 +27,30 @@ Create a basic PyMC model using the time-varying GP multiplier:
     import numpy as np
     import pymc as pm
     import pandas as pd
+
+    from pymc_marketing.hsgp_kwargs import HSGPKwargs
     from pymc_marketing.mmm.tvp import create_time_varying_gp_multiplier, infer_time_index
 
     # Generate example data
     np.random.seed(0)
-    dates = pd.date_range(start="2020-01-01", periods=365)
+    dates = pd.Series(pd.date_range(start="2020-01-01", periods=365))
     sales = np.random.normal(100, 10, size=len(dates))
 
     # Infer time index
     time_index = infer_time_index(dates, dates, time_resolution=5)
 
     # Define model configuration
-    model_config = {
-        "sales_tvp_config": {
-            "m": 200,
-            "L": None,
-            "eta_lam": 1,
-            "ls_mu": None,
-            "ls_sigma": 5,
-            "cov_func": None,
-        }
-    }
+    hsgp_kwargs = HSGPKwargs(
+        m=200,
+        L=None,
+        eta_lam=1,
+        ls_mu=10,
+        ls_sigma=5,
+        cov_func=None,
+    )
 
-    with pm.Model() as model:
+    coords = {"time": dates}
+    with pm.Model(coords=coords) as model:
         # Shared time index variable
         time_index_shared = pm.Data("time_index", time_index)
 
@@ -63,7 +64,7 @@ Create a basic PyMC model using the time-varying GP multiplier:
             time_index=time_index_shared,
             time_index_mid=int(len(dates) / 2),
             time_resolution=5,
-            model_config=model_config,
+            hsgp_kwargs=hsgp_kwargs,
         )
 
         # Final sales parameter


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

Fix the old module docstring

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1533.org.readthedocs.build/en/1533/

<!-- readthedocs-preview pymc-marketing end -->