### PR TITLE
Enable JAX backend in `BudgetOptimizer`

### DIFF
--- a/pymc_marketing/mmm/budget_optimizer.py
+++ b/pymc_marketing/mmm/budget_optimizer.py
@@ -363,6 +363,11 @@ class BudgetOptimizer(BaseModel):
         ),
     )
 
+    jax_backend: bool = Field(
+        default=False,
+        description="Boolean flag controlling jax backend. Needed for GPU support",
+    )
+
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     DEFAULT_MINIMIZE_KWARGS: ClassVar[dict] = {
@@ -684,10 +689,23 @@ class BudgetOptimizer(BaseModel):
         )
         objective_grad = pt.grad(rewrite_pregrad(objective), budgets_flat)
 
-        objective_and_grad_func = function([budgets_flat], [objective, objective_grad])
+        if self.jax_backend:
+            # Use PyMC's JAX infrastructure for robust compilation
+            from pymc.sampling.jax import get_jaxified_graph
+
+            objective_and_grad_func = get_jaxified_graph(
+                inputs=[budgets_flat], outputs=[objective, objective_grad]
+            )
+        else:
+            # Standard PyTensor compilation
+            objective_and_grad_func = function(
+                [budgets_flat],
+                [objective, objective_grad],
+            )
 
         # Avoid repeated input validation for performance
-        objective_and_grad_func.trust_input = True
+        if hasattr(objective_and_grad_func, "trust_input"):
+            objective_and_grad_func.trust_input = True
 
         self._compiled_functions[self.utility_function] = {
             "objective_and_grad": objective_and_grad_func,

--- a/pymc_marketing/mmm/multidimensional.py
+++ b/pymc_marketing/mmm/multidimensional.py
@@ -2146,7 +2146,9 @@ def create_sample_kwargs(
 class MultiDimensionalBudgetOptimizerWrapper(OptimizerCompatibleModelWrapper):
     """Wrapper for the BudgetOptimizer to handle multi-dimensional model."""
 
-    def __init__(self, model: MMM, start_date: str, end_date: str):
+    def __init__(
+        self, model: MMM, start_date: str, end_date: str, jax_backend: bool = False
+    ):
         self.model_class = model
         self.start_date = start_date
         self.end_date = end_date
@@ -2158,6 +2160,7 @@ class MultiDimensionalBudgetOptimizerWrapper(OptimizerCompatibleModelWrapper):
             include_carryover=False,
         )
         self.num_periods = len(self.zero_data[self.model_class.date_column].unique())
+        self.jax_backend = jax_backend
         # Adding missing dependencies for compatibility with BudgetOptimizer
         self._channel_scales = 1.0
 
@@ -2256,6 +2259,7 @@ class MultiDimensionalBudgetOptimizerWrapper(OptimizerCompatibleModelWrapper):
             budgets_to_optimize=budgets_to_optimize,
             budget_distribution_over_period=budget_distribution_over_period,
             model=self,  # Pass the wrapper instance itself to the BudgetOptimizer
+            jax_backend=self.jax_backend,
         )
 
         return allocator.allocate_budget(


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->
Enables computation of `BudgetOptimizer.objective_and_grad_func` via JAX backend. 
This enables GPU based computation if present (and enabled) through JAX envvars.


## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->
