### PR TITLE
Specify target scaling dimensions

### DIFF
--- a/pymc_marketing/mmm/multidimensional.py
+++ b/pymc_marketing/mmm/multidimensional.py
@@ -196,7 +196,11 @@ def create_event_mu_effect(
 
 
 class VariableScaling(BaseModel):
-    """How to scale a variable."""
+    """How to scale a variable.
+
+    The scaling through the dimension of 'date' is assumed and doesn't need to be specified.
+
+    """
 
     method: Literal["max", "mean"] = Field(..., description="The scaling method.")
     dims: str | tuple[str, ...] = Field(
@@ -219,7 +223,25 @@ class VariableScaling(BaseModel):
 
 
 class Scaling(BaseModel):
-    """Scaling configuration for the MMM."""
+    """Scaling configuration for the MMM.
+
+    Examples
+    --------
+    Scale the target variable by max value by group of 'DMA'
+
+    .. code-block:: python
+
+        from pymc_marketing.mmm.multidimensional import Scaling
+
+        scaling = Scaling(**{
+            "target": {
+                "method": "max",
+                # Exclude 'DMA' from dims here.
+                "dims": (),
+            },
+        })
+
+    """
 
     target: VariableScaling = Field(
         ...,

--- a/pymc_marketing/mmm/scaling.py
+++ b/pymc_marketing/mmm/scaling.py
@@ -1,4 +1,4 @@
-#   Copyright 2025 - 2025 The PyMC Labs Developers
+#   Copyright 2022 - 2025 The PyMC Labs Developers
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/pymc_marketing/mmm/scaling.py
+++ b/pymc_marketing/mmm/scaling.py
@@ -1,0 +1,73 @@
+#   Copyright 2025 - 2025 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Scaling configuration for the MMMM."""
+
+from typing import Literal
+
+from pydantic import BaseModel, Field, model_validator
+from typing_extensions import Self
+
+
+class VariableScaling(BaseModel):
+    """How to scale a variable.
+
+    The scaling through the dimension of 'date' is assumed and doesn't need to be specified.
+
+    """
+
+    method: Literal["max", "mean"] = Field(..., description="The scaling method.")
+    dims: str | tuple[str, ...] = Field(
+        ...,
+        description="The dimensions to perform operation through.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_dims(self) -> Self:
+        if isinstance(self.dims, str):
+            self.dims = (self.dims,)
+
+        if "date" in self.dims:
+            raise ValueError("dim of 'date' of is already assumed in the model.")
+
+        if len(set(self.dims)) != len(self.dims):
+            raise ValueError("dims must be unique.")
+
+        return self
+
+
+class Scaling(BaseModel):
+    """Scaling configuration for the MMM.
+
+    Examples
+    --------
+    Scale the target variable by max value by group of 'DMA'
+
+    .. code-block:: python
+
+        from pymc_marketing.mmm.multidimensional import Scaling
+
+        scaling = Scaling(**{
+            "target": {
+                "method": "max",
+                # Exclude 'DMA' from dims here.
+                "dims": (),
+            },
+        })
+
+    """
+
+    target: VariableScaling = Field(
+        ...,
+        description="The scaling for the target variable.",
+    )

--- a/tests/mmm/test_multidimensional.py
+++ b/tests/mmm/test_multidimensional.py
@@ -577,11 +577,11 @@ def test_check_for_incompatible_dims(adstock, saturation, dims) -> None:
 
 def test_different_target_scaling(multi_dim_data, mock_pymc_sample) -> None:
     X, y = multi_dim_data
-    target_scaling = {"method": "mean", "dims": ()}
+    scaling = {"target": {"method": "mean", "dims": ()}}
     mmm = MMM(
         adstock=GeometricAdstock(l_max=2),
         saturation=LogisticSaturation(),
-        target_scaling=target_scaling,
+        scaling=scaling,
         date_column="date",
         target_column="target",
         channel_columns=["channel_1", "channel_2"],
@@ -593,13 +593,13 @@ def test_different_target_scaling(multi_dim_data, mock_pymc_sample) -> None:
 
 
 def test_target_scaling_raises() -> None:
-    target_scaling = {"method": "mean", "dims": ("country",)}
-    match = "target_scaling dims"
+    scaling = {"target": {"method": "mean", "dims": ("country",)}}
+    match = "Target scaling dims"
     with pytest.raises(ValueError, match=match):
         MMM(
             adstock=GeometricAdstock(l_max=2),
             saturation=LogisticSaturation(),
-            target_scaling=target_scaling,
+            scaling=scaling,
             date_column="date",
             target_column="target",
             channel_columns=["channel_1", "channel_2"],

--- a/tests/mmm/test_multidimensional.py
+++ b/tests/mmm/test_multidimensional.py
@@ -222,6 +222,25 @@ def test_fit(
 
     idata = mmm.fit(X, y, random_seed=random_seed)
 
+    def normalization(data):
+        return data.div(data.max())
+
+    def unstack(data, name):
+        if not name:
+            return data
+
+        return data.unstack(name)
+
+    actual = mmm.model["target_scaled"].eval()
+    expected = (
+        mmm.xarray_dataset._target.to_series()
+        .pipe(normalization)
+        .pipe(unstack, name=None if not dims else dims[0])
+        .values
+    )
+
+    np.testing.assert_allclose(actual, expected)
+
     # Assertions
     assert hasattr(mmm, "model"), "Model attribute should be set after build_model."
     assert isinstance(mmm.model, pm.Model), "mmm.model should be a PyMC Model instance."

--- a/tests/mmm/test_multidimensional.py
+++ b/tests/mmm/test_multidimensional.py
@@ -26,9 +26,9 @@ from pymc_marketing.mmm import GeometricAdstock, LogisticSaturation
 from pymc_marketing.mmm.events import EventEffect, GaussianBasis
 from pymc_marketing.mmm.multidimensional import (
     MMM,
-    VariableScaling,
     create_event_mu_effect,
 )
+from pymc_marketing.mmm.scaling import VariableScaling
 from pymc_marketing.prior import Prior
 
 

--- a/tests/mmm/test_multidimensional.py
+++ b/tests/mmm/test_multidimensional.py
@@ -24,7 +24,11 @@ from pytensor.tensor.basic import TensorVariable
 
 from pymc_marketing.mmm import GeometricAdstock, LogisticSaturation
 from pymc_marketing.mmm.events import EventEffect, GaussianBasis
-from pymc_marketing.mmm.multidimensional import MMM, create_event_mu_effect
+from pymc_marketing.mmm.multidimensional import (
+    MMM,
+    VariableScaling,
+    create_event_mu_effect,
+)
 from pymc_marketing.prior import Prior
 
 
@@ -587,6 +591,7 @@ def test_different_target_scaling(multi_dim_data, mock_pymc_sample) -> None:
         channel_columns=["channel_1", "channel_2"],
         dims=("country",),
     )
+    assert mmm.scaling.target == VariableScaling(method="mean", dims=())
     mmm.fit(X, y)
     assert mmm.xarray_dataset._target.dims == ("date", "country")
     assert mmm.scalers._target.dims == ("country",)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

This allows a user to specify the `scaling` parameter 

```python
from pymc_marketing.mmm.multidimensional import MMM

mmm = MMM(..., 
    dims=("DMA", "product"),
    scaling={
        "target": {
            # Take max through DMA (and date) 
            "method": "max",
            "dims": ("DMA", )
        },
    },
)
```

The dims are where the operation is done through. So specifying dims = DMA results in DMA not being included. Maybe the parameterization of this 
should be the opposite, the dims are the ones that will be result `mmm.scalers`


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1562.org.readthedocs.build/en/1562/

<!-- readthedocs-preview pymc-marketing end -->