### PR TITLE
Replace `batched_convolution` by PyTensor native implementation

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,8 @@ dependencies:
 - preliz
 - pyprojroot
 # NOTE: Keep minimum pymc version in sync with ci.yml `OLDEST_PYMC_VERSION`
-- pymc>=5.21.1
+- pymc>=5.22.0
+- pytensor>=2.30.3
 - pymc-extras>=0.2.1
 - blackjax>=1.2.4
 - scikit-learn>=1.1.1

--- a/pymc_marketing/mmm/transformers.py
+++ b/pymc_marketing/mmm/transformers.py
@@ -21,7 +21,7 @@ import numpy.typing as npt
 import pymc as pm
 import pytensor.tensor as pt
 from pymc.distributions.dist_math import check_parameters
-from pytensor.tensor.random.utils import params_broadcast_shapes
+from pytensor.npy_2_compat import normalize_axis_index
 
 
 class ConvMode(str, Enum):
@@ -103,58 +103,29 @@ def batched_convolution(
     """
     # We move the axis to the last dimension of the array so that it's easier to
     # reason about parameter broadcasting. We will move the axis back at the end
-    orig_ndim = x.ndim
-    axis = axis if axis >= 0 else orig_ndim + axis
+    x = pt.as_tensor(x)
     w = pt.as_tensor(w)
+
+    axis = normalize_axis_index(axis, x.ndim)
     x = pt.moveaxis(x, axis, -1)
-    l_max = w.type.shape[-1]
-    if l_max is None:
-        try:
-            l_max = w.shape[-1].eval()
-        except Exception:  # noqa: S110
-            pass
-    # Get the broadcast shapes of x and w but ignoring their last dimension.
-    # The last dimension of x is the "time" axis, which doesn't get broadcast
-    # The last dimension of w is the number of time steps that go into the convolution
-    x_shape, w_shape = params_broadcast_shapes([x.shape, w.shape], [1, 1])
+    x_batch_shape = tuple(x.shape)[:-1]
+    lags = w.shape[-1]
 
-    x = pt.broadcast_to(x, x_shape)
-    w = pt.broadcast_to(w, w_shape)
-    x_time = x.shape[-1]
-    # Make a tensor with x at the different time lags needed for the convolution
-    x_shape = x.shape
-    # Add the size of the kernel to the time axis
-    shape = (*x_shape[:-1], x_shape[-1] + w.shape[-1] - 1, w.shape[-1])
-    padded_x = pt.zeros(shape, dtype=x.dtype)
-
-    if l_max is None:  # pragma: no cover
-        raise NotImplementedError(
-            "At the moment, convolving with weight arrays that don't have a concrete shape "
-            "at compile time is not supported."
-        )
-    # The window is the slice of the padded array that corresponds to the original x
-    if l_max <= 1:
-        window = slice(None)
+    if mode == ConvMode.After:
+        zeros = pt.zeros((*x_batch_shape, lags - 1), dtype=x.dtype)
+        padded_x = pt.join(-1, zeros, x)
     elif mode == ConvMode.Before:
-        window = slice(l_max - 1, None)
-    elif mode == ConvMode.After:
-        window = slice(None, -l_max + 1)
+        zeros = pt.zeros((*x_batch_shape, lags - 1), dtype=x.dtype)
+        padded_x = pt.join(-1, x, zeros)
     elif mode == ConvMode.Overlap:
-        # Handle even and odd l_max differently if l_max is odd then we can split evenly otherwise we drop from the end
-        window = slice((l_max // 2) - (1 if l_max % 2 == 0 else 0), -(l_max // 2))
+        zeros_left = pt.zeros((*x_batch_shape, lags // 2), dtype=x.dtype)
+        zeros_right = pt.zeros((*x_batch_shape, (lags - 1) // 2), dtype=x.dtype)
+        padded_x = pt.join(-1, zeros_left, x, zeros_right)
     else:
-        raise ValueError(f"Wrong Mode: {mode}, expected of ConvMode")
+        raise ValueError(f"Wrong Mode: {mode}, expected one of {', '.join(ConvMode)}")
 
-    for i in range(l_max):
-        padded_x = pt.set_subtensor(padded_x[..., i : x_time + i, i], x)
-
-    padded_x = padded_x[..., window, :]
-
-    # The convolution is treated as an element-wise product, that then gets reduced
-    # along the dimension that represents the convolution time lags
-    conv = pt.sum(padded_x * w[..., None, :], axis=-1)
-    # Move the "time" axis back to where it was in the original x array
-    return pt.moveaxis(conv, -1, axis + conv.ndim - orig_ndim)
+    conv = pt.signal.convolve1d(padded_x, w, mode="valid")
+    return pt.moveaxis(conv, -1, axis + conv.ndim - x.ndim)
 
 
 def geometric_adstock(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
     "pandas",
     "pydantic>=2.1.0",
     # NOTE: Used as minimum pymc version with test.yml `OLDEST_PYMC_VERSION`
-    "pymc>=5.21.1",
+    "pymc>=5.22.0",
+    "pytensor>=2.30.3",
     "scikit-learn>=1.1.1",
     "seaborn>=0.12.2",
     "xarray>=2024.1.0",


### PR DESCRIPTION
This will depend on the not yet released https://github.com/pymc-devs/pytensor/pull/1318

That will also require a dependency bump on PyMC before we can use it here.

The PyTensor impl gives us batching out of the box, without a graph compile and runtime penalty. I got these runtime differences before and after my changes: 

```python
import numpy as np
import pytensor.tensor as pt
import pytensor
from pymc_marketing.mmm.transformers import batched_convolution

for kernel_size in (8, 80, 800):
    for data_size in (12, 120, 1200):
        data = pt.vector("x", shape=(data_size,))
        kernel = pt.vector("kernel", shape=(kernel_size,))

        out = batched_convolution(data, kernel, mode="After")
        fn = pytensor.function([data, kernel], out, trust_input=True)

        rng = np.random.default_rng((kernel_size, data_size))
        data_test = rng.normal(size=data.type.shape)
        kernel_test = rng.normal(size=kernel.type.shape)

        print(f"{kernel_size=}, {data_size=}")
        %timeit fn(data_test, kernel_test)

# Before changes:
# kernel_size=8, data_size=12
# 35.3 μs ± 4.67 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
# kernel_size=8, data_size=120
# 29.7 μs ± 432 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
# kernel_size=8, data_size=1200
# 30.1 μs ± 391 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

# kernel_size=80, data_size=12
# 398 μs ± 1.82 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
# kernel_size=80, data_size=120
# 402 μs ± 5.93 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
# kernel_size=80, data_size=1200
# 401 μs ± 6.74 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

# kernel_size=800, data_size=12
# 7.28 ms ± 45.7 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
# kernel_size=800, data_size=120
# 7.97 ms ± 469 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
# kernel_size=800, data_size=1200
# 7.5 ms ± 406 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)

# After changes:
# kernel_size=8, data_size=12
# 6.06 μs ± 61.9 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
# kernel_size=8, data_size=120
# 6.32 μs ± 18.2 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
# kernel_size=8, data_size=1200
# 9.18 μs ± 67.7 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

# kernel_size=80, data_size=12
# 6.67 μs ± 180 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
# kernel_size=80, data_size=120
# 9.81 μs ± 60.2 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
# kernel_size=80, data_size=1200
# 39.3 μs ± 1.15 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

# kernel_size=800, data_size=12
# 9.22 μs ± 21.6 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
# kernel_size=800, data_size=120
# 24.6 μs ± 425 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
# kernel_size=800, data_size=1200
# 179 μs ± 2.92 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```
Not seen here is also the widely different compile times for very large kernel_sizes, which in the old implementation would be a series of unrolled `set_subtensor`. Now the compile time is constant on the number of lags. It's also no longer needed to have statically known lags.

The gradient should provide a nice speedup as well, with room for further cleverness outside of pymc-marketing: https://github.com/pymc-devs/pytensor/issues/1320

In practice users won't be doing a crazy number of lags, so speedup on runtime is perhaps just those 3-4x I saw locally for `kernel_size=8`, and not some of the 1000x I got for other combinations. It may be a higher/ lower delta in other backends, feel free to check. 

The compile time and simpler graphs are what drove me to do these changes

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1583.org.readthedocs.build/en/1583/

<!-- readthedocs-preview pymc-marketing end -->