### PR TITLE
Fix casting bug when x0 is not supplied to optimizer

### DIFF
--- a/pymc_marketing/mmm/budget_optimizer.py
+++ b/pymc_marketing/mmm/budget_optimizer.py
@@ -480,7 +480,7 @@ class BudgetOptimizer(BaseModel):
 
         # 5. Construct the initial guess (x0) if not provided
         if x0 is None:
-            x0 = np.ones(budgets_size) * (total_budget / budgets_size).astype(
+            x0 = (np.ones(budgets_size) * (total_budget / budgets_size)).astype(
                 self._budgets_flat.type.dtype
             )
 


### PR DESCRIPTION
This is a quick fix on a very small but problematic bug introduced in https://github.com/pymc-labs/pymc-marketing/pull/1565 . I am unclear how the tests added in that PR did not trigger this bug. If anyone has time to figure out that mystery and/or sanity-check this fix, I would very much appreciate it.

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1636.org.readthedocs.build/en/1636/

<!-- readthedocs-preview pymc-marketing end -->