### PR TITLE
Speed up the CLV test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,10 +32,16 @@ jobs:
       matrix:
         config: [ {python-version: "3.10", oldest-pymc: false}, {python-version: "3.12", oldest-pymc: true}]
         split:
+          - "--ignore tests/mmm --ignore tests/clv"
           - "tests/mmm --ignore tests/mmm/test_tvp.py --ignore tests/mmm/test_budget_optimizer.py --ignore tests/mmm/test_hsgp.py --ignore tests/mmm/test_transformers.py"
           - "tests/mmm/test_tvp.py tests/mmm/test_budget_optimizer.py tests/mmm/test_hsgp.py tests/mmm/test_transformers.py"
-          - "tests/clv"
-          - "--ignore tests/mmm --ignore tests/clv"
+          - "tests/clv/models/test_pareto_nbd.py"
+          - "tests/clv/models/test_beta_geo_beta_binom.py"
+          - "tests/clv/models/test_beta_geo.py"
+          - "tests/clv/models/test_shifted_beta_geo.py"
+          - "tests/clv/models/test_basic.py"
+          - "tests/clv/test_distributions.py"
+          - "tests/clv/ --ignore=tests/clv/models/test_pareto_nbd.py --ignore=tests/clv/models/test_beta_geo_beta_binom.py --ignore=tests/clv/models/test_beta_geo.py --ignore=tests/clv/models/test_shifted_beta_geo.py --ignore=tests/clv/models/test_basic.py --ignore=tests/clv/test_distributions.py"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/tests/clv/models/test_basic.py
+++ b/tests/clv/models/test_basic.py
@@ -159,7 +159,7 @@ class TestCLVModel:
         ):
             model.fit(method="wrong_method")
 
-    def test_fit_exception(self):
+    def test_fit_exception(self, mock_pymc_sample):
         model = CLVModelTest()
         with pytest.warns(
             DeprecationWarning,

--- a/tests/clv/models/test_pareto_nbd.py
+++ b/tests/clv/models/test_pareto_nbd.py
@@ -392,7 +392,7 @@ class TestParetoNBDModel:
         assert self.model.idata == loaded_model.idata
         os.remove("test_model")
 
-    def test_fit_exception(self):
+    def test_fit_exception(self, mock_pymc_sample):
         with pytest.warns(
             DeprecationWarning,
             match=(


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

- Breaking up the tests by file as they were taking 16mins 
- Not using actual sample if not need

CC: @ColtAllen

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1558.org.readthedocs.build/en/1558/

<!-- readthedocs-preview pymc-marketing end -->