### PR TITLE
Hotfix: use `target_column` in `create_fit_data` and `build_from_idata`

### DIFF
--- a/pymc_marketing/mmm/multidimensional.py
+++ b/pymc_marketing/mmm/multidimensional.py
@@ -2016,7 +2016,7 @@ class MMM(RegressionModelBuilder):
             y_s = pd.Series(y, index=X_df.index)
         else:
             y_s = y.copy()
-        y_s.name = self.output_var
+        y_s.name = self.target_column
 
         dims_in_X = [d for d in self.dims if d in X_df.columns]
         coord_cols = [self.date_column, *dims_in_X]
@@ -2035,10 +2035,10 @@ class MMM(RegressionModelBuilder):
                     how="left",
                 )
             else:
-                X_df[self.output_var] = aligned.values
+                X_df[self.target_column] = aligned.values
         elif len(y_s) == len(X_df):
             # Positional
-            X_df[self.output_var] = y_s.to_numpy()
+            X_df[self.target_column] = y_s.to_numpy()
         else:
             # Try merge if y has columns as index levels
             if isinstance(y_s.index, pd.MultiIndex) and set(coord_cols).issubset(
@@ -2050,7 +2050,7 @@ class MMM(RegressionModelBuilder):
                     "Cannot align y with X; incompatible indices / lengths"
                 )
 
-        if self.output_var not in X_df.columns:
+        if self.target_column not in X_df.columns:
             raise RuntimeError("Target column missing after alignment")
 
         ds = X_df.sort_values(coord_cols).set_index(coord_cols).to_xarray()
@@ -2090,8 +2090,8 @@ class MMM(RegressionModelBuilder):
         ):
             dataset = dataset.reset_index()
         # type: ignore
-        X = dataset.drop(columns=[self.output_var])
-        y = dataset[self.output_var]
+        X = dataset.drop(columns=[self.target_column])
+        y = dataset[self.target_column]
 
         self.build_model(X, y)  # type: ignore
 

--- a/pymc_marketing/mmm/multidimensional.py
+++ b/pymc_marketing/mmm/multidimensional.py
@@ -2051,7 +2051,9 @@ class MMM(RegressionModelBuilder):
                 )
 
         if self.target_column not in X_df.columns:
-            raise RuntimeError("Target column missing after alignment")
+            raise RuntimeError(
+                f"Target column {self.target_column} missing after alignment"
+            )
 
         ds = X_df.sort_values(coord_cols).set_index(coord_cols).to_xarray()
         return ds


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->
Use `target_column` as name for `idata.fit_data.y` so the model can be reloaded

I overlooked this issue in #1902, so I improved the tests around it so this does not happen again

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [x] Related to #1902 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1918.org.readthedocs.build/en/1918/

<!-- readthedocs-preview pymc-marketing end -->