### PR TITLE
MMM: Fix Scaling Intercept

### DIFF
--- a/pymc_marketing/mmm/mmm.py
+++ b/pymc_marketing/mmm/mmm.py
@@ -1983,12 +1983,34 @@ class MMM(
                 date=slice(self.adstock.l_max, None)
             )
 
+        intercept_condition = (
+            "intercept" in posterior_predictive_samples.data_vars
+            and not self.time_varying_intercept
+        )
+
         if original_scale:
+            # We need to expand the intercept to the date dimension
+            # because the target transformer is applied to the date dimension
+            if intercept_condition:
+                posterior_predictive_samples["intercept"] = (
+                    posterior_predictive_samples["intercept"]
+                    .expand_dims(
+                        dim={"date": posterior_predictive_samples["date"]}, axis=0
+                    )
+                    .rename("intercept")
+                )
+
             posterior_predictive_samples = apply_sklearn_transformer_across_dim(
                 data=posterior_predictive_samples,
                 func=self.get_target_transformer().inverse_transform,
                 dim_name="date",
             )
+
+            # We need to remove the date dimension after the inverse transform
+            if intercept_condition:
+                posterior_predictive_samples["intercept"] = (
+                    posterior_predictive_samples["intercept"].isel(date=0)
+                )
 
         return posterior_predictive_samples
 

--- a/pymc_marketing/mmm/mmm.py
+++ b/pymc_marketing/mmm/mmm.py
@@ -1984,7 +1984,7 @@ class MMM(
             )
 
         intercept_condition = (
-            "intercept" in posterior_predictive_samples.data_vars
+            "intercept" in sample_posterior_predictive_kwargs.get("var_names", [])
             and not self.time_varying_intercept
         )
 

--- a/tests/mmm/test_mmm.py
+++ b/tests/mmm/test_mmm.py
@@ -1002,6 +1002,7 @@ def new_date_ranges_to_test():
 )
 @pytest.mark.parametrize("combined", [True, False])
 @pytest.mark.parametrize("original_scale", [True, False])
+@pytest.mark.parametrize("var_names", [None, ["mu", "sigma"], ["mu", "intercept"]])
 def test_new_data_sample_posterior_predictive_method(
     generate_data,
     toy_X,
@@ -1009,6 +1010,7 @@ def test_new_data_sample_posterior_predictive_method(
     new_dates: pd.DatetimeIndex,
     combined: bool,
     original_scale: bool,
+    var_names: list[str] | None,
     request,
 ) -> None:
     """This is the method that is used in all the other methods that generate predictions."""
@@ -1020,6 +1022,7 @@ def test_new_data_sample_posterior_predictive_method(
         extend_idata=False,
         combined=combined,
         original_scale=original_scale,
+        var_names=var_names,
     )
     pd.testing.assert_index_equal(
         pd.DatetimeIndex(posterior_predictive.coords["date"]),

--- a/tests/mmm/test_mmm.py
+++ b/tests/mmm/test_mmm.py
@@ -1000,9 +1000,21 @@ def new_date_ranges_to_test():
     "new_dates",
     new_date_ranges_to_test(),
 )
-@pytest.mark.parametrize("combined", [True, False])
-@pytest.mark.parametrize("original_scale", [True, False])
-@pytest.mark.parametrize("var_names", [None, ["mu", "sigma"], ["mu", "intercept"]])
+@pytest.mark.parametrize(
+    argnames="combined",
+    argvalues=[True, False],
+    ids=["combined", "not_combined"],
+)
+@pytest.mark.parametrize(
+    argnames="original_scale",
+    argvalues=[True, False],
+    ids=["original_scale", "scaled"],
+)
+@pytest.mark.parametrize(
+    argnames="var_names",
+    argvalues=[None, ["mu", "y_sigma", "channel_contribution"], ["mu", "intercept"]],
+    ids=["no_var_names", "var_names", "var_names_with_intercept"],
+)
 def test_new_data_sample_posterior_predictive_method(
     generate_data,
     toy_X,
@@ -1017,17 +1029,22 @@ def test_new_data_sample_posterior_predictive_method(
     mmm = request.getfixturevalue(model_name)
     X = generate_data(new_dates)
 
+    kwargs = {"var_names": var_names} if var_names is not None else {}
+
     posterior_predictive = mmm.sample_posterior_predictive(
         X=X,
         extend_idata=False,
         combined=combined,
         original_scale=original_scale,
-        var_names=var_names,
+        **kwargs,
     )
     pd.testing.assert_index_equal(
         pd.DatetimeIndex(posterior_predictive.coords["date"]),
         new_dates,
     )
+
+    if var_names is not None:
+        assert var_names == list(posterior_predictive.data_vars)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes https://github.com/pymc-labs/pymc-marketing/issues/1835

The problem comes from 

https://github.com/pymc-labs/pymc-marketing/blob/1f259a8c1c9e247f138cc6f8aee0f1e7a7f0cb06/pymc_marketing/mmm/mmm.py#L1986-L1991

as the intercept component does not have a "date" coordinate.

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1845.org.readthedocs.build/en/1845/

<!-- readthedocs-preview pymc-marketing end -->