### PR TITLE
Getattr support for distributions

### DIFF
--- a/pymc_marketing/prior.py
+++ b/pymc_marketing/prior.py
@@ -99,6 +99,7 @@ from __future__ import annotations
 import copy
 import warnings
 from collections.abc import Callable
+from functools import partial
 from inspect import signature
 from typing import Any, Protocol, runtime_checkable
 
@@ -1342,3 +1343,31 @@ def _is_censored_type(data: dict) -> bool:
 
 register_deserialization(is_type=_is_prior_type, deserialize=Prior.from_dict)
 register_deserialization(is_type=_is_censored_type, deserialize=Censored.from_dict)
+
+
+def __getattr__(name: str):
+    """Get Prior class through the module.
+
+    Examples
+    --------
+    Create a normal distribution.
+
+    .. code-block:: python
+
+        from pymc_marketing.prior import Normal
+
+        dist = Normal(mu=1, sigma=2)
+
+    Create a hierarchical normal distribution.
+
+    .. code-block:: python
+
+        from pymc_marketing import prior as pr
+
+        dist = pr.Normal(mu=pr.Normal(), sigma=pr.HalfNormal(), dims="channel")
+
+        samples = dist.sample_prior(coords={"channel": ["C1", "C2", "C3"]})
+
+    """
+    _get_pymc_distribution(name)
+    return partial(Prior, distribution=name)

--- a/tests/test_prior.py
+++ b/tests/test_prior.py
@@ -24,6 +24,7 @@ from preliz.distributions.distributions import Distribution
 from pydantic import ValidationError
 from pymc.model_graph import fast_eval
 
+from pymc_marketing import prior as pr
 from pymc_marketing.deserialize import (
     DESERIALIZERS,
     deserialize,
@@ -454,7 +455,7 @@ def test_sample_prior() -> None:
     )
 
     coords = {"channel": ["A", "B", "C"]}
-    prior = var.sample_prior(coords=coords, samples=25)
+    prior = var.sample_prior(coords=coords, draws=25)
 
     assert isinstance(prior, xr.Dataset)
     assert prior.sizes == {"chain": 1, "draw": 25, "channel": 3}
@@ -628,7 +629,7 @@ def test_custom_transform() -> None:
     register_tensor_transform(new_transform_name, lambda x: x**2)
 
     dist = Prior("Normal", transform=new_transform_name)
-    prior = dist.sample_prior(samples=10)
+    prior = dist.sample_prior(draws=10)
     df_prior = prior.to_dataframe()
 
     np.testing.assert_array_equal(
@@ -641,7 +642,7 @@ def test_custom_transform_comes_first() -> None:
     register_tensor_transform("square", lambda x: 2 * x)
 
     dist = Prior("Normal", transform="square")
-    prior = dist.sample_prior(samples=10)
+    prior = dist.sample_prior(draws=10)
     df_prior = prior.to_dataframe()
 
     np.testing.assert_array_equal(
@@ -742,7 +743,7 @@ def test_censored_sample_prior() -> None:
     censored_normal = Censored(normal, lower=0)
 
     coords = {"channel": ["A", "B", "C"]}
-    prior = censored_normal.sample_prior(coords=coords, samples=25)
+    prior = censored_normal.sample_prior(coords=coords, draws=25)
 
     assert isinstance(prior, xr.Dataset)
     assert prior.sizes == {"chain": 1, "draw": 25, "channel": 3}
@@ -1024,3 +1025,20 @@ def test_from_json_deprecation() -> None:
     match = "The `from_json` method is deprecated"
     with pytest.warns(DeprecationWarning, match=match):
         Prior.from_json(data)
+
+
+def test_getattr() -> None:
+    dist = pr.Normal(mu=0, sigma=1)
+
+    assert dist == Prior("Normal", mu=0, sigma=1)
+
+
+def test_import_distribution() -> None:
+    from pymc_marketing.prior import Normal
+
+    assert Normal() == Prior("Normal")
+
+
+def test_import_distribution_error() -> None:
+    with pytest.raises(UnsupportedDistributionError):
+        from pymc_marketing.prior import Invalid  # noqa: F401


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

This is a convenience which allows users to use the prior class in a familiar way to pymc and preliz

For example, 

```python
import pymc_marketing.prior as pr
import pymc as pm
import preliz as pz

dist = pr.Normal(mu=0, sigma=1) # Prior("Normal", mu=0, sigma=1)
# which is similar to 
pm.Normal.dist(mu=0, sigma=1)
pz.Normal(mu=0, sigma=1)
```

Can also import directly. For instance: 

```python
from pymc_marketing.prior import Normal, Gamma
```

Then when using:

```python
dist = pr.Normal(
    mu=pr.Normal(mu=0, sigma=1),
    sigma=pr.Gamma(mu=1, sigma=0.25),
    dims="geo",
)
```

Doesn't change any functionality but creates a new way to create the priors

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1534.org.readthedocs.build/en/1534/

<!-- readthedocs-preview pymc-marketing end -->