### PR TITLE
1570 target scaled and variable need to be broadcasted with non global scaling

### DIFF
--- a/pymc_marketing/mmm/multidimensional.py
+++ b/pymc_marketing/mmm/multidimensional.py
@@ -933,10 +933,17 @@ class MMM(ModelBuilder):
         with self.model:
             for v in var:
                 self._validate_contribution_variable(v)
+                dims = self.model.named_vars_to_dims[v]
+                dim_handler = create_dim_handler(dims)
+
                 pm.Deterministic(
                     name=v + "_original_scale",
-                    var=self.model[v] * self.model["target_scale"],
-                    dims=self.model.named_vars_to_dims[v],
+                    var=self.model[v]
+                    * dim_handler(
+                        self.model["target_scale"],
+                        self.scalers._target.dims,
+                    ),
+                    dims=dims,
                 )
 
     def build_model(

--- a/tests/mmm/test_multidimensional.py
+++ b/tests/mmm/test_multidimensional.py
@@ -647,3 +647,36 @@ def test_target_scaling_raises() -> None:
             target_column="target",
             channel_columns=["channel_1", "channel_2"],
         )
+
+
+@pytest.mark.parametrize("dims", [(), ("country",)], ids=["global", "country-level"])
+def test_target_scaling_and_contributions(
+    multi_dim_data,
+    dims,
+    mock_pymc_sample,
+) -> None:
+    X, y = multi_dim_data
+
+    scaling = {"target": {"method": "mean", "dims": dims}}
+    mmm = MMM(
+        adstock=GeometricAdstock(l_max=2),
+        saturation=LogisticSaturation(),
+        scaling=scaling,
+        date_column="date",
+        target_column="target",
+        channel_columns=["channel_1", "channel_2"],
+        dims=("country",),
+    )
+
+    var_names = ["channel_contribution", "intercept_contribution", "y"]
+    mmm.build_model(X, y)
+    mmm.add_original_scale_contribution_variable(var=var_names)
+
+    for var in var_names:
+        new_var_name = f"{var}_original_scale"
+        assert new_var_name in mmm.model.named_vars
+
+    try:
+        mmm.fit(X, y)
+    except Exception as e:
+        pytest.fail(f"Unexpected error: {e}")

--- a/tests/mmm/test_multidimensional.py
+++ b/tests/mmm/test_multidimensional.py
@@ -649,7 +649,7 @@ def test_target_scaling_raises() -> None:
         )
 
 
-@pytest.mark.parametrize("dims", [(), ("country",)], ids=["global", "country-level"])
+@pytest.mark.parametrize("dims", [(), ("country",)], ids=["country-level", "global"])
 def test_target_scaling_and_contributions(
     multi_dim_data,
     dims,


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

This allows the user to use the non-global scaling with the `add_original_scale_contribution_variable` method. The broadcasting was missing

- **add checks for original_scale_contributions**
- **handle the broadcasting**

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #1570
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1571.org.readthedocs.build/en/1571/

<!-- readthedocs-preview pymc-marketing end -->