### PR TITLE
More granular ModelBuilder errors upon load

### DIFF
--- a/pymc_marketing/model_builder.py
+++ b/pymc_marketing/model_builder.py
@@ -567,7 +567,17 @@ class ModelBuilder(ABC):
         model.build_from_idata(idata)
         model.post_sample_model_transformation()
 
-        if model.id != idata.attrs["id"]:
+        if (model_version := model.version) != (
+            loaded_version := idata.attrs["version"]
+        ):
+            msg = (
+                f"The model version ({loaded_version}) in the InferenceData does not "
+                f"match the model version ({model_version}). "
+                "There was no error loading the inference data, but the model structure "
+                "is different. "
+            )
+            raise DifferentModelError(msg)
+        elif model.id != idata.attrs["id"]:
             msg = (
                 "The model id in the InferenceData does not match the model id. "
                 "There was no error loading the inference data, but the model may "


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

This separates out version differences from id differences while using the `load` method of the ModelBuilder class

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1765.org.readthedocs.build/en/1765/

<!-- readthedocs-preview pymc-marketing end -->