### PR TITLE
Major updates on utils functions

### DIFF
--- a/docs/source/notebooks/mmm/mmm_build_from_yml_example.ipynb
+++ b/docs/source/notebooks/mmm/mmm_build_from_yml_example.ipynb
@@ -3105,7 +3105,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.13"
+   "version": "3.12.11"
   }
  },
  "nbformat": 4,

--- a/pymc_marketing/mmm/budget_optimizer.py
+++ b/pymc_marketing/mmm/budget_optimizer.py
@@ -204,7 +204,7 @@ Notes
 
 import warnings
 from collections.abc import Sequence
-from typing import Any, ClassVar, Protocol, runtime_checkable
+from typing import Any, ClassVar, Protocol, cast, runtime_checkable
 
 import numpy as np
 import pytensor.tensor as pt
@@ -225,7 +225,7 @@ from pymc_marketing.mmm.constraints import (
     compile_constraints_for_scipy,
 )
 from pymc_marketing.mmm.utility import UtilityFunctionType, average_response
-from pymc_marketing.pytensor_utils import extract_response_distribution
+from pymc_marketing.pytensor_utils import extract_response_distribution, merge_models
 
 
 def optimizer_xarray_builder(value, **kwargs):
@@ -394,24 +394,36 @@ class BudgetOptimizer(BaseModel):
         self._budget_shape = tuple(len(coord) for coord in self._budget_coords.values())
 
         # 4. Ensure that we only optmize over non-zero channels
-        if self.budgets_to_optimize is None:
-            # If no mask is provided, we optimize all channels
-            self.budgets_to_optimize = (
-                self.mmm_model.idata.posterior.channel_contribution.mean(
-                    ("chain", "draw", "date")
-                ).astype(bool)
+        def _should_enforce_mask_validation() -> bool:
+            # Duck-typing: allow wrappers to opt-in by providing this attribute
+            return bool(
+                getattr(self.mmm_model, "enforce_budget_mask_validation", False)
             )
-        else:
-            # If a mask is provided, ensure it has the correct shape
-            expected_mask = self.mmm_model.idata.posterior.channel_contribution.mean(
-                ("chain", "draw", "date")
-            ).astype(bool)
 
-            # Check if we are asking to optimize over channels that are not present in the model
-            if np.any(self.budgets_to_optimize.values > expected_mask.values):
-                raise ValueError(
-                    "budgets_to_optimize mask contains True values at coordinates where the model has no "
-                    "information."
+        if _should_enforce_mask_validation():
+            if self.budgets_to_optimize is None:
+                self.budgets_to_optimize = (
+                    self.mmm_model.idata.posterior.channel_contribution.mean(
+                        ("chain", "draw", "date")
+                    ).astype(bool)
+                )
+            else:
+                expected_mask = (
+                    self.mmm_model.idata.posterior.channel_contribution.mean(
+                        ("chain", "draw", "date")
+                    ).astype(bool)
+                )
+                if np.any(self.budgets_to_optimize.values > expected_mask.values):
+                    raise ValueError(
+                        "budgets_to_optimize mask contains True values at coordinates "
+                        "where the model has no information."
+                    )
+        else:
+            if self.budgets_to_optimize is None:
+                self.budgets_to_optimize = xr.DataArray(
+                    np.ones(self._budget_shape, dtype=bool),
+                    dims=self._budget_dims,
+                    coords=self._budget_coords,
                 )
 
         size_budgets = self.budgets_to_optimize.sum().item()
@@ -893,3 +905,166 @@ class BudgetOptimizer(BaseModel):
 
         else:
             raise MinimizeException(f"Optimization failed: {result.message}")
+
+
+class MultiModelWrapper(OptimizerCompatibleModelWrapper):
+    """Wrapper that merges multiple OptimizerCompatibleModelWrapper models.
+
+    - Keeps a persistent merged model for optimization via `_set_predictors_for_optimization`.
+    - Provides a dynamic merged `model` property for inspection (non-persistent), if needed.
+    """
+
+    def __init__(
+        self,
+        models: list[OptimizerCompatibleModelWrapper],
+        prefixes: list[str] | None = None,
+        merge_on: str | None = "channel_data",
+        use_every_n_draw: int = 1,
+    ) -> None:
+        if len(models) < 1:
+            raise ValueError("Need at least 1 model")
+
+        self._channel_scales = 1.0
+        self.models = models
+        self.num_models = len(models)
+
+        # Auto-generate prefixes if not provided - ALL models get prefixes
+        if prefixes is None:
+            self.prefixes = [f"model{i + 1}" for i in range(self.num_models)]
+        else:
+            if len(prefixes) != len(models):
+                raise ValueError(
+                    f"Number of prefixes ({len(prefixes)}) must match number of models ({len(models)})"
+                )
+            self.prefixes = prefixes
+
+        self.merge_on = merge_on
+        self.use_every_n_draw = use_every_n_draw
+
+        # Use first model as primary for attributes
+        self.primary_model = models[0]
+        self.num_periods = getattr(self.primary_model, "num_periods", None)
+
+        # Merge idata from all models with appropriate prefixes
+        self._merge_idata()
+
+        if hasattr(self.primary_model, "adstock"):
+            self.adstock = self.primary_model.adstock
+
+        # Signal to BudgetOptimizer to enforce mask validation
+        self.enforce_budget_mask_validation = False
+
+        # Persistent merged model used for optimization
+        self._persistent_merged_model: Model | None = None
+        self._persistent_num_periods: int | None = None
+
+    def _merge_idata(self) -> None:
+        if self.num_models == 1:
+            idata = self.models[0].idata.isel(
+                draw=slice(None, None, self.use_every_n_draw)
+            )
+            if self.prefixes[0]:
+                idata = self._prefix_idata(idata, self.prefixes[0])
+            self.idata = idata
+            return
+
+        merged_idata = None
+        for i, model in enumerate(self.models):
+            prefix = self.prefixes[i]
+            idata_i = model.idata.isel(
+                draw=slice(None, None, self.use_every_n_draw)
+            ).copy()
+            if prefix:
+                idata_i = self._prefix_idata(idata_i, prefix)
+
+            if merged_idata is None:
+                merged_idata = idata_i
+            else:
+                for group in ("posterior", "constant_data", "observed_data"):
+                    if group in idata_i:
+                        if group in merged_idata:
+                            merged_idata[group] = xr.merge(
+                                [merged_idata[group], idata_i[group]]
+                            )
+                        else:
+                            merged_idata[group] = idata_i[group]
+
+        self.idata = merged_idata
+
+    def _prefix_idata(self, idata, prefix: str):
+        shared_vars = {"chain", "draw", "__obs__"}
+        if self.merge_on:
+            shared_vars.add(self.merge_on)
+
+        shared_dims = set(shared_vars)
+        if (
+            self.merge_on
+            and "constant_data" in idata
+            and self.merge_on in idata.constant_data
+        ):
+            merge_dims = list(idata.constant_data[self.merge_on].dims)
+            shared_dims.update(merge_dims)
+
+        prefixed_idata = idata.copy()
+        for group in ("posterior", "constant_data", "observed_data"):
+            if group in prefixed_idata:
+                rename_dict = {}
+                for var in prefixed_idata[group].data_vars:
+                    if var not in shared_vars and not var.startswith(f"{prefix}_"):
+                        rename_dict[var] = f"{prefix}_{var}"
+                for dim in prefixed_idata[group].dims:
+                    if dim not in shared_dims and not dim.startswith(f"{prefix}_"):
+                        rename_dict[dim] = f"{prefix}_{dim}"
+                if rename_dict:
+                    prefixed_idata[group] = prefixed_idata[group].rename(rename_dict)
+
+        return prefixed_idata
+
+    def _set_predictors_for_optimization(self, num_periods: int) -> Model:
+        # If we already built a persistent model for this horizon, reuse it
+        if (
+            self._persistent_merged_model is not None
+            and self._persistent_num_periods == int(num_periods)
+        ):
+            return self._persistent_merged_model
+
+        # Build per-model optimization models
+        pymc_models = [
+            m._set_predictors_for_optimization(num_periods=num_periods)
+            for m in self.models
+        ]
+        if self.num_models == 1:
+            self._persistent_merged_model = freeze_dims_and_data(pymc_models[0])
+        else:
+            self._persistent_merged_model = merge_models(
+                models=pymc_models, prefixes=self.prefixes, merge_on=self.merge_on
+            )
+
+        self._persistent_num_periods = int(num_periods)
+        return self._persistent_merged_model
+
+    @property
+    def model(self) -> Model:
+        """Return the merged PyMC model.
+
+        If a persistent optimization model exists, return it. Otherwise, try to lazily
+        construct it using the known number of periods. As a fallback, merge the
+        underlying training models from each wrapper (non-persistent).
+        """
+        # If a persistent optimization model exists, expose it for mutation
+        if self._persistent_merged_model is not None:
+            return self._persistent_merged_model
+
+        # If we know the number of periods, lazily build the persistent model now
+        if self.num_periods is not None:
+            return self._set_predictors_for_optimization(int(self.num_periods))
+
+        # Fallback: dynamic merged training models (non-persistent)
+        # Obtain each wrapper's training model dynamically; not all wrappers statically expose `.model`.
+        # Cast to Any first to avoid mypy attr-defined errors for Protocol wrappers.
+        pymc_models = [cast(Any, model).model for model in self.models]
+        if self.num_models == 1:
+            return pymc_models[0]
+        return merge_models(
+            models=pymc_models, prefixes=self.prefixes, merge_on=self.merge_on
+        )

--- a/pymc_marketing/mmm/multidimensional.py
+++ b/pymc_marketing/mmm/multidimensional.py
@@ -2146,6 +2146,9 @@ def create_sample_kwargs(
 class MultiDimensionalBudgetOptimizerWrapper(OptimizerCompatibleModelWrapper):
     """Wrapper for the BudgetOptimizer to handle multi-dimensional model."""
 
+    # Signal to BudgetOptimizer that this wrapper should enforce budget mask validation
+    enforce_budget_mask_validation = True
+
     def __init__(self, model: MMM, start_date: str, end_date: str):
         self.model_class = model
         self.start_date = start_date

--- a/pymc_marketing/pytensor_utils.py
+++ b/pymc_marketing/pytensor_utils.py
@@ -14,12 +14,24 @@
 
 """PyTensor utility functions."""
 
+from typing import Any
+
 import arviz as az
+import numpy as np
+import pandas as pd
+import pymc as pm
+import pytensor
 import pytensor.tensor as pt
 from arviz import InferenceData
 from pymc import Model
+from pymc.model.fgraph import (
+    ModelVar,
+    extract_dims,
+    fgraph_from_model,
+    model_from_fgraph,
+)
 from pytensor import clone_replace
-from pytensor.graph import rewrite_graph, vectorize_graph
+from pytensor.graph import FunctionGraph, rewrite_graph, vectorize_graph
 from pytensor.graph.basic import ancestors
 
 try:
@@ -27,33 +39,45 @@ try:
 except ImportError:
     from pymc.logprob.utils import rvs_in_graph
 
+from pymc_extras.deserialize import deserialize, register_deserialization
+from pymc_extras.prior import Prior, handle_dims
+
 
 def extract_response_distribution(
     pymc_model: Model,
     idata: InferenceData,
     response_variable: str,
 ) -> pt.TensorVariable:
-    """Extract the response distribution graph, conditioned on posterior parameters.
+    """Extract the response distribution graph conditioned on posterior parameters.
 
     Parameters
     ----------
     pymc_model : Model
         The PyMC model to extract the response distribution from.
     idata : InferenceData
-        The inference data containing posterior samples.
+        Inference data containing posterior samples.
     response_variable : str
-        The name of the response variable to extract.
+        Name of the response variable to extract from the model.
 
     Returns
     -------
     pt.TensorVariable
-        The response distribution graph.
+        A graph that computes the requested response variable as a function of
+        newly introduced inputs (e.g., budgets) and the posterior of model parameters.
 
-    Example
-    -------
-    `extract_response_distribution(model, idata, "channel_contribution")`
-    returns a graph that computes `"channel_contribution"` as a function of both
-    the newly introduced budgets and the posterior of model parameters.
+    Examples
+    --------
+    Build a graph for a response variable, evaluated under the posterior:
+
+    .. code-block:: python
+
+        from pymc_marketing.pytensor_utils import extract_response_distribution
+
+        # response_graph can be compiled with pytensor.function and evaluated by
+        # providing the required inputs (e.g., new budget allocations)
+        response_graph = extract_response_distribution(
+            model, idata, "channel_contribution"
+        )
     """
     # Convert InferenceData to a sample-major xarray
     posterior = az.extract(idata).transpose("sample", ...)  # type: ignore
@@ -106,3 +130,828 @@ def extract_response_distribution(
     )
 
     return response_distribution
+
+
+class MaskedDist(Prior):
+    """Create a masked deterministic from a Prior over full dims.
+
+    The foal is to reduce the number of parameters in the model by creating a masked deterministic
+    and only active the parameters that are needed.
+
+    The active RV is created without labeled dims; its shape is inferred from its parameters and equals
+    the number of active positions. The mask is treated as a NumPy boolean array at model build time. It must be
+    fully specified (non-symbolic) and match the product of the coordinate lengths of the distribution dims.
+
+    Parameters
+    ----------
+    distribution : Prior
+        A Prior object whose dims define the full grid structure.
+    mask : array-like
+        Boolean mask with same total number of positions as the distribution dims.
+        Can be same shape as dims or 1D flattened.
+    active_dim_name : str, default "active"
+        Name for the active dimension in the reduced distribution.
+
+    Examples
+    --------
+    Create a masked normal distribution over a 2D grid:
+
+    .. code-block:: python
+
+        import numpy as np
+        import pymc as pm
+        from pymc_extras.prior import Prior
+        from pymc_marketing.pytensor_utils import MaskedDist
+
+        # Define a 3x4 grid
+        coords = {"row": [0, 1, 2], "col": [0, 1, 2, 3]}
+
+        # Create mask - only activate positions (0,0), (1,2), (2,3)
+        mask = np.array(
+            [
+                [True, False, False, False],
+                [False, False, True, False],
+                [False, False, False, True],
+            ]
+        )
+
+        # Define prior over full grid
+        prior = Prior("Normal", mu=0, sigma=1, dims=("row", "col"))
+
+        with pm.Model(coords=coords):
+            # Create masked distribution
+            masked_dist = MaskedDist(prior, mask)
+            coeff = masked_dist.create_variable("coeff")
+    """
+
+    def __init__(
+        self, distribution: Prior, mask: Any, active_dim_name: str = "active"
+    ) -> None:
+        # Initialize as a Prior by copying fields from the wrapped prior
+        super().__init__(
+            distribution=distribution.distribution,
+            dims=distribution.dims,
+            centered=distribution.centered,
+            transform=distribution.transform,
+            **distribution.parameters,
+        )
+        self.mask = mask
+        self.active_dim_name = active_dim_name
+
+    # Inherit dims property and behavior from Prior
+
+    def _aligned_param_full(
+        self,
+        *,
+        model: pm.Model,
+        name: str,
+        param_name: str,
+        value: Any,
+        full_dims: tuple[str, ...],
+        full_sizes: tuple[int, ...],
+    ) -> Any:
+        """Create the full-grid parameter aligned to ``full_dims``.
+
+        Parameters
+        ----------
+        model : pm.Model
+            Active PyMC model context.
+        name : str
+            Base name used when creating variables from nested ``Prior`` objects.
+        param_name : str
+            Name of the parameter in the wrapped ``Prior``.
+        value : Any
+            Parameter value. Can be a ``Prior``-like object, NumPy array, PyTensor
+            variable, scalar, or other broadcastable values.
+        full_dims : tuple of str
+            Target named dimensions (from the full grid).
+        full_sizes : tuple of int
+            Sizes corresponding to ``full_dims``.
+
+        Returns
+        -------
+        Any
+            Aligned parameter on the full grid. If ``value`` is a ``Prior`` it returns
+            its created variable aligned to ``full_dims``; arrays/tensors are reshaped
+            or broadcast when feasible; scalars are returned unchanged.
+        """
+        if hasattr(value, "create_variable"):
+            var_full = value.create_variable(f"{name}_{param_name}")
+            return handle_dims(var_full, value.dims, full_dims)
+
+        if isinstance(value, np.ndarray | pt.TensorVariable):
+            x = pt.as_tensor_variable(value)
+            if x.ndim == 0:
+                return x
+
+            # Try to reshape or broadcast to the full grid
+            if x.ndim != len(full_sizes):
+                total = int(np.prod(full_sizes))
+                if x.ndim == 1 and int(x.shape[0]) == total:
+                    return pt.reshape(x, full_sizes)
+                raise ValueError(
+                    "Parameter array must be scalar, 1D flat over full grid, or have same ndim as distribution dims",
+                )
+
+            cur_shape = tuple(x.shape)
+            if cur_shape == full_sizes:
+                return x
+
+            # Broadcast dimensions that are 1 to the target size
+            can_broadcast = all(
+                cs in (1, s) for cs, s in zip(cur_shape, full_sizes, strict=False)
+            )
+            if can_broadcast:
+                return pt.broadcast_to(x, full_sizes)
+
+            raise ValueError(
+                "Parameter array shape incompatible with distribution dims"
+            )
+
+        return value
+
+    def create_variable(self, name: str) -> pt.TensorVariable:
+        """Create the masked deterministic and the underlying active RV.
+
+        Parameters
+        ----------
+        name : str
+            Base name for the created variables. The active RV will be named
+            ``"{name}_dist"`` and the returned deterministic will be named ``"{name}"``.
+
+        Returns
+        -------
+        pt.TensorVariable
+            A deterministic tensor with the same shape as the full distribution grid,
+            with active positions filled by the learned parameters and zeros elsewhere.
+
+        Examples
+        --------
+        Create a masked distribution over a 2D grid and materialize the deterministic:
+
+        .. code-block:: python
+
+            prior = Prior("Normal", mu=0, sigma=1, dims=("country", "channel"))
+            mask = np.array([[True, False, False], [False, False, True]])
+            masked = MaskedDist(prior, mask)
+            with pm.Model(
+                coords={"country": ["A", "B"], "channel": ["C1", "C2", "C3"]}
+            ):
+                out = masked.create_variable("coeff")
+        """
+        model = pm.modelcontext(None)
+        full_dims: tuple[str, ...] = (
+            (self.dims if isinstance(self.dims, tuple) else (self.dims,))
+            if self.dims
+            else ()
+        )
+
+        if not full_dims:
+            raise ValueError(
+                "MaskedDist requires the wrapped Prior to define named dims"
+            )
+
+        # Prepare mask as a concrete NumPy boolean array
+        if isinstance(self.mask, pt.TensorVariable):
+            mask_np = np.asarray(self.mask.eval()).astype(bool)
+        else:
+            mask_np = np.asarray(self.mask).astype(bool)
+        # Require coords for all dims to be present; do not auto-create
+        try:
+            full_sizes = tuple(len(model.coords[dim]) for dim in full_dims)
+        except KeyError as err:
+            raise KeyError(
+                f"Missing coords for dim {err.args[0]!r} in the current model. "
+                "Pass coords when building the model or when calling sample_prior."
+            ) from err
+
+        if mask_np.ndim == 1:
+            total_size = int(np.prod(full_sizes))
+            if mask_np.size != total_size:
+                raise ValueError(
+                    "1D mask length must equal the product of coordinates across dims",
+                )
+            mask_np = mask_np.reshape(full_sizes)
+        elif mask_np.shape != full_sizes:
+            raise ValueError(
+                "Mask must have the same shape as the distribution dims or be a 1D vector of matching length",
+            )
+
+        n_active = int(mask_np.sum())
+
+        # Build active parameters by indexing the full-grid parameters
+        params_active: dict[str, Any] = {}
+        for param_name, value in self.parameters.items():
+            full_param = self._aligned_param_full(
+                model=model,
+                name=name,
+                param_name=param_name,
+                value=value,
+                full_dims=full_dims,
+                full_sizes=full_sizes,
+            )
+
+            if isinstance(full_param, int | float):
+                params_active[param_name] = full_param
+            elif isinstance(full_param, pt.TensorVariable):
+                if full_param.ndim == 0:
+                    params_active[param_name] = full_param
+                else:
+                    params_active[param_name] = full_param[mask_np]
+            elif isinstance(full_param, np.ndarray):
+                if full_param.ndim == 0:
+                    params_active[param_name] = float(full_param)
+                else:
+                    params_active[param_name] = full_param[mask_np]
+            else:
+                params_active[param_name] = full_param
+
+        # Ensure resulting active distribution has vector shape (n_active,)
+        has_vector_param = False
+        for val in params_active.values():
+            if isinstance(val, pt.TensorVariable):
+                if val.ndim >= 1:
+                    has_vector_param = True
+                    break
+            elif isinstance(val, np.ndarray):
+                if val.ndim >= 1:
+                    has_vector_param = True
+                    break
+
+        if not has_vector_param:
+            # Broadcast the first parameter to length n_active
+            for key in self.parameters.keys():
+                val = params_active[key]
+                if isinstance(val, int | float):
+                    params_active[key] = np.full((n_active,), val)
+                    break
+                if isinstance(val, np.ndarray) and val.ndim == 0:
+                    params_active[key] = np.full((n_active,), float(val))
+                    break
+                if isinstance(val, pt.TensorVariable) and val.ndim == 0:
+                    params_active[key] = pt.broadcast_to(val, (n_active,))
+                    break
+
+        # Ensure an active coordinate exists (and matches length)
+        active_dim = self.active_dim_name
+        if active_dim in model.coords and len(model.coords[active_dim]) != n_active:
+            active_dim = f"{active_dim}_{name}"
+        if active_dim not in model.coords:
+            # Create a simple integer coordinate
+            model.add_coord(active_dim, np.arange(n_active))
+
+        # Create the active RV with labeled active dim
+        active_prior = Prior(
+            self.distribution,
+            dims=(active_dim,),
+            centered=self.centered,
+            transform=self.transform,
+            **params_active,
+        )
+        active_rv = active_prior.create_variable(f"{name}_dist")
+
+        # Scatter active RV back into a full tensor and wrap as Deterministic
+        zeros_full = pt.zeros(full_sizes, dtype=active_rv.dtype)
+        filled = zeros_full[mask_np].set(active_rv)
+
+        return pm.Deterministic(name, filled, dims=full_dims)
+
+    def create_likelihood_variable(
+        self,
+        name: str,
+        *,
+        mu: pt.TensorLike,
+        observed: Any,
+        **kwargs: Any,
+    ):
+        """Create a masked likelihood by applying the mask over the likelihood dims.
+
+        Parameters
+        ----------
+        name : str
+            Name of the likelihood variable.
+        mu : pt.TensorLike
+            Mean/location parameter of the likelihood over the full grid dims.
+        observed : array-like or TensorLike
+            Observations over the full grid dims.
+        **kwargs : Any
+            Additional keyword arguments forwarded to the underlying likelihood
+            creation (e.g., transform, tags, etc.).
+
+        Notes
+        -----
+        This method selects the active positions defined by ``mask`` across the
+        likelihood dims and creates the likelihood only for those positions under
+        a new 1D active dimension. This effectively excludes masked-out positions
+        from the log-likelihood.
+        """
+        model = pm.modelcontext(None)
+
+        full_dims: tuple[str, ...] = (
+            (self.dims if isinstance(self.dims, tuple) else (self.dims,))
+            if self.dims
+            else ()
+        )
+        if not full_dims:
+            raise ValueError(
+                "MaskedDist requires the wrapped Prior to define named dims"
+            )
+
+        # Prepare mask as a concrete NumPy boolean array
+        if isinstance(self.mask, pt.TensorVariable):
+            mask_np = np.asarray(self.mask.eval()).astype(bool)
+        else:
+            mask_np = np.asarray(self.mask).astype(bool)
+
+        # Validate dims exist in model coords
+        try:
+            full_sizes = tuple(len(model.coords[dim]) for dim in full_dims)
+        except KeyError as err:
+            raise KeyError(
+                f"Missing coords for dim {err.args[0]!r} in the current model. "
+                "Pass coords when building the model or when calling sample_prior."
+            ) from err
+
+        if mask_np.ndim == 1:
+            total_size = int(np.prod(full_sizes))
+            if mask_np.size != total_size:
+                raise ValueError(
+                    "1D mask length must equal the product of coordinates across dims",
+                )
+            mask_np = mask_np.reshape(full_sizes)
+        elif mask_np.shape != full_sizes:
+            raise ValueError(
+                "Mask must have the same shape as the distribution dims or be a 1D vector of matching length",
+            )
+
+        n_active = int(mask_np.sum())
+
+        # Build active parameters by indexing the full-grid parameters
+        params_active: dict[str, Any] = {}
+        for param_name, value in self.parameters.items():
+            full_param = self._aligned_param_full(
+                model=model,
+                name=name,
+                param_name=param_name,
+                value=value,
+                full_dims=full_dims,
+                full_sizes=full_sizes,
+            )
+
+            if isinstance(full_param, int | float):
+                params_active[param_name] = full_param
+            elif isinstance(full_param, pt.TensorVariable):
+                if full_param.ndim == 0:
+                    params_active[param_name] = full_param
+                else:
+                    params_active[param_name] = full_param[mask_np]
+            elif isinstance(full_param, np.ndarray):
+                if full_param.ndim == 0:
+                    params_active[param_name] = float(full_param)
+                else:
+                    params_active[param_name] = full_param[mask_np]
+            else:
+                params_active[param_name] = full_param
+
+        # Ensure active coordinate exists
+        active_dim = self.active_dim_name
+        if active_dim in model.coords and len(model.coords[active_dim]) != n_active:
+            active_dim = f"{active_dim}_{name}"
+        if active_dim not in model.coords:
+            model.add_coord(active_dim, np.arange(n_active))
+
+        # Build masked mu and observed
+        if isinstance(mu, pt.TensorVariable | np.ndarray):
+            mu_active = mu[mask_np]
+        else:
+            mu_active = mu
+
+        if isinstance(observed, pt.TensorVariable | np.ndarray):
+            observed_active = observed[mask_np]
+        else:
+            observed_active = observed
+
+        # Create active likelihood prior and variable
+        active_prior = Prior(
+            self.distribution,
+            dims=(active_dim,),
+            centered=self.centered,
+            transform=self.transform,
+            **params_active,
+        )
+
+        return active_prior.create_likelihood_variable(
+            name=name,
+            mu=mu_active,
+            observed=observed_active,
+            **kwargs,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation of the masked distribution.
+
+        Returns
+        -------
+        dict
+            A dictionary with the wrapped distribution config and boolean mask.
+        """
+        base = super().to_dict()
+        if isinstance(self.mask, pt.TensorVariable):
+            mask_val = np.asarray(self.mask.eval()).astype(bool).tolist()
+        else:
+            mask_val = np.asarray(self.mask).astype(bool).tolist()
+        return {
+            "class": "MaskedDist",
+            "data": {
+                "dist": base,
+                "active_dim_name": self.active_dim_name,
+                "mask": mask_val,
+            },
+        }
+
+
+def _is_masked_dist(data: dict) -> bool:
+    """Check if the data is a wrapped MaskedDist dictionary."""
+    return data.keys() == {"class", "data"} and data["class"] == "MaskedDist"
+
+
+def _masked_dist_from_dict(data: dict) -> MaskedDist:  # type: ignore
+    """Deserialize a wrapped MaskedDist dictionary.
+
+    Parameters
+    ----------
+    data : dict
+        Wrapped schema: {"class": "MaskedDist", "data": {"dist": prior_dict,
+        "mask": list[bool] | list[list[bool]], "active_dim_name": str}}
+
+    Returns
+    -------
+    MaskedDist
+        Reconstructed masked distribution instance.
+    """
+    payload = data["data"]
+    base = deserialize(payload["dist"])  # type: ignore
+    mask = np.array(payload["mask"]).astype(bool)
+    active_dim_name = payload.get("active_dim_name", "active")
+    return MaskedDist(distribution=base, mask=mask, active_dim_name=active_dim_name)
+
+
+register_deserialization(is_type=_is_masked_dist, deserialize=_masked_dist_from_dict)
+
+
+def _prefix_model(f2, prefix: str, exclude_vars: set | None = None):
+    """Prefix variable and dimension names in a FunctionGraph.
+
+    Variables listed in ``exclude_vars`` (e.g., a shared variable like ``channel_data``)
+    are kept unprefixed, and their dims/coords are also preserved without prefix.
+    """
+    if exclude_vars is None:
+        exclude_vars = set()
+
+    # First, collect dimensions that belong to excluded variables
+    exclude_dims = set()
+    for v in f2.outputs:
+        if v.name in exclude_vars:
+            v_dims = extract_dims(v)
+            for dim in v_dims:
+                exclude_dims.add(dim.data)
+
+    dims = set()
+    for v in f2.outputs:
+        # Only prefix if not in exclude_vars
+        if v.name not in exclude_vars:
+            new_name = f"{prefix}_{v.name}"
+            v.name = new_name
+            if isinstance(v.owner.op, ModelVar):
+                rv = v.owner.inputs[0]
+                rv.name = new_name
+        dims.update(extract_dims(v))
+
+    # Don't rename dimensions that belong to excluded variables
+    dims_rename = {
+        dim: pytensor.as_symbolic(f"{prefix}_{dim.data}")
+        for dim in dims
+        if dim.data not in exclude_dims
+    }
+    if dims_rename:
+        f2.replace_all(tuple(dims_rename.items()))
+
+    # Don't prefix coordinates for excluded dimensions
+    new_coords = {}
+    for k, v in f2._coords.items():  # type: ignore[attr-defined]
+        if k not in exclude_dims:
+            new_coords[f"{prefix}_{k}"] = v
+        else:
+            new_coords[k] = v
+    f2._coords = new_coords  # type: ignore[attr-defined]
+
+    return f2
+
+
+def merge_models(
+    models: list[Model],
+    *,
+    prefixes: list[str] | None = None,
+    merge_on: str | None = None,
+) -> Model:
+    """Merge multiple PyMC models into a single model.
+
+    Parameters
+    ----------
+    models : list of pm.Model
+        List of models to merge.
+    prefixes : list of str or None
+        List of prefixes for each model. If None, will auto-generate as 'model1', 'model2', ...
+    merge_on : str or None
+        Variable name to merge on (shared across all models) - this variable will NOT be prefixed.
+
+    Returns
+    -------
+    pm.Model
+        Merged model.
+    """
+    if len(models) < 2:
+        raise ValueError("Need at least 2 models to merge")
+
+    # Auto-generate prefixes if not provided
+    if prefixes is None:
+        prefixes = [f"model{i + 1}" for i in range(len(models))]
+    elif len(prefixes) != len(models):
+        raise ValueError(
+            f"Number of prefixes ({len(prefixes)}) must match number of models ({len(models)})"
+        )
+
+    # Variables to exclude from prefixing
+    exclude_vars = {merge_on} if merge_on else set()
+
+    # Convert all models to FunctionGraphs and apply prefixes
+    fgraphs: list[FunctionGraph] = []
+    for model, prefix in zip(models, prefixes, strict=False):
+        fg, _ = fgraph_from_model(model, inlined_views=True)
+        if prefix is not None:
+            fg = _prefix_model(fg, prefix=prefix, exclude_vars=exclude_vars)
+        fgraphs.append(fg)
+
+    # Handle merge_on logic
+    if merge_on is not None:
+        # Find the merge variable in the first model (unprefixed)
+        first_merge_vars = [out for out in fgraphs[0].outputs if out.name == merge_on]
+        if not first_merge_vars:
+            raise ValueError(f"Variable '{merge_on}' not found in first model")
+        first_merge_var = first_merge_vars[0]
+
+        # Replace the merge variable in all other models with the one from the first model
+        for i in range(1, len(fgraphs)):
+            merge_vars = [out for out in fgraphs[i].outputs if out.name == merge_on]
+            if not merge_vars:
+                raise ValueError(f"Variable '{merge_on}' not found in model {i + 1}")
+            fgraphs[i].replace(merge_vars[0], first_merge_var, import_missing=True)
+
+    # Combine all outputs
+    all_outputs = []
+    for fg in fgraphs:
+        all_outputs.extend(fg.outputs)
+
+    # Create merged FunctionGraph
+    f = FunctionGraph(outputs=all_outputs, clone=False)
+
+    # Merge coordinates from all models
+    merged_coords: dict = {}
+    for fg in fgraphs:
+        merged_coords.update(fg._coords)  # type: ignore[attr-defined]
+    f._coords = merged_coords  # type: ignore[attr-defined]
+
+    return model_from_fgraph(f, mutate_fgraph=True)
+
+
+class ModelSamplerEstimator:
+    """Estimate computational characteristics of a PyMC model using JAX/NumPyro.
+
+    This utility measures the average evaluation time of the model's logp and gradients
+    and estimates the number of integrator steps taken by NUTS during warmup + sampling.
+    It then compiles the information into a single-row pandas DataFrame with helpful
+    metadata to guide planning and benchmarking.
+
+    Parameters
+    ----------
+    tune : int, default 1000
+        Number of warmup iterations to use when estimating NUTS steps.
+    draws : int, default 1000
+        Number of sampling iterations to use when estimating NUTS steps.
+    chains : int, default 1
+        Intended number of chains (metadata only; not used in JAX runs here).
+    sequential_chains : int, default 1
+        Number of chains expected to run sequentially on the target environment.
+        Used to scale the wall-clock time estimate.
+    seed : int | None, default None
+        Random seed used for the step estimation runs.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        est = ModelSamplerEstimator(
+            tune=1000, draws=1000, chains=4, sequential_chains=1, seed=1
+        )
+        df = est.run(model)
+        print(df)
+    """
+
+    def __init__(
+        self,
+        *,
+        tune: int = 1000,
+        draws: int = 1000,
+        chains: int = 1,
+        sequential_chains: int = 1,
+        seed: int | None = None,
+    ) -> None:
+        self.tune = int(tune)
+        self.draws = int(draws)
+        self.chains = int(chains)
+        self.sequential_chains = int(sequential_chains)
+        self.seed = seed
+
+    def estimate_model_eval_time(self, model: Model, n: int | None = None) -> float:
+        """Estimate average evaluation time (seconds) of logp+dlogp using JAX.
+
+        Parameters
+        ----------
+        model : Model
+            PyMC model whose logp and gradients are jitted and evaluated.
+        n : int | None, optional
+            Number of repeated evaluations to average over. If ``None``, a value
+            is chosen to take roughly 5 seconds in total for a stable estimate.
+
+        Returns
+        -------
+        float
+            Average evaluation time in seconds.
+        """
+        from time import perf_counter_ns
+
+        import numpy as np
+
+        try:
+            import jax
+            from pymc.sampling.jax import get_jaxified_logp
+        except Exception as err:  # pragma: no cover - environment specific
+            raise RuntimeError(
+                "JAX backend is required for ModelSamplerEstimator."
+            ) from err
+
+        initial_point = list(model.initial_point().values())
+        logp_fn = get_jaxified_logp(model)
+        logp_dlogp_fn = jax.jit(jax.value_and_grad(logp_fn, argnums=0))
+        logp_res, grad_res = logp_dlogp_fn(initial_point)
+        for val in (logp_res, *grad_res):
+            if not np.isfinite(val).all():
+                raise RuntimeError(
+                    "logp or gradients are not finite at the model initial point; the model may be misspecified"
+                )
+
+        if n is None:
+            start = perf_counter_ns()
+            jax.block_until_ready(logp_dlogp_fn(initial_point))
+            end = perf_counter_ns()
+            n = max(5, int(5e9 / max(end - start, 1)))
+
+        start = perf_counter_ns()
+        for _ in range(n):
+            jax.block_until_ready(logp_dlogp_fn(initial_point))
+        end = perf_counter_ns()
+        eval_time = (end - start) / n * 1e-9
+        return float(eval_time)
+
+    def estimate_num_steps_sampling(
+        self,
+        model: Model,
+        *,
+        tune: int | None = None,
+        draws: int | None = None,
+        seed: int | None = None,
+    ) -> int:
+        """Estimate total number of NUTS steps during warmup + sampling using NumPyro.
+
+        Parameters
+        ----------
+        model : Model
+            PyMC model to estimate steps for using a JAX/NumPyro NUTS kernel.
+        tune : int | None, optional
+            Warmup iterations. Defaults to the estimator setting if ``None``.
+        draws : int | None, optional
+            Sampling iterations. Defaults to the estimator setting if ``None``.
+        seed : int | None, optional
+            Random seed for the JAX run. Defaults to the estimator setting if ``None``.
+
+        Returns
+        -------
+        int
+            Total number of leapfrog steps across warmup + sampling.
+        """
+        import numpy as np
+
+        try:
+            import jax
+            from numpyro.infer import MCMC, NUTS
+            from pymc.sampling.jax import get_jaxified_logp
+        except Exception as err:  # pragma: no cover - environment specific
+            raise RuntimeError(
+                "JAX and NumPyro are required for ModelSamplerEstimator."
+            ) from err
+
+        num_warmup = int(self.tune if tune is None else tune)
+        num_samples = int(self.draws if draws is None else draws)
+
+        initial_point = list(model.initial_point().values())
+        logp_fn = get_jaxified_logp(model, negative_logp=False)
+        nuts_kernel = NUTS(
+            potential_fn=logp_fn,
+            target_accept_prob=0.8,
+            adapt_step_size=True,
+            adapt_mass_matrix=True,
+            dense_mass=False,
+        )
+
+        mcmc = MCMC(
+            nuts_kernel,
+            num_warmup=num_warmup,
+            num_samples=num_samples,
+            num_chains=1,
+            postprocess_fn=None,
+            chain_method="sequential",
+            progress_bar=False,
+        )
+
+        if seed is None:
+            rng_seed = int(np.random.default_rng().integers(2**32))
+        else:
+            rng_seed = int(seed)
+
+        tune_rng, sample_rng = jax.random.split(jax.random.PRNGKey(int(rng_seed)), 2)
+        mcmc.warmup(
+            tune_rng,
+            init_params=initial_point,
+            extra_fields=("num_steps",),
+            collect_warmup=True,
+        )
+        warmup_steps = int(mcmc.get_extra_fields()["num_steps"].sum())
+        mcmc.run(sample_rng, extra_fields=("num_steps",))
+        sample_steps = int(mcmc.get_extra_fields()["num_steps"].sum())
+        return int(warmup_steps + sample_steps)
+
+    def run(self, model: Model) -> pd.DataFrame:
+        """Execute the estimation pipeline and return a single-row DataFrame.
+
+        Parameters
+        ----------
+        model : Model
+            PyMC model to evaluate.
+
+        Returns
+        -------
+        pandas.DataFrame
+            Single-row DataFrame with columns including ``num_steps``, ``eval_time_seconds``,
+            ``sequential_chains``, and estimated sampling wall-clock time in seconds,
+            minutes, and hours, along with metadata such as ``tune``, ``draws``, ``chains``,
+            ``seed``, ``timestamp``, and ``model_name``.
+
+        Examples
+        --------
+        .. code-block:: python
+
+            df = ModelSamplerEstimator().run(model)
+            df[
+                [
+                    "num_steps",
+                    "eval_time_seconds",
+                    "estimated_sampling_time_minutes",
+                ]
+            ]
+        """
+        import time
+
+        steps = self.estimate_num_steps_sampling(
+            model, tune=self.tune, draws=self.draws, seed=self.seed
+        )
+        eval_time_s = self.estimate_model_eval_time(model)
+
+        sampling_time_seconds = float(
+            eval_time_s * steps * max(self.sequential_chains, 1)
+        )
+        data = {
+            "model_name": getattr(model, "name", "PyMCModel"),
+            "num_steps": int(steps),
+            "eval_time_seconds": float(eval_time_s),
+            "sequential_chains": int(self.sequential_chains),
+            "estimated_sampling_time_seconds": sampling_time_seconds,
+            "estimated_sampling_time_minutes": sampling_time_seconds / 60.0,
+            "estimated_sampling_time_hours": sampling_time_seconds / 3600.0,
+            "tune": int(self.tune),
+            "draws": int(self.draws),
+            "chains": int(self.chains),
+            "seed": int(self.seed) if self.seed is not None else None,
+            "timestamp": pd.Timestamp.utcfromtimestamp(int(time.time())),
+        }
+        df = pd.DataFrame([data])
+        return df

--- a/pymc_marketing/pytensor_utils.py
+++ b/pymc_marketing/pytensor_utils.py
@@ -177,10 +177,10 @@ class MaskedDist(Prior):
 
         # Define prior over full grid
         prior = Prior("Normal", mu=0, sigma=1, dims=("row", "col"))
+        masked_dist = MaskedDist(prior, mask)
 
         with pm.Model(coords=coords):
             # Create masked distribution
-            masked_dist = MaskedDist(prior, mask)
             coeff = masked_dist.create_variable("coeff")
     """
 

--- a/tests/mmm/test_multidimensional.py
+++ b/tests/mmm/test_multidimensional.py
@@ -369,6 +369,7 @@ def test_sample_posterior_predictive_new_data(
         # Build a per-date mask over the training horizon
         n_train = X_train["date"].nunique()
         mask = np.ones((n_train,), dtype=bool)
+        mask[:1] = False
         model_config = {
             "likelihood": MaskedDist(
                 Prior("Normal", sigma=Prior("HalfNormal", sigma=1.0), dims=("date",)),

--- a/tests/test_mlflow.py
+++ b/tests/test_mlflow.py
@@ -163,7 +163,7 @@ def basic_logging_checks(run_data: RunData) -> None:
 def test_file_system_uri_supported(model_with_likelihood) -> None:
     mlflow.set_tracking_uri(uri=Path("./mlruns"))
     mlflow.set_experiment("pymc-marketing-test-suite-local-file")
-    with mlflow.start_run() as run:
+    with mlflow.start_run(nested=True) as run:
         pm.sample(
             model=model_with_likelihood,
             chains=1,
@@ -181,7 +181,7 @@ def test_file_system_uri_supported(model_with_likelihood) -> None:
 
 def test_log_with_data_in_likelihood(model_with_data_in_likelihood) -> None:
     mlflow.set_experiment("pymc-marketing-test-suite-only-target")
-    with mlflow.start_run() as run:
+    with mlflow.start_run(nested=True) as run:
         pm.sample(
             model=model_with_data_in_likelihood,
             chains=1,
@@ -218,7 +218,7 @@ def no_input_model_checks(run_data: RunData) -> None:
 
 def test_log_data_no_data(no_input_model) -> None:
     mlflow.set_experiment("pymc-marketing-test-suite-no-data")
-    with mlflow.start_run() as run:
+    with mlflow.start_run(nested=True) as run:
         pm.sample(
             model=no_input_model,
             chains=1,
@@ -235,7 +235,7 @@ def test_log_data_no_data(no_input_model) -> None:
 
 def test_multi_likelihood_type(multi_likelihood_model) -> None:
     mlflow.set_experiment("pymc-marketing-test-suite-multi-likelihood")
-    with mlflow.start_run() as run:
+    with mlflow.start_run(nested=True) as run:
         log_likelihood_type(multi_likelihood_model)
 
     run_id = run.info.run_id
@@ -274,7 +274,7 @@ def test_log_model_graph_no_graphviz(
         to_patch,
         side_effect=side_effect,
     )
-    with mlflow.start_run() as run:
+    with mlflow.start_run(nested=True) as run:
         with caplog.at_level(logging.INFO):
             log_model_graph(model_with_likelihood, "model_graph")
 
@@ -327,7 +327,7 @@ def param_checks(params, draws: int, chains: int, tune: int, nuts_sampler: str) 
 )
 def test_autolog_pymc_model(model_with_likelihood, nuts_sampler) -> None:
     mlflow.set_experiment("pymc-marketing-test-suite-pymc-model")
-    with mlflow.start_run() as run:
+    with mlflow.start_run(nested=True) as run:
         draws = 30
         tune = 25
         chains = 2
@@ -396,7 +396,7 @@ def bad_starting_point_model() -> pm.Model:
 )
 def test_sample_error_logged(bad_starting_point_model, nuts_sampler: str) -> None:
     mlflow.set_experiment("pymc-marketing-test-suite-error-model")
-    with mlflow.start_run() as run:
+    with mlflow.start_run(nested=True) as run:
         draws = 30
         tune = 25
         chains = 2
@@ -471,7 +471,7 @@ def mmm() -> MMM:
 
 def test_autolog_mmm(mmm, toy_X, toy_y) -> None:
     mlflow.set_experiment("pymc-marketing-test-suite-mmm")
-    with mlflow.start_run() as run:
+    with mlflow.start_run(nested=True) as run:
         draws = 10
         tune = 5
         chains = 1
@@ -599,7 +599,7 @@ def test_clv_fit_mcmc(model_cls, clv_data) -> None:
     }
 
     model = model_cls(data=clv_data, sampler_config=sampler_config)
-    with mlflow.start_run() as run:
+    with mlflow.start_run(nested=True) as run:
         model.fit()
 
     assert mlflow.active_run() is None
@@ -633,7 +633,7 @@ def test_clv_fit_map(model_cls, clv_data) -> None:
     mlflow.set_experiment("pymc-marketing-test-suite-clv")
 
     model = model_cls(data=clv_data)
-    with mlflow.start_run() as run:
+    with mlflow.start_run(nested=True) as run:
         model.fit(fit_method="map")
 
     assert mlflow.active_run() is None
@@ -709,7 +709,7 @@ def test_log_mmm_evaluation_metrics() -> None:
     custom_metrics = ["r_squared", "rmse"]
 
     prefix: str = "in-sample"
-    with mlflow.start_run() as run:
+    with mlflow.start_run(nested=True) as run:
         log_mmm_evaluation_metrics(
             y_true,
             y_pred,
@@ -756,7 +756,7 @@ def test_logging_callback(model_with_likelihood) -> None:
         parameters=["mu"],
         take_every=10,
     )
-    with mlflow.start_run() as run:
+    with mlflow.start_run(nested=True) as run:
         pm.sample(
             model=model_with_likelihood,
             draws=100,
@@ -794,7 +794,7 @@ def test_log_error() -> None:
     file_name = "sample-error.txt"
     main = log_error(baz, file_name=file_name)
 
-    with mlflow.start_run() as run:
+    with mlflow.start_run(nested=True) as run:
         with pytest.raises(MyException, match="This is an error"):
             main()
 

--- a/tests/test_mlflow.py
+++ b/tests/test_mlflow.py
@@ -56,8 +56,10 @@ def setup_module():
 
     yield
 
-    pm.sample = pm.sample.__wrapped__
-    MMM.fit = MMM.fit.__wrapped__
+    while "__wrapped__" in dir(pm.sample):
+        pm.sample = pm.sample.__wrapped__
+    while "__wrapped__" in dir(MMM.fit):
+        MMM.fit = MMM.fit.__wrapped__
 
 
 @pytest.fixture(scope="module")
@@ -163,7 +165,7 @@ def basic_logging_checks(run_data: RunData) -> None:
 def test_file_system_uri_supported(model_with_likelihood) -> None:
     mlflow.set_tracking_uri(uri=Path("./mlruns"))
     mlflow.set_experiment("pymc-marketing-test-suite-local-file")
-    with mlflow.start_run(nested=True) as run:
+    with mlflow.start_run() as run:
         pm.sample(
             model=model_with_likelihood,
             chains=1,
@@ -181,7 +183,7 @@ def test_file_system_uri_supported(model_with_likelihood) -> None:
 
 def test_log_with_data_in_likelihood(model_with_data_in_likelihood) -> None:
     mlflow.set_experiment("pymc-marketing-test-suite-only-target")
-    with mlflow.start_run(nested=True) as run:
+    with mlflow.start_run() as run:
         pm.sample(
             model=model_with_data_in_likelihood,
             chains=1,
@@ -218,7 +220,7 @@ def no_input_model_checks(run_data: RunData) -> None:
 
 def test_log_data_no_data(no_input_model) -> None:
     mlflow.set_experiment("pymc-marketing-test-suite-no-data")
-    with mlflow.start_run(nested=True) as run:
+    with mlflow.start_run() as run:
         pm.sample(
             model=no_input_model,
             chains=1,
@@ -235,7 +237,7 @@ def test_log_data_no_data(no_input_model) -> None:
 
 def test_multi_likelihood_type(multi_likelihood_model) -> None:
     mlflow.set_experiment("pymc-marketing-test-suite-multi-likelihood")
-    with mlflow.start_run(nested=True) as run:
+    with mlflow.start_run() as run:
         log_likelihood_type(multi_likelihood_model)
 
     run_id = run.info.run_id
@@ -274,7 +276,7 @@ def test_log_model_graph_no_graphviz(
         to_patch,
         side_effect=side_effect,
     )
-    with mlflow.start_run(nested=True) as run:
+    with mlflow.start_run() as run:
         with caplog.at_level(logging.INFO):
             log_model_graph(model_with_likelihood, "model_graph")
 
@@ -327,7 +329,7 @@ def param_checks(params, draws: int, chains: int, tune: int, nuts_sampler: str) 
 )
 def test_autolog_pymc_model(model_with_likelihood, nuts_sampler) -> None:
     mlflow.set_experiment("pymc-marketing-test-suite-pymc-model")
-    with mlflow.start_run(nested=True) as run:
+    with mlflow.start_run() as run:
         draws = 30
         tune = 25
         chains = 2
@@ -396,7 +398,7 @@ def bad_starting_point_model() -> pm.Model:
 )
 def test_sample_error_logged(bad_starting_point_model, nuts_sampler: str) -> None:
     mlflow.set_experiment("pymc-marketing-test-suite-error-model")
-    with mlflow.start_run(nested=True) as run:
+    with mlflow.start_run() as run:
         draws = 30
         tune = 25
         chains = 2
@@ -471,7 +473,7 @@ def mmm() -> MMM:
 
 def test_autolog_mmm(mmm, toy_X, toy_y) -> None:
     mlflow.set_experiment("pymc-marketing-test-suite-mmm")
-    with mlflow.start_run(nested=True) as run:
+    with mlflow.start_run() as run:
         draws = 10
         tune = 5
         chains = 1
@@ -599,7 +601,7 @@ def test_clv_fit_mcmc(model_cls, clv_data) -> None:
     }
 
     model = model_cls(data=clv_data, sampler_config=sampler_config)
-    with mlflow.start_run(nested=True) as run:
+    with mlflow.start_run() as run:
         model.fit()
 
     assert mlflow.active_run() is None
@@ -633,7 +635,7 @@ def test_clv_fit_map(model_cls, clv_data) -> None:
     mlflow.set_experiment("pymc-marketing-test-suite-clv")
 
     model = model_cls(data=clv_data)
-    with mlflow.start_run(nested=True) as run:
+    with mlflow.start_run() as run:
         model.fit(fit_method="map")
 
     assert mlflow.active_run() is None
@@ -709,7 +711,7 @@ def test_log_mmm_evaluation_metrics() -> None:
     custom_metrics = ["r_squared", "rmse"]
 
     prefix: str = "in-sample"
-    with mlflow.start_run(nested=True) as run:
+    with mlflow.start_run() as run:
         log_mmm_evaluation_metrics(
             y_true,
             y_pred,
@@ -756,7 +758,7 @@ def test_logging_callback(model_with_likelihood) -> None:
         parameters=["mu"],
         take_every=10,
     )
-    with mlflow.start_run(nested=True) as run:
+    with mlflow.start_run() as run:
         pm.sample(
             model=model_with_likelihood,
             draws=100,
@@ -794,7 +796,7 @@ def test_log_error() -> None:
     file_name = "sample-error.txt"
     main = log_error(baz, file_name=file_name)
 
-    with mlflow.start_run(nested=True) as run:
+    with mlflow.start_run() as run:
         with pytest.raises(MyException, match="This is an error"):
             main()
 

--- a/tests/test_pytensor_utils.py
+++ b/tests/test_pytensor_utils.py
@@ -77,7 +77,7 @@ def sample_multidim_data():
 
 
 @pytest.fixture
-def fitted_multidim_mmm(sample_multidim_data):
+def fitted_multidim_mmm(sample_multidim_data, mock_pymc_sample):
     """Create and fit a multidimensional MMM model."""
     mmm = MMM(
         date_column="date",
@@ -631,7 +631,7 @@ def test_merge_models_with_shared_input_container():
         assert out.shape == (n,), "Merged model produced unexpected shape"
 
 
-def test_simple_masked_linear_model_with_oos_extension():
+def test_simple_masked_linear_model_with_oos_extension(mock_pymc_sample):
     rng = np.random.default_rng(0)
 
     # Dimensions
@@ -705,7 +705,7 @@ def test_simple_masked_linear_model_with_oos_extension():
         pm.sample_posterior_predictive(idata, var_names=["y"], progressbar=False)
 
 
-def test_test_only_oos_with_masked_likelihood_raises():
+def test_test_only_oos_with_masked_likelihood_raises(mock_pymc_sample):
     rng = np.random.default_rng(1)
 
     # Train dimensions

--- a/tests/test_pytensor_utils.py
+++ b/tests/test_pytensor_utils.py
@@ -685,7 +685,7 @@ def test_simple_masked_linear_model_with_oos_extension():
         masked_likelihood.create_likelihood_variable("y", mu=mu, observed=y)
 
         idata = pm.sample(
-            draws=150, tune=150, chains=2, cores=1, random_seed=11, progressbar=False
+            draws=150, tune=150, chains=2, cores=1, random_seed=22, progressbar=False
         )
         # sample posterior pred
         idata.extend(
@@ -749,7 +749,7 @@ def test_test_only_oos_with_masked_likelihood_raises():
         likelihood_prior.create_likelihood_variable("y", mu=mu, observed=y)
 
         idata = pm.sample(
-            draws=100, tune=100, chains=2, cores=1, random_seed=22, progressbar=False
+            draws=150, tune=150, chains=2, cores=1, random_seed=22, progressbar=False
         )
 
     # Predict only over test set (last 5 periods) by updating coords and X only for test
@@ -806,7 +806,7 @@ def test_test_only_oos_without_masked_likelihood_succeeds():
         mu = (m["X"] * beta).sum(axis=-1)
         likelihood_prior.create_likelihood_variable("y", mu=mu, observed=y)
         idata = pm.sample(
-            draws=100, tune=100, chains=2, cores=1, random_seed=33, progressbar=False
+            draws=150, tune=150, chains=2, cores=1, random_seed=22, progressbar=False
         )
 
     # Test-only OOS


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->
Hey team, major updates in the utility functions. Feel free to jump, comment or modify if you think something can be done better!

### New Masked Distribution Prior
As users have the multidimensionality capabilities, models can grow without control, for example, currently is possible to make a model with dims (date, country, state, city, brand, product, channel) & shape (720, 50, 90, 10, 100, 12).

Even when is great to bring this flexibility to the users, probably given the huge dimensional space not all data will be perfectly balance, probably some values in the matrix can be missing. The `MaskedDist` allow the user to add a mask over the prior, modifying the tensor graph behind it to avoid to sample does none existent parameters, optimizing the process.

**What it does (in short)**
1. Wraps a Prior that is defined over named dims.
2. Applies a boolean mask to those dims to:
3. Build an “active” 1D RV only for unmasked positions (under a new active dim).
4. Scatter the active RV back to the original full grid and return a deterministic with the original dims.
5. Can also create masked likelihoods so only active positions contribute to the log-likelihood.

**Benefits**
1. Efficient parameterization: optimizes only the active positions, reducing parameter count and gradients.
2. Performance: faster sampling/optimization and lower memory use when grids are large and sparse.
3. Shape safety: validates against model coords; handles scalars, broadcastable arrays, and nested priors consistently.
4. Likelihood masking: excludes masked cells from the logp cleanly (no NaN gymnastics).
5. Portable: supports to_dict/from-dict for serialization.

```python
import numpy as np
import pymc as pm
from pymc_extras.prior import Prior
from pymc_marketing.pytensor_utils import MaskedDist

# Define a 3x4 grid
coords = {"row": [0, 1, 2], "col": [0, 1, 2, 3]}

# Create mask - only activate positions (0,0), (1,2), (2,3)
mask = np.array(
    [
        [True, False, False, False],
        [False, False, True, False],
        [False, False, False, True],
    ]
)

# Define prior over full grid
prior = Prior("Normal", mu=0, sigma=1, dims=("row", "col"))
masked_dist = MaskedDist(prior, mask)

with pm.Model(coords=coords):
    # Create masked distribution
    coeff = masked_dist.create_variable("coeff")
```

Users can combine this to modify the params into their functions, such as `saturation` or `adstock`.

```python
LogisticSaturation(
    priors={
        "lam": MaskedDist(
            Prior("HalfNormal", sigma=1.0, dims=("country", "region")),
            mask=mask,
        ),
        "beta": MaskedDist(
            Prior("HalfNormal", sigma=1.0, dims=("country", "region")),
            mask=mask,
        ),
    }
)
```

If from the full grid, some panels are missing they can mask the likelihood as well to not sample on dates or combos dates-region-city which doesn't exist.

```python
mu_prior = Prior("Normal", mu=0.0, sigma=1.0, dims=("date", "geo"))
masked_mu = MaskedDist(mu_prior, mask=mask)

observed = np.zeros((len(coords["date"]), len(coords["geo"])))

likelihood_prior = Prior(
    "Normal",
    sigma=Prior("HalfNormal", sigma=1.0),
    dims=("date", "geo"),
)
masked_lik = MaskedDist(likelihood_prior, mask=mask)

with pm.Model(coords=coords):
    # Masked deterministic mean over full grid (zeros where mask is False)
    mu_full = masked_mu.create_variable("mu_full")

    # Build likelihood as a Prior and mask it, so both mu and observed are masked
    masked_lik.create_likelihood_variable(
        name="y",
        mu=mu_full,
        observed=observed,
    )
```

Reducing the dimensionality brings huge improvements in efficiency. Already some examples show, even in low dimensional problems a 30% less of computational time given a mask which cuts a few diagonals in our matrix.

> [!IMPORTANT]  
> Out of sample with only test data can't handle the masking around likelihood. So, in order to make out of sample, you must share the full X_train and X_test to the sample posterior predictive.

### Model JAX sampling estimation
Related to the above, I added a helper in JAX to users estimate the minimum sample time from their models. Doing so, users could compare the minimum amount of time that their given model will take.

```python
with pm.Model() as model:
        pm.Normal("x", mu=0.0, sigma=1.0, observed=np.array([0.0]))

estimator = ModelSamplerEstimator(
    tune=100, draws=200, chains=1, sequential_chains=1, seed=123
)

df = estimator.run(model)
```

This tool is great for comparison, helps to have ideas around how heavy is your model and make changes before even properly sample the first time.

### Merge graphical models
Combines multiple independent PyMC Models into a single Model.

As we move forward in causality, and discover new DAGs, a way to collect direct or indirect effects could be create different regressions, every one adjusting by the minimum set of variables. _Each regression will respond to the same DAG but will uncover different effects per channel depending on the adjustment_.

Nevertheless, we probably want to optimize all regressions together or we want to join the mode to make several operations. But how to? Well let's remember PyMC models are graphical generative model so, each model can be represent as a function graph, and their nodes/variables could be prefixed (e.g., model1_, model2_). Doing so, we could decide which variable or data will be the one to merge_on="some_var" and the variable is kept **unprefixed** and shared across the merged models. All outputs and coordinates are merged into a single function graph.

Quick example, imagine you have the following DAG:
```
digraph G {
  rankdir=LR; splines=true; nodesep=0.4; ranksep=0.5;
  node [shape=ellipse, fontsize=12];

  C1 -> X1; C1 -> Y;
  C2 -> X2; C2 -> Y;
  C3 -> X3; C3 -> Y;

  X1 -> X2; X2 -> X3;
  X1 -> Y;  X2 -> Y;  X3 -> Y;

  // styling
  {rank=same; C1; C2; C3}
  {rank=same; X1; X2; X3}
  Y [shape=doublecircle];
}
```

This structure makes the minimal sufficient sets different for each channel’s **direct** effect on \(Y\):

- **For \(X_1\):** backdoor via \(C_1\); mediated paths via \(X_2(\to X_3)\).  
  **Adjust:** \(\{C_1, X_2\}\) (conditioning on \(X_2\) also blocks the \(X_1 \to X_2 \to X_3 \to Y\) path).

- **For \(X_2\):** backdoors via \(C_2\) and via \(X_1\) (since \(X_1 \to X_2\) and \(X_1 \to Y\)); mediated path via \(X_3\).  
  **Adjust:** \(\{C_2, X_1, X_3\}\).

- **For \(X_3\):** backdoors via \(C_3\) and via \(X_2\) (since \(X_2 \to X_3\) and \(X_2 \to Y\)).  
  **Adjust:** \(\{C_3, X_2\}\).

Meaning, we need three models to uncover the effects:
```python
# Get x1 over Y
mask = np.array([True, False, False])
mmm_x1_effect = MMM(  # (Y ~ X1 + C1 + X2)
    date_column="date",
    target_column="Y",
    channel_columns=[
        "X1",
        "X2",
        "X3",
    ],  # always use all channels, but mask the ones that are not used
    control_columns=["X2", "C1"],
    adstock=NoAdstock(l_max=1),
    saturation=NoSaturation(
        priors={
            "beta": MaskedDist(
                Prior("HalfNormal", sigma=1.0, dims="channel"), mask=mask
            )
        }
    ),
)

# get x2 over Y
# make mask for channels making x1,x2 false
mask2 = np.array([False, True, False])
mmm_x2_effect = MMM(  # (Y ~ X2 + C2 + X1 + X3)
    date_column="date",
    target_column="Y",
    channel_columns=[
        "X1",
        "X2",
        "X3",
    ],  # always use all channels, but mask the ones that are not used
    control_columns=["X1", "C2", "X3"],
    adstock=NoAdstock(l_max=1),
    saturation=NoSaturation(
        priors={
            "beta": MaskedDist(
                Prior("HalfNormal", sigma=1.0, dims="channel"), mask=mask2
            )
        }
    ),
)

# get x3 over Y
# make mask for channels making x1,x2 false
mask3 = np.array([False, False, True])
mmm_x3_effect = MMM(  # (Y ~ X3 + C3 + X2)
    date_column="date",
    target_column="Y",
    channel_columns=[
        "X1",
        "X2",
        "X3",
    ],  # always use all channels, but mask the ones that are not used
    control_columns=["X2", "C3"],
    adstock=NoAdstock(l_max=1),
    saturation=NoSaturation(
        priors={
            "beta": MaskedDist(
                Prior("HalfNormal", sigma=1.0, dims="channel"), mask=mask3
            )
        }
    ),
)
```

As you can see we should be able to _zero out with mask the distributions to avoid calculate the contributions for the channels we don't want to adjust in the regression_. Nevertheless, even when channels are zero out given the priors and not consider during the sampling, the data input is the same for all.

We could merge based on it.

```python
optimizable_model1 = MultiDimensionalBudgetOptimizerWrapper(
    model=mmm_x1_effect, start_date="2026-01-01", end_date="2026-01-31"
)

optimizable_model2 = MultiDimensionalBudgetOptimizerWrapper(
    model=mmm_x2_effect, start_date="2026-01-01", end_date="2026-01-31"
)

optimizable_model3 = MultiDimensionalBudgetOptimizerWrapper(
    model=mmm_x3_effect, start_date="2026-01-01", end_date="2026-01-31"
)

multi_model = MultiModelWrapper(
    models=[optimizable_model1, optimizable_model2, optimizable_model3],
    prefixes=["model1", "model2", "model3"],
    merge_on="channel_data",
)
```

And finally, optimize.

```python
optimizer = BudgetOptimizer(
    num_periods=multi_model.num_periods,
    model=multi_model,
    response_variable="total_media_contribution_original_scale",
)
```

This opens the door to make optimization of different effects (total, indirects or directs) together. Allows for multi-objective optimization. Every model could have a different target variable but the target depends on same inputs, and consequently we want to optimize A and B together.

## Conclusion
These examples are just the tip of the iceberg, but they allow users to scale their models in dimensionality and optimize them as much as possible, even in cases with panel imbalance. Estimate sampling time to decide if MCMC is feasible or VI methods could be a better option. Even for cases where they could end with multiple models, they can merge them together to consolidate their learnings or optimize together mixing different outputs.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1927.org.readthedocs.build/en/1927/

<!-- readthedocs-preview pymc-marketing end -->