### PR TITLE
Allow for tvp priors in multidimensional.MMM

### DIFF
--- a/pymc_marketing/mmm/multidimensional.py
+++ b/pymc_marketing/mmm/multidimensional.py
@@ -206,7 +206,7 @@ class MMM(ModelBuilder):
         sampler_config = sampler_config
         model_config = parse_model_config(
             model_config,  # type: ignore
-            hsgp_kwargs_fields=["intercept_tvp_config", "media_tvp_config"],
+            non_distributions=["intercept_tvp_config", "media_tvp_config"],
         )
 
         if model_config is not None:


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

There is no object that stores the parameters for this method:

https://github.com/pymc-labs/pymc-marketing/blob/6e73bd4818d6fa92eb0452f99af4f57bbc8e68c7/pymc_marketing/mmm/hsgp.py?plain=1#L752-L767

Just going to keep the "intercept_tvp_config" and "media_tvp_config" passed as dictionarys

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #1784
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1785.org.readthedocs.build/en/1785/

<!-- readthedocs-preview pymc-marketing end -->