### PR TITLE
use fixture in more model_builder tests

### DIFF
--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -16,7 +16,6 @@ import json
 import sys
 import tempfile
 
-import arviz as az
 import graphviz
 import numpy as np
 import pandas as pd
@@ -211,7 +210,7 @@ def test_save_without_fit_raises_runtime_error():
         model_builder.save("saved_model")
 
 
-def test_empty_sampler_config_fit(toy_X, toy_y):
+def test_empty_sampler_config_fit(toy_X, toy_y, mock_pymc_sample):
     sampler_config = {}
     model_builder = ModelBuilderTest(sampler_config=sampler_config)
     model_builder.idata = model_builder.fit(
@@ -562,12 +561,7 @@ def test_fit_sampler_config_seed_reproducibility(toy_X, toy_y) -> None:
     assert idata.posterior.equals(idata2.posterior)
 
 
-def test_fit_sampler_config_with_rng_fails(mocker, toy_X, toy_y) -> None:
-    def mock_sample(*args, **kwargs):
-        idata = pm.sample_prior_predictive(10)
-        return az.InferenceData(posterior=idata.prior)
-
-    mocker.patch("pymc.sample", mock_sample)
+def test_fit_sampler_config_with_rng_fails(toy_X, toy_y, mock_pymc_sample) -> None:
     sampler_config = {
         "chains": 1,
         "draws": 10,


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

Just making use of the common fixture when actual posterior sample isn't needed

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1592.org.readthedocs.build/en/1592/

<!-- readthedocs-preview pymc-marketing end -->