### PR TITLE
Cosmetic changes to #1829

### DIFF
--- a/pymc_marketing/mmm/budget_optimizer.py
+++ b/pymc_marketing/mmm/budget_optimizer.py
@@ -546,8 +546,7 @@ class BudgetOptimizer(BaseModel):
 
             # Evaluate constraint values and gradients if available
             if self._compiled_constraints:
-                constraint_values = []
-                constraint_jacs = []
+                constraint_info = []
 
                 for _, constraint in enumerate(self._compiled_constraints):
                     # Evaluate constraint function
@@ -555,18 +554,17 @@ class BudgetOptimizer(BaseModel):
                     # Evaluate constraint gradient
                     c_jac = constraint["jac"](xk)
 
-                    constraint_values.append(
+                    constraint_info.append(
                         {
                             "type": constraint["type"],
                             "value": float(c_val)
                             if np.ndim(c_val) == 0
                             else np.array(c_val),
+                            "jac": np.array(c_jac) if c_jac is not None else None,
                         }
                     )
-                    constraint_jacs.append(np.array(c_jac))
 
-                iter_info["constraint_values"] = constraint_values
-                iter_info["constraint_jacs"] = constraint_jacs
+                iter_info["constraint_info"] = constraint_info
 
             callback_info.append(iter_info)
 

--- a/tests/mmm/test_budget_optimizer.py
+++ b/tests/mmm/test_budget_optimizer.py
@@ -545,8 +545,7 @@ def test_callback_functionality_parametrized(
         assert first_iter["x"].shape == first_iter["jac"].shape
 
         # Check constraints (default constraint should be present)
-        assert "constraint_values" in first_iter
-        assert "constraint_jacs" in first_iter
+        assert "constraint_info" in first_iter
 
         # Verify all iterations have same structure
         for iter_info in callback_info:


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->
@cetagostini these are the minor changes suggested to #1829 we've talked about 


## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [x] Related to #1829 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->
