### PR TITLE
Normalize gaussian basis

### DIFF
--- a/pymc_marketing/mmm/events.py
+++ b/pymc_marketing/mmm/events.py
@@ -261,7 +261,9 @@ class GaussianBasis(Basis):
 
     def function(self, x: pt.TensorLike, sigma: pt.TensorLike) -> TensorVariable:
         """Gaussian bump function."""
-        return pm.math.exp(-0.5 * (x / sigma) ** 2)
+        rv = pm.Normal.dist(mu=0.0, sigma=sigma)
+        out = pm.math.exp(pm.logp(rv, x))
+        return out
 
     default_priors = {
         "sigma": Prior("Gamma", mu=7, sigma=1),


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

Before: unnormalized bell, [exp(-0.5 * (x/σ)^2)]
<img width="585" height="392" alt="image" src="https://github.com/user-attachments/assets/41d7d7a2-8921-43c8-b0da-34a9919a36bf" />

After: normalized Normal pdf, 1/(σ√(2π)) * exp(-0.5 * (x/σ)^2).
<img width="558" height="393" alt="image" src="https://github.com/user-attachments/assets/b5b44a71-0c91-46df-9e4d-1d8b4d90e669" />

Implications:
* Amplitude scales with 1/σ; larger σ lowers the peak.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Related to #1465 
- [x] Related to #1911 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->
