### PR TITLE
Add fivetran pandas accessor

### DIFF
--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -10,6 +10,7 @@
   bass
   clv
   customer_choice
+  data
   deserialize
   hsgp_kwargs
   metrics

--- a/pymc_marketing/__init__.py
+++ b/pymc_marketing/__init__.py
@@ -13,6 +13,8 @@
 #   limitations under the License.
 """PyMC-Marketing."""
 
+# Load the data accessor
+import pymc_marketing.data.fivetran  # noqa: F401
 from pymc_marketing import clv, customer_choice, mmm
 from pymc_marketing.version import __version__
 

--- a/pymc_marketing/data/__init__.py
+++ b/pymc_marketing/data/__init__.py
@@ -1,0 +1,14 @@
+#   Copyright 2022 - 2025 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Data adaptors for PyMC-Marketing."""

--- a/pymc_marketing/data/fivetran.py
+++ b/pymc_marketing/data/fivetran.py
@@ -21,6 +21,12 @@ Example usage for MMM:
 
 .. code-block:: python
 
+    from pymc_marketing.data.fivetran import (
+        process_fivetran_ad_reporting,
+        process_fivetran_shopify_unique_orders,
+    )
+    from pymc_marketing.mmm import MMM
+
     # Process ad spend data for media channels
     x = process_fivetran_ad_reporting(
         campaign_df, value_columns="spend", rename_date_to="date"

--- a/pymc_marketing/data/fivetran.py
+++ b/pymc_marketing/data/fivetran.py
@@ -34,6 +34,28 @@ Example usage for MMM:
     # Use in MMM model
     mmm = MMM(...)
     mmm.fit(X=x, y=y["orders"])
+
+There are also pandas accessors for these functions which allows calling them from a
+pandas DataFrame. These accessors are registered under the ``fivetran`` namespace and
+can be accessed after importing pymc_marketing.
+
+.. code-block:: python
+
+    import pandas as pd
+
+    from pymc_marketing.mmm import MMM
+
+
+    campaign_df: pd.DataFrame = ...
+    orders_df: pd.DataFrame = ...
+
+    X: pd.DataFrame = campaign_df.fivetran.process_ad_reporting(value_columns="spend")
+    y: pd.DataFrame = orders_df.fivetran.process_shopify_unique_orders()
+
+    # Use in MMM model
+    mmm = MMM(...)
+    mmm.fit(X=x, y=y["orders"])
+
 """
 
 from collections.abc import Sequence

--- a/pymc_marketing/data/fivetran.py
+++ b/pymc_marketing/data/fivetran.py
@@ -59,9 +59,10 @@ can be accessed after importing pymc_marketing.
 """
 
 from collections.abc import Sequence
-from functools import wraps
 
 import pandas as pd
+
+from pymc_marketing.decorators import copy_docstring
 
 
 def _normalize_and_validate_inputs(
@@ -213,19 +214,6 @@ def _finalize_wide_output(
     ordered_cols = [first_col] + [c for c in wide.columns if c != first_col]
     wide[first_col] = pd.to_datetime(wide[first_col]).dt.normalize()
     return wide[ordered_cols]
-
-
-def copy_docstring(function):
-    """Copy docstring from one function to other."""
-
-    def decorator(func):
-        @wraps(function)
-        def wrapper(*args, **kwargs):
-            return func(*args, **kwargs)
-
-        return wrapper
-
-    return decorator
 
 
 def process_fivetran_ad_reporting(

--- a/pymc_marketing/decorators.py
+++ b/pymc_marketing/decorators.py
@@ -1,0 +1,29 @@
+#   Copyright 2022 - 2025 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Various decorators for PyMC-Marketing."""
+
+from functools import wraps
+
+
+def copy_docstring(function):
+    """Copy docstring from one function to other."""
+
+    def decorator(func):
+        @wraps(function)
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -1,0 +1,13 @@
+#   Copyright 2022 - 2025 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.

--- a/tests/data/test_fivetran.py
+++ b/tests/data/test_fivetran.py
@@ -308,6 +308,7 @@ def example_ad_report_df() -> pd.DataFrame:
     return pd.DataFrame(data)
 
 
+@pytest.mark.parametrize("accessor", [True, False])
 @pytest.mark.parametrize(
     "value_columns, expected_columns, expected_values",
     [
@@ -329,11 +330,17 @@ def example_ad_report_df() -> pd.DataFrame:
     ],
 )
 def test_ad_report_schema(
-    example_ad_report_df, value_columns, expected_columns, expected_values
+    example_ad_report_df,
+    accessor: bool,
+    value_columns,
+    expected_columns,
+    expected_values,
 ):
-    result = process_fivetran_ad_reporting(
-        example_ad_report_df, value_columns=value_columns, rename_date_to="date"
-    )
+    kwargs = dict(value_columns=value_columns, rename_date_to="date")
+    if accessor:
+        result = example_ad_report_df.fivetran.process_ad_reporting(**kwargs)
+    else:
+        result = process_fivetran_ad_reporting(example_ad_report_df, **kwargs)
 
     expected = (
         pd.DataFrame(
@@ -352,6 +359,7 @@ def test_ad_report_schema(
     pd.testing.assert_frame_equal(result_subset, expected, check_dtype=False)
 
 
+@pytest.mark.parametrize("accessor", [True, False])
 @pytest.mark.parametrize(
     "value_columns, expected_columns, expected_values",
     [
@@ -373,11 +381,17 @@ def test_ad_report_schema(
     ],
 )
 def test_account_report_schema(
-    example_account_report_df, value_columns, expected_columns, expected_values
+    example_account_report_df,
+    accessor: bool,
+    value_columns,
+    expected_columns,
+    expected_values,
 ):
-    result = process_fivetran_ad_reporting(
-        example_account_report_df, value_columns=value_columns, rename_date_to="date"
-    )
+    kwargs = dict(value_columns=value_columns, rename_date_to="date")
+    if accessor:
+        result = example_account_report_df.fivetran.process_ad_reporting(**kwargs)
+    else:
+        result = process_fivetran_ad_reporting(example_account_report_df, **kwargs)
 
     expected = (
         pd.DataFrame(
@@ -394,6 +408,7 @@ def test_account_report_schema(
     pd.testing.assert_frame_equal(result_subset, expected, check_dtype=False)
 
 
+@pytest.mark.parametrize("accessor", [True, False])
 @pytest.mark.parametrize(
     "value_columns, expected_columns, expected_values",
     [
@@ -415,11 +430,17 @@ def test_account_report_schema(
     ],
 )
 def test_campaign_report_schema(
-    example_campaign_report_df, value_columns, expected_columns, expected_values
+    example_campaign_report_df,
+    accessor: bool,
+    value_columns,
+    expected_columns,
+    expected_values,
 ):
-    result = process_fivetran_ad_reporting(
-        example_campaign_report_df, value_columns=value_columns, rename_date_to="date"
-    )
+    kwargs = dict(value_columns=value_columns, rename_date_to="date")
+    if accessor:
+        result = example_campaign_report_df.fivetran.process_ad_reporting(**kwargs)
+    else:
+        result = process_fivetran_ad_reporting(example_campaign_report_df, **kwargs)
 
     expected = (
         pd.DataFrame(
@@ -575,8 +596,15 @@ def example_shopify_orders_df() -> pd.DataFrame:
     )
 
 
-def test_shopify_orders_unique_orders(example_shopify_orders_df: pd.DataFrame) -> None:
-    result = process_fivetran_shopify_unique_orders(example_shopify_orders_df)
+@pytest.mark.parametrize("accessor", [True, False])
+def test_shopify_orders_unique_orders(
+    example_shopify_orders_df: pd.DataFrame,
+    accessor: bool,
+) -> None:
+    if accessor:
+        result = example_shopify_orders_df.fivetran.process_shopify_unique_orders()
+    else:
+        result = process_fivetran_shopify_unique_orders(example_shopify_orders_df)
 
     expected = pd.DataFrame(
         {


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

This adds `fivetran` accessor for pandas DataFrames upon import of `pymc_marketing`. This makes it 
easier to access the `fivetran` functionality directly from pandas DataFrames.

For example:

```python
import pandas as pd

# Also registers when pymc_marketing is imported
from pymc_marketing.mmm import MMM

campaign_df: pd.DataFrame = ...
orders_df: pd.DataFrame = ...

assert hasattr(campaign_df, "fivetran")

X = compaign_df.fivetran.process_ad_reporting()
y = orders_df.fivetran.process_shopify_unique_orders()

model = MMM(...)
model.fit(X, y["orders"])

```

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1924.org.readthedocs.build/en/1924/

<!-- readthedocs-preview pymc-marketing end -->