### PR TITLE
Follow `ModelBuilder` interface in `MultidimensionalMMM.build_model`

### DIFF
--- a/pymc_marketing/mmm/multidimensional.py
+++ b/pymc_marketing/mmm/multidimensional.py
@@ -987,8 +987,8 @@ class MMM(ModelBuilder):
             )
 
         self._generate_and_preprocess_model_data(
-            X=X,  # type: ignore
-            y=y,  # type: ignore
+            X=X,
+            y=y,
         )
         # Compute and save scales
         self._compute_scales()


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->
`MuldimensionalMMM.build_model` overrides `ModelBuilder.build_model` in a way that is not respecting the `super` type hints.

This PR fixes that, and casts the inputs in a way that is compatible with the signatures of `_generate_and_preprocess_model_data(X: pd.DataFrame, y: pd.Series)`


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1806.org.readthedocs.build/en/1806/

<!-- readthedocs-preview pymc-marketing end -->