### PR TITLE
Add approximate_fit method for variational inference

### DIFF
--- a/pymc_marketing/model_builder.py
+++ b/pymc_marketing/model_builder.py
@@ -1129,8 +1129,6 @@ class RegressionModelBuilder(ModelBuilder):
                 _sample_kwargs.update(sample_kwargs)
             # Use sampler_config draws if not explicitly provided
             _sample_kwargs.setdefault("draws", self.sampler_config.get("draws", 1_000))
-            if progressbar is not None:
-                _sample_kwargs.setdefault("progressbar", progressbar)
             if random_seed is not None:
                 _sample_kwargs.setdefault("random_seed", random_seed)
             _sample_kwargs.setdefault("return_inferencedata", True)

--- a/pymc_marketing/model_builder.py
+++ b/pymc_marketing/model_builder.py
@@ -1057,6 +1057,120 @@ class RegressionModelBuilder(ModelBuilder):
         )
         return posterior_means.data
 
+    def approximate_fit(
+        self,
+        X: pd.DataFrame | xr.Dataset | xr.DataArray,
+        y: pd.Series | xr.DataArray | np.ndarray | None = None,
+        progressbar: bool | None = None,
+        random_seed: RandomState | None = None,
+        *,
+        fit_kwargs: dict[str, Any] | None = None,
+        sample_kwargs: dict[str, Any] | None = None,
+    ) -> az.InferenceData:
+        """Fit a model using Variational Inference and return InferenceData.
+
+        This performs variational inference via `pymc.fit`, then draws posterior samples
+        from the fitted approximation via `Approximation.sample`, returning an
+        `arviz.InferenceData` compatible with the rest of the API (same structure as `.fit`).
+
+        Parameters
+        ----------
+        X : array-like | array, shape (n_obs, n_features)
+            The training input samples. If scikit-learn is available, array-like, otherwise array.
+        y : array-like | array, shape (n_obs,)
+            The target values (real numbers). If scikit-learn is available, array-like, otherwise array.
+        progressbar : bool, optional
+            Specifies whether the fitting/sample progress bar should be displayed. Defaults to True.
+        random_seed : Optional[RandomState]
+            Provides stochastic procedures with initial random seed for reproducibility.
+        fit_kwargs : dict, optional
+            Extra keyword arguments forwarded to `pymc.fit` (e.g., {"n": 10_000, "method": "advi"}).
+        sample_kwargs : dict, optional
+            Extra keyword arguments forwarded to `Approximation.sample` (e.g., {"draws": 1_000}).
+
+        Returns
+        -------
+        az.InferenceData
+            Inference data of the variationally fitted model.
+        """
+        if (
+            isinstance(y, pd.Series)
+            and isinstance(X, pd.DataFrame)
+            and not X.index.equals(y.index)
+        ):
+            raise ValueError("Index of X and y must match.")
+
+        if y is None:
+            y = np.zeros(X.shape[0])
+
+        if self.output_var in X:
+            raise ValueError(
+                f"X includes a column named '{self.output_var}', which conflicts with the target variable."
+            )
+
+        if not hasattr(self, "model"):
+            self.build_model(X, y)
+
+        # Prepare kwargs for pymc.fit
+        _fit_kwargs: dict[str, Any] = {}
+        if fit_kwargs is not None:
+            _fit_kwargs.update(fit_kwargs)
+        if progressbar is not None:
+            _fit_kwargs["progressbar"] = progressbar
+        if random_seed is not None:
+            _fit_kwargs["random_seed"] = random_seed
+
+        # Run variational inference and then sample from the approximation
+        with self.model:
+            approximation = pm.fit(**_fit_kwargs)
+
+            _sample_kwargs: dict[str, Any] = {}
+            if sample_kwargs is not None:
+                _sample_kwargs.update(sample_kwargs)
+            # Use sampler_config draws if not explicitly provided
+            _sample_kwargs.setdefault("draws", self.sampler_config.get("draws", 1_000))
+            if progressbar is not None:
+                _sample_kwargs.setdefault("progressbar", progressbar)
+            if random_seed is not None:
+                _sample_kwargs.setdefault("random_seed", random_seed)
+            _sample_kwargs.setdefault("return_inferencedata", True)
+
+            idata: az.InferenceData = approximation.sample(**_sample_kwargs)  # type: ignore[assignment]
+
+        # Compute deterministics after sampling for parity with MCMC `.fit`
+        with self.model:
+            idata.posterior = pm.compute_deterministics(
+                idata.posterior, merge_dataset=True
+            )
+
+        self.post_sample_model_transformation()
+
+        # Extend or set self.idata
+        if self.idata:
+            self.idata = self.idata.copy()
+            self.idata.extend(idata, join="right")
+        else:
+            self.idata = idata
+
+        # Annotate, attach fit_data, and set attrs
+        self.idata["posterior"].attrs["pymc_marketing_version"] = __version__
+
+        if "fit_data" in self.idata:
+            del self.idata.fit_data
+
+        fit_data = self.create_fit_data(X, y)
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                category=UserWarning,
+                message="The group fit_data is not defined in the InferenceData scheme",
+            )
+            self.idata.add_groups(fit_data=fit_data)
+
+        self.set_idata_attrs(self.idata)
+        return self.idata  # type: ignore
+
     def sample_prior_predictive(
         self,
         X=None,

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -1058,8 +1058,6 @@ def test_approximate_fit_variational(toy_X, toy_y) -> None:
     assert idata.posterior.sizes["draw"] == 20
     assert idata.posterior.sizes["chain"] == 1
     assert "fit_data" in idata
-    # Check one parameter shape matches coordinates length
-    assert idata.posterior["a"].sizes.get("numbers", len(toy_X)) == len(toy_X)
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -1050,7 +1050,7 @@ def test_approximate_fit_variational(toy_X, toy_y) -> None:
         progressbar=False,
         random_seed=42,
         fit_kwargs={"n": 200, "method": "advi", "progressbar": False},
-        sample_kwargs={"draws": 20, "progressbar": False},
+        sample_kwargs={"draws": 20},
     )
 
     assert idata is not None

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -1040,43 +1040,26 @@ def test_unmatched_index(toy_X, toy_y) -> None:
         model.fit(toy_X, toy_y)
 
 
-def test_approximate_fit_variational(toy_X, toy_y, monkeypatch) -> None:
-    """Ensure approximate_fit uses pm.fit and returns proper InferenceData."""
-    model = RegressionModelBuilderTest(sampler_config={"draws": 50})
+def test_approximate_fit_variational(toy_X, toy_y) -> None:
+    """Ensure approximate_fit runs real VI and returns proper InferenceData."""
+    model = RegressionModelBuilderTest(sampler_config={"draws": 20, "chains": 1})
 
-    class FakeApproximation:
-        def __init__(self, model):
-            self._model = model
-
-        def sample(
-            self,
-            draws: int = 100,
-            chains: int = 1,
-            random_seed=None,
-            progressbar: bool = True,
-            return_inferencedata: bool = True,
-            **kwargs,
-        ):
-            n = len(self._model.coords.get("numbers", [])) or len(toy_X)
-            posterior = {
-                "a": np.zeros((chains, draws, n)),
-                "b": np.zeros((chains, draws)),
-                "σ_model_fmc": np.zeros((chains, draws)),
-            }
-            return az.from_dict(posterior=posterior)
-
-    def fake_fit(*args, **kwargs):
-        current_model = pm.modelcontext(None)
-        return FakeApproximation(current_model)
-
-    monkeypatch.setattr(pm, "fit", fake_fit)
-
-    idata = model.approximate_fit(toy_X, toy_y, sample_kwargs={"draws": 20})
+    idata = model.approximate_fit(
+        toy_X,
+        toy_y,
+        progressbar=False,
+        random_seed=42,
+        fit_kwargs={"n": 200, "method": "advi", "progressbar": False},
+        sample_kwargs={"draws": 20, "progressbar": False},
+    )
 
     assert idata is not None
     assert "posterior" in idata.groups()
     assert idata.posterior.sizes["draw"] == 20
+    assert idata.posterior.sizes["chain"] == 1
     assert "fit_data" in idata
+    # Check one parameter shape matches coordinates length
+    assert idata.posterior["a"].sizes.get("numbers", len(toy_X)) == len(toy_X)
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -1049,7 +1049,7 @@ def test_approximate_fit_variational(toy_X, toy_y) -> None:
         toy_y,
         progressbar=False,
         random_seed=42,
-        fit_kwargs={"n": 200, "method": "advi", "progressbar": False},
+        fit_kwargs={"n": 200, "method": "advi"},
         sample_kwargs={"draws": 20},
     )
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->
Introduces the approximate_fit method to RegressionModelBuilder, enabling model fitting via PyMC's variational inference (pm.fit) and returning ArviZ InferenceData. Includes a corresponding test to verify correct usage and output structure.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1923.org.readthedocs.build/en/1923/

<!-- readthedocs-preview pymc-marketing end -->