### PR TITLE
Fix LinearTrend out of sample

### DIFF
--- a/pymc_marketing/mmm/linear_trend.py
+++ b/pymc_marketing/mmm/linear_trend.py
@@ -305,7 +305,7 @@ class LinearTrend(BaseModel):
         dim_handler = create_dim_handler(desired_dims=out_dims)
 
         # (changepoints, )
-        s = pt.linspace(0, pt.max(t), self.n_changepoints)
+        s = pt.linspace(0, pt.max(t).eval(), self.n_changepoints)
         s.type.shape = (self.n_changepoints,)
         s = dim_handler(
             s,

--- a/tests/mmm/test_additive_effect.py
+++ b/tests/mmm/test_additive_effect.py
@@ -137,6 +137,7 @@ def test_linear_trend_effect(create_mock_mmm, new_dates, linear_trend_model) -> 
 
     assert set(mmm.model.named_vars) == {f"{prefix}_t"}
     assert set(mmm.model.coords) == {"date"}
+    assert effect.linear_trend_first_date == mmm.model.coords["date"][0]
 
     with mmm.model:
         pm.Deterministic("effect", effect.create_effect(mmm), dims=("date", *mmm.dims))


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

This allows the `LinearTrend` and `LinearTrendEffect` to have out of sample predictions that are 
just linear extrapolations using the final changepoint of the trend. 

> [!NOTE]
>
> There are no new changepoints added to the model so distant predictions will likely be less accurate.


## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #1569 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->