### PR TITLE
Fourier transformation and HSGPs for streamlit app

### DIFF
--- a/streamlit/mmm-explainer/README.md
+++ b/streamlit/mmm-explainer/README.md
@@ -14,6 +14,10 @@ In this case, you would just need to install the requirements.txt within the str
 
 - **Bayesian Priors**: Interactive charts that demonstrate Bayesian prior distributions, designed to showcase the power of Bayesian methods in handling uncertainty and incorporating prior knowledge into MMM.
 
+- **Fourier Modes Exploration**: Interactive charts that demonstrate Fourier Modes, used to capture seasonal effects. Users can adjust parameters explore differnt periodic trends.
+
+- **Time-Varying Parameters**: Interactive charts that demonstrate Time-Varying effects. Users can adjust parameters to explore different configurations that help capture hidden latent temporal variations within media effects.
+
 - **Customizable Parameters**: All sections of the app include options to customize parameters, allowing users to experiment with different scenarios and understand their impacts on MMM.
 
 ## Getting Started

--- a/streamlit/mmm-explainer/pages/Fourier_Seasonality.py
+++ b/streamlit/mmm-explainer/pages/Fourier_Seasonality.py
@@ -33,7 +33,7 @@ st.set_page_config(
 
 # Give some context for what the page displays
 st.title("Fourier Modes")
-# TODO: Update this !
+
 st.markdown(
     "This page demonstrates Fourier seasonality transformations for use \
         in MMM. Fourier seasonality relies on sine and cosine \

--- a/streamlit/mmm-explainer/pages/Fourier_Seasonality.py
+++ b/streamlit/mmm-explainer/pages/Fourier_Seasonality.py
@@ -115,7 +115,7 @@ with tab1:
     )
 
     fig.update_layout(
-        title="Fourier Trend with Uncertainty",
+        title="Yearly Fourier Trend",
         xaxis_title="Day",
         yaxis_title="Trend",
         height=PLOT_HEIGHT,
@@ -155,7 +155,7 @@ with tab2:
     )
 
     fig.update_layout(
-        title="Fourier Trend with Uncertainty",
+        title="Monthly Fourier Trend",
         xaxis_title="Day",
         yaxis_title="Trend",
         height=PLOT_HEIGHT,

--- a/streamlit/mmm-explainer/pages/Fourier_Seasonality.py
+++ b/streamlit/mmm-explainer/pages/Fourier_Seasonality.py
@@ -1,0 +1,165 @@
+#   Copyright 2022 - 2025 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Streamlit page for fourier modes."""
+
+import plotly.graph_objects as go
+
+import streamlit as st
+from pymc_marketing.mmm import MonthlyFourier, YearlyFourier
+from pymc_marketing.prior import Prior
+
+# Constants
+PLOT_HEIGHT = 500
+PLOT_WIDTH = 1000
+
+# -------------------------- TOP OF PAGE INFORMATION -------------------------
+
+# Set browser / tab config
+st.set_page_config(
+    page_title="MMM App - Fourier Modes",
+    page_icon="🧊",
+)
+
+# Give some context for what the page displays
+st.title("Fourier Modes")
+# TODO: Update this !
+st.markdown(
+    "This page demonstrates Fourier seasonality transformations for use \
+        in MMM. Fourier seasonality relies on sine and cosine \
+        functions to capture recurring patterns in the data, making it useful \
+        for modeling periodic trends."
+)
+
+st.markdown("___The Fourier component takes the form:___")
+
+# LaTeX string for Fourier seasonal component
+fourier_formula = r"""
+f(t) = \sum_{k=1}^{K} \Bigg[ a_k \cos\Big(\frac{2 \pi k t}{T}\Big)
+      + b_k \sin\Big(\frac{2 \pi k t}{T}\Big) \Bigg]
+"""
+st.latex(fourier_formula)
+
+st.markdown("""
+**Where:**
+
+- $t$ = time index (e.g., day, week, month)
+- $T$ = period of the seasonality (e.g., 12 for monthly, 365 for yearly)
+- $K$ = order of the Fourier series (number of sine/cosine pairs)
+- $a_k, b_k$ = Fourier coefficients
+""")
+
+st.markdown(
+    "🗒️ **Note:** \n \
+- Yearly Fourier: A yearly seasonality with a period ($T$) of **_:red[365.25 days]_** \n \
+- Monthly Fourier: A monthly seasonality with a period ($T$) of **_:red[365.25 / 12 days]_**"
+)
+
+st.divider()
+
+# User inputs
+st.subheader(":orange[User Inputs]")
+# Slider for selecting the order
+n_order = st.slider(
+    "Fourier order $K$ (n_order)", min_value=1, max_value=20, value=6, step=1
+)
+# Slider for selecting the scale param
+b = st.slider(
+    "Laplace scale (__b__)", min_value=0.01, max_value=1.0, value=0.1, step=0.01
+)
+
+# Setup
+prior = Prior("Laplace", mu=0, b=b, dims="fourier")
+
+# Create tabs for plots
+tab1, tab2 = st.tabs(["Yearly", "Monthly"])
+
+# -------------------------- YEARLY SEASONALITY -------------------------
+with tab1:
+    st.subheader(":orange[Yearly Seasonality]")
+
+    fourier = YearlyFourier(n_order=n_order, prior=prior)
+
+    # Displayed in the APP
+    parameters = fourier.sample_prior()
+    curve = fourier.sample_curve(parameters)
+    # Drop chain if it's always 1
+    curve = curve.squeeze("chain")
+    # Compute mean and quantiles across draws
+    mean_trend = curve.mean("draw")
+    # Grab the days for the x-axis
+    days = curve.coords["day"].values
+
+    # Build Plotly figure
+    fig = go.Figure()
+
+    # Mean line
+    fig.add_trace(
+        go.Scatter(
+            x=days,
+            y=mean_trend.values,
+            mode="lines",
+            line=dict(color="blue"),
+            name="Mean trend",
+        )
+    )
+
+    fig.update_layout(
+        title="Fourier Trend with Uncertainty",
+        xaxis_title="Day",
+        yaxis_title="Trend",
+        height=PLOT_HEIGHT,
+        width=PLOT_WIDTH,
+    )
+
+    st.plotly_chart(fig, use_container_width=True)
+
+# -------------------------- MONTHLY SEASONALITY -------------------------
+with tab2:
+    st.subheader(":orange[Monthly Seasonality]")
+
+    fourier = MonthlyFourier(n_order=n_order, prior=prior)
+
+    # Displayed in the APP
+    parameters = fourier.sample_prior()
+    curve = fourier.sample_curve(parameters)
+    # Drop chain if it's always 1
+    curve = curve.squeeze("chain")
+    # Compute mean and quantiles across draws
+    mean_trend = curve.mean("draw")
+    # Grab the days for the x-axis
+    days = curve.coords["day"].values
+
+    # Build Plotly figure
+    fig = go.Figure()
+
+    # Mean line
+    fig.add_trace(
+        go.Scatter(
+            x=days,
+            y=mean_trend.values,
+            mode="lines",
+            line=dict(color="blue"),
+            name="Mean trend",
+        )
+    )
+
+    fig.update_layout(
+        title="Fourier Trend with Uncertainty",
+        xaxis_title="Day",
+        yaxis_title="Trend",
+        height=PLOT_HEIGHT,
+        width=PLOT_WIDTH,
+    )
+
+    st.plotly_chart(fig, use_container_width=True)

--- a/streamlit/mmm-explainer/pages/Time_Varying_Parameters.py
+++ b/streamlit/mmm-explainer/pages/Time_Varying_Parameters.py
@@ -122,7 +122,7 @@ fig.add_trace(
 )
 
 fig.update_layout(
-    title="Posterior Mean with 95% CI (demeaned='False')",
+    title="Time-Dependent Variation",
     xaxis_title="Time",
     yaxis_title="Value",
     template="plotly_white",

--- a/streamlit/mmm-explainer/pages/Time_Varying_Parameters.py
+++ b/streamlit/mmm-explainer/pages/Time_Varying_Parameters.py
@@ -1,0 +1,131 @@
+#   Copyright 2022 - 2025 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Streamlit page for HSGP."""
+
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+
+import streamlit as st
+from pymc_marketing.mmm import HSGP
+
+# Constants
+PLOT_HEIGHT = 500
+PLOT_WIDTH = 1000
+SEED = sum(map(ord, "Out of the box GP"))
+RNG = np.random.default_rng(SEED)
+
+# -------------------------- TOP OF PAGE INFORMATION -------------------------
+
+# Set browser / tab config
+st.set_page_config(
+    page_title="MMM App - HSGP",
+    page_icon="🧊",
+)
+
+# Give some context for what the page displays
+st.title("Time-Varying Parameters")
+# TODO: Update this !
+st.markdown(
+    "In real-world scenarios, the effectiveness of marketing activities is not \
+        static but varies over time due to factors like competitive actions, \
+        and market dynamics. To account for this, we introduce a time-dependent \
+        component into the MMM framework using a Gaussian Process, specifically a \
+        [Hilbert Space GP](https://www.pymc.io/projects/docs/en/stable/api/gp/generated/pymc.gp.HSGP.html). \
+        This allows us to capture the hidden latent temporal variation of the \
+        marketing contributions. \
+    "
+)
+
+st.markdown("""
+    When `time_media_varying` is set to `True`, we capture a single latent \
+        process that multiplies all channels. We assume all channels \
+        share the same time-dependent fluctuations, contrasting with \
+        implementations where each channel has an independent latent \
+        process. The modified model can be represented as:
+""")
+
+tvp_media_formula = r"""
+    y_{t} = \alpha + \lambda_{t} \cdot \sum_{m=1}^{M}\beta_{m}f(x_{m, t}) \ +
+    \sum_{c=1}^{C}\gamma_{c}z_{c, t} + \varepsilon_{t},
+"""
+st.latex(tvp_media_formula)
+
+st.markdown("""
+    **Where:**
+
+    $\\lambda_{t}$ is the time-varying component modeled as a latent process. This shared time-dependent \
+        variation $\\lambda_{t}$ allows us to capture the overall temporal effects that influence all \
+        media channels simultaneously.
+""")
+
+# Generate some data for the example
+n = 52
+X = np.arange(n)
+
+st.divider()
+
+# User inputs
+st.subheader(":blue[User Inputs]")
+
+# Sliders for params
+ls = st.slider("Lengthscale (ls)", min_value=1, max_value=100, value=25, step=1)
+eta = st.slider("Variance (eta)", min_value=0.1, max_value=5.0, value=1.0, step=0.1)
+m = st.slider(
+    "The number of basis vectors (m)", min_value=50, max_value=500, value=200, step=10
+)
+L = st.slider("Boundary condition (L)", min_value=50, max_value=500, value=150, step=10)
+
+# Fixed parameters
+dims = "time"
+drop_first = False
+
+# Collect kwargs
+kwargs = dict(X=X, ls=ls, eta=eta, dims=dims, m=m, L=L, drop_first=drop_first)
+
+hsgp = HSGP(**kwargs)
+
+dates = pd.date_range("2022-01-01", periods=n, freq="W-MON")
+coords = {"time": dates}
+
+
+def sample_curve(hsgp):
+    """Use to sample HSGP."""
+    return hsgp.sample_prior(coords=coords, random_seed=RNG)["f"]
+
+
+curve = sample_curve(hsgp).rename("False")
+curve = curve.squeeze("chain")  # drop chain=1
+time = curve.coords["time"].values
+
+# Compute posterior mean and credible interval
+mean_vals = curve.mean("draw")
+
+fig = go.Figure()
+
+# Mean line
+fig.add_trace(
+    go.Scatter(
+        x=time, y=mean_vals.values, mode="lines", line=dict(color="blue"), name="Mean"
+    )
+)
+
+fig.update_layout(
+    title="Posterior Mean with 95% CI (demeaned='False')",
+    xaxis_title="Time",
+    yaxis_title="Value",
+    template="plotly_white",
+)
+
+st.plotly_chart(fig, use_container_width=True)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
This PR adds new pages to the streamlit app. Each addition has their own dedicated page with needed context and information. 

Pages added:

1. Fourier Transformations
2. Time-Varying Parameters

### Fourier Transformations
The user will select vales for `n_order` and `b` via a slider. Given those values we create the curve and plot it. There is an option for both `YearlyFourier` and `MonthlyFourier`. 

<img width="1889" height="976" alt="Screenshot 2025-08-19 at 4 19 56 PM" src="https://github.com/user-attachments/assets/afb2da6f-0c27-4301-bb07-67e878f01892" />


### Time-Varying Parameters
Focusing on the time-varying media effects, the user will select parameter values for: `ls`, `eta`, `m`, and `L`.  Based on those, we create the curve and plot it.

<img width="1915" height="974" alt="Screenshot 2025-08-19 at 4 20 05 PM" src="https://github.com/user-attachments/assets/84cb82a8-ec27-4472-92a5-13eb772cdcfc" />


## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #1384
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1898.org.readthedocs.build/en/1898/

<!-- readthedocs-preview pymc-marketing end -->