### PR TITLE
Deprecate and disable budget optimization method

### DIFF
--- a/pymc_marketing/mmm/mmm.py
+++ b/pymc_marketing/mmm/mmm.py
@@ -2336,9 +2336,9 @@ class MMM(
         tuple[DataArray, OptimizeResult]
         | tuple[DataArray, OptimizeResult, list[dict[str, Any]]]
     ):
-        """Optimize the given budget based on the specified utility function over a specified time period.
+        """Optimize the given budget based on the specified utility function over a specified time period (DEPRECATED).
 
-        This function optimizes the allocation of a given budget across different channels
+        DEPRECATED: This function optimizes the allocation of a given budget across different channels
         to maximize the response, considering adstock and saturation effects. It scales the
         budget and budget bounds, performs the optimization, and generates a synthetic dataset
         for posterior predictive sampling.
@@ -2390,22 +2390,9 @@ class MMM(
         ValueError
             If the noise level is not a float.
         """
-        from pymc_marketing.mmm.budget_optimizer import BudgetOptimizer
-
-        allocator = BudgetOptimizer(
-            num_periods=num_periods,
-            utility_function=utility_function,
-            response_variable=response_variable,
-            custom_constraints=constraints,
-            default_constraints=default_constraints,
-            model=self,
-        )
-
-        return allocator.allocate_budget(
-            total_budget=budget,
-            budget_bounds=budget_bounds,
-            callback=callback,
-            **minimize_kwargs,
+        raise NotImplementedError(
+            "This method is deprecated and no longer available. "
+            "Please migrate to the `Multidimensal.MMM` class."
         )
 
     def plot_budget_allocation(


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->
<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->
Marked the budget optimization method as deprecated and replaced its implementation with a NotImplementedError. Users are advised to migrate to the `Multidimensal.MMM` class.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->
