### PR TITLE
Add callback tracking to budget optimizer

### DIFF
--- a/pymc_marketing/mmm/budget_optimizer.py
+++ b/pymc_marketing/mmm/budget_optimizer.py
@@ -408,7 +408,11 @@ class BudgetOptimizer(BaseModel):
         x0: np.ndarray | None = None,
         minimize_kwargs: dict[str, Any] | None = None,
         return_if_fail: bool = False,
-    ) -> tuple[DataArray, OptimizeResult]:
+        callback: bool = False,
+    ) -> (
+        tuple[DataArray, OptimizeResult]
+        | tuple[DataArray, OptimizeResult, list[dict[str, Any]]]
+    ):
         """
         Allocate the budget based on `total_budget`, optional `budget_bounds`, and custom constraints.
 
@@ -432,6 +436,11 @@ class BudgetOptimizer(BaseModel):
             ftol=1e-9, maxiter=1_000.
         return_if_fail : bool, optional
             Return output even if optimization fails. Default is False.
+        callback : bool, optional
+            Whether to return callback information tracking optimization progress. When True, returns a third
+            element containing a list of dictionaries with optimization information at each iteration including
+            'x' (parameter values), 'fun' (objective value), 'jac' (gradient), and constraint information.
+            Default is False for backward compatibility.
 
         Returns
         -------
@@ -439,6 +448,9 @@ class BudgetOptimizer(BaseModel):
             The optimized budget allocation across channels.
         result : OptimizeResult
             The raw scipy optimization result.
+        callback_info : list[dict[str, Any]], optional
+            Only returned if callback=True. List of dictionaries containing optimization
+            information at each iteration.
 
         Raises
         ------
@@ -515,13 +527,59 @@ class BudgetOptimizer(BaseModel):
         # will raise a TypeError if x0 does not have acceptable shape and/or type
         x0 = self._budgets_flat.type.filter(x0)
 
+        # 5. Set up callback tracking if requested
+        callback_info = []
+
+        def track_progress(xk):
+            """Track optimization progress at each iteration."""
+            # Evaluate objective and gradient
+            obj_val, grad_val = self._compiled_functions[self.utility_function][
+                "objective_and_grad"
+            ](xk)
+
+            # Store iteration info
+            iter_info = {
+                "x": np.array(xk),  # Current parameter values
+                "fun": float(obj_val),  # Objective function value (scalar)
+                "jac": np.array(grad_val),  # Gradient values
+            }
+
+            # Evaluate constraint values and gradients if available
+            if self._compiled_constraints:
+                constraint_values = []
+                constraint_jacs = []
+
+                for _, constraint in enumerate(self._compiled_constraints):
+                    # Evaluate constraint function
+                    c_val = constraint["fun"](xk)
+                    # Evaluate constraint gradient
+                    c_jac = constraint["jac"](xk)
+
+                    constraint_values.append(
+                        {
+                            "type": constraint["type"],
+                            "value": float(c_val)
+                            if np.ndim(c_val) == 0
+                            else np.array(c_val),
+                        }
+                    )
+                    constraint_jacs.append(np.array(c_jac))
+
+                iter_info["constraint_values"] = constraint_values
+                iter_info["constraint_jacs"] = constraint_jacs
+
+            callback_info.append(iter_info)
+
         # 5. Run the SciPy optimizer
+        scipy_callback = track_progress if callback else None
+
         result = minimize(
             fun=self._compiled_functions[self.utility_function]["objective_and_grad"],
             x0=x0,
             jac=True,
             bounds=bounds,
             constraints=self._compiled_constraints,
+            callback=scipy_callback,
             **minimize_kwargs,
         )
 
@@ -537,7 +595,11 @@ class BudgetOptimizer(BaseModel):
             optimal_budgets = DataArray(
                 optimal_budgets, dims=self._budget_dims, coords=self._budget_coords
             )
-            return optimal_budgets, result
+
+            if callback:
+                return optimal_budgets, result, callback_info
+            else:
+                return optimal_budgets, result
 
         else:
             raise MinimizeException(f"Optimization failed: {result.message}")

--- a/pymc_marketing/mmm/mmm.py
+++ b/pymc_marketing/mmm/mmm.py
@@ -69,7 +69,7 @@ class BaseMMM(BaseValidateMMM):
 
     References
     ----------
-    .. [1] Jin, Yuxue, et al. “Bayesian methods for media mix modeling with carryover and shape effects.” (2017).
+    .. [1] Jin, Yuxue, et al. "Bayesian methods for media mix modeling with carryover and shape effects." (2017).
 
     """
 
@@ -2330,8 +2330,12 @@ class MMM(
         utility_function: UtilityFunctionType = average_response,
         constraints: Sequence[dict[str, Any]] = (),
         default_constraints: bool = True,
+        callback: bool = False,
         **minimize_kwargs,
-    ) -> tuple[DataArray, OptimizeResult]:
+    ) -> (
+        tuple[DataArray, OptimizeResult]
+        | tuple[DataArray, OptimizeResult, list[dict[str, Any]]]
+    ):
         """Optimize the given budget based on the specified utility function over a specified time period.
 
         This function optimizes the allocation of a given budget across different channels
@@ -2366,6 +2370,10 @@ class MMM(
             [{"key":...,"constraint_fun":...,"constraint_type":...}]
         default_constraints : bool, optional
             Whether to add the default sum constraint to the optimizer. Default is True.
+        callback : bool, optional
+            Whether to return callback information tracking optimization progress. When True, returns a third
+            element containing a list of dictionaries with optimization information at each iteration.
+            Default is False for backward compatibility.
         **minimize_kwargs
             Additional arguments to pass to the `BudgetOptimizer`.
 
@@ -2396,6 +2404,7 @@ class MMM(
         return allocator.allocate_budget(
             total_budget=budget,
             budget_bounds=budget_bounds,
+            callback=callback,
             **minimize_kwargs,
         )
 

--- a/pymc_marketing/mmm/multidimensional.py
+++ b/pymc_marketing/mmm/multidimensional.py
@@ -1772,9 +1772,41 @@ class MultiDimensionalBudgetOptimizerWrapper(OptimizerCompatibleModelWrapper):
         constraints: Sequence[dict[str, Any]] = (),
         default_constraints: bool = True,
         budgets_to_optimize: xr.DataArray | None = None,
+        callback: bool = False,
         **minimize_kwargs,
-    ) -> tuple[xr.DataArray, OptimizeResult]:
-        """Optimize the budget allocation for the model."""
+    ) -> (
+        tuple[xr.DataArray, OptimizeResult]
+        | tuple[xr.DataArray, OptimizeResult, list[dict[str, Any]]]
+    ):
+        """Optimize the budget allocation for the model.
+
+        Parameters
+        ----------
+        budget : float | int
+            Total budget to allocate.
+        budget_bounds : xr.DataArray | None
+            Budget bounds per channel.
+        response_variable : str
+            Response variable to optimize.
+        utility_function : UtilityFunctionType
+            Utility function to maximize.
+        constraints : Sequence[dict[str, Any]]
+            Custom constraints for the optimizer.
+        default_constraints : bool
+            Whether to add default constraints.
+        budgets_to_optimize : xr.DataArray | None
+            Mask defining which budgets to optimize.
+        callback : bool
+            Whether to return callback information tracking optimization progress.
+        **minimize_kwargs
+            Additional arguments for the optimizer.
+
+        Returns
+        -------
+        tuple
+            Optimal budgets and optimization result. If callback=True, also returns
+            a list of dictionaries with optimization information at each iteration.
+        """
         from pymc_marketing.mmm.budget_optimizer import BudgetOptimizer
 
         allocator = BudgetOptimizer(
@@ -1790,6 +1822,7 @@ class MultiDimensionalBudgetOptimizerWrapper(OptimizerCompatibleModelWrapper):
         return allocator.allocate_budget(
             total_budget=budget,
             budget_bounds=budget_bounds,
+            callback=callback,
             **minimize_kwargs,
         )
 

--- a/tests/mmm/test_budget_optimizer.py
+++ b/tests/mmm/test_budget_optimizer.py
@@ -19,6 +19,7 @@ import pandas as pd
 import pytensor
 import pytensor.tensor as pt
 import pytest
+import xarray as xr
 
 from pymc_marketing.mmm import MMM
 from pymc_marketing.mmm.budget_optimizer import (
@@ -471,3 +472,162 @@ def test_allocate_budget_custom_response_constraint(
     final_resp = test_fn(res.x)
 
     np.testing.assert_allclose(final_resp, target_response, rtol=1e-2)
+
+
+@pytest.mark.parametrize(
+    "callback, total_budget, expected_return_length",
+    [
+        # Basic cases
+        (False, 100, 2),  # Default behavior - no callback
+        (True, 100, 3),  # With callback
+    ],
+    ids=[
+        "default_no_callback",
+        "basic_with_callback",
+    ],
+)
+def test_callback_functionality_parametrized(
+    dummy_df,
+    dummy_idata,
+    callback,
+    total_budget,
+    expected_return_length,
+):
+    """Test callback functionality with various parameter combinations."""
+    df_kwargs, X_dummy, y_dummy = dummy_df
+
+    mmm = MMM(
+        adstock=GeometricAdstock(l_max=4),
+        saturation=LogisticSaturation(),
+        **df_kwargs,
+    )
+
+    mmm.build_model(X=X_dummy, y=y_dummy)
+    mmm.idata = dummy_idata
+
+    # Create BudgetOptimizer Instance
+    match = "Using default equality constraint"
+    with pytest.warns(UserWarning, match=match):
+        optimizer = BudgetOptimizer(
+            model=mmm,
+            num_periods=30,
+        )
+
+    # Run allocation
+    result = optimizer.allocate_budget(
+        total_budget=total_budget,
+        callback=callback,
+    )
+
+    # Check return length
+    assert len(result) == expected_return_length
+
+    if callback:
+        # Unpack with callback
+        optimal_budgets, opt_result, callback_info = result
+
+        # Verify callback info structure
+        assert isinstance(callback_info, list)
+        assert len(callback_info) > 0
+
+        # Check first iteration
+        first_iter = callback_info[0]
+        assert "x" in first_iter
+        assert "fun" in first_iter
+        assert "jac" in first_iter
+
+        # Check data types
+        assert isinstance(first_iter["x"], np.ndarray)
+        assert isinstance(first_iter["fun"], float | np.float64 | np.float32)
+        assert isinstance(first_iter["jac"], np.ndarray)
+
+        # Check dimensions
+        assert first_iter["x"].shape == first_iter["jac"].shape
+
+        # Check constraints (default constraint should be present)
+        assert "constraint_values" in first_iter
+        assert "constraint_jacs" in first_iter
+
+        # Verify all iterations have same structure
+        for iter_info in callback_info:
+            assert set(iter_info.keys()) == set(first_iter.keys())
+
+    else:
+        # Unpack without callback
+        optimal_budgets, opt_result = result
+
+    # Common checks
+    assert isinstance(optimal_budgets, xr.DataArray)
+    assert hasattr(opt_result, "x")
+    assert hasattr(opt_result, "success")
+
+    # Check budget allocation sums to total
+    assert np.abs(optimal_budgets.sum().item() - total_budget) < 1e-3
+
+
+@pytest.mark.parametrize(
+    "callback",
+    [
+        False,  # Default no callback
+        True,  # With callback
+    ],
+    ids=[
+        "no_callback",
+        "with_callback",
+    ],
+)
+def test_mmm_optimize_budget_callback_parametrized(dummy_df, dummy_idata, callback):
+    """Test callback functionality through MMM.optimize_budget interface."""
+    df_kwargs, X_dummy, y_dummy = dummy_df
+
+    mmm = MMM(
+        adstock=GeometricAdstock(l_max=4),
+        saturation=LogisticSaturation(),
+        **df_kwargs,
+    )
+
+    mmm.build_model(X=X_dummy, y=y_dummy)
+    mmm.idata = dummy_idata
+
+    # Test the MMM interface
+    result = mmm.optimize_budget(
+        budget=100,
+        num_periods=10,
+        callback=callback,
+    )
+
+    # Check return value count
+    if callback:
+        assert len(result) == 3
+        optimal_budgets, opt_result, callback_info = result
+
+        # Validate callback info
+        assert isinstance(callback_info, list)
+        assert len(callback_info) > 0
+
+        # Each iteration should have required keys
+        for iter_info in callback_info:
+            assert "x" in iter_info
+            assert "fun" in iter_info
+            assert "jac" in iter_info
+
+        # Check that objective values are finite
+        objectives = [iter_info["fun"] for iter_info in callback_info]
+        assert all(np.isfinite(obj) for obj in objectives)
+
+    else:
+        assert len(result) == 2
+        optimal_budgets, opt_result = result
+
+    # Common validations
+    assert isinstance(optimal_budgets, xr.DataArray)
+    assert optimal_budgets.dims == ("channel",)
+    assert len(optimal_budgets) == len(mmm.channel_columns)
+
+    # Budget should sum to total (within tolerance)
+    assert np.abs(optimal_budgets.sum().item() - 100) < 1e-6
+
+    # Check optimization result
+    assert hasattr(opt_result, "success")
+    assert hasattr(opt_result, "x")
+    assert hasattr(opt_result, "fun")


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->
Introduces a 'callback' option to BudgetOptimizer, MMM.optimize_budget, and MultiDimensionalBudgetOptimizerWrapper.optimize_budget, enabling tracking and return of optimization progress at each iteration. Updates docstrings and adds comprehensive tests to validate callback output structure and integration.

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->
