### PR TITLE
lift test requires 'date' in df_lift_test Data Frame with time_varying_media=True

### DIFF
--- a/pymc_marketing/mmm/mmm.py
+++ b/pymc_marketing/mmm/mmm.py
@@ -2094,6 +2094,13 @@ class MMM(
                 "The 'channel' column is required to map the lift measurements to the model."
             )
 
+        if self.time_varying_media and "date" not in df_lift_test.columns:
+            # `time_varying_media=True` parameter requires the date in the df_lift_test DataFrame.
+            # The `add_lift_test_measurements` method itself doesn't need a date
+            # We need to make sure the `date` coord is present in model_coords
+            # By adding this we make sure the model_coords match
+            df_lift_test["date"] = pd.to_datetime(self.model_coords["date"][0])
+
         df_lift_test_scaled = scale_lift_measurements(
             df_lift_test=df_lift_test,
             channel_col="channel",


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
Using the `time_varying_media=True` parameter requires that the date is provided in the `df_lift_test` DataFrame. 

Instead of adding additional documentation within the `add_lift_test_measurements` method as well as the example notebook, we are automatically adding in the `date` column to the `df_lift_test` DataFrame. Going this route could make it more user friendly, since the `date` column isn't needed for the method itself. More so needed to have the coords matching when using `time_varying_media=True`.


## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #1287
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->
