### PR TITLE
Handle 0-dim channel_xr in create_zero_dataset

### DIFF
--- a/pymc_marketing/mmm/utils.py
+++ b/pymc_marketing/mmm/utils.py
@@ -349,26 +349,41 @@ def create_zero_dataset(
         if date_col in channel_xr.dims:
             raise ValueError("`channel_xr` must NOT include the date dimension.")
 
-        # --- 4.3 Convert to DataFrame & merge ----------------------------------
-        channel_df = channel_xr.to_dataframe().reset_index()
+        # --- 4.3 Inject constants ----------------------------------------------
+        # Special-case: when there are NO dims (e.g., only channel dimension in the
+        # allocation which was pivoted into variables), xarray can't create an index
+        # for to_dataframe(). In this scenario, simply broadcast scalar values
+        # across all rows.
+        if len(channel_xr.dims) == 0:
+            for ch in channel_cols:
+                if ch in channel_xr.data_vars:
+                    # assign scalar value across all rows
+                    try:
+                        pred_df[ch] = channel_xr[ch].item()
+                    except Exception:
+                        pred_df[ch] = channel_xr[ch].values
+        else:
+            # Convert to DataFrame & merge when dims are present
+            channel_df = channel_xr.to_dataframe().reset_index()
 
-        # Left-join on every dimension; suffix prevents collisions during merge
-        pred_df = pred_df.merge(
-            channel_df,
-            on=dim_cols,
-            how="left",
-            suffixes=("", "_chan"),
-        )
+            # Left-join on every dimension; suffix prevents collisions during merge
+            pred_df = pred_df.merge(
+                channel_df,
+                on=dim_cols,
+                how="left",
+                suffixes=("", "_chan"),
+            )
 
         # --- 4.4 Copy merged values into official channel columns --------------
-        for ch in channel_cols:
-            chan_col = f"{ch}_chan"
-            if chan_col in pred_df.columns:
-                pred_df[ch] = pred_df[chan_col]
-                pred_df.drop(columns=chan_col, inplace=True)
+        if len(channel_xr.dims) != 0:
+            for ch in channel_cols:
+                chan_col = f"{ch}_chan"
+                if chan_col in pred_df.columns:
+                    pred_df[ch] = pred_df[chan_col]
+                    pred_df.drop(columns=chan_col, inplace=True)
 
-        # Replace any remaining NaNs introduced by the merge
-        pred_df[channel_cols] = pred_df[channel_cols].fillna(0.0)
+            # Replace any remaining NaNs introduced by the merge
+            pred_df[channel_cols] = pred_df[channel_cols].fillna(0.0)
 
     # ---- 5. Bring in any “other” columns from the training data ----------------
     other_cols = [


### PR DESCRIPTION
Update create_zero_dataset to support channel_xr Datasets with no dimensions by broadcasting scalar values for each channel across all rows. Add tests to verify correct behavior when channel_xr is 0-dim and when some channels are missing.

<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->
