### PR TITLE
support case with additional dimension

### DIFF
--- a/pymc_marketing/mmm/components/base.py
+++ b/pymc_marketing/mmm/components/base.py
@@ -368,14 +368,7 @@ class Transformation:
 
         dims = dims or self.combined_dims
         if idx is not None:
-            n_idx_dims = len(idx)
-            dummy_dims = tuple(f"DUMMY_{i}" for i in range(n_idx_dims))
-            if len(dummy_dims) > 1:
-                raise NotImplementedError(
-                    "The indexing with multiple dimensions is not supported yet."
-                )
-
-            dims = (*dummy_dims, *dims)
+            dims = ("N", *dims)
 
         dim_handler = create_dim_handler(dims)
 
@@ -387,12 +380,11 @@ class Transformation:
             var = dist.create_variable(variable_name)
 
             dist_dims = dist.dims
-            if idx is not None:
+            if idx is not None and any(dim in idx for dim in dist_dims):
                 var = index_variable(var, dist.dims, idx)
 
-                dist_dims = tuple(
-                    [(dim if dim not in idx else "DUMMY_0") for dim in dist.dims]
-                )
+                dist_dims = [dim for dim in dist_dims if dim not in idx]
+                dist_dims = ("N", *dist_dims)
 
             return dim_handler(var, dist_dims)
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

follow up to https://github.com/pymc-labs/pymc-marketing/pull/1847 to allow for additional dimensions


```python
import numpy as np

saturation = ...

# Data in long format
# (n, n_channels) 
X = ...

coords = {
    "geo": ["A", "B", "C"],
    "product": ["X", "Y"],
}
with pm.Model(coords=coords) as model:
    Y = saturation.apply(X, idx={"geo": ..., "product": ...}, dims="channel")
```

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->
