### PR TITLE
Fix SoftPlusHSGP out of sample

### DIFF
--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -16,5 +16,6 @@
   mmm
   model_builder
   model_config
+  model_graph
   prior
 ```

--- a/pymc_marketing/mmm/hsgp.py
+++ b/pymc_marketing/mmm/hsgp.py
@@ -261,7 +261,8 @@ class HSGPBase(BaseModel):
     X_mid: float | None = Field(None, description="The mean of the training data")
     dims: Dims = Field(..., description="The dimensions of the variable")
 
-    def deterministics_to_replace(self, name: str) -> list[str]:
+    @staticmethod
+    def deterministics_to_replace(name: str) -> list[str]:
         """Name of the deterministics variables that will have to be replaced in the pm.Model."""
         return []
 
@@ -1144,7 +1145,8 @@ class SoftPlusHSGP(HSGP):
         plt.show()
     """
 
-    def deterministics_to_replace(self, name: str) -> list[str]:
+    @staticmethod
+    def deterministics_to_replace(name: str) -> list[str]:
         """Name of the deterministics variables that will have to be replaced in the pm.Model."""
         return [f"{name}_f_mean"]
 

--- a/pymc_marketing/mmm/hsgp.py
+++ b/pymc_marketing/mmm/hsgp.py
@@ -263,7 +263,12 @@ class HSGPBase(BaseModel):
 
     @staticmethod
     def deterministics_to_replace(name: str) -> list[str]:
-        """Name of the deterministics variables that will have to be replaced in the pm.Model."""
+        """Name of the Deterministic variables that are replaced with pm.Flat for out-of-sample.
+
+        This is required for out-of-sample predictions for some HSGP variables. Replacing with
+        pm.Flat will sample from the values learned in the training data.
+
+        """
         return []
 
     def register_data(self, X: TensorLike) -> Self:
@@ -1154,7 +1159,13 @@ class SoftPlusHSGP(HSGP):
 
     @staticmethod
     def deterministics_to_replace(name: str) -> list[str]:
-        """Name of the deterministics variables that will have to be replaced in the pm.Model."""
+        """Name of the Deterministic variables that are replaced with pm.Flat for out-of-sample.
+
+        This is required for in order to keep out-of-sample predictions use mean of 1.0
+        from the training set. Without this, the training and test data will not be
+        continuous, showing a jump from the training data to the test data.
+
+        """
         return [f"{name}_f_mean"]
 
     def create_variable(self, name: str) -> TensorVariable:

--- a/pymc_marketing/model_builder.py
+++ b/pymc_marketing/model_builder.py
@@ -642,6 +642,10 @@ class ModelBuilder(ABC):
 
         return xr.merge([X, y])
 
+    def post_sample_model_transformation(self) -> None:
+        """Perform transformation on the model after sampling."""
+        return
+
     def fit(
         self,
         X: pd.DataFrame | xr.Dataset | xr.DataArray,
@@ -706,6 +710,8 @@ class ModelBuilder(ABC):
         )
         with self.model:
             idata = pm.sample(**sampler_kwargs)
+
+        self.post_sample_model_transformation()
 
         if self.idata:
             self.idata = self.idata.copy()

--- a/pymc_marketing/model_builder.py
+++ b/pymc_marketing/model_builder.py
@@ -561,6 +561,7 @@ class ModelBuilder(ABC):
 
         model.idata = idata
         model.build_from_idata(idata)
+        model.post_sample_model_transformation()
 
         if model.id != idata.attrs["id"]:
             msg = (

--- a/pymc_marketing/model_graph.py
+++ b/pymc_marketing/model_graph.py
@@ -1,0 +1,72 @@
+#   Copyright 2022 - 2025 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Functions to manipulate PyMC models as graphs."""
+
+import pymc as pm
+from pymc.model.fgraph import (
+    extract_dims,
+    fgraph_from_model,
+    model_free_rv,
+    model_from_fgraph,
+)
+from pymc.pytensorf import toposort_replace
+from pytensor.graph import rewrite_graph
+from pytensor.tensor.basic import infer_shape_db
+
+
+def deterministics_to_flat(model, names):
+    """Replace all Deterministics in a model with Flat.
+
+    Parameters
+    ----------
+    model : pm.Model
+        PyMC model to be transformed
+    names : list[str]
+        Names of the deterministic variables to be replaced by flat
+
+    Returns
+    -------
+    new_model : pm.Model
+        New model with all priors replaced by flat priors
+    """
+    fg, memo = fgraph_from_model(model, inlined_views=True)
+
+    model_variables = [x for x in set(model.deterministics) if x.name in names]
+    replacements = {}
+
+    for variable in model_variables:
+        model_var = memo[variable]
+        dims = extract_dims(model_var)
+
+        new_rv = pm.Flat.dist(shape=model_var.shape)
+        new_rv.name = model_var.name
+
+        replacements[model_var] = model_free_rv(
+            new_rv,
+            new_rv.type(name=model_var.name),
+            None,
+            *dims,
+        )
+
+    toposort_replace(fg, replacements=tuple(replacements.items()))
+    fg = rewrite_graph(
+        fg,
+        include=("ShapeOpt",),
+        custom_rewrite=infer_shape_db.default_query,
+        clone=False,
+    )
+
+    new_model = model_from_fgraph(fg, mutate_fgraph=True)
+
+    return new_model

--- a/pymc_marketing/model_graph.py
+++ b/pymc_marketing/model_graph.py
@@ -25,8 +25,16 @@ from pytensor.graph import rewrite_graph
 from pytensor.tensor.basic import infer_shape_db
 
 
-def deterministics_to_flat(model, names):
+def deterministics_to_flat(model: pm.Model, names: list[str]) -> pm.Model:
     """Replace all specified Deterministic nodes in a pm.Model with Flat.
+
+    This is useful to capture some state from a model and to then sample from
+    the model using that state. For example, capturing the mean of a distribution
+    or a value of a deterministic variable.
+
+    See :class:`pymc_marketing.mmm.hsgp.SoftPlusHSGP` for an example of how this
+    is used to keep a variable centered around 1.0 during sampling but stay continuous
+    with new values.
 
     Parameters
     ----------
@@ -42,7 +50,7 @@ def deterministics_to_flat(model, names):
 
     Examples
     --------
-    Use on a toy model:
+    Replace single Deterministic with Flat and sample as if it were zeros.
 
     .. code-block:: python
 
@@ -68,6 +76,7 @@ def deterministics_to_flat(model, names):
             model=new_model,
             var_names=["x", "z"],
         ).posterior_predictive
+
         np.testing.assert_allclose(
             x_z_given_y["x"],
             x_z_given_y["z"],

--- a/tests/mmm/test_hsgp.py
+++ b/tests/mmm/test_hsgp.py
@@ -31,6 +31,7 @@ from pymc_marketing.mmm.hsgp import (
     approx_hsgp_hyperparams,
     create_complexity_penalizing_prior,
 )
+from pymc_marketing.model_graph import deterministics_to_flat
 from pymc_marketing.prior import Prior
 
 
@@ -380,7 +381,7 @@ def test_soft_plus_hsgp_continous_with_new_data() -> None:
     # set posterior as prior for out of sample
     idata["posterior"] = idata.prior
 
-    with model:
+    with deterministics_to_flat(model, names=hsgp.deterministics_to_replace("f")):
         pm.set_data({"X": outsample}, coords={"date": outsample})
 
         idata.extend(

--- a/tests/mmm/test_mmm.py
+++ b/tests/mmm/test_mmm.py
@@ -1379,7 +1379,11 @@ def test_initialize_defaults_channel_media_dims() -> None:
     ],
 )
 def test_save_load_with_tvp(
-    time_varying_intercept, time_varying_media, toy_X, toy_y
+    time_varying_intercept,
+    time_varying_media,
+    toy_X,
+    toy_y,
+    mock_pymc_sample,
 ) -> None:
     adstock = GeometricAdstock(l_max=5)
     saturation = LogisticSaturation()
@@ -1403,6 +1407,19 @@ def test_save_load_with_tvp(
 
     # clean up
     os.remove(file)
+
+    expected_flats = []
+    if time_varying_intercept:
+        expected_flats.append("intercept_temporal_latent_multiplier_f_mean")
+    if time_varying_media:
+        expected_flats.append("media_temporal_latent_multiplier_f_mean")
+
+    def get_random_variable_name(var):
+        return var.owner.op.__class__.__name__
+
+    for free_RV in loaded_mmm.model.free_RVs:
+        if free_RV.name in expected_flats:
+            assert get_random_variable_name(free_RV) == "FlatRV"
 
 
 class CustomSaturation(SaturationTransformation):

--- a/tests/test_model_graph.py
+++ b/tests/test_model_graph.py
@@ -1,0 +1,69 @@
+#   Copyright 2022 - 2025 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+import pymc as pm
+import pytest
+from pymc.model_graph import ModelGraph
+
+from pymc_marketing.model_graph import deterministics_to_flat
+
+
+@pytest.fixture
+def toy_model() -> pm.Model:
+    coords = {"time": [1, 2, 3], "covariate": ["A", "B"]}
+    with pm.Model(coords=coords) as model:
+        x = pm.Normal("x", dims=("time", "covariate"))
+        x_mean = pm.Deterministic("x_mean", x.mean(axis=0), dims="covariate")
+        pm.Deterministic("centered", x - x_mean, dims=("time", "covariate"))
+
+    return model
+
+
+@pytest.fixture
+def toy_model_given_x_mean(toy_model):
+    return deterministics_to_flat(toy_model, ["x_mean"])
+
+
+def test_original_model_is_not_modified(toy_model):
+    assert toy_model.deterministics == [
+        toy_model["x_mean"],
+        toy_model["centered"],
+    ]
+    assert toy_model.free_RVs == [toy_model["x"]]
+    model_graph = ModelGraph(toy_model)
+    compute_graph = model_graph.make_compute_graph()
+    assert compute_graph == {
+        "x": set(),
+        "x_mean": {"x"},
+        "centered": {"x", "x_mean"},
+    }
+
+
+def get_rv_class_name(var):
+    return var.owner.op.__class__.__name__
+
+
+def test_is_flat_distribution(toy_model_given_x_mean):
+    x_mean = toy_model_given_x_mean["x_mean"]
+    assert get_rv_class_name(x_mean) == "FlatRV"
+
+
+def test_no_inputs(toy_model_given_x_mean):
+    model_graph = ModelGraph(toy_model_given_x_mean)
+    compute_graph = model_graph.make_compute_graph()
+
+    assert compute_graph == {
+        "x": set(),
+        "x_mean": set(),
+        "centered": {"x", "x_mean"},
+    }


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

Using `eval` in a model will be different upon rebuilds. Initially thought to be a solution to the out of sample bug fix. Yes, this makes it continuous, but it doesn't hold the property that the mean is 1.0

See Jesse's example gist showing how using `eval` is wrong: https://gist.github.com/jessegrabowski/5d30a470102b7faaec428f7c7bc723e1

The difference is that instead of rebuilding the model, we use the `deterministics_to_flat` function to change the specific deterministics. The values from training are then sampled via the `pm.Flat`.

This affects both `MMM` classes since they use the `SoftPlusHSGP` class.

TODO: 

- [x] Modify the graph of the MMM after doing `fit` or upon `predict` method. I lean toward after `fit` however, this will make the model samplable only once...

- [x] Build correct graph upon load to have the Flats instead of the Deterministics
- [ ] Additional tests and documentation

Any thoughts on this?

@jessegrabowski @cetagostini @juanitorduz


## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1544.org.readthedocs.build/en/1544/

<!-- readthedocs-preview pymc-marketing end -->