### PR TITLE
Allow for media scaling settings

### DIFF
--- a/pymc_marketing/mmm/multidimensional.py
+++ b/pymc_marketing/mmm/multidimensional.py
@@ -1077,6 +1077,7 @@ class MMM(ModelBuilder):
                 _channel_scale,
                 self.scalers._channel.dims,
             )
+            channel_data_ = pt.switch(pt.isnan(channel_data_), 0.0, channel_data_)
             channel_data_.name = "channel_data_scaled"
             channel_data_.dims = ("date", *self.dims, "channel")
 

--- a/pymc_marketing/mmm/multidimensional.py
+++ b/pymc_marketing/mmm/multidimensional.py
@@ -287,9 +287,9 @@ class MMM(ModelBuilder):
                 f"Target scaling dims {self.scaling.target.dims} must contain {self.dims} and 'date'"
             )
 
-        if set(self.scaling.channel.dims).difference([*self.dims, "date"]):
+        if set(self.scaling.channel.dims).difference([*self.dims, "channel", "date"]):
             raise ValueError(
-                f"Channel scaling dims {self.scaling.channel.dims} must contain {self.dims} and 'date'"
+                f"Channel scaling dims {self.scaling.channel.dims} must contain {self.dims}, 'channel', and 'date'"
             )
 
         model_config = model_config if model_config is not None else {}

--- a/pymc_marketing/mmm/multidimensional.py
+++ b/pymc_marketing/mmm/multidimensional.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import warnings
+from copy import deepcopy
 from typing import Any, Literal, Protocol
 
 import arviz as az
@@ -267,15 +268,28 @@ class MMM(ModelBuilder):
         self.dims = dims
 
         if isinstance(scaling, dict):
+            scaling = deepcopy(scaling)
+
+            if "channel" not in scaling:
+                scaling["channel"] = VariableScaling(method="max", dims=self.dims)
+            if "target" not in scaling:
+                scaling["target"] = VariableScaling(method="max", dims=self.dims)
+
             scaling = Scaling(**scaling)
 
         self.scaling: Scaling = scaling or Scaling(
-            target=VariableScaling(method="max", dims=self.dims)
+            target=VariableScaling(method="max", dims=self.dims),
+            channel=VariableScaling(method="max", dims=self.dims),
         )
 
         if set(self.scaling.target.dims).difference([*self.dims, "date"]):
             raise ValueError(
                 f"Target scaling dims {self.scaling.target.dims} must contain {self.dims} and 'date'"
+            )
+
+        if set(self.scaling.channel.dims).difference([*self.dims, "date"]):
+            raise ValueError(
+                f"Channel scaling dims {self.scaling.channel.dims} must contain {self.dims} and 'date'"
             )
 
         model_config = model_config if model_config is not None else {}
@@ -864,11 +878,21 @@ class MMM(ModelBuilder):
 
     def _compute_scales(self) -> None:
         """Compute and save scaling factors for channels and target."""
-        method = getattr(self.xarray_dataset, self.scaling.target.method)
-        self.scalers = method(dim=("date", *self.dims))
-        self.scalers["_target"] = method(dim=("date", *self.scaling.target.dims))[
-            "_target"
-        ]
+        self.scalers = xr.Dataset()
+
+        channel_method = getattr(
+            self.xarray_dataset["_channel"],
+            self.scaling.channel.method,
+        )
+        self.scalers["_channel"] = channel_method(
+            dim=("date", *self.scaling.channel.dims)
+        )
+
+        target_method = getattr(
+            self.xarray_dataset["_target"],
+            self.scaling.target.method,
+        )
+        self.scalers["_target"] = target_method(dim=("date", *self.scaling.target.dims))
 
     def get_scales_as_xarray(self) -> dict[str, xr.DataArray]:
         """Return the saved scaling factors as xarray DataArrays.
@@ -1023,7 +1047,7 @@ class MMM(ModelBuilder):
             _channel_scale = pm.Data(
                 "channel_scale",
                 self.scalers._channel.values,
-                dims="channel",
+                dims=self.scalers._channel.dims,
             )
             _target_scale = pm.Data(
                 "target_scale",
@@ -1048,7 +1072,11 @@ class MMM(ModelBuilder):
             )
 
             # Scale `channel_data` and `target`
-            channel_data_ = _channel_data / _channel_scale
+            channel_dim_handler = create_dim_handler(("date", *self.dims, "channel"))
+            channel_data_ = _channel_data / channel_dim_handler(
+                _channel_scale,
+                self.scalers._channel.dims,
+            )
             channel_data_.name = "channel_data_scaled"
             channel_data_.dims = ("date", *self.dims, "channel")
 

--- a/pymc_marketing/mmm/scaling.py
+++ b/pymc_marketing/mmm/scaling.py
@@ -71,3 +71,7 @@ class Scaling(BaseModel):
         ...,
         description="The scaling for the target variable.",
     )
+    channel: VariableScaling = Field(
+        ...,
+        description="The scaling for the channel variable.",
+    )

--- a/tests/mmm/test_multidimensional.py
+++ b/tests/mmm/test_multidimensional.py
@@ -123,12 +123,14 @@ def single_dim_data():
     # Generate random channel data
     channel_1 = np.random.randint(100, 500, size=len(date_range))
     channel_2 = np.random.randint(100, 500, size=len(date_range))
+    channel_3 = np.nan
 
     df = pd.DataFrame(
         {
             "date": date_range,
             "channel_1": channel_1,
             "channel_2": channel_2,
+            "channel_3": channel_3,
         }
     )
     # Target is sum of channels with noise
@@ -137,7 +139,7 @@ def single_dim_data():
         + df["channel_2"]
         + np.random.randint(100, 300, size=len(date_range))
     )
-    X = df[["date", "channel_1", "channel_2"]].copy()
+    X = df[["date", "channel_1", "channel_2", "channel_3"]].copy()
 
     return X, df.set_index(["date"])["target"].copy()
 
@@ -161,14 +163,16 @@ def multi_dim_data():
         for date in date_range:
             channel_1 = np.random.randint(100, 500)
             channel_2 = np.random.randint(100, 500)
+            channel_3 = np.nan
             target = channel_1 + channel_2 + np.random.randint(50, 150)
-            records.append((date, country, channel_1, channel_2, target))
+            records.append((date, country, channel_1, channel_2, channel_3, target))
 
     df = pd.DataFrame(
-        records, columns=["date", "country", "channel_1", "channel_2", "target"]
+        records,
+        columns=["date", "country", "channel_1", "channel_2", "channel_3", "target"],
     )
 
-    X = df[["date", "country", "channel_1", "channel_2"]].copy()
+    X = df[["date", "country", "channel_1", "channel_2", "channel_3"]].copy()
 
     return X, df["target"].copy()
 
@@ -208,7 +212,7 @@ def test_fit(
     mmm = MMM(
         date_column="date",
         target_column="target",
-        channel_columns=["channel_1", "channel_2"],
+        channel_columns=["channel_1", "channel_2", "channel_3"],
         dims=dims,
         adstock=adstock,
         saturation=saturation,
@@ -296,7 +300,7 @@ def test_sample_posterior_predictive_new_data(single_dim_data, mock_pymc_sample)
     mmm = MMM(
         date_column="date",
         target_column="target",
-        channel_columns=["channel_1", "channel_2"],
+        channel_columns=["channel_1", "channel_2", "channel_3"],
         adstock=adstock,
         saturation=saturation,
     )
@@ -306,6 +310,11 @@ def test_sample_posterior_predictive_new_data(single_dim_data, mock_pymc_sample)
     mmm.fit(X_train, y_train, draws=200, tune=100, chains=1, random_seed=42)
 
     mmm.sample_posterior_predictive(X_train, extend_idata=True, random_seed=42)
+
+    def no_null_values(ds):
+        return ds.y.isnull().mean()
+
+    np.testing.assert_allclose(no_null_values(mmm.idata.posterior_predictive), 0)
 
     # Sample posterior predictive on new data
     out_of_sample_idata = mmm.sample_posterior_predictive(
@@ -317,6 +326,8 @@ def test_sample_posterior_predictive_new_data(single_dim_data, mock_pymc_sample)
         "After calling sample_posterior_predictive with new data, "
         "there should be a 'posterior_predictive' group in the inference data."
     )
+
+    np.testing.assert_allclose(no_null_values(out_of_sample_idata), 0)
 
     # Check the shape of that group. We expect the new date dimension to match X_new length
     # plus no addition if we didn't set include_last_observations (which is False by default).
@@ -349,7 +360,7 @@ def test_sample_posterior_predictive_same_data(single_dim_data, mock_pymc_sample
     mmm = MMM(
         date_column="date",
         target_column="target",
-        channel_columns=["channel_1", "channel_2"],
+        channel_columns=["channel_1", "channel_2", "channel_3"],
         adstock=adstock,
         saturation=saturation,
     )
@@ -587,7 +598,7 @@ def test_check_for_incompatible_dims(adstock, saturation, dims) -> None:
     kwargs = dict(
         date_column="date",
         target_column="target",
-        channel_columns=["channel_1", "channel_2"],
+        channel_columns=["channel_1", "channel_2", "channel_3"],
     )
     with pytest.raises(ValueError):
         MMM(
@@ -608,7 +619,7 @@ def test_different_target_scaling(method, multi_dim_data, mock_pymc_sample) -> N
         scaling=scaling,
         date_column="date",
         target_column="target",
-        channel_columns=["channel_1", "channel_2"],
+        channel_columns=["channel_1", "channel_2", "channel_3"],
         dims=("country",),
     )
     assert mmm.scaling.target == VariableScaling(method=method, dims=())
@@ -645,7 +656,7 @@ def test_target_scaling_raises() -> None:
             scaling=scaling,
             date_column="date",
             target_column="target",
-            channel_columns=["channel_1", "channel_2"],
+            channel_columns=["channel_1", "channel_2", "channel_3"],
         )
 
 
@@ -664,7 +675,7 @@ def test_target_scaling_and_contributions(
         scaling=scaling,
         date_column="date",
         target_column="target",
-        channel_columns=["channel_1", "channel_2"],
+        channel_columns=["channel_1", "channel_2", "channel_3"],
         dims=("country",),
     )
 
@@ -701,7 +712,7 @@ def test_channel_scaling(multi_dim_data, dims, expected_dims, mock_pymc_sample) 
         scaling=scaling,
         date_column="date",
         target_column="target",
-        channel_columns=["channel_1", "channel_2"],
+        channel_columns=["channel_1", "channel_2", "channel_3"],
         dims=("country",),
     )
 
@@ -719,7 +730,7 @@ def test_scaling_dict_doesnt_mutate() -> None:
         scaling=scaling,
         date_column="date",
         target_column="target",
-        channel_columns=["channel_1", "channel_2"],
+        channel_columns=["channel_1", "channel_2", "channel_3"],
         dims=dims,
     )
 

--- a/tests/mmm/test_multidimensional.py
+++ b/tests/mmm/test_multidimensional.py
@@ -682,10 +682,19 @@ def test_target_scaling_and_contributions(
         pytest.fail(f"Unexpected error: {e}")
 
 
-def test_channel_scaling(multi_dim_data, mock_pymc_sample) -> None:
+@pytest.mark.parametrize(
+    "dims, expected_dims",
+    [
+        ((), ("country", "channel")),
+        (("country",), ("channel",)),
+        (("channel",), ("country",)),
+    ],
+    ids=["country-channel", "country", "channel"],
+)
+def test_channel_scaling(multi_dim_data, dims, expected_dims, mock_pymc_sample) -> None:
     X, y = multi_dim_data
 
-    scaling = {"channel": {"method": "mean", "dims": ()}}
+    scaling = {"channel": {"method": "mean", "dims": dims}}
     mmm = MMM(
         adstock=GeometricAdstock(l_max=2),
         saturation=LogisticSaturation(),
@@ -698,7 +707,7 @@ def test_channel_scaling(multi_dim_data, mock_pymc_sample) -> None:
 
     mmm.fit(X, y)
 
-    assert mmm.scalers._channel.dims == ("country", "channel")
+    assert mmm.scalers._channel.dims == expected_dims
 
 
 def test_scaling_dict_doesnt_mutate() -> None:


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

Allows for specification just like the `target`

Also puts in switch statement to set nan values to 0 

```python

X, y = ...

scaling = {
    "channel": {
        # Take the mean through the nothing (except date) -> max by (country, channel)
        "method": "mean", 
        "dims": ()
    },
}
mmm = MMM(
    ...,
    dims=("country",),
    scaling=scaling,
)

mmm.fit(X, y)
```

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1573.org.readthedocs.build/en/1573/

<!-- readthedocs-preview pymc-marketing end -->