### PR TITLE
Revert "Getattr support for distributions"

### DIFF
--- a/pymc_marketing/prior.py
+++ b/pymc_marketing/prior.py
@@ -99,7 +99,6 @@ from __future__ import annotations
 import copy
 import warnings
 from collections.abc import Callable
-from functools import partial
 from inspect import signature
 from typing import Any, Protocol, runtime_checkable
 
@@ -1343,31 +1342,3 @@ def _is_censored_type(data: dict) -> bool:
 
 register_deserialization(is_type=_is_prior_type, deserialize=Prior.from_dict)
 register_deserialization(is_type=_is_censored_type, deserialize=Censored.from_dict)
-
-
-def __getattr__(name: str):
-    """Get Prior class through the module.
-
-    Examples
-    --------
-    Create a normal distribution.
-
-    .. code-block:: python
-
-        from pymc_marketing.prior import Normal
-
-        dist = Normal(mu=1, sigma=2)
-
-    Create a hierarchical normal distribution.
-
-    .. code-block:: python
-
-        from pymc_marketing import prior as pr
-
-        dist = pr.Normal(mu=pr.Normal(), sigma=pr.HalfNormal(), dims="channel")
-
-        samples = dist.sample_prior(coords={"channel": ["C1", "C2", "C3"]})
-
-    """
-    _get_pymc_distribution(name)
-    return partial(Prior, distribution=name)

--- a/tests/test_prior.py
+++ b/tests/test_prior.py
@@ -24,7 +24,6 @@ from preliz.distributions.distributions import Distribution
 from pydantic import ValidationError
 from pymc.model_graph import fast_eval
 
-from pymc_marketing import prior as pr
 from pymc_marketing.deserialize import (
     DESERIALIZERS,
     deserialize,
@@ -455,7 +454,7 @@ def test_sample_prior() -> None:
     )
 
     coords = {"channel": ["A", "B", "C"]}
-    prior = var.sample_prior(coords=coords, draws=25)
+    prior = var.sample_prior(coords=coords, samples=25)
 
     assert isinstance(prior, xr.Dataset)
     assert prior.sizes == {"chain": 1, "draw": 25, "channel": 3}
@@ -629,7 +628,7 @@ def test_custom_transform() -> None:
     register_tensor_transform(new_transform_name, lambda x: x**2)
 
     dist = Prior("Normal", transform=new_transform_name)
-    prior = dist.sample_prior(draws=10)
+    prior = dist.sample_prior(samples=10)
     df_prior = prior.to_dataframe()
 
     np.testing.assert_array_equal(
@@ -642,7 +641,7 @@ def test_custom_transform_comes_first() -> None:
     register_tensor_transform("square", lambda x: 2 * x)
 
     dist = Prior("Normal", transform="square")
-    prior = dist.sample_prior(draws=10)
+    prior = dist.sample_prior(samples=10)
     df_prior = prior.to_dataframe()
 
     np.testing.assert_array_equal(
@@ -743,7 +742,7 @@ def test_censored_sample_prior() -> None:
     censored_normal = Censored(normal, lower=0)
 
     coords = {"channel": ["A", "B", "C"]}
-    prior = censored_normal.sample_prior(coords=coords, draws=25)
+    prior = censored_normal.sample_prior(coords=coords, samples=25)
 
     assert isinstance(prior, xr.Dataset)
     assert prior.sizes == {"chain": 1, "draw": 25, "channel": 3}
@@ -1025,20 +1024,3 @@ def test_from_json_deprecation() -> None:
     match = "The `from_json` method is deprecated"
     with pytest.warns(DeprecationWarning, match=match):
         Prior.from_json(data)
-
-
-def test_getattr() -> None:
-    dist = pr.Normal(mu=0, sigma=1)
-
-    assert dist == Prior("Normal", mu=0, sigma=1)
-
-
-def test_import_distribution() -> None:
-    from pymc_marketing.prior import Normal
-
-    assert Normal() == Prior("Normal")
-
-
-def test_import_distribution_error() -> None:
-    with pytest.raises(UnsupportedDistributionError):
-        from pymc_marketing.prior import Invalid  # noqa: F401


### PR DESCRIPTION
Reverts pymc-labs/pymc-marketing#1534, to test  https://github.com/pymc-labs/pymc-marketing/issues/1539

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1541.org.readthedocs.build/en/1541/

<!-- readthedocs-preview pymc-marketing end -->