### PR TITLE
Fix FourierEffect

### DIFF
--- a/pymc_marketing/mmm/additive_effect.py
+++ b/pymc_marketing/mmm/additive_effect.py
@@ -112,7 +112,7 @@ class FourierEffect:
             pm.Deterministic(
                 f"{self.fourier.prefix}_contribution",
                 x,
-                dims=("date", *self.fourier.prior.dims),
+                dims=(self.date_dim_name, *self.fourier.prior.dims),
             )
 
         fourier_effect = self.fourier.apply(

--- a/pymc_marketing/mmm/additive_effect.py
+++ b/pymc_marketing/mmm/additive_effect.py
@@ -107,7 +107,17 @@ class FourierEffect:
 
         # Apply the Fourier transformation to data
         day_data = model[f"{self.fourier.prefix}_day"]
-        fourier_effect = self.fourier.apply(day_data)
+
+        def create_deterministic(x: pt.TensorVariable) -> None:
+            pm.Deterministic(
+                f"{self.fourier.prefix}_contribution",
+                x,
+                dims=("date", *self.fourier.prior.dims),
+            )
+
+        fourier_effect = self.fourier.apply(
+            day_data, result_callback=create_deterministic
+        )
 
         # Create a deterministic variable for the effect
         dims = (dim for dim in mmm.dims if dim in self.fourier.prior.dims)

--- a/pymc_marketing/mmm/fourier.py
+++ b/pymc_marketing/mmm/fourier.py
@@ -944,14 +944,19 @@ class WeeklyFourier(FourierBase):
         )
 
     def _get_days_in_period(self, dates: pd.DatetimeIndex) -> pd.Index:
-        """Return the weekday within the weekly periodicity.
+        """Return dayofyear associated with dates.
+
+        With no gaps, a pure weekly Fourier basis sin(2π k t/7) will evaluate the same whether
+        you pass t=dayofyear or t=weekday, because the sine/cos only depend on t mod 7.
+        However, there are empirical reasons to prefer this representation,
+        since it avoids divergences when used in combination with tvp.
 
         Returns
         -------
         int or float
             The relevant period within the characteristic periodicity
         """
-        return dates.weekday
+        return dates.dayofyear
 
 
 def _is_yearly_fourier(data: Any) -> bool:

--- a/tests/mmm/test_additive_effect.py
+++ b/tests/mmm/test_additive_effect.py
@@ -122,6 +122,7 @@ def test_fourier_effect(
         [
             f"{fourier.prefix}_day",
             f"{fourier.prefix}_beta",
+            f"{fourier.prefix}_contribution",
             f"{fourier.prefix}_effect",
         ]
     )


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->
Add fourier_contribution deterministic

* Broadcasts `day_data` over `(*mmm.dims, "fourier_mode")`
* dim_handler then sums over ("fourier_mode") dim

Previously:
* Broadcasts `day_data` over `(*mmm.dims)` only. This is not right, since we are not having the right fourier modes


## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [X] Related to #1442 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1909.org.readthedocs.build/en/1909/

<!-- readthedocs-preview pymc-marketing end -->