### PR TITLE
Support for string in `plot_curve` and add to docs

### DIFF
--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -19,4 +19,5 @@
   model_config
   model_graph
   prior
+  plot
 ```

--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -18,6 +18,6 @@
   model_builder
   model_config
   model_graph
-  prior
   plot
+  prior
 ```

--- a/pymc_marketing/plot.py
+++ b/pymc_marketing/plot.py
@@ -433,7 +433,7 @@ def _plot_across_coord(
 
 def plot_hdi(
     curve: xr.DataArray,
-    non_grid_names: set[str],
+    non_grid_names: str | set[str],
     hdi_kwargs: dict | None = None,
     subplot_kwargs: dict[str, Any] | None = None,
     plot_kwargs: dict[str, Any] | None = None,
@@ -449,7 +449,7 @@ def plot_hdi(
     ----------
     curve : xr.DataArray
         Curve to plot
-    non_grid_names : set[str]
+    non_grid_names : str | set[str]
         The names to exclude from the grid. chain and draw are
         excluded automatically
     n : int, optional
@@ -472,6 +472,9 @@ def plot_hdi(
     get_plot_data = _create_get_hdi_plot_data(hdi_kwargs or {})
     make_selection = _make_hdi_selection
     plot_selection = _plot_hdi_selection
+
+    if isinstance(non_grid_names, str):
+        non_grid_names = {non_grid_names}
 
     plot_kwargs = plot_kwargs or {}
     plot_kwargs = {**{"alpha": 0.25}, **plot_kwargs}
@@ -496,7 +499,7 @@ def plot_hdi(
 
 def plot_samples(
     curve: xr.DataArray,
-    non_grid_names: set[str],
+    non_grid_names: str | set[str],
     n: int = 10,
     rng: np.random.Generator | None = None,
     axes: npt.NDArray[Axes] | None = None,
@@ -513,7 +516,7 @@ def plot_samples(
     ----------
     curve : xr.DataArray
         Curve to plot
-    non_grid_names : set[str]
+    non_grid_names : str | set[str]
         The names to exclude from the grid. chain and draw are
         excluded automatically
     n : int, optional
@@ -536,6 +539,9 @@ def plot_samples(
 
     """
     get_plot_data = _get_sample_plot_data
+
+    if isinstance(non_grid_names, str):
+        non_grid_names = {non_grid_names}
 
     n_chains = curve.sizes["chain"]
     n_draws = curve.sizes["draw"]
@@ -573,7 +579,7 @@ def plot_samples(
 
 def plot_curve(
     curve: xr.DataArray,
-    non_grid_names: set[str],
+    non_grid_names: str | set[str],
     subplot_kwargs: dict | None = None,
     sample_kwargs: dict | None = None,
     hdi_kwargs: dict | None = None,
@@ -589,7 +595,7 @@ def plot_curve(
     ----------
     curve : xr.DataArray
         Curve to plot
-    non_grid_names : set[str]
+    non_grid_names : str | set[str]
         The names to exclude from the grid. HDI and samples both
         have defaults of hdi and chain, draw, respectively
     subplot_kwargs : dict, optional

--- a/pymc_marketing/plot.py
+++ b/pymc_marketing/plot.py
@@ -660,7 +660,7 @@ def plot_curve(
 
         fig, axes = plot_curve(
             curve,
-            non_grid_names={"date"},
+            "date",
             subplot_kwargs={"figsize": (15, 5)},
         )
         plt.show()
@@ -674,7 +674,7 @@ def plot_curve(
         colors = ["red", "blue"]
         fig, axes = plot_curve(
             curve,
-            non_grid_names={"date"},
+            "date",
             same_axes=True,
             colors=colors,
         )

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -111,8 +111,12 @@ def test_plot_functions(mock_curve, plot_func, same_axes: bool, legend: bool) ->
     plt.close(fig)
 
 
-def test_plot_curve(mock_curve) -> None:
-    fig, axes = plot_curve(mock_curve, non_grid_names={"day"})
+@pytest.mark.parametrize(
+    "non_grid_names",
+    [pytest.param("day", id="string"), pytest.param({"day"}, id="set")],
+)
+def test_plot_curve(mock_curve, non_grid_names) -> None:
+    fig, axes = plot_curve(mock_curve, non_grid_names)
 
     assert axes.size == mock_curve.sizes["geo"]
     assert isinstance(fig, plt.Figure)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

No longer needing to wrap in a set

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1650.org.readthedocs.build/en/1650/

<!-- readthedocs-preview pymc-marketing end -->