### PR TITLE
support for additional dimension in LinearTrend

### DIFF
--- a/pymc_marketing/mmm/linear_trend.py
+++ b/pymc_marketing/mmm/linear_trend.py
@@ -211,7 +211,7 @@ class LinearTrend(BaseModel):
         None,
         description="Priors for the trend parameters.",
     )
-    dims: tuple[str] | InstanceOf[Dims] | str | None = Field(
+    dims: tuple[str, ...] | InstanceOf[Dims] | str | None = Field(
         None,
         description="The additional dimensions for the trend.",
     )

--- a/tests/mmm/test_linear_trend.py
+++ b/tests/mmm/test_linear_trend.py
@@ -75,27 +75,46 @@ def test_apply(include_intercept, expected_keys) -> None:
 
 
 @pytest.mark.parametrize(
-    "delta_dims",
-    [None, ("changepoint",), ("changepoint", "geo")],
-    ids=["scalar", "1d", "2d"],
+    "delta_dims, dims",
+    [
+        pytest.param(None, ("geo",), id="1d-scalar"),
+        pytest.param(("changepoint",), ("geo",), id="1d-changpoint"),
+        pytest.param(("changepoint", "geo"), ("geo",), id="1d-changepoint-geo"),
+        pytest.param(
+            ("geo", "product", "changepoint"),
+            ("geo", "product"),
+            id="2d",
+        ),
+    ],
 )
-def test_apply_additional_dims(delta_dims) -> None:
+def test_apply_additional_dims(delta_dims, dims) -> None:
     priors = {
         "delta": Prior("Normal", dims=delta_dims),
     }
-    trend = LinearTrend(priors=priors, dims=("geo",))
+    trend = LinearTrend(priors=priors, dims=dims)
 
     n_obs = 100
     x = np.linspace(0, 1, n_obs)
     geos = ["A", "B", "C"]
+    products = ["X", "Y"]
     coords = {
         "geo": geos,
+        "product": products,
     }
     with pm.Model(coords=coords):
         mu = trend.apply(x)
 
-    n_cols = len(geos) if delta_dims is not None and "geo" in delta_dims else 1
-    assert mu.eval().shape == (n_obs, n_cols)
+    if delta_dims is None:
+        additional_sizes = (1,)
+    else:
+        additional_sizes = tuple(
+            len(coords[dim]) for dim in delta_dims if dim in coords
+        )
+
+    if not additional_sizes:
+        additional_sizes = (1,)
+
+    assert mu.eval().shape == (n_obs, *additional_sizes)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

Bug fix where LinearTrend was not supporting more dimensions

This will now work instead of throwing an error:

```python
import matplotlib.pyplot as plt

from pymc_marketing.mmm import LinearTrend
from pymc_marketing.prior import Prior

trend = LinearTrend(
    n_changepoints=8,
    include_intercept=False,
    priors={
        "delta": Prior("Laplace", mu=0, b=0.2, dims=("geo", "product", "changepoint"))
    },
    dims=("geo", "product"),
)

coords = {
    "geo": ["A", "B"],
    "product": ["X", "Y", "Z"],
}
prior = trend.sample_prior(coords=coords)
curve = trend.sample_curve(prior)
trend.plot_curve(curve)
plt.show()
```

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->
