### PR TITLE
Clip noisy channel predictors

### DIFF
--- a/pymc_marketing/mmm/utils.py
+++ b/pymc_marketing/mmm/utils.py
@@ -376,6 +376,9 @@ def add_noise_to_channel_allocation(
     noisy_df = df.copy()
     noisy_df[channels] += noise
 
+    # Ensure no negative spends
+    noisy_df[channels] = noisy_df[channels].clip(lower=0.0)
+
     return noisy_df
 
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->
`add_noise_to_channel_allocation` introduces some noise in oos predictors. 
This is done to avoid having a too static oss picture. 

There are potential edge cases in which the introduced noise makes the predictors negative. 
That makes no sense for channel columns, so we are clipping the values to be positive.
 

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [x] Related to #1762 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->
