### PR TITLE
Deterministic seed in advi tests

### DIFF
--- a/pymc_marketing/clv/models/basic.py
+++ b/pymc_marketing/clv/models/basic.py
@@ -205,7 +205,7 @@ class CLVModel(ModelBuilder):
         if self.sampler_config is not None:
             sampler_config = self.sampler_config.copy()
 
-        sampler_config.update(**kwargs)
+        sampler_config = {**sampler_config, **kwargs}
         if sampler_config.get("method") is not None:
             raise ValueError(
                 "The 'method' parameter is set in sampler_config. Cannot be called with 'advi'."

--- a/tests/clv/models/test_beta_geo.py
+++ b/tests/clv/models/test_beta_geo.py
@@ -31,7 +31,8 @@ class TestBetaGeoModel:
     @classmethod
     def setup_class(cls):
         # Set random seed
-        cls.rng = np.random.default_rng(34)
+        cls.seed = 42
+        cls.rng = np.random.default_rng(cls.seed)
 
         # parameters
         cls.a_true = 0.793
@@ -309,7 +310,10 @@ class TestBetaGeoModel:
         )
         model.build_model()
 
-        sample_kwargs = dict(random_seed=self.rng, chains=2) if method == "mcmc" else {}
+        sample_kwargs = dict(random_seed=self.seed)
+        sample_kwargs = (
+            {**sample_kwargs, "chains": 2} if method == "mcmc" else sample_kwargs
+        )
         model.fit(method=method, progressbar=False, **sample_kwargs)
 
         fit = model.idata.posterior


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->
`test_model_convergence` now uses a deterministic seed.


## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #1584 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->
