### PR TITLE
Minor convenience to override model_kwargs in build_mmm_from_yaml

### DIFF
--- a/pymc_marketing/mmm/builders/yaml.py
+++ b/pymc_marketing/mmm/builders/yaml.py
@@ -48,6 +48,7 @@ def build_mmm_from_yaml(
     *,
     X: pd.DataFrame | None = None,
     y: pd.DataFrame | pd.Series | None = None,
+    model_kwargs: dict | None = None,
 ) -> MMM:
     """
     Build an MMM model from *config_path*.
@@ -70,6 +71,9 @@ def build_mmm_from_yaml(
     y : pandas.DataFrame | pandas.Series, optional
         Pre-loaded target vector.  If omitted, the loader tries to read it
         from a path in the YAML under `data.y_path`.
+    model_kwargs : dict, optional
+        Additional keyword arguments for the model.
+        They override any defaults specified in the YAML config.
 
     Returns
     -------
@@ -78,7 +82,9 @@ def build_mmm_from_yaml(
     cfg: Mapping[str, Any] = yaml.safe_load(Path(config_path).read_text())
 
     # 1 ─────────────────────────────────── shell (no effects yet)
-    model_config = cfg["model"]["kwargs"]  # Get model kwargs
+    # Merge model_kwargs into cfg["model"]["kwargs"], with model_kwargs taking precedence
+    model_config = {**cfg["model"].get("kwargs", {}), **(model_kwargs or {})}
+    cfg["model"]["kwargs"] = model_config
 
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=DeprecationWarning)

--- a/tests/mmm/builders/test_yaml.py
+++ b/tests/mmm/builders/test_yaml.py
@@ -54,8 +54,21 @@ def get_yaml_files():
     ]
 
 
+@pytest.mark.parametrize(
+    "model_kwargs",
+    [
+        None,
+        {
+            "adstock": {
+                "class": "pymc_marketing.mmm.components.adstock.GeometricAdstock",
+                "kwargs": {"l_max": 28},
+            }
+        },
+        {"time_varying_intercept": False},
+    ],
+)
 @pytest.mark.parametrize("config_path", get_yaml_files())
-def test_build_mmm_from_yaml(config_path, X_data, y_data):
+def test_build_mmm_from_yaml(config_path, X_data, y_data, model_kwargs):
     """Test that build_mmm_from_yaml can create models from all config files."""
     # Load YAML to check if effects are defined
     with open(config_path) as file:
@@ -63,9 +76,7 @@ def test_build_mmm_from_yaml(config_path, X_data, y_data):
 
     # Build model from YAML
     model = build_mmm_from_yaml(
-        config_path=config_path,
-        X=X_data,
-        y=y_data.squeeze(),
+        config_path=config_path, X=X_data, y=y_data.squeeze(), model_kwargs=model_kwargs
     )
 
     # Check that model was created successfully
@@ -87,6 +98,21 @@ def test_build_mmm_from_yaml(config_path, X_data, y_data):
 
     # Verify that the result is an xarray dataset
     assert isinstance(prior_predictive, xr.Dataset)
+
+    if model_kwargs:
+        # assert that model_kwargs are reflected in the model
+        for key, value in model_kwargs.items():
+            attr = getattr(model, key, None)
+            if isinstance(value, dict) and "class" in value and "kwargs" in value:
+                # Check class name
+                expected_class_name = value["class"].split(".")[-1]
+                assert attr.__class__.__name__ == expected_class_name
+                # Check only the specified kwargs
+                for k, v in value["kwargs"].items():
+                    assert hasattr(attr, k), f"{key} missing attribute {k}"
+                    assert getattr(attr, k) == v, f"{key}.{k}={getattr(attr, k)} != {v}"
+            else:
+                assert attr == value
 
 
 def test_wrong_adstock_class():


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->
`build_mmm_from_yaml` accepts passing `model_kwargs`. When passed, they will override the `model_kwargs` present in the yaml file.

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1907.org.readthedocs.build/en/1907/

<!-- readthedocs-preview pymc-marketing end -->