### PR TITLE
additive effects for MVITS model

### DIFF
--- a/pymc_marketing/customer_choice/mv_its.py
+++ b/pymc_marketing/customer_choice/mv_its.py
@@ -26,6 +26,7 @@ from matplotlib.axes import Axes
 from pymc_extras.prior import Prior
 from xarray import DataArray
 
+from pymc_marketing.mmm.additive_effect import MuEffect
 from pymc_marketing.model_builder import ModelBuilder, create_idata_accessor
 from pymc_marketing.model_config import parse_model_config
 
@@ -68,6 +69,10 @@ class MVITS(ModelBuilder):
 
         model_config = model_config or {}
         model_config = parse_model_config(model_config)
+
+        self.mu_effects: list[MuEffect] = []
+        # extras dims for the likelihood
+        self.dims = ("existing_product",)
 
         super().__init__(model_config=model_config, sampler_config=sampler_config)
 
@@ -264,7 +269,7 @@ class MVITS(ModelBuilder):
         """
         self._generate_and_preprocess_model_data(X, y)  # type: ignore
 
-        with pm.Model(coords=self.coords) as model:
+        with pm.Model(coords=self.coords) as self.model:
             # data
             _existing_sales = pm.Data(
                 "existing_sales",
@@ -276,6 +281,9 @@ class MVITS(ModelBuilder):
                 y if not isinstance(y, pd.Series) else y.values,
                 dims="time",
             )
+
+            for mu_effect in self.mu_effects:
+                mu_effect.create_data(self)
 
             # priors
             intercept = self.model_config["intercept"].create_variable(name="intercept")
@@ -301,11 +309,13 @@ class MVITS(ModelBuilder):
                 pm.Deterministic("new sales", beta_all[-1])
 
             # expectation
-            mu = pm.Deterministic(
-                "mu",
-                intercept[None, :] - y[:, None] * beta[None, :],
-                dims=("time", "existing_product"),
-            )
+
+            mu = intercept[None, :] - y[:, None] * beta[None, :]
+
+            for mu_effect in self.mu_effects:
+                mu += mu_effect.create_effect(self)
+
+            mu = pm.Deterministic("mu", mu, dims=("time", "existing_product"))
 
             # likelihood
             self.model_config["likelihood"].create_likelihood_variable(
@@ -313,8 +323,6 @@ class MVITS(ModelBuilder):
                 mu=mu,
                 observed=_existing_sales,
             )
-
-        self.model = model
 
     def _data_setter(
         self,

--- a/pymc_marketing/customer_choice/synthetic_data.py
+++ b/pymc_marketing/customer_choice/synthetic_data.py
@@ -57,6 +57,33 @@ def generate_saturated_data(
     data: pd.DataFrame
         The synthetic data generated.
 
+
+    Examples
+    --------
+    Generate some synthetic data for the MVITS model:
+
+    .. code-block:: python
+
+        import numpy as np
+
+        from pymc_marketing.customer_choice import generate_saturated_data
+
+        seed = sum(map(ord, "Saturated Market Data"))
+        rng = np.random.default_rng(seed)
+
+        scenario = {
+            "total_sales_mu": 1_000,
+            "total_sales_sigma": 5,
+            "treatment_time": 40,
+            "n_observations": 100,
+            "market_shares_before": [[0.7, 0.3, 0]],
+            "market_shares_after": [[0.65, 0.25, 0.1]],
+            "market_share_labels": ["competitor", "own", "new"],
+            "random_seed": rng,
+        }
+
+        data = generate_saturated_data(**scenario)
+
     """
     rng: np.random.Generator = (
         random_seed


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

Allows for arbitrary MuEffects like with the MMMM class. Here is example of adding fourier term:

```python
import numpy as np

from pymc_marketing.customer_choice import MVITS, generate_saturated_data
from pymc_marketing.mmm import YearlyFourier
from pymc_marketing.mmm.additive_effect import FourierEffect

seed = sum(map(ord, "Saturated Market Data"))
rng = np.random.default_rng(seed)

scenario = {
    "total_sales_mu": 1_000,
    "total_sales_sigma": 5,
    "treatment_time": 40,
    "n_observations": 100,
    "market_shares_before": [[0.7, 0.3, 0]],
    "market_shares_after": [[0.65, 0.25, 0.1]],
    "market_share_labels": ["competitor", "own", "new"],
    "random_seed": rng,
}

data = generate_saturated_data(**scenario)

model = MVITS(["competitor", "own"])

# Add a Fourier effect to the model 
fourier = YearlyFourier(n_order=5)
effect = FourierEffect(fourier=fourier, date_dim_name="time")
model.mu_effects.append(effect)

X = data[["competitor", "own"]]
y = data["new"]

model.sample(X, y)
```

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->
