### PR TITLE
Pydantic `MuEffect`

### DIFF
--- a/tests/mmm/test_additive_effect.py
+++ b/tests/mmm/test_additive_effect.py
@@ -168,7 +168,7 @@ def test_fourier_effect_multidimensional(
     prefix = "weekly"
     prior = Prior("Laplace", mu=0, b=0.1, dims=prior_dims)
     fourier = WeeklyFourier(n_order=10, prefix=prefix, prior=prior)
-    fourier_effect = FourierEffect(fourier)
+    fourier_effect = FourierEffect(fourier=fourier)
 
     with mmm.model:
         fourier_effect.create_data(mmm)

--- a/tests/mmm/test_additive_effect.py
+++ b/tests/mmm/test_additive_effect.py
@@ -98,7 +98,7 @@ def test_fourier_effect(
     dims,
     coords,
 ) -> None:
-    effect = FourierEffect(fourier)
+    effect = FourierEffect(fourier=fourier)
 
     mmm = create_mock_mmm(
         dims=dims,
@@ -215,7 +215,7 @@ def test_linear_trend_effect(
 ) -> None:
     prefix = "linear_trend"
     effect = LinearTrendEffect(
-        LinearTrend(priors=priors, dims=linear_trend_dims),
+        trend=LinearTrend(priors=priors, dims=linear_trend_dims),
         prefix=prefix,
     )
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->
Provides serialization/deserialization of MuEffect using Pydantic BaseModel


## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->
