### PR TITLE
BUG: FourierEffect with multidimensional case

### DIFF
--- a/pymc_marketing/mmm/additive_effect.py
+++ b/pymc_marketing/mmm/additive_effect.py
@@ -105,15 +105,16 @@ class FourierEffect:
 
         # Create a deterministic variable for the effect
         dims = (dim for dim in mmm.dims if dim in self.fourier.prior.dims)
+        fourier_dims = ("date", *dims)
         fourier_effect_det = pm.Deterministic(
             f"{self.fourier.prefix}_effect",
             fourier_effect,
-            dims=("date", *dims),
+            dims=fourier_dims,
         )
 
         # Handle dimensions for the MMM model
         dim_handler = create_dim_handler(("date", *mmm.dims))
-        return dim_handler(fourier_effect_det, ("date", *dims))
+        return dim_handler(fourier_effect_det, fourier_dims)
 
     def set_data(self, mmm: MMM, model: pm.Model, X: xr.Dataset) -> None:
         """Set the data for new predictions.

--- a/pymc_marketing/mmm/additive_effect.py
+++ b/pymc_marketing/mmm/additive_effect.py
@@ -113,7 +113,7 @@ class FourierEffect:
 
         # Handle dimensions for the MMM model
         dim_handler = create_dim_handler(("date", *mmm.dims))
-        return dim_handler(fourier_effect_det, "date")
+        return dim_handler(fourier_effect_det, ("date", *dims))
 
     def set_data(self, mmm: MMM, model: pm.Model, X: xr.Dataset) -> None:
         """Set the data for new predictions.

--- a/tests/mmm/test_additive_effect.py
+++ b/tests/mmm/test_additive_effect.py
@@ -141,14 +141,28 @@ def test_fourier_effect(
     pd.testing.assert_index_equal(effect_predictions.date.to_index(), new_dates)
 
 
-def test_fourier_effect_multidimensional(create_mock_mmm, create_fourier_model) -> None:
+@pytest.mark.parametrize(
+    "prior_dims",
+    [
+        (),
+        ("weekly",),
+        ("weekly", "geo"),
+        ("geo", "weekly"),
+    ],
+    ids=["no-dims", "exclude", "include", "include_reverse"],
+)
+def test_fourier_effect_multidimensional(
+    create_mock_mmm,
+    create_fourier_model,
+    prior_dims,
+) -> None:
     mmm = create_mock_mmm(
         dims=("geo",),
         model=create_fourier_model(coords={"geo": ["A", "B"]}),
     )
 
     prefix = "weekly"
-    prior = Prior("Laplace", mu=0, b=0.1, dims=(prefix, "geo"))
+    prior = Prior("Laplace", mu=0, b=0.1, dims=prior_dims)
     fourier = WeeklyFourier(n_order=10, prefix=prefix, prior=prior)
     fourier_effect = FourierEffect(fourier)
 

--- a/tests/mmm/test_additive_effect.py
+++ b/tests/mmm/test_additive_effect.py
@@ -61,9 +61,12 @@ def set_new_model_dates(dates):
 
 
 @pytest.fixture(scope="function")
-def fourier_model(dates) -> pm.Model:
-    coords = {"date": dates}
-    return pm.Model(coords=coords)
+def create_fourier_model(dates):
+    def model(coords):
+        coords = coords | {"date": dates}
+        return pm.Model(coords=coords)
+
+    return model
 
 
 @pytest.mark.parametrize(
@@ -75,33 +78,48 @@ def fourier_model(dates) -> pm.Model:
     ],
     ids=["weekly", "monthly", "yearly"],
 )
-def test_fourier_effect(create_mock_mmm, new_dates, fourier_model, fourier) -> None:
+@pytest.mark.parametrize(
+    "dims, coords",
+    [
+        ((), {}),
+        (("geo",), {"geo": ["A", "B"]}),
+    ],
+    ids=["no_dims", "with_dims"],
+)
+def test_fourier_effect(
+    create_mock_mmm,
+    new_dates,
+    create_fourier_model,
+    fourier,
+    dims,
+    coords,
+) -> None:
     effect = FourierEffect(fourier)
 
-    mmm = create_mock_mmm(dims=(), model=fourier_model)
+    mmm = create_mock_mmm(
+        dims=dims,
+        model=create_fourier_model(coords=coords),
+    )
 
     with mmm.model:
         effect.create_data(mmm)
 
     assert set(mmm.model.named_vars) == set([f"{fourier.prefix}_day"])
-    assert set(mmm.model.coords) == {"date"}
+    assert set(mmm.model.coords) == {"date", *dims}
 
     with mmm.model:
-        pm.Deterministic(
-            "effect",
-            effect.create_effect(mmm),
-            dims=("date", *mmm.dims),
-        )
+        # Should just be broadcastable with target.
+        # Not necessarily the same shape
+        effect.create_effect(mmm)
 
     assert set(mmm.model.named_vars) == set(
         [
             f"{fourier.prefix}_day",
-            "effect",
             f"{fourier.prefix}_beta",
             f"{fourier.prefix}_effect",
         ]
     )
-    assert set(mmm.model.coords) == {"date", fourier.prefix}
+    assert set(mmm.model.coords) == {"date", *dims, fourier.prefix}
 
     with mmm.model:
         idata = pm.sample_prior_predictive()
@@ -111,11 +129,11 @@ def test_fourier_effect(create_mock_mmm, new_dates, fourier_model, fourier) -> N
         idata.extend(
             pm.sample_posterior_predictive(
                 idata.prior,
-                var_names=["effect"],
+                var_names=[f"{fourier.prefix}_effect"],
             )
         )
 
-    effect_predictions = idata.posterior_predictive.effect
+    effect_predictions = idata.posterior_predictive[f"{fourier.prefix}_effect"]
     np.testing.assert_allclose(effect_predictions.notnull().mean().item(), 1.0)
     pd.testing.assert_index_equal(effect_predictions.date.to_index(), new_dates)
 

--- a/tests/mmm/test_additive_effect.py
+++ b/tests/mmm/test_additive_effect.py
@@ -110,7 +110,9 @@ def test_fourier_effect(
     with mmm.model:
         # Should just be broadcastable with target.
         # Not necessarily the same shape
-        effect.create_effect(mmm)
+        created_variable = effect.create_effect(mmm)
+
+    assert created_variable.ndim == len(mmm.dims) + 1
 
     assert set(mmm.model.named_vars) == set(
         [


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

The FourierEffect was not broadcasting correctly with the target. This modification fixes this issue

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1594.org.readthedocs.build/en/1594/

<!-- readthedocs-preview pymc-marketing end -->