### PR TITLE
Remove unused function argument

### DIFF
--- a/pymc_marketing/mmm/budget_optimizer.py
+++ b/pymc_marketing/mmm/budget_optimizer.py
@@ -369,14 +369,11 @@ class BudgetOptimizer(BaseModel):
     def _compile_objective_and_grad(self):
         """Compile the objective function and its gradient, both referencing `self._budgets_flat`."""
         budgets_flat = self._budgets_flat
-        budgets = self._budgets
         response_distribution = self.extract_response_distribution(
             self.response_variable
         )
 
-        objective = -self.utility_function(
-            samples=response_distribution, budgets=budgets
-        )
+        objective = -self.utility_function(samples=response_distribution)
         objective_grad = pt.grad(rewrite_pregrad(objective), budgets_flat)
 
         objective_and_grad_func = function([budgets_flat], [objective, objective_grad])

--- a/pymc_marketing/mmm/mmm.py
+++ b/pymc_marketing/mmm/mmm.py
@@ -50,7 +50,7 @@ from pymc_marketing.mmm.lift_test import (
 )
 from pymc_marketing.mmm.preprocessing import MaxAbsScaleChannels, MaxAbsScaleTarget
 from pymc_marketing.mmm.tvp import create_time_varying_gp_multiplier, infer_time_index
-from pymc_marketing.mmm.utility import UtilityFunctionType, average_response
+from pymc_marketing.mmm.utility import UnivariateUtilityFunctionType, average_response
 from pymc_marketing.mmm.utils import (
     apply_sklearn_transformer_across_dim,
     create_new_spend_data,
@@ -2323,7 +2323,7 @@ class MMM(
         num_periods: int,
         budget_bounds: DataArray | dict[str, tuple[float, float]] | None = None,
         response_variable: str = "total_contribution",
-        utility_function: UtilityFunctionType = average_response,
+        utility_function: UnivariateUtilityFunctionType = average_response,
         constraints: Sequence[dict[str, Any]] = (),
         default_constraints: bool = True,
         **minimize_kwargs,
@@ -2355,7 +2355,7 @@ class MMM(
             for each channel. If None, no bounds are applied.
         response_variable : str, optional
             The response variable to optimize. Default is "total_contribution".
-        utility_function : UtilityFunctionType, optional
+        utility_function : UnivariateUtilityFunctionType, optional
             The utility function to maximize. Default is the mean of the response distribution.
         custom_constraints : list[dict[str, Any]], optional
             Custom constraints for the optimization. If None, no custom constraints are applied. Format:

--- a/pymc_marketing/mmm/utility.py
+++ b/pymc_marketing/mmm/utility.py
@@ -46,6 +46,7 @@ from collections.abc import Callable
 
 import pytensor.tensor as pt
 
+UnivariateUtilityFunctionType = Callable[[pt.TensorVariable], pt.TensorVariable]
 UtilityFunctionType = Callable[[pt.TensorVariable, pt.TensorVariable], float]
 
 
@@ -86,7 +87,7 @@ def _compute_quantile(x: pt.TensorVariable, q: float) -> pt.TensorVariable:
 
 
 def average_response(
-    samples: pt.TensorVariable, budgets: pt.TensorVariable
+    samples: pt.TensorVariable,
 ) -> pt.TensorVariable:
     """Compute the average response of the posterior predictive distribution."""
     return pt.mean(_check_samples_dimensionality(samples))

--- a/tests/mmm/test_budget_optimizer.py
+++ b/tests/mmm/test_budget_optimizer.py
@@ -359,13 +359,13 @@ def mean_response_eq_constraint_fun(
     return mean_resp - target_response
 
 
-def minimize_budget_utility(samples, budgets):
+def minimize_budget_utility(samples):
     """
     A trivial "utility" that just tries to minimize total budget.
     Since the BudgetOptimizer by default *maximizes* the utility,
     we use the negative sign to effectively force minimization.
     """
-    return -pt.sum(budgets)
+    return -pt.sum(samples)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->
`average_response` utility function contains an unused function argument. 
Removing the unused function argument for improved code clarity.


## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [X] Related to #1762 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1791.org.readthedocs.build/en/1791/

<!-- readthedocs-preview pymc-marketing end -->