### PR TITLE
ruff format docstring code blocks

### DIFF
--- a/pymc_marketing/clv/models/basic.py
+++ b/pymc_marketing/clv/models/basic.py
@@ -281,7 +281,7 @@ class CLVModel(ModelBuilder):
         --------
         >>> class MyModel(ModelBuilder):
         >>>     ...
-        >>> name = './mymodel.nc'
+        >>> name = "./mymodel.nc"
         >>> imported_model = MyModel.load(name)
 
         """

--- a/pymc_marketing/clv/models/beta_geo_beta_binom.py
+++ b/pymc_marketing/clv/models/beta_geo_beta_binom.py
@@ -82,7 +82,7 @@ class BetaGeoBetaBinomModel(CLVModel):
         from pymc_marketing.prior import Prior
         from pymc_marketing.clv import BetaGeoBetaBinomModel
 
-        rfm_df = rfm_summary(raw_data,'id_col_name','date_col_name')
+        rfm_df = rfm_summary(raw_data, "id_col_name", "date_col_name")
 
         # Initialize model with customer data; `model_config` parameter is optional
         model = BetaGeoBetaBinomModel(
@@ -96,11 +96,11 @@ class BetaGeoBetaBinomModel(CLVModel):
         )
 
         # Fit model quickly to large datasets via Maximum a Posteriori
-        model.fit(fit_method='map')
+        model.fit(fit_method="map")
         print(model.fit_summary())
 
         # Fit with the default 'mcmc' for more informative predictions and reliable performance on smaller datasets
-        model.fit(fit_method='mcmc')
+        model.fit(fit_method="mcmc")
         print(model.fit_summary())
 
         # Predict number of purchases for customers over the next 10 time periods
@@ -113,15 +113,15 @@ class BetaGeoBetaBinomModel(CLVModel):
         # Data parameter is omitted here because predictions are ran on original dataset
         expected_num_purchases = model.expected_purchase_probability(
             n=[0, 1, 2, 3],
-            future_t=[10,20,30,40],
+            future_t=[10, 20, 30, 40],
         )
 
         new_data = pd.DataFrame(
-            data = {
-            "customer_id": [0, 1, 2, 3],
-            "frequency": [5, 2, 1, 8],
-            "recency": [7, 4, 2.5, 11],
-            "T": [10, 8, 10, 22]
+            data={
+                "customer_id": [0, 1, 2, 3],
+                "frequency": [5, 2, 1, 8],
+                "recency": [7, 4, 2.5, 11],
+                "T": [10, 8, 10, 22],
             }
         )
 

--- a/pymc_marketing/clv/models/gamma_gamma.py
+++ b/pymc_marketing/clv/models/gamma_gamma.py
@@ -248,15 +248,17 @@ class GammaGammaModel(BaseGammaGammaModel):
         from pymc_marketing.clv import GammaGammaModel
 
         model = GammaGammaModel(
-            data=pandas.DataFrame({
-                "customer_id": [0, 1, 2, 3, ...],
-                "monetary_value" :[23.5, 19.3, 11.2, 100.5, ...],
-                "frequency": [6, 8, 2, 1, ...],
-            }),
+            data=pandas.DataFrame(
+                {
+                    "customer_id": [0, 1, 2, 3, ...],
+                    "monetary_value": [23.5, 19.3, 11.2, 100.5, ...],
+                    "frequency": [6, 8, 2, 1, ...],
+                }
+            ),
             model_config={
-                "p": {'dist': 'HalfNormal', kwargs: {}},
-                "q": {'dist': 'HalfStudentT', kwargs: {"nu": 4, "sigma": 10}},
-                "v": {'dist': 'HalfCauchy', kwargs: {"beta":1}},
+                "p": {"dist": "HalfNormal", kwargs: {}},
+                "q": {"dist": "HalfStudentT", kwargs: {"nu": 4, "sigma": 10}},
+                "v": {"dist": "HalfCauchy", kwargs: {"beta": 1}},
             },
             sampler_config={
                 "draws": 1000,
@@ -271,15 +273,17 @@ class GammaGammaModel(BaseGammaGammaModel):
         print(model.fit_summary())
 
         # Predict spend of customers for which we know transaction history, conditioned on data.
-        expected_customer_spend = model.expected_customer_spend(
-            data=pandas.DataFrame(
-                {
-                "customer_id": [0, 1, 2, 3, ...],
-                "monetary_value" :[23.5, 19.3, 11.2, 100.5, ...],
-                "frequency": [6, 8, 2, 1, ...],
-                }
+        expected_customer_spend = (
+            model.expected_customer_spend(
+                data=pandas.DataFrame(
+                    {
+                        "customer_id": [0, 1, 2, 3, ...],
+                        "monetary_value": [23.5, 19.3, 11.2, 100.5, ...],
+                        "frequency": [6, 8, 2, 1, ...],
+                    }
+                ),
             ),
-        ),
+        )
         print(expected_customer_spend.mean("customer_id"))
 
         # Predict spend of 10 new customers, conditioned on data

--- a/pymc_marketing/clv/plotting.py
+++ b/pymc_marketing/clv/plotting.py
@@ -78,10 +78,7 @@ def plot_customer_exposure(
 
     .. code-block:: python
 
-        df = pd.DataFrame({
-            "recency": [0, 1, 2, 3, 4],
-            "T": [5, 5, 5, 5, 5]
-        })
+        df = pd.DataFrame({"recency": [0, 1, 2, 3, 4], "T": [5, 5, 5, 5, 5]})
 
         plot_customer_exposure(df)
 
@@ -89,21 +86,13 @@ def plot_customer_exposure(
 
     .. code-block:: python
 
-        (
-            df
-            .sort_values(["recency", "T"])
-            .pipe(plot_customer_exposure)
-        )
+        (df.sort_values(["recency", "T"]).pipe(plot_customer_exposure))
 
     Plot exposure for only those with time until last purchase is less than 3
 
     .. code-block:: python
 
-        (
-            df
-            .query("T - recency < 3")
-            .pipe(plot_customer_exposure)
-        )
+        (df.query("T - recency < 3").pipe(plot_customer_exposure))
 
     """
     if padding < 0:

--- a/pymc_marketing/customer_choice/mnl_logit.py
+++ b/pymc_marketing/customer_choice/mnl_logit.py
@@ -83,9 +83,9 @@ class MNLogit(ModelBuilder):
     Example `utility_equations` list:
 
     >>> utility_equations = [
-    ...     'alt_1 ~ X1_alt1 + X2_alt1 | income',
-    ...     'alt_2 ~ X1_alt2 + X2_alt2 | income',
-    ...     'alt_3 ~ X1_alt3 + X2_alt3 | income'
+    ...     "alt_1 ~ X1_alt1 + X2_alt1 | income",
+    ...     "alt_2 ~ X1_alt2 + X2_alt2 | income",
+    ...     "alt_3 ~ X1_alt3 + X2_alt3 | income",
     ... ]
 
     """

--- a/pymc_marketing/customer_choice/nested_logit.py
+++ b/pymc_marketing/customer_choice/nested_logit.py
@@ -93,18 +93,16 @@ class NestedLogit(ModelBuilder):
     Example `utility_equations` list:
 
     >>> utility_equations = [
-    ...     'alt_1 ~ X1_alt1 + X2_alt1 | income',
-    ...     'alt_2 ~ X1_alt2 + X2_alt2 | income',
-    ...     'alt_3 ~ X1_alt3 + X2_alt3 | income'
+    ...     "alt_1 ~ X1_alt1 + X2_alt1 | income",
+    ...     "alt_2 ~ X1_alt2 + X2_alt2 | income",
+    ...     "alt_3 ~ X1_alt3 + X2_alt3 | income",
     ... ]
 
     Example nesting structure:
 
     >>> nesting_structure = {
-    ... "Nest1": ["alt1"],
-    ... "Nest2": {"Nest2_1": ["alt_2", "alt_3"],
-    ...           "Nest_2_2": ["alt_4", "alt_5"]
-    ...          }
+    ...     "Nest1": ["alt1"],
+    ...     "Nest2": {"Nest2_1": ["alt_2", "alt_3"], "Nest_2_2": ["alt_4", "alt_5"]},
     ... }
 
     """

--- a/pymc_marketing/deserialize.py
+++ b/pymc_marketing/deserialize.py
@@ -29,10 +29,7 @@ Make use of the already registered PyMC-Marketing deserializers:
 
     from pymc_marketing.deserialize import deserialize
 
-    prior_class_data = {
-        "dist": "Normal",
-        "kwargs": {"mu": 0, "sigma": 1}
-    }
+    prior_class_data = {"dist": "Normal", "kwargs": {"mu": 0, "sigma": 1}}
     prior = deserialize(prior_class_data)
     # Prior("Normal", mu=0, sigma=1)
 
@@ -42,6 +39,7 @@ Register custom class deserialization:
 
     from pymc_marketing.deserialize import register_deserialization
 
+
     class MyClass:
         def __init__(self, value: int):
             self.value = value
@@ -50,8 +48,10 @@ Register custom class deserialization:
             # Example of what the to_dict method might look like.
             return {"value": self.value}
 
+
     register_deserialization(
-        is_type=lambda data: data.keys() == {"value"} and isinstance(data["value"], int),
+        is_type=lambda data: data.keys() == {"value"}
+        and isinstance(data["value"], int),
         deserialize=lambda data: MyClass(value=data["value"]),
     )
 
@@ -96,17 +96,22 @@ class Deserializer:
 
         from typing import Any
 
+
         class MyClass:
             def __init__(self, value: int):
                 self.value = value
 
+
         from pymc_marketing.deserialize import Deserializer
+
 
         def is_type(data: Any) -> bool:
             return data.keys() == {"value"} and isinstance(data["value"], int)
 
+
         def deserialize(data: dict) -> MyClass:
             return MyClass(value=data["value"])
+
 
         deserialize_logic = Deserializer(is_type=is_type, deserialize=deserialize)
 
@@ -216,6 +221,7 @@ def register_deserialization(is_type: IsType, deserialize: Deserialize) -> None:
 
         from pymc_marketing.deserialize import register_deserialization
 
+
         class MyClass:
             def __init__(self, value: int):
                 self.value = value
@@ -224,8 +230,10 @@ def register_deserialization(is_type: IsType, deserialize: Deserialize) -> None:
                 # Example of what the to_dict method might look like.
                 return {"value": self.value}
 
+
         register_deserialization(
-            is_type=lambda data: data.keys() == {"value"} and isinstance(data["value"], int),
+            is_type=lambda data: data.keys() == {"value"}
+            and isinstance(data["value"], int),
             deserialize=lambda data: MyClass(value=data["value"]),
         )
 

--- a/pymc_marketing/mlflow.py
+++ b/pymc_marketing/mlflow.py
@@ -86,7 +86,7 @@ Autologging for a PyMC-Marketing MMM:
     data_url = "https://raw.githubusercontent.com/pymc-labs/pymc-marketing/main/data/mmm_example.csv"
     data = pd.read_csv(data_url, parse_dates=["date_week"])
 
-    X = data.drop("y",axis=1)
+    X = data.drop("y", axis=1)
     y = data["y"]
 
     mmm = MMM(
@@ -842,7 +842,7 @@ def log_mmm(
         data_url = "https://raw.githubusercontent.com/pymc-labs/pymc-marketing/main/data/mmm_example.csv"
         data = pd.read_csv(data_url, parse_dates=["date_week"])
 
-        X = data.drop("y",axis=1)
+        X = data.drop("y", axis=1)
         y = data["y"]
 
         mmm = MMM(
@@ -1005,8 +1005,10 @@ def log_error(func: Callable, file_name: str):
 
         from pymc_marketing.mlflow import log_error
 
+
         def raising_function():
             raise NotImplementedError("Sorry. Not implemented")
+
 
         func = log_error(raising_function, file_name="raising-function")
 
@@ -1124,7 +1126,7 @@ def autolog(
         data_url = "https://raw.githubusercontent.com/pymc-labs/pymc-marketing/main/data/mmm_example.csv"
         data = pd.read_csv(data_url, parse_dates=["date_week"])
 
-        X = data.drop("y",axis=1)
+        X = data.drop("y", axis=1)
         y = data["y"]
 
         mmm = MMM(

--- a/pymc_marketing/mmm/components/__init__.py
+++ b/pymc_marketing/mmm/components/__init__.py
@@ -26,6 +26,7 @@ Use custom transformations for media in the MMM model:
         WeibullPDFAdstock,
     )
 
+
     class InfiniteReturns(SaturationTransformation):
         def function(self, x, b):
             return b * x

--- a/pymc_marketing/mmm/components/adstock.py
+++ b/pymc_marketing/mmm/components/adstock.py
@@ -28,6 +28,7 @@ Create a new adstock transformation:
     from pymc_marketing.mmm import AdstockTransformation
     from pymc_marketing.prior import Prior
 
+
     class MyAdstock(AdstockTransformation):
         lookup_name: str = "my_adstock"
 

--- a/pymc_marketing/mmm/components/base.py
+++ b/pymc_marketing/mmm/components/base.py
@@ -222,11 +222,13 @@ class Transformation:
             from pymc_marketing.mmm.components.base import Transformation
             from pymc_marketing.prior import Prior
 
+
             class MyTransformation(Transformation):
                 lookup_name: str = "my_transformation"
                 prefix: str = "transformation"
                 function = lambda x, lam: x * lam
                 default_priors = {"lam": Prior("Gamma", alpha=3, beta=1)}
+
 
             transformation = MyTransformation()
             transformation.update_priors(

--- a/pymc_marketing/mmm/components/saturation.py
+++ b/pymc_marketing/mmm/components/saturation.py
@@ -27,6 +27,7 @@ Create a new saturation transformation:
     from pymc_marketing.mmm import SaturationTransformation
     from pymc_marketing.prior import Prior
 
+
     class InfiniteReturns(SaturationTransformation):
         lookup_name: str = "infinite_returns"
 
@@ -119,8 +120,10 @@ class SaturationTransformation(Transformation, metaclass=SaturationRegistrationM
         from pymc_marketing.mmm import SaturationTransformation
         from pymc_marketing.prior import Prior
 
+
         def infinite_returns(x, b):
             return b * x
+
 
         class InfiniteReturns(SaturationTransformation):
             lookup_name = "infinite_returns"

--- a/pymc_marketing/mmm/evaluation.py
+++ b/pymc_marketing/mmm/evaluation.py
@@ -201,7 +201,7 @@ def compute_summary_metrics(
         data_url = "https://raw.githubusercontent.com/pymc-labs/pymc-marketing/main/data/mmm_example.csv"
         data = pd.read_csv(data_url, parse_dates=["date_week"])
 
-        X = data.drop("y",axis=1)
+        X = data.drop("y", axis=1)
         y = data["y"]
         mmm = MMM(
             adstock=GeometricAdstock(l_max=8),
@@ -225,7 +225,7 @@ def compute_summary_metrics(
             y_true=mmm.y,
             y_pred=posterior_preds.y,
             metrics_to_calculate=["r_squared", "rmse", "mae"],
-            hdi_prob=0.89
+            hdi_prob=0.89,
         )
 
         # Print the results neatly

--- a/pymc_marketing/mmm/fourier.py
+++ b/pymc_marketing/mmm/fourier.py
@@ -130,8 +130,8 @@ used in the model.
     periods = 52 * 3
     dates = pd.date_range("2022-01-01", periods=periods, freq="W-MON")
 
-    training_dates = dates[:52 * 2]
-    testing_dates = dates[52 * 2:]
+    training_dates = dates[: 52 * 2]
+    testing_dates = dates[52 * 2 :]
 
     yearly = YearlyFourier(n_order=3)
 
@@ -438,8 +438,10 @@ class FourierBase(BaseModel):
 
             fourier = YearlyFourier(n_order=3)
 
+
             def callback(result):
                 pm.Deterministic("fourier_trend", result, dims=("date", "fourier"))
+
 
             dates = pd.date_range("2023-01-01", periods=52, freq="W-MON")
 

--- a/pymc_marketing/mmm/lift_test.py
+++ b/pymc_marketing/mmm/lift_test.py
@@ -97,10 +97,12 @@ def exact_row_indices(df: pd.DataFrame, model: pm.Model) -> Indices:
 
         from pymc_marketing.mmm.lift_test import exact_row_indices
 
-        df_lift_test = pd.DataFrame({
-            "channel": [0, 1, 0],
-            "geo": ["A", "B", "B"],
-        })
+        df_lift_test = pd.DataFrame(
+            {
+                "channel": [0, 1, 0],
+                "geo": ["A", "B", "B"],
+            }
+        )
 
         coords = {"channel": [0, 1, 2], "geo": ["A", "B", "C"]}
         model = pm.Model(coords=coords)
@@ -338,15 +340,19 @@ def add_saturation_observations(
         import pandas as pd
         from pymc_marketing.mmm.lift_test import add_saturation_observations
 
-        df_base_lift_test = pd.DataFrame({
-            "x": [1, 2, 3],
-            "delta_x": [1, 2, 3],
-            "delta_y": [1, 2, 3],
-            "sigma": [0.1, 0.2, 0.3],
-        })
+        df_base_lift_test = pd.DataFrame(
+            {
+                "x": [1, 2, 3],
+                "delta_x": [1, 2, 3],
+                "delta_y": [1, 2, 3],
+                "sigma": [0.1, 0.2, 0.3],
+            }
+        )
+
 
         def saturation_function(x, alpha, lam):
             return alpha * x / (x + lam)
+
 
         # These are required since alpha and lam
         # have both channel and date dimensions
@@ -387,12 +393,14 @@ def add_saturation_observations(
 
         saturation = LogisticSaturation()
 
-        df_base_lift_test = pd.DataFrame({
-            "x": [1, 2, 3],
-            "delta_x": [1, 2, 3],
-            "delta_y": [1, 2, 3],
-            "sigma": [0.1, 0.2, 0.3],
-        })
+        df_base_lift_test = pd.DataFrame(
+            {
+                "x": [1, 2, 3],
+                "delta_x": [1, 2, 3],
+                "delta_y": [1, 2, 3],
+                "sigma": [0.1, 0.2, 0.3],
+            }
+        )
 
         df_lift_test = df_base_lift_test.assign(
             channel="channel_1",
@@ -425,12 +433,14 @@ def add_saturation_observations(
 
         saturation = LogisticSaturation()
 
-        df_base_lift_test = pd.DataFrame({
-            "x": [1, 2, 3],
-            "delta_x": [1, 2, 3],
-            "delta_y": [1, 2, 3],
-            "sigma": [0.1, 0.2, 0.3],
-        })
+        df_base_lift_test = pd.DataFrame(
+            {
+                "x": [1, 2, 3],
+                "delta_x": [1, 2, 3],
+                "delta_y": [1, 2, 3],
+                "sigma": [0.1, 0.2, 0.3],
+            }
+        )
 
         df_lift_test = df_base_lift_test.assign(
             channel="channel_1",

--- a/pymc_marketing/mmm/media_transformation.py
+++ b/pymc_marketing/mmm/media_transformation.py
@@ -49,18 +49,20 @@ Create a combined media configuration for offline and online media channels:
         MediaConfigList,
     )
 
-    media_configs: MediaConfigList([
-        MediaConfig(
-            name="offline",
-            columns=["TV", "Radio"],
-            media_transformation=offline_media_transform,
-        ),
-        MediaConfig(
-            name="online",
-            columns=["Facebook", "Instagram", "YouTube", "TikTok"],
-            media_transformation=online_media_transform,
-        ),
-    ])
+    media_configs: MediaConfigList(
+        [
+            MediaConfig(
+                name="offline",
+                columns=["TV", "Radio"],
+                media_transformation=offline_media_transform,
+            ),
+            MediaConfig(
+                name="online",
+                columns=["Facebook", "Instagram", "YouTube", "TikTok"],
+                media_transformation=online_media_transform,
+            ),
+        ]
+    )
 
 
 Apply the media transformation to media data in PyMC model:
@@ -81,9 +83,7 @@ Apply the media transformation to media data in PyMC model:
     }
     with pm.Model(coords=coords) as model:
         media_data = pm.Data(
-            "media_data",
-            df.loc[:, media_columns].to_numpy(),
-            dims=("date", "media")
+            "media_data", df.loc[:, media_columns].to_numpy(), dims=("date", "media")
         )
         transformed_media_data = media_configs(media_data)
 

--- a/pymc_marketing/mmm/mmm.py
+++ b/pymc_marketing/mmm/mmm.py
@@ -1457,7 +1457,9 @@ class MMM(
 
             n_channels = len(model.channel_columns)
             spend = np.ones(n_channels)
-            new_spend_contributions = model.new_spend_contributions(spend=spend, one_time=False)
+            new_spend_contributions = model.new_spend_contributions(
+                spend=spend, one_time=False
+            )
 
         Channel contributions from 1 unit on each channel only once but with 1 unit leading up to the spend.
 
@@ -1466,7 +1468,9 @@ class MMM(
             n_channels = len(model.channel_columns)
             spend = np.ones(n_channels)
             spend_leading_up = np.ones(n_channels)
-            new_spend_contributions = model.new_spend_contributions(spend=spend, spend_leading_up=spend_leading_up)
+            new_spend_contributions = model.new_spend_contributions(
+                spend=spend, spend_leading_up=spend_leading_up
+            )
 
         """
         if spend is None:
@@ -1649,7 +1653,7 @@ class MMM(
 
         Example
         -------
-        >>> self.format_recovered_transformation_parameters(quantile=.5)
+        >>> self.format_recovered_transformation_parameters(quantile=0.5)
         >>> Output:
         {
             'x1': {
@@ -2004,10 +2008,7 @@ class MMM(
 
         .. code-block:: python
 
-            model_estimated_lift = (
-                saturation_curve(x + delta_x)
-                - saturation_curve(x)
-            )
+            model_estimated_lift = saturation_curve(x + delta_x) - saturation_curve(x)
             empirical_lift = delta_y
             dist(abs(model_estimated_lift), sigma=sigma, observed=abs(empirical_lift))
 
@@ -2069,13 +2070,15 @@ class MMM(
 
             model.build_model(X, y)
 
-            df_lift_test = pd.DataFrame({
-                "channel": ["x1", "x1"],
-                "x": [1, 1],
-                "delta_x": [0.1, 0.2],
-                "delta_y": [0.1, 0.1],
-                "sigma": [0.1, 0.1],
-            })
+            df_lift_test = pd.DataFrame(
+                {
+                    "channel": ["x1", "x1"],
+                    "x": [1, 1],
+                    "delta_x": [0.1, 0.2],
+                    "delta_y": [0.1, 0.1],
+                    "sigma": [0.1, 0.1],
+                }
+            )
 
             model.add_lift_test_measurements(df_lift_test)
 

--- a/pymc_marketing/mmm/scaling.py
+++ b/pymc_marketing/mmm/scaling.py
@@ -57,13 +57,15 @@ class Scaling(BaseModel):
 
         from pymc_marketing.mmm.multidimensional import Scaling
 
-        scaling = Scaling(**{
-            "target": {
-                "method": "max",
-                # Exclude 'DMA' from dims here.
-                "dims": (),
-            },
-        })
+        scaling = Scaling(
+            **{
+                "target": {
+                    "method": "max",
+                    # Exclude 'DMA' from dims here.
+                    "dims": (),
+                },
+            }
+        )
 
     """
 

--- a/pymc_marketing/mmm/tvp.py
+++ b/pymc_marketing/mmm/tvp.py
@@ -29,7 +29,10 @@ Create a basic PyMC model using the time-varying GP multiplier:
     import pandas as pd
 
     from pymc_marketing.hsgp_kwargs import HSGPKwargs
-    from pymc_marketing.mmm.tvp import create_time_varying_gp_multiplier, infer_time_index
+    from pymc_marketing.mmm.tvp import (
+        create_time_varying_gp_multiplier,
+        infer_time_index,
+    )
 
     # Generate example data
     np.random.seed(0)

--- a/pymc_marketing/model_builder.py
+++ b/pymc_marketing/model_builder.py
@@ -226,7 +226,6 @@ class ModelBuilder(ABC):
         .. code-block:: python
 
             def _data_setter(self, X, y=None):
-
                 data = {"X": X}
                 if y is None:
                     y = np.zeros(len(X))
@@ -466,8 +465,10 @@ class ModelBuilder(ABC):
         >>>     def __init__(self):
         >>>         super().__init__()
         >>> model = MyModel()
-        >>> model.fit(X,y)
-        >>> model.save('model_results.nc')  # This will call the overridden method in MyModel
+        >>> model.fit(X, y)
+        >>> model.save(
+        ...     "model_results.nc"
+        ... )  # This will call the overridden method in MyModel
 
         """
         if self.idata is not None and "posterior" in self.idata:
@@ -694,7 +695,7 @@ class ModelBuilder(ABC):
         Examples
         --------
         >>> model = MyModel()
-        >>> idata = model.fit(X,y)
+        >>> idata = model.fit(X, y)
         Auto-assigning NUTS sampler...
         Initializing NUTS using jitter+adapt_diag...
 
@@ -814,9 +815,9 @@ class ModelBuilder(ABC):
         Examples
         --------
         >>> model = MyModel()
-        >>> idata = model.fit(X,y)
+        >>> idata = model.fit(X, y)
         >>> x_pred = []
-        >>> prediction_data = pd.DataFrame({'input':x_pred})
+        >>> prediction_data = pd.DataFrame({"input": x_pred})
         >>> pred_mean = model.predict(prediction_data)
 
         """

--- a/pymc_marketing/model_graph.py
+++ b/pymc_marketing/model_graph.py
@@ -61,15 +61,18 @@ def deterministics_to_flat(model: pm.Model, names: list[str]) -> pm.Model:
 
         with pm.Model() as model:
             x = pm.Normal("x", mu=0, sigma=1)
-            y = pm.Deterministic("y", x ** 2)
+            y = pm.Deterministic("y", x**2)
             z = pm.Deterministic("z", x + y)
 
         new_model = deterministics_to_flat(model, ["y"])
 
         chains, draws = 2, 100
-        mock_posterior = xr.Dataset({
-            "y": (("chain", "draw"), np.zeros((chains, draws))),
-        }, coords={"chain": np.arange(chains), "draw": np.arange(draws)})
+        mock_posterior = xr.Dataset(
+            {
+                "y": (("chain", "draw"), np.zeros((chains, draws))),
+            },
+            coords={"chain": np.arange(chains), "draw": np.arange(draws)},
+        )
 
         x_z_given_y = pm.sample_posterior_predictive(
             mock_posterior,

--- a/pymc_marketing/prior.py
+++ b/pymc_marketing/prior.py
@@ -85,8 +85,10 @@ Create a prior with a custom transform function by registering it with
 
     from pymc_marketing.prior import register_tensor_transform
 
+
     def custom_transform(x):
-        return x ** 2
+        return x**2
+
 
     register_tensor_transform("square", custom_transform)
 
@@ -247,8 +249,10 @@ def register_tensor_transform(name: str, transform: Transform) -> None:
             register_tensor_transform,
         )
 
+
         def custom_transform(x):
-            return x ** 2
+            return x**2
+
 
         register_tensor_transform("square", custom_transform)
 
@@ -335,6 +339,7 @@ def sample_prior(
 
         from pymc_marketing.prior import sample_prior
 
+
         class CustomVariableDefinition:
             def __init__(self, dims, n: int):
                 self.dims = dims
@@ -342,7 +347,8 @@ def sample_prior(
 
             def create_variable(self, name: str) -> "TensorVariable":
                 x = pm.Normal(f"{name}_x", mu=0, sigma=1, dims=self.dims)
-                return pt.sum([x ** n for n in range(1, self.n + 1)], axis=0)
+                return pt.sum([x**n for n in range(1, self.n + 1)], axis=0)
+
 
         cubic = CustomVariableDefinition(dims=("channel",), n=3)
         coords = {"channel": ["C1", "C2", "C3"]}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,8 @@ replacement = '[\1](https://github.com/pymc-labs/pymc-marketing/tree/main/\g<2>)
 repository = "https://github.com/pymc-labs/pymc-marketing"
 homepage = "https://www.pymc-marketing.io"
 
+[tool.ruff.format]
+docstring-code-format = true
 
 [tool.ruff.lint]
 select = ["B", "D", "DOC", "E", "F", "I", "RUF", "S", "UP", "W"]


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

Thought this would be nice. If not, feel free to close it or suggest changes

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1794.org.readthedocs.build/en/1794/

<!-- readthedocs-preview pymc-marketing end -->