### PR TITLE
BUG [Issue with fourier]

### DIFF
--- a/tests/customer_choice/test_mv_its.py
+++ b/tests/customer_choice/test_mv_its.py
@@ -317,7 +317,7 @@ def test_support_for_mu_effects(saturated_data, mock_pymc_sample) -> None:
     n_existing_products = 2
     posterior_size = {"chain": 1, "draw": 10}
 
-    assert model.posterior["fourier_effect"].sizes == {
+    assert model.posterior["fourier_contribution"].sizes == {
         **posterior_size,
         "time": n_time,
         "existing_product": n_existing_products,


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->
Current way of making Fourier show a disconnected node.
<img width="961" height="682" alt="image" src="https://github.com/user-attachments/assets/a06acce6-ecf7-43df-a435-995c92079de5" />

After a few adjustments we can show all informations flows to fourier contribution, with an small name change, allowing users to add their original scale version.
<img width="991" height="854" alt="image" src="https://github.com/user-attachments/assets/73d24e53-5b0e-4d47-b0ae-c07b9aa13213" />

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->
