### PR TITLE
Add support for time-based budget distribution in optimizer

### DIFF
--- a/pymc_marketing/mmm/budget_optimizer.py
+++ b/pymc_marketing/mmm/budget_optimizer.py
@@ -123,6 +123,10 @@ class BudgetOptimizer(BaseModel):
         Custom constraints for the optimizer.
     default_constraints : bool, optional
         Whether to add a default sum constraint on the total budget. Default is True.
+    budget_distribution_over_period : xarray.DataArray, optional
+        Distribution factors for budget allocation over time. Should have dims ("date", *budget_dims)
+        where date dimension has length num_periods. Values along date dimension should sum to 1 for
+        each combination of other dimensions. If None, budget is distributed evenly across periods.
     """
 
     num_periods: int = Field(
@@ -163,6 +167,15 @@ class BudgetOptimizer(BaseModel):
     default_constraints: bool = Field(
         default=True,
         description="Whether to add a default sum constraint on the total budget.",
+    )
+
+    budget_distribution_over_period: DataArray | None = Field(
+        default=None,
+        description=(
+            "Distribution factors for budget allocation over time. Should have dims ('date', *budget_dims) "
+            "where date dimension has length num_periods. Values along date dimension should sum to 1 for "
+            "each combination of other dimensions. If None, budget is distributed evenly across periods."
+        ),
     )
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -226,16 +239,26 @@ class BudgetOptimizer(BaseModel):
         bool_mask = np.asarray(self.budgets_to_optimize).astype(bool)
         self._budgets = budgets_zeros[bool_mask].set(self._budgets_flat)
 
-        # 5. Replace channel_data with budgets in the PyMC model
+        # 5. Validate and process budget_distribution_over_period
+        self._budget_distribution_over_period_tensor = (
+            self._validate_and_process_budget_distribution(
+                budget_distribution_over_period=self.budget_distribution_over_period,
+                num_periods=self.num_periods,
+                budget_dims=self._budget_dims,
+                budgets_to_optimize=self.budgets_to_optimize,
+            )
+        )
+
+        # 6. Replace channel_data with budgets in the PyMC model
         self._pymc_model = self._replace_channel_data_by_optimization_variable(
             pymc_model
         )
 
-        # 6. Compile objective & gradient
+        # 7. Compile objective & gradient
         self._compiled_functions = {}
         self._compile_objective_and_grad()
 
-        # 7. Build constraints
+        # 8. Build constraints
         self._constraints = {}
         self.set_constraints(
             default=self.default_constraints, constraints=self.custom_constraints
@@ -268,6 +291,125 @@ class BudgetOptimizer(BaseModel):
             constraints=self._constraints, optimizer=self
         )
 
+    def _validate_and_process_budget_distribution(
+        self,
+        budget_distribution_over_period: DataArray | None,
+        num_periods: int,
+        budget_dims: list[str],
+        budgets_to_optimize: DataArray,
+    ) -> pt.TensorVariable | None:
+        """Validate and process budget distribution over periods.
+
+        Parameters
+        ----------
+        budget_distribution_over_period : DataArray | None
+            Distribution factors for budget allocation over time.
+        num_periods : int
+            Number of time periods to allocate budget for.
+        budget_dims : list[str]
+            List of budget dimensions (excluding 'date').
+        budgets_to_optimize : DataArray
+            Mask defining which budgets to optimize.
+
+        Returns
+        -------
+        pt.TensorVariable | None
+            Processed tensor containing masked time factors, or None if no distribution provided.
+        """
+        if budget_distribution_over_period is None:
+            return None
+
+        # Validate dimensions - date should be first
+        expected_dims = ("date", *budget_dims)
+        if set(budget_distribution_over_period.dims) != set(expected_dims):
+            raise ValueError(
+                f"budget_distribution_over_period must have dims {expected_dims}, "
+                f"but got {budget_distribution_over_period.dims}"
+            )
+
+        # Validate date dimension length
+        if len(budget_distribution_over_period.coords["date"]) != num_periods:
+            raise ValueError(
+                f"budget_distribution_over_period date dimension must have length {num_periods}, "
+                f"but got {len(budget_distribution_over_period.coords['date'])}"
+            )
+
+        # Validate that factors sum to 1 along date dimension
+        sums = budget_distribution_over_period.sum(dim="date")
+        if not np.allclose(sums.values, 1.0, rtol=1e-5):
+            raise ValueError(
+                "budget_distribution_over_period must sum to 1 along the date dimension "
+                "for each combination of other dimensions"
+            )
+
+        # Pre-process: Apply the mask to get only factors for optimized budgets
+        # This avoids shape mismatches during gradient computation
+        time_factors_full = budget_distribution_over_period.transpose(
+            *expected_dims
+        ).values
+
+        # Reshape to (num_periods, flat_budget_dims) and apply mask
+        time_factors_flat = time_factors_full.reshape((num_periods, -1))
+        bool_mask = budgets_to_optimize.values.flatten()
+        time_factors_masked = time_factors_flat[:, bool_mask]
+
+        # Store only the masked tensor
+        return pt.constant(time_factors_masked, name="budget_distribution_over_period")
+
+    def _apply_budget_distribution_over_period(
+        self,
+        budgets: pt.TensorVariable,
+        num_periods: int,
+        date_dim_idx: int,
+    ) -> pt.TensorVariable:
+        """Apply budget distribution over periods to budgets across time periods.
+
+        Parameters
+        ----------
+        budgets : pt.TensorVariable
+            The scaled budget tensor with shape matching budget dimensions.
+        num_periods : int
+            Number of time periods to distribute budget across.
+        date_dim_idx : int
+            Index position where the date dimension should be inserted.
+
+        Returns
+        -------
+        pt.TensorVariable
+            Budget tensor repeated across time periods with distribution factors applied.
+            Shape will be (*budget_dims[:date_dim_idx], num_periods, *budget_dims[date_dim_idx:])
+        """
+        # Apply time distribution factors
+        # The time factors are already masked and have shape (num_periods, num_optimized_budgets)
+        # budgets has full shape (e.g., (2, 2) for geo x channel)
+        # We need to extract only the optimized budgets
+
+        # Get the optimized budget values
+        bool_mask = np.asarray(self.budgets_to_optimize).astype(bool)
+        budgets_optimized = budgets[bool_mask]  # Shape: (num_optimized_budgets,)
+
+        # Now multiply budgets by time factors
+        budgets_expanded = pt.expand_dims(
+            budgets_optimized, 0
+        )  # Shape: (1, num_optimized_budgets)
+        repeated_budgets_flat = (
+            budgets_expanded * self._budget_distribution_over_period_tensor
+        )  # Shape: (num_periods, num_optimized_budgets)
+
+        # Reconstruct the full shape for each time period
+        repeated_budgets_list = []
+        for t in range(num_periods):
+            # Create a zero tensor with the full budget shape
+            budgets_t = pt.zeros_like(budgets)
+            # Set the optimized values
+            budgets_t = budgets_t[bool_mask].set(repeated_budgets_flat[t])
+            repeated_budgets_list.append(budgets_t)
+
+        # Stack the time periods
+        repeated_budgets = pt.stack(repeated_budgets_list, axis=date_dim_idx)
+
+        return repeated_budgets
+
     def _replace_channel_data_by_optimization_variable(self, model: Model) -> Model:
         """Replace `channel_data` in the model graph with our newly created `_budgets` variable."""
         num_periods = self.num_periods
@@ -283,10 +425,19 @@ class BudgetOptimizer(BaseModel):
         # Repeat budgets over num_periods
         repeated_budgets_shape = list(tuple(budgets.shape))
         repeated_budgets_shape.insert(date_dim_idx, num_periods)
-        repeated_budgets = pt.broadcast_to(
-            pt.expand_dims(budgets, date_dim_idx),
-            shape=repeated_budgets_shape,
-        )
+
+        if self._budget_distribution_over_period_tensor is not None:
+            # Apply time distribution factors
+            repeated_budgets = self._apply_budget_distribution_over_period(
+                budgets, num_periods, date_dim_idx
+            )
+        else:
+            # Default behavior: distribute evenly across periods
+            repeated_budgets = pt.broadcast_to(
+                pt.expand_dims(budgets, date_dim_idx),
+                shape=repeated_budgets_shape,
+            )
+
         repeated_budgets.name = "repeated_budgets"
 
         # Pad the repeated budgets with zeros to account for carry-over effects

--- a/pymc_marketing/mmm/budget_optimizer.py
+++ b/pymc_marketing/mmm/budget_optimizer.py
@@ -407,6 +407,7 @@ class BudgetOptimizer(BaseModel):
 
         # Stack the time periods
         repeated_budgets = pt.stack(repeated_budgets_list, axis=date_dim_idx)
+        repeated_budgets *= num_periods
 
         return repeated_budgets
 

--- a/pymc_marketing/mmm/multidimensional.py
+++ b/pymc_marketing/mmm/multidimensional.py
@@ -1871,7 +1871,11 @@ class MultiDimensionalBudgetOptimizerWrapper(OptimizerCompatibleModelWrapper):
             self.channel_columns
         ].to_xarray()
 
-        var_names = ["y"]
+        var_names = [
+            "y",
+            "channel_contribution",
+            "total_media_contribution_original_scale",
+        ]
         if additional_var_names is not None:
             var_names.extend(additional_var_names)
 

--- a/pymc_marketing/mmm/multidimensional.py
+++ b/pymc_marketing/mmm/multidimensional.py
@@ -1772,6 +1772,7 @@ class MultiDimensionalBudgetOptimizerWrapper(OptimizerCompatibleModelWrapper):
         constraints: Sequence[dict[str, Any]] = (),
         default_constraints: bool = True,
         budgets_to_optimize: xr.DataArray | None = None,
+        budget_distribution_over_period: xr.DataArray | None = None,
         callback: bool = False,
         **minimize_kwargs,
     ) -> (
@@ -1796,6 +1797,10 @@ class MultiDimensionalBudgetOptimizerWrapper(OptimizerCompatibleModelWrapper):
             Whether to add default constraints.
         budgets_to_optimize : xr.DataArray | None
             Mask defining which budgets to optimize.
+        budget_distribution_over_period : xr.DataArray | None
+            Distribution factors for budget allocation over time. Should have dims ("date", *budget_dims)
+            where date dimension has length num_periods. Values along date dimension should sum to 1 for
+            each combination of other dimensions. If None, budget is distributed evenly across periods.
         callback : bool
             Whether to return callback information tracking optimization progress.
         **minimize_kwargs
@@ -1816,6 +1821,7 @@ class MultiDimensionalBudgetOptimizerWrapper(OptimizerCompatibleModelWrapper):
             custom_constraints=constraints,
             default_constraints=default_constraints,
             budgets_to_optimize=budgets_to_optimize,
+            budget_distribution_over_period=budget_distribution_over_period,
             model=self,  # Pass the wrapper instance itself to the BudgetOptimizer
         )
 

--- a/tests/mmm/test_budget_optimizer.py
+++ b/tests/mmm/test_budget_optimizer.py
@@ -630,3 +630,275 @@ def test_mmm_optimize_budget_callback_parametrized(dummy_df, dummy_idata, callba
     assert hasattr(opt_result, "success")
     assert hasattr(opt_result, "x")
     assert hasattr(opt_result, "fun")
+
+
+@pytest.mark.parametrize(
+    "budget_distribution_over_period, num_periods, should_error, error_message",
+    [
+        # Valid case: uniform distribution
+        (
+            {
+                "channel_1": [0.25, 0.25, 0.25, 0.25],
+                "channel_2": [0.25, 0.25, 0.25, 0.25],
+            },
+            4,
+            False,
+            None,
+        ),
+        # Valid case: front-loaded distribution
+        (
+            {"channel_1": [0.7, 0.2, 0.1, 0.0], "channel_2": [0.4, 0.3, 0.2, 0.1]},
+            4,
+            False,
+            None,
+        ),
+        # Invalid case: factors don't sum to 1
+        (
+            {"channel_1": [0.3, 0.3, 0.3, 0.3], "channel_2": [0.25, 0.25, 0.25, 0.25]},
+            4,
+            True,
+            "budget_distribution_over_period must sum to 1 along the date dimension",
+        ),
+        # Invalid case: wrong number of periods
+        (
+            {"channel_1": [0.5, 0.5], "channel_2": [0.5, 0.5]},
+            4,
+            True,
+            "budget_distribution_over_period date dimension must have length 4",
+        ),
+    ],
+    ids=[
+        "valid_uniform",
+        "valid_front_loaded",
+        "invalid_sum",
+        "invalid_periods",
+    ],
+)
+def test_budget_distribution_over_period(
+    dummy_df,
+    dummy_idata,
+    budget_distribution_over_period,
+    num_periods,
+    should_error,
+    error_message,
+):
+    """Test that budget_distribution_over_period correctly distributes budget over time."""
+    df_kwargs, X_dummy, y_dummy = dummy_df
+
+    mmm = MMM(
+        adstock=GeometricAdstock(l_max=4),
+        saturation=LogisticSaturation(),
+        **df_kwargs,
+    )
+
+    mmm.build_model(X=X_dummy, y=y_dummy)
+    mmm.idata = dummy_idata
+
+    # Create time distribution factors DataArray
+    if budget_distribution_over_period is not None:
+        budget_distribution_over_period_array = np.array(
+            [budget_distribution_over_period[ch] for ch in df_kwargs["channel_columns"]]
+        )
+        budget_distribution_over_period_factors = xr.DataArray(
+            budget_distribution_over_period_array,
+            coords={
+                "channel": df_kwargs["channel_columns"],
+                "date": list(range(len(budget_distribution_over_period["channel_1"]))),
+            },
+            dims=["channel", "date"],
+        )
+    else:
+        budget_distribution_over_period_factors = None
+
+    if should_error:
+        with pytest.raises(ValueError, match=error_message):
+            BudgetOptimizer(
+                model=mmm,
+                num_periods=num_periods,
+                budget_distribution_over_period=budget_distribution_over_period_factors,
+                default_constraints=True,
+            )
+    else:
+        # Create optimizer with time distribution factors
+        match = "Using default equality constraint"
+        with pytest.warns(UserWarning, match=match):
+            optimizer = BudgetOptimizer(
+                model=mmm,
+                num_periods=num_periods,
+                budget_distribution_over_period=budget_distribution_over_period_factors,
+                default_constraints=True,
+            )
+
+        # Check that the time distribution factors were stored correctly
+        if budget_distribution_over_period_factors is not None:
+            assert optimizer._budget_distribution_over_period_tensor is not None
+            # The tensor is now pre-processed and has shape (num_periods, num_optimized_budgets)
+            num_optimized = optimizer.budgets_to_optimize.sum().item()
+            expected_shape = (num_periods, num_optimized)
+            assert (
+                tuple(optimizer._budget_distribution_over_period_tensor.shape.eval())
+                == expected_shape
+            )
+        else:
+            assert optimizer._budget_distribution_over_period_tensor is None
+
+
+def test_budget_distribution_over_period_wrong_dims(dummy_df, dummy_idata):
+    """Test that budget_distribution_over_period with wrong dimensions raises error."""
+    df_kwargs, X_dummy, y_dummy = dummy_df
+
+    mmm = MMM(
+        adstock=GeometricAdstock(l_max=4),
+        saturation=LogisticSaturation(),
+        **df_kwargs,
+    )
+
+    mmm.build_model(X=X_dummy, y=y_dummy)
+    mmm.idata = dummy_idata
+
+    # Create time factors with wrong dimensions (missing channel dimension)
+    budget_distribution_over_period = xr.DataArray(
+        [0.25, 0.25, 0.25, 0.25],
+        coords={"date": list(range(4))},
+        dims=["date"],
+    )
+
+    with pytest.raises(
+        ValueError, match="budget_distribution_over_period must have dims"
+    ):
+        BudgetOptimizer(
+            model=mmm,
+            num_periods=4,
+            budget_distribution_over_period=budget_distribution_over_period,
+            default_constraints=True,
+        )
+
+
+def test_budget_distribution_over_period_applied_correctly(dummy_df, dummy_idata):
+    """Test that budget distribution factors are correctly applied to budgets."""
+    df_kwargs, X_dummy, y_dummy = dummy_df
+
+    mmm = MMM(
+        adstock=GeometricAdstock(l_max=4),
+        saturation=LogisticSaturation(),
+        **df_kwargs,
+    )
+
+    mmm.build_model(X=X_dummy, y=y_dummy)
+    mmm.idata = dummy_idata
+
+    # Create non-uniform time distribution factors
+    budget_distribution_over_period_data = {
+        "channel_1": [0.7, 0.2, 0.1, 0.0],
+        "channel_2": [0.4, 0.3, 0.2, 0.1],
+    }
+    budget_distribution_over_period_array = np.array(
+        [
+            budget_distribution_over_period_data[ch]
+            for ch in df_kwargs["channel_columns"]
+        ]
+    )
+    budget_distribution_over_period_factors = xr.DataArray(
+        budget_distribution_over_period_array,
+        coords={
+            "channel": df_kwargs["channel_columns"],
+            "date": list(range(4)),
+        },
+        dims=["channel", "date"],
+    )
+
+    # Create optimizer with time distribution factors
+    match = "Using default equality constraint"
+    with pytest.warns(UserWarning, match=match):
+        optimizer = BudgetOptimizer(
+            model=mmm,
+            num_periods=4,
+            budget_distribution_over_period=budget_distribution_over_period_factors,
+            default_constraints=True,
+        )
+
+    # Verify that the time distribution factors tensor was created correctly
+    assert optimizer._budget_distribution_over_period_tensor is not None
+
+    # Verify the values match what we provided (stored tensor is pre-processed and transposed)
+    stored_values = optimizer._budget_distribution_over_period_tensor.eval()
+    # The stored tensor has shape (num_periods, num_optimized_budgets)
+    # and the original has shape (channels, periods), so we need to transpose
+    np.testing.assert_array_almost_equal(
+        stored_values, budget_distribution_over_period_array.T
+    )
+
+
+def test_budget_distribution_over_period_integration(dummy_df, dummy_idata):
+    """Integration test: verify budget allocation with time distribution factors."""
+    df_kwargs, X_dummy, y_dummy = dummy_df
+
+    mmm = MMM(
+        adstock=GeometricAdstock(l_max=4),
+        saturation=LogisticSaturation(),
+        **df_kwargs,
+    )
+
+    mmm.build_model(X=X_dummy, y=y_dummy)
+    mmm.idata = dummy_idata
+
+    # Create front-loaded time distribution
+    num_periods = 4
+    budget_distribution_over_period_data = {
+        "channel_1": [0.7, 0.2, 0.1, 0.0],  # Heavy front-loading
+        "channel_2": [0.25, 0.25, 0.25, 0.25],  # Uniform distribution
+    }
+    budget_distribution_over_period_array = np.array(
+        [
+            budget_distribution_over_period_data[ch]
+            for ch in df_kwargs["channel_columns"]
+        ]
+    )
+    budget_distribution_over_period_factors = xr.DataArray(
+        budget_distribution_over_period_array,
+        coords={
+            "channel": df_kwargs["channel_columns"],
+            "date": list(range(num_periods)),
+        },
+        dims=["channel", "date"],
+    )
+
+    # Create two optimizers: one with and one without time distribution
+    optimizer_with_factors = BudgetOptimizer(
+        model=mmm,
+        num_periods=num_periods,
+        budget_distribution_over_period=budget_distribution_over_period_factors,
+        default_constraints=True,
+    )
+
+    optimizer_without_factors = BudgetOptimizer(
+        model=mmm,
+        num_periods=num_periods,
+        budget_distribution_over_period=None,
+        default_constraints=True,
+    )
+
+    # Both should allocate budget successfully
+    total_budget = 100
+    budget_bounds = None
+
+    result_with_factors, _ = optimizer_with_factors.allocate_budget(
+        total_budget=total_budget,
+        budget_bounds=budget_bounds,
+    )
+
+    result_without_factors, _ = optimizer_without_factors.allocate_budget(
+        total_budget=total_budget,
+        budget_bounds=budget_bounds,
+    )
+
+    # Both should sum to the total budget
+    assert np.abs(result_with_factors.sum().item() - total_budget) < 1e-6
+    assert np.abs(result_without_factors.sum().item() - total_budget) < 1e-6
+
+    # Results should potentially be different due to time distribution
+    # (though in practice they might be similar depending on the model)
+    assert isinstance(result_with_factors, xr.DataArray)
+    assert isinstance(result_without_factors, xr.DataArray)
+    assert result_with_factors.dims == ("channel",)
+    assert result_without_factors.dims == ("channel",)

--- a/tests/mmm/test_budget_optimizer_multidimensional.py
+++ b/tests/mmm/test_budget_optimizer_multidimensional.py
@@ -53,7 +53,9 @@ def dummy_df():
     return df_kwargs, df, y
 
 
-def test_budget_optimizer_no_mask(dummy_df):
+@pytest.fixture(scope="module")
+def fitted_mmm(dummy_df):
+    """Create and fit a model once for all tests."""
     df_kwargs, X_dummy, y_dummy = dummy_df
 
     mmm = MMM(
@@ -61,7 +63,10 @@ def test_budget_optimizer_no_mask(dummy_df):
         saturation=LogisticSaturation(),
         **df_kwargs,
     )
+
     mmm.build_model(X=X_dummy, y=y_dummy)
+
+    # Fit the model once
     mmm.fit(
         X=X_dummy,
         y=y_dummy,
@@ -69,15 +74,25 @@ def test_budget_optimizer_no_mask(dummy_df):
         target_accept=0.8,
         tune=50,
         draws=50,
+        progressbar=False,  # Disable progress bar for cleaner test output
     )
+
+    # Sample posterior predictive
     mmm.sample_posterior_predictive(
         X=X_dummy,
         extend_idata=True,
         combined=True,
+        progressbar=False,
     )
 
+    return mmm
+
+
+def test_budget_optimizer_no_mask(dummy_df, fitted_mmm):
+    df_kwargs, X_dummy, y_dummy = dummy_df
+
     optimizable_model = MultiDimensionalBudgetOptimizerWrapper(
-        model=mmm,
+        model=fitted_mmm,
         start_date=X_dummy["date_week"].max() + pd.Timedelta(1, freq="1W"),
         end_date=X_dummy["date_week"].max() + pd.Timedelta(2, freq="1W"),
     )
@@ -92,9 +107,7 @@ def test_budget_optimizer_no_mask(dummy_df):
     assert result.success
 
 
-def test_budget_optimizer_correct_mask(
-    dummy_df,
-):
+def test_budget_optimizer_correct_mask(dummy_df, fitted_mmm):
     df_kwargs, X_dummy, y_dummy = dummy_df
 
     budgets_to_optimize = xr.DataArray(
@@ -106,28 +119,8 @@ def test_budget_optimizer_correct_mask(
         },
     )
 
-    mmm = MMM(
-        adstock=GeometricAdstock(l_max=4),
-        saturation=LogisticSaturation(),
-        **df_kwargs,
-    )
-    mmm.build_model(X=X_dummy, y=y_dummy)
-    mmm.fit(
-        X=X_dummy,
-        y=y_dummy,
-        chains=2,
-        target_accept=0.8,
-        tune=50,
-        draws=50,
-    )
-    mmm.sample_posterior_predictive(
-        X=X_dummy,
-        extend_idata=True,
-        combined=True,
-    )
-
     optimizable_model = MultiDimensionalBudgetOptimizerWrapper(
-        model=mmm,
+        model=fitted_mmm,
         start_date=X_dummy["date_week"].max() + pd.Timedelta(1, freq="1W"),
         end_date=X_dummy["date_week"].max() + pd.Timedelta(2, freq="1W"),
     )
@@ -142,14 +135,38 @@ def test_budget_optimizer_correct_mask(
     assert result.success
 
 
-def test_budget_optimizer_incorrect_mask(
-    dummy_df,
-):
+def test_budget_optimizer_incorrect_mask(dummy_df, fitted_mmm):
     df_kwargs, X_dummy, y_dummy = dummy_df
 
-    # Remove spend for one channel in one geo
-    X_dummy.loc[X_dummy["geo"] == "A", "channel_2"] = 0.0
+    # Simulate a case where the model has no information for one channel-geo combination
+    # by creating a new model with modified data
+    X_modified = X_dummy.copy()
+    X_modified.loc[X_modified["geo"] == "A", "channel_2"] = 0.0
 
+    # Create a new model with modified data (channel_2 in geo A has no spend)
+    mmm_modified = MMM(
+        adstock=GeometricAdstock(l_max=4),
+        saturation=LogisticSaturation(),
+        **df_kwargs,
+    )
+    mmm_modified.build_model(X=X_modified, y=y_dummy)
+    mmm_modified.fit(
+        X=X_modified,
+        y=y_dummy,
+        chains=2,
+        target_accept=0.8,
+        tune=50,
+        draws=50,
+        progressbar=False,
+    )
+    mmm_modified.sample_posterior_predictive(
+        X=X_modified,
+        extend_idata=True,
+        combined=True,
+        progressbar=False,
+    )
+
+    # Create a mask that tries to optimize all channels including the zero one
     budgets_to_optimize = xr.DataArray(
         np.array([[True, True], [True, True]]),
         dims=["channel", "geo"],
@@ -159,30 +176,10 @@ def test_budget_optimizer_incorrect_mask(
         },
     )
 
-    mmm = MMM(
-        adstock=GeometricAdstock(l_max=4),
-        saturation=LogisticSaturation(),
-        **df_kwargs,
-    )
-    mmm.build_model(X=X_dummy, y=y_dummy)
-    mmm.fit(
-        X=X_dummy,
-        y=y_dummy,
-        chains=2,
-        target_accept=0.8,
-        tune=50,
-        draws=50,
-    )
-    mmm.sample_posterior_predictive(
-        X=X_dummy,
-        extend_idata=True,
-        combined=True,
-    )
-
     optimizable_model = MultiDimensionalBudgetOptimizerWrapper(
-        model=mmm,
-        start_date=X_dummy["date_week"].max() + pd.Timedelta(1, freq="1W"),
-        end_date=X_dummy["date_week"].max() + pd.Timedelta(2, freq="1W"),
+        model=mmm_modified,
+        start_date=X_modified["date_week"].max() + pd.Timedelta(1, freq="1W"),
+        end_date=X_modified["date_week"].max() + pd.Timedelta(2, freq="1W"),
     )
 
     msg = (
@@ -193,4 +190,503 @@ def test_budget_optimizer_incorrect_mask(
         optimizable_model.optimize_budget(
             budget=1,
             budgets_to_optimize=budgets_to_optimize,
+        )
+
+
+def test_time_distribution_by_geo_only(dummy_df, fitted_mmm):
+    """Test time distribution factors that vary by geo only (same for all channels in a geo)."""
+    df_kwargs, X_dummy, y_dummy = dummy_df
+
+    optimizable_model = MultiDimensionalBudgetOptimizerWrapper(
+        model=fitted_mmm,
+        start_date=X_dummy["date_week"].max() + pd.Timedelta(1, freq="1W"),
+        end_date=X_dummy["date_week"].max() + pd.Timedelta(4, freq="1W"),  # 4 weeks
+    )
+
+    # Create time distribution factors that vary by geo only
+    # Geo A: front-loaded, Geo B: back-loaded
+    time_factors_data = np.array(
+        [
+            # date 0
+            [
+                [0.7, 0.7],  # geo A: channel_1, channel_2
+                [0.1, 0.1],
+            ],  # geo B: channel_1, channel_2
+            # date 1
+            [
+                [0.2, 0.2],  # geo A: channel_1, channel_2
+                [0.2, 0.2],
+            ],  # geo B: channel_1, channel_2
+            # date 2
+            [
+                [0.1, 0.1],  # geo A: channel_1, channel_2
+                [0.3, 0.3],
+            ],  # geo B: channel_1, channel_2
+            # date 3
+            [
+                [0.0, 0.0],  # geo A: channel_1, channel_2
+                [0.4, 0.4],
+            ],  # geo B: channel_1, channel_2
+        ]
+    )
+
+    budget_distribution_over_period = xr.DataArray(
+        time_factors_data,
+        dims=["date", "geo", "channel"],
+        coords={
+            "date": [0, 1, 2, 3],
+            "geo": ["A", "B"],
+            "channel": ["channel_1", "channel_2"],
+        },
+    )
+
+    from pymc_marketing.mmm.budget_optimizer import BudgetOptimizer
+
+    # Create the budget optimizer directly with time factors
+    optimizer = BudgetOptimizer(
+        model=optimizable_model,
+        num_periods=4,
+        budget_distribution_over_period=budget_distribution_over_period,
+        response_variable="total_media_contribution_original_scale",
+        # No custom utility function needed with fitted model!
+        default_constraints=True,
+    )
+
+    optimal_budgets, result = optimizer.allocate_budget(
+        total_budget=100,
+    )
+
+    assert isinstance(optimal_budgets, xr.DataArray)
+    assert optimal_budgets.shape == (2, 2)  # 2 channels, 2 geos
+    assert result.success
+    assert np.abs(optimal_budgets.sum().item() - 100) < 1e-6
+
+
+def test_time_distribution_by_channel_geo(dummy_df, fitted_mmm):
+    """Test time distribution factors that vary by both channel and geo."""
+    df_kwargs, X_dummy, y_dummy = dummy_df
+
+    optimizable_model = MultiDimensionalBudgetOptimizerWrapper(
+        model=fitted_mmm,
+        start_date=X_dummy["date_week"].max() + pd.Timedelta(1, freq="1W"),
+        end_date=X_dummy["date_week"].max() + pd.Timedelta(4, freq="1W"),  # 4 weeks
+    )
+
+    # Create time distribution factors that vary by both channel and geo
+    # Each channel-geo combination has a unique pattern
+    budget_distribution_over_period = xr.DataArray(
+        np.array(
+            [
+                # date 0
+                [
+                    [0.7, 0.0],  # geo A: channel_1 front-loaded, channel_2 back-loaded
+                    [0.25, 0.4],
+                ],  # geo B: channel_1 uniform, channel_2 decreasing
+                # date 1
+                [
+                    [0.2, 0.1],  # geo A
+                    [0.25, 0.3],
+                ],  # geo B
+                # date 2
+                [
+                    [0.1, 0.3],  # geo A
+                    [0.25, 0.2],
+                ],  # geo B
+                # date 3
+                [
+                    [0.0, 0.6],  # geo A
+                    [0.25, 0.1],
+                ],  # geo B
+            ]
+        ),
+        dims=["date", "geo", "channel"],
+        coords={
+            "date": [0, 1, 2, 3],
+            "geo": ["A", "B"],
+            "channel": ["channel_1", "channel_2"],
+        },
+    )
+
+    from pymc_marketing.mmm.budget_optimizer import BudgetOptimizer
+
+    # Create the budget optimizer directly with time factors
+    optimizer = BudgetOptimizer(
+        model=optimizable_model,
+        num_periods=4,
+        budget_distribution_over_period=budget_distribution_over_period,
+        response_variable="total_media_contribution_original_scale",
+        default_constraints=True,
+    )
+
+    optimal_budgets, result = optimizer.allocate_budget(
+        total_budget=100,
+    )
+
+    assert isinstance(optimal_budgets, xr.DataArray)
+    assert optimal_budgets.shape == (2, 2)  # 2 channels, 2 geos
+    assert result.success
+    assert np.abs(optimal_budgets.sum().item() - 100) < 1e-6
+
+
+def test_time_distribution_with_zero_bounds(dummy_df, fitted_mmm):
+    """Test time distribution with some channels having zero budget bounds."""
+    df_kwargs, X_dummy, y_dummy = dummy_df
+
+    optimizable_model = MultiDimensionalBudgetOptimizerWrapper(
+        model=fitted_mmm,
+        start_date=X_dummy["date_week"].max() + pd.Timedelta(1, freq="1W"),
+        end_date=X_dummy["date_week"].max() + pd.Timedelta(4, freq="1W"),  # 4 weeks
+    )
+
+    # Create time distribution factors for all channel-geo combinations
+    budget_distribution_over_period = xr.DataArray(
+        np.array(
+            [
+                # date 0
+                [
+                    [0.7, 0.1],  # geo A: channel_1, channel_2
+                    [0.25, 0.4],
+                ],  # geo B: channel_1, channel_2
+                # date 1
+                [
+                    [0.2, 0.2],  # geo A
+                    [0.25, 0.3],
+                ],  # geo B
+                # date 2
+                [
+                    [0.1, 0.3],  # geo A
+                    [0.25, 0.2],
+                ],  # geo B
+                # date 3
+                [
+                    [0.0, 0.4],  # geo A
+                    [0.25, 0.1],
+                ],  # geo B
+            ]
+        ),
+        dims=["date", "geo", "channel"],
+        coords={
+            "date": [0, 1, 2, 3],
+            "geo": ["A", "B"],
+            "channel": ["channel_1", "channel_2"],
+        },
+    )
+
+    # Set budget bounds: channel_2 in geo A gets zero budget
+    budget_bounds = xr.DataArray(
+        np.array(
+            [
+                # channel_1: normal bounds for both geos
+                [[[0, 50], [0, 50]]],
+                # channel_2: zero for geo A, normal for geo B
+                [[[0, 0], [0, 50]]],
+            ]
+        ).squeeze(),
+        dims=["channel", "geo", "bound"],
+        coords={
+            "channel": ["channel_1", "channel_2"],
+            "geo": ["A", "B"],
+            "bound": ["lower", "upper"],
+        },
+    )
+
+    from pymc_marketing.mmm.budget_optimizer import BudgetOptimizer
+
+    # Create the budget optimizer with time factors
+    optimizer = BudgetOptimizer(
+        model=optimizable_model,
+        num_periods=4,
+        budget_distribution_over_period=budget_distribution_over_period,
+        response_variable="total_media_contribution_original_scale",
+        default_constraints=True,
+    )
+
+    optimal_budgets, result = optimizer.allocate_budget(
+        total_budget=50,
+        budget_bounds=budget_bounds,
+    )
+
+    assert isinstance(optimal_budgets, xr.DataArray)
+    assert optimal_budgets.shape == (2, 2)  # 2 channels, 2 geos
+    assert result.success
+
+    # Check that channel_2 in geo A has zero budget
+    assert optimal_budgets.sel(channel="channel_2", geo="A").item() == 0.0
+
+    # Check total budget constraint
+    assert np.abs(optimal_budgets.sum().item() - 50) < 1e-6
+
+
+def test_budget_distribution_over_period_wrong_dims_multidimensional(
+    dummy_df, fitted_mmm
+):
+    """Test that time distribution factors with wrong dimensions raise error in multidimensional case."""
+    df_kwargs, X_dummy, y_dummy = dummy_df
+
+    optimizable_model = MultiDimensionalBudgetOptimizerWrapper(
+        model=fitted_mmm,
+        start_date=X_dummy["date_week"].max() + pd.Timedelta(1, freq="1W"),
+        end_date=X_dummy["date_week"].max() + pd.Timedelta(4, freq="1W"),
+    )
+
+    # Create time factors with missing geo dimension
+    budget_distribution_over_period = xr.DataArray(
+        [
+            [0.25, 0.25],  # date 0
+            [0.25, 0.25],  # date 1
+            [0.25, 0.25],  # date 2
+            [0.25, 0.25],
+        ],  # date 3
+        coords={
+            "date": [0, 1, 2, 3],
+            "channel": ["channel_1", "channel_2"],
+        },
+        dims=["date", "channel"],
+    )
+
+    from pymc_marketing.mmm.budget_optimizer import BudgetOptimizer
+
+    with pytest.raises(
+        ValueError, match="budget_distribution_over_period must have dims"
+    ):
+        BudgetOptimizer(
+            model=optimizable_model,
+            num_periods=4,
+            budget_distribution_over_period=budget_distribution_over_period,
+            response_variable="total_media_contribution_original_scale",
+            default_constraints=True,
+        )
+
+
+def test_time_distribution_multidim(dummy_df, fitted_mmm):
+    """Test time distribution factors with fitted model."""
+    df_kwargs, X_dummy, y_dummy = dummy_df
+
+    optimizable_model = MultiDimensionalBudgetOptimizerWrapper(
+        model=fitted_mmm,
+        start_date=X_dummy["date_week"].max() + pd.Timedelta(1, freq="1W"),
+        end_date=X_dummy["date_week"].max() + pd.Timedelta(4, freq="1W"),  # 4 weeks
+    )
+
+    # Create time distribution factors that vary by geo only
+    budget_distribution_over_period = xr.DataArray(
+        np.array(
+            [
+                # date 0
+                [
+                    [0.7, 0.7],  # geo A: both channels front-loaded
+                    [0.1, 0.1],
+                ],  # geo B: both channels back-loaded
+                # date 1
+                [
+                    [0.2, 0.2],  # geo A
+                    [0.2, 0.2],
+                ],  # geo B
+                # date 2
+                [
+                    [0.1, 0.1],  # geo A
+                    [0.3, 0.3],
+                ],  # geo B
+                # date 3
+                [
+                    [0.0, 0.0],  # geo A
+                    [0.4, 0.4],
+                ],  # geo B
+            ]
+        ),
+        dims=["date", "geo", "channel"],
+        coords={
+            "date": [0, 1, 2, 3],
+            "geo": ["A", "B"],
+            "channel": ["channel_1", "channel_2"],
+        },
+    )
+
+    from pymc_marketing.mmm.budget_optimizer import BudgetOptimizer
+
+    # Create the budget optimizer with time factors
+    with pytest.warns(UserWarning, match="Using default equality constraint"):
+        optimizer = BudgetOptimizer(
+            model=optimizable_model,
+            num_periods=4,
+            budget_distribution_over_period=budget_distribution_over_period,
+            response_variable="total_media_contribution_original_scale",
+            default_constraints=True,
+        )
+
+    optimal_budgets, result = optimizer.allocate_budget(
+        total_budget=100,
+    )
+
+    assert isinstance(optimal_budgets, xr.DataArray)
+    assert optimal_budgets.shape == (2, 2)  # 2 channels, 2 geos
+    assert result.success
+    assert np.abs(optimal_budgets.sum().item() - 100) < 1e-6
+
+
+def test_time_distribution_channel_specific_pattern(dummy_df, fitted_mmm):
+    """Test channel-specific time distribution patterns."""
+    df_kwargs, X_dummy, y_dummy = dummy_df
+
+    optimizable_model = MultiDimensionalBudgetOptimizerWrapper(
+        model=fitted_mmm,
+        start_date=X_dummy["date_week"].max() + pd.Timedelta(1, freq="1W"),
+        end_date=X_dummy["date_week"].max() + pd.Timedelta(4, freq="1W"),
+    )
+
+    # Different patterns for each channel-geo combination
+    budget_distribution_over_period = xr.DataArray(
+        np.array(
+            [
+                # date 0
+                [
+                    [1.0, 0.0],  # geo A: channel_1 all front, channel_2 all back
+                    [0.6, 0.0],
+                ],  # geo B: channel_1 mostly front, channel_2 mostly back
+                # date 1
+                [
+                    [0.0, 0.0],  # geo A
+                    [0.3, 0.1],
+                ],  # geo B
+                # date 2
+                [
+                    [0.0, 0.0],  # geo A
+                    [0.1, 0.3],
+                ],  # geo B
+                # date 3
+                [
+                    [0.0, 1.0],  # geo A
+                    [0.0, 0.6],
+                ],  # geo B
+            ]
+        ),
+        dims=["date", "geo", "channel"],
+        coords={
+            "date": [0, 1, 2, 3],
+            "geo": ["A", "B"],
+            "channel": ["channel_1", "channel_2"],
+        },
+    )
+
+    # Set specific budget bounds
+    budget_bounds = xr.DataArray(
+        np.array(
+            [
+                # channel_1: higher bounds
+                [[[0, 80], [0, 80]]],
+                # channel_2: lower bounds
+                [[[0, 20], [0, 20]]],
+            ]
+        ).squeeze(),
+        dims=["channel", "geo", "bound"],
+        coords={
+            "channel": ["channel_1", "channel_2"],
+            "geo": ["A", "B"],
+            "bound": ["lower", "upper"],
+        },
+    )
+
+    from pymc_marketing.mmm.budget_optimizer import BudgetOptimizer
+
+    with pytest.warns(UserWarning, match="Using default equality constraint"):
+        optimizer = BudgetOptimizer(
+            model=optimizable_model,
+            num_periods=4,
+            budget_distribution_over_period=budget_distribution_over_period,
+            response_variable="total_media_contribution_original_scale",
+            default_constraints=True,
+        )
+
+    optimal_budgets, result = optimizer.allocate_budget(
+        total_budget=80,
+        budget_bounds=budget_bounds,
+    )
+
+    assert isinstance(optimal_budgets, xr.DataArray)
+    assert optimal_budgets.shape == (2, 2)
+    assert result.success
+
+    # Check bounds are respected
+    assert (optimal_budgets.sel(channel="channel_1") <= 80).all()
+    assert (optimal_budgets.sel(channel="channel_2") <= 20).all()
+
+    # Check total budget
+    assert np.abs(optimal_budgets.sum().item() - 80) < 1e-6
+
+
+def test_time_distribution_validation_multidim(dummy_df, fitted_mmm):
+    """Test validation of time distribution factors in multidimensional case."""
+    df_kwargs, X_dummy, y_dummy = dummy_df
+
+    optimizable_model = MultiDimensionalBudgetOptimizerWrapper(
+        model=fitted_mmm,
+        start_date=X_dummy["date_week"].max() + pd.Timedelta(1, freq="1W"),
+        end_date=X_dummy["date_week"].max() + pd.Timedelta(4, freq="1W"),
+    )
+
+    # Test 1: Factors don't sum to 1
+    bad_factors = xr.DataArray(
+        np.array(
+            [
+                # date 0
+                [
+                    [0.5, 0.25],  # geo A: channel_1 bad, channel_2 ok
+                    [0.25, 0.5],
+                ],  # geo B: channel_1 ok, channel_2 bad
+                # date 1
+                [[0.5, 0.25], [0.25, 0.5]],
+                # date 2
+                [[0.5, 0.25], [0.25, 0.5]],
+                # date 3
+                [[0.5, 0.25], [0.25, 0.5]],
+            ]
+        ),
+        dims=["date", "geo", "channel"],
+        coords={
+            "date": [0, 1, 2, 3],
+            "geo": ["A", "B"],
+            "channel": ["channel_1", "channel_2"],
+        },
+    )
+
+    from pymc_marketing.mmm.budget_optimizer import BudgetOptimizer
+
+    with pytest.raises(
+        ValueError, match="budget_distribution_over_period must sum to 1"
+    ):
+        BudgetOptimizer(
+            model=optimizable_model,
+            num_periods=4,
+            budget_distribution_over_period=bad_factors,
+            response_variable="total_media_contribution_original_scale",
+            default_constraints=True,
+        )
+
+    # Test 2: Wrong number of periods
+    wrong_periods_factors = xr.DataArray(
+        np.array(
+            [
+                # only 2 dates
+                [[0.5, 0.5], [0.5, 0.5]],
+                [[0.5, 0.5], [0.5, 0.5]],
+            ]
+        ),
+        dims=["date", "geo", "channel"],
+        coords={
+            "date": [0, 1],
+            "geo": ["A", "B"],
+            "channel": ["channel_1", "channel_2"],
+        },
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="budget_distribution_over_period date dimension must have length 4",
+    ):
+        BudgetOptimizer(
+            model=optimizable_model,
+            num_periods=4,
+            budget_distribution_over_period=wrong_periods_factors,
+            response_variable="total_media_contribution_original_scale",
+            default_constraints=True,
         )


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

Introduces the `budget_distribution_over_period` parameter to BudgetOptimizer and MultiDimensionalBudgetOptimizerWrapper, allowing users to specify how budgets are distributed across time periods for each budget dimension. Adds validation, processing, and application logic for these factors, and includes comprehensive tests for correct and incorrect usage, integration, and multidimensional scenarios.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1841.org.readthedocs.build/en/1841/

<!-- readthedocs-preview pymc-marketing end -->