### PR TITLE
Accelerate documentation build

### DIFF
--- a/docs/source/_templates/autosummary/class.rst
+++ b/docs/source/_templates/autosummary/class.rst
@@ -10,7 +10,7 @@
    .. rubric:: Methods
 
    .. autosummary::
-      :toctree:
+      :toctree: classmethods
 
    {% for item in methods %}
       {{ objname }}.{{ item }}

--- a/docs/source/_templates/autosummary/module.rst
+++ b/docs/source/_templates/autosummary/module.rst
@@ -34,7 +34,9 @@
       :toctree:
 
    {% for item in classes %}
+      {% if not item.endswith("RV") %}
       {{ item }}
+      {% endif %}
    {%- endfor %}
    {% endif %}
    {% endblock %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,6 +33,7 @@ extensions = [
     "notfound.extension",
     "sphinx_copybutton",
     "sphinx_design",
+    "sphinx_remove_toctrees",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -76,6 +77,9 @@ pygments_style = "friendly"
 
 # configure notfound extension to not add any prefix to the urls
 notfound_urls_prefix = "/en/latest/"
+
+# exclude method pages from toctree to make pages lighter and build faster
+remove_from_toctrees = ["**/classmethods/*"]
 
 # myst config
 nb_execution_mode = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ docs = [
     "sphinx-copybutton",
     "sphinx-design",
     "sphinx-notfound-page",
+    "sphinx-remove-toctrees",
     "sphinx",
     "sphinxext-opengraph",
     "watermark",


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->
Accelerate documentation build. This will fix all the readthedocs failures due to excessive time
required to build the docs. I did some local check and I really don't think it is a memory issue.

As of now, the changes are quite minimal and mostly cosmetic.

* The main thing is pruning the toctree. The toctree is currently huge and with a lot of nesting,
  this removes the class methods from the toctree which makes it much shorter and reduces nesting
  significantly too. That also means they will no longer appear on the sidebar but we have been
  doing this for PyMC for a while and nobody has complained.
  For example, [pymc.Model](https://www.pymc.io/projects/docs/en/stable/api/model/generated/pymc.model.core.Model.html)
  has the methods linked in the page itself but not on the sidebar, and visiting [one of the methods](https://www.pymc.io/projects/docs/en/stable/api/model/generated/classmethods/pymc.model.core.Model.add_coords.html#pymc.model.core.Model.add_coords)
  shows the sidebar without focusing on it (as it isn't there)
* I also removed the few RV classes (they are also not present in pymc docs and don't really have any relevant docs)

There is still room for other things, but even this few changes might be enough already.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1695.org.readthedocs.build/en/1695/

<!-- readthedocs-preview pymc-marketing end -->