### PR TITLE
Keep zeroes in add_noise_to_channel_allocation

### DIFF
--- a/pymc_marketing/mmm/utils.py
+++ b/pymc_marketing/mmm/utils.py
@@ -450,6 +450,10 @@ def add_noise_to_channel_allocation(
     noisy_df = df.copy()
     noisy_df[channels] += noise
 
+    # Override channels with zero spend, we don't want to add noise to those ones
+    zero_spend_mask = df[channels] == 0
+    noisy_df[zero_spend_mask] = 0.0
+
     # Ensure no negative spends
     noisy_df[channels] = noisy_df[channels].clip(lower=0.0)
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->
Epsilon channel values strike back -> NaNs 

We don't want to create noise for channels with strict zero value.
Allowing those channels to have noise implies those channels taking extremely small values after scaling.
As I painfully learned, this leads to NaNs in `sample_posterior_predictive`


## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1916.org.readthedocs.build/en/1916/

<!-- readthedocs-preview pymc-marketing end -->