### PR TITLE
Fix/replace deprecated budget method

### DIFF
--- a/tests/mmm/test_mmm.py
+++ b/tests/mmm/test_mmm.py
@@ -19,7 +19,6 @@ import pandas as pd
 import pymc as pm
 import pytest
 import xarray as xr
-import warnings
 from matplotlib import pyplot as plt
 
 from pymc_marketing.mmm.budget_optimizer import optimizer_xarray_builder
@@ -572,24 +571,18 @@ class TestMMM:
     ) -> None:
         budget = 2.0
         num_periods = 8
-        time_granularity = "weekly"
         budget_bounds = optimizer_xarray_builder(
             value=[[0.5, 1.2], [0.5, 1.5]],
             channel=["channel_1", "channel_2"],
             bound=["lower", "upper"],
         )
-        noise_level = "bad_noise_level"
 
         with pytest.raises(ValueError, match="noise_level must be a float"):
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
-                mmm_fitted.allocate_budget_to_maximize_response(
-                    budget=budget,
-                    time_granularity=time_granularity,
-                    num_periods=num_periods,
-                    budget_bounds=budget_bounds,
-                    noise_level=noise_level,
-                )
+            mmm_fitted.optimize_budget(
+                budget=budget,
+                num_periods=num_periods,
+                budget_bounds=budget_bounds,
+            )
 
     @pytest.mark.parametrize(
         argnames="original_scale",

--- a/tests/mmm/test_mmm.py
+++ b/tests/mmm/test_mmm.py
@@ -19,6 +19,7 @@ import pandas as pd
 import pymc as pm
 import pytest
 import xarray as xr
+import warnings
 from matplotlib import pyplot as plt
 
 from pymc_marketing.mmm.budget_optimizer import optimizer_xarray_builder
@@ -580,13 +581,15 @@ class TestMMM:
         noise_level = "bad_noise_level"
 
         with pytest.raises(ValueError, match="noise_level must be a float"):
-            mmm_fitted.allocate_budget_to_maximize_response(
-                budget=budget,
-                time_granularity=time_granularity,
-                num_periods=num_periods,
-                budget_bounds=budget_bounds,
-                noise_level=noise_level,
-            )
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                mmm_fitted.allocate_budget_to_maximize_response(
+                    budget=budget,
+                    time_granularity=time_granularity,
+                    num_periods=num_periods,
+                    budget_bounds=budget_bounds,
+                    noise_level=noise_level,
+                )
 
     @pytest.mark.parametrize(
         argnames="original_scale",


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
This PR updates the test test_allocate_budget_to_maximize_response_bad_noise_level by replacing the usage of the deprecated method allocate_budget_to_maximize_response with the recommended optimize_budget method.

This aligns the codebase with the current API and avoids suppressing DeprecationWarnings, as discussed in [issue #1598](https://github.com/pymc-labs/pymc-marketing/issues/1598) and the feedback on [PR #1603](https://github.com/pymc-labs/pymc-marketing/pull/1603).

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #1598 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ x ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ x ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ x ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->
