### PR TITLE
Bump version to 0.16.0

### DIFF
--- a/pymc_marketing/version.py
+++ b/pymc_marketing/version.py
@@ -13,4 +13,4 @@
 #   limitations under the License.
 """Version of the package."""
 
-__version__ = "0.15.1"
+__version__ = "0.16.0"


### PR DESCRIPTION
Prepare for 0.16.0 release

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1915.org.readthedocs.build/en/1915/

<!-- readthedocs-preview pymc-marketing end -->