### PR TITLE
Add model merging utilities and tests for multi-model optimization

### DIFF
--- a/pymc_marketing/mmm/budget_optimizer.py
+++ b/pymc_marketing/mmm/budget_optimizer.py
@@ -225,7 +225,8 @@ from pymc_marketing.mmm.constraints import (
     compile_constraints_for_scipy,
 )
 from pymc_marketing.mmm.utility import UtilityFunctionType, average_response
-from pymc_marketing.pytensor_utils import extract_response_distribution
+
+# Delayed import inside methods to avoid circular dependency on pytensor_utils
 
 
 def optimizer_xarray_builder(value, **kwargs):
@@ -670,6 +671,9 @@ class BudgetOptimizer(BaseModel):
         returns a graph that computes `"channel_contribution"` as a function of both
         the newly introduced budgets and the posterior of model parameters.
         """
+        # Local import to avoid circular import at module load time
+        from pymc_marketing.pytensor_utils import extract_response_distribution
+
         return extract_response_distribution(
             pymc_model=self._pymc_model,
             idata=self.mmm_model.idata,

--- a/pymc_marketing/pytensor_utils.py
+++ b/pymc_marketing/pytensor_utils.py
@@ -14,18 +14,324 @@
 
 """PyTensor utility functions."""
 
+from typing import Any, cast
+
 import arviz as az
+import pytensor
 import pytensor.tensor as pt
+import xarray as xr
 from arviz import InferenceData
 from pymc import Model
+from pymc.model.fgraph import (
+    FunctionGraph,
+    ModelVar,
+    extract_dims,
+    fgraph_from_model,
+    model_from_fgraph,
+)
+from pymc.model.transform.optimization import freeze_dims_and_data
 from pytensor import clone_replace
 from pytensor.graph import rewrite_graph, vectorize_graph
 from pytensor.graph.basic import ancestors
 
 try:
+    # Prefer importing the Protocol when available without triggering circular import
+    from pymc_marketing.mmm.budget_optimizer import OptimizerCompatibleModelWrapper
+except Exception:  # pragma: no cover - during circular import bootstrap
+    from typing import Protocol as OptimizerCompatibleModelWrapper  # type: ignore
+
+try:
     from pymc.pytensorf import rvs_in_graph
 except ImportError:
     from pymc.logprob.utils import rvs_in_graph
+
+
+def _prefix_model(f2, prefix: str, exclude_vars: set | None = None):
+    """Prefix variable and dimension names in a FunctionGraph.
+
+    Variables listed in ``exclude_vars`` (e.g., a shared variable like ``channel_data``)
+    are kept unprefixed, and their dims/coords are also preserved without prefix.
+    """
+    if exclude_vars is None:
+        exclude_vars = set()
+
+    # First, collect dimensions that belong to excluded variables
+    exclude_dims = set()
+    for v in f2.outputs:
+        if v.name in exclude_vars:
+            v_dims = extract_dims(v)
+            for dim in v_dims:
+                exclude_dims.add(dim.data)
+
+    dims = set()
+    for v in f2.outputs:
+        # Only prefix if not in exclude_vars
+        if v.name not in exclude_vars:
+            new_name = f"{prefix}_{v.name}"
+            v.name = new_name
+            if isinstance(v.owner.op, ModelVar):
+                rv = v.owner.inputs[0]
+                rv.name = new_name
+        dims.update(extract_dims(v))
+
+    # Don't rename dimensions that belong to excluded variables
+    dims_rename = {
+        dim: pytensor.as_symbolic(f"{prefix}_{dim.data}")
+        for dim in dims
+        if dim.data not in exclude_dims
+    }
+    if dims_rename:
+        f2.replace_all(tuple(dims_rename.items()))
+
+    # Don't prefix coordinates for excluded dimensions
+    new_coords = {}
+    for k, v in f2._coords.items():  # type: ignore[attr-defined]
+        if k not in exclude_dims:
+            new_coords[f"{prefix}_{k}"] = v
+        else:
+            new_coords[k] = v
+    f2._coords = new_coords  # type: ignore[attr-defined]
+
+    return f2
+
+
+def merge_models(
+    models: list[Model],
+    *,
+    prefixes: list[str] | None = None,
+    merge_on: str | None = None,
+) -> Model:
+    """Merge multiple PyMC models into a single model.
+
+    Parameters
+    ----------
+    models : list of pm.Model
+        List of models to merge.
+    prefixes : list of str or None
+        List of prefixes for each model. If None, will auto-generate as 'model1', 'model2', ...
+    merge_on : str or None
+        Variable name to merge on (shared across all models) - this variable will NOT be prefixed.
+
+    Returns
+    -------
+    pm.Model
+        Merged model.
+    """
+    if len(models) < 2:
+        raise ValueError("Need at least 2 models to merge")
+
+    # Auto-generate prefixes if not provided
+    if prefixes is None:
+        prefixes = [f"model{i + 1}" for i in range(len(models))]
+    elif len(prefixes) != len(models):
+        raise ValueError(
+            f"Number of prefixes ({len(prefixes)}) must match number of models ({len(models)})"
+        )
+
+    # Variables to exclude from prefixing
+    exclude_vars = {merge_on} if merge_on else set()
+
+    # Convert all models to FunctionGraphs and apply prefixes
+    fgraphs: list[FunctionGraph] = []
+    for model, prefix in zip(models, prefixes, strict=False):
+        fg, _ = fgraph_from_model(model, inlined_views=True)
+        if prefix is not None:
+            fg = _prefix_model(fg, prefix=prefix, exclude_vars=exclude_vars)
+        fgraphs.append(fg)
+
+    # Handle merge_on logic
+    if merge_on is not None:
+        # Find the merge variable in the first model (unprefixed)
+        first_merge_vars = [out for out in fgraphs[0].outputs if out.name == merge_on]
+        if not first_merge_vars:
+            raise ValueError(f"Variable '{merge_on}' not found in first model")
+        first_merge_var = first_merge_vars[0]
+
+        # Replace the merge variable in all other models with the one from the first model
+        for i in range(1, len(fgraphs)):
+            merge_vars = [out for out in fgraphs[i].outputs if out.name == merge_on]
+            if not merge_vars:
+                raise ValueError(f"Variable '{merge_on}' not found in model {i + 1}")
+            fgraphs[i].replace(merge_vars[0], first_merge_var, import_missing=True)
+
+    # Combine all outputs
+    all_outputs = []
+    for fg in fgraphs:
+        all_outputs.extend(fg.outputs)
+
+    # Create merged FunctionGraph
+    f = FunctionGraph(outputs=all_outputs, clone=False)
+
+    # Merge coordinates from all models
+    merged_coords: dict = {}
+    for fg in fgraphs:
+        merged_coords.update(fg._coords)  # type: ignore[attr-defined]
+    f._coords = merged_coords  # type: ignore[attr-defined]
+
+    return model_from_fgraph(f, mutate_fgraph=True)
+
+
+class BuildMergedModel(OptimizerCompatibleModelWrapper):
+    """Wrapper that merges multiple OptimizerCompatibleModelWrapper models.
+
+    - Keeps a persistent merged model for optimization via `_set_predictors_for_optimization`.
+    - Provides a dynamic merged `model` property for inspection (non-persistent), if needed.
+    """
+
+    def __init__(
+        self,
+        models: list[OptimizerCompatibleModelWrapper],
+        prefixes: list[str] | None = None,
+        merge_on: str | None = "channel_data",
+        use_every_n_draw: int = 1,
+    ) -> None:
+        if len(models) < 1:
+            raise ValueError("Need at least 1 model")
+
+        self._channel_scales = 1.0
+        self.models = models
+        self.num_models = len(models)
+
+        # Auto-generate prefixes if not provided - ALL models get prefixes
+        if prefixes is None:
+            self.prefixes = [f"model{i + 1}" for i in range(self.num_models)]
+        else:
+            if len(prefixes) != len(models):
+                raise ValueError(
+                    f"Number of prefixes ({len(prefixes)}) must match number of models ({len(models)})"
+                )
+            self.prefixes = prefixes
+
+        self.merge_on = merge_on
+        self.use_every_n_draw = use_every_n_draw
+
+        # Use first model as primary for attributes
+        self.primary_model = models[0]
+        self.num_periods = getattr(self.primary_model, "num_periods", None)
+
+        # Merge idata from all models with appropriate prefixes
+        self._merge_idata()
+
+        if hasattr(self.primary_model, "adstock"):
+            self.adstock = self.primary_model.adstock
+
+        # Signal to BudgetOptimizer to enforce mask validation
+        self.enforce_budget_mask_validation = False
+
+        # Persistent merged model used for optimization
+        self._persistent_merged_model: Model | None = None
+        self._persistent_num_periods: int | None = None
+
+    def _merge_idata(self) -> None:
+        if self.num_models == 1:
+            idata = self.models[0].idata.isel(
+                draw=slice(None, None, self.use_every_n_draw)
+            )
+            if self.prefixes[0]:
+                idata = self._prefix_idata(idata, self.prefixes[0])
+            self.idata = idata
+            return
+
+        merged_idata = None
+        for i, model in enumerate(self.models):
+            prefix = self.prefixes[i]
+            idata_i = model.idata.isel(
+                draw=slice(None, None, self.use_every_n_draw)
+            ).copy()
+            if prefix:
+                idata_i = self._prefix_idata(idata_i, prefix)
+
+            if merged_idata is None:
+                merged_idata = idata_i
+            else:
+                for group in ("posterior", "constant_data", "observed_data"):
+                    if group in idata_i:
+                        if group in merged_idata:
+                            merged_idata[group] = xr.merge(
+                                [merged_idata[group], idata_i[group]]
+                            )
+                        else:
+                            merged_idata[group] = idata_i[group]
+
+        self.idata = merged_idata
+
+    def _prefix_idata(self, idata, prefix: str):
+        shared_vars = {"chain", "draw", "__obs__"}
+        if self.merge_on:
+            shared_vars.add(self.merge_on)
+
+        shared_dims = set(shared_vars)
+        if (
+            self.merge_on
+            and "constant_data" in idata
+            and self.merge_on in idata.constant_data
+        ):
+            merge_dims = list(idata.constant_data[self.merge_on].dims)
+            shared_dims.update(merge_dims)
+
+        prefixed_idata = idata.copy()
+        for group in ("posterior", "constant_data", "observed_data"):
+            if group in prefixed_idata:
+                rename_dict = {}
+                for var in prefixed_idata[group].data_vars:
+                    if var not in shared_vars and not var.startswith(f"{prefix}_"):
+                        rename_dict[var] = f"{prefix}_{var}"
+                for dim in prefixed_idata[group].dims:
+                    if dim not in shared_dims and not dim.startswith(f"{prefix}_"):
+                        rename_dict[dim] = f"{prefix}_{dim}"
+                if rename_dict:
+                    prefixed_idata[group] = prefixed_idata[group].rename(rename_dict)
+
+        return prefixed_idata
+
+    def _set_predictors_for_optimization(self, num_periods: int) -> Model:
+        # If we already built a persistent model for this horizon, reuse it
+        if (
+            self._persistent_merged_model is not None
+            and self._persistent_num_periods == int(num_periods)
+        ):
+            return self._persistent_merged_model
+
+        # Build per-model optimization models
+        pymc_models = [
+            m._set_predictors_for_optimization(num_periods=num_periods)
+            for m in self.models
+        ]
+        if self.num_models == 1:
+            self._persistent_merged_model = freeze_dims_and_data(pymc_models[0])
+        else:
+            self._persistent_merged_model = merge_models(
+                models=pymc_models, prefixes=self.prefixes, merge_on=self.merge_on
+            )
+
+        self._persistent_num_periods = int(num_periods)
+        return self._persistent_merged_model
+
+    @property
+    def model(self) -> Model:
+        """Return the merged PyMC model.
+
+        If a persistent optimization model exists, return it. Otherwise, try to lazily
+        construct it using the known number of periods. As a fallback, merge the
+        underlying training models from each wrapper (non-persistent).
+        """
+        # If a persistent optimization model exists, expose it for mutation
+        if self._persistent_merged_model is not None:
+            return self._persistent_merged_model
+
+        # If we know the number of periods, lazily build the persistent model now
+        if self.num_periods is not None:
+            return self._set_predictors_for_optimization(int(self.num_periods))
+
+        # Fallback: dynamic merged training models (non-persistent)
+        # Obtain each wrapper's training model dynamically; not all wrappers statically expose `.model`.
+        # Cast to Any first to avoid mypy attr-defined errors for Protocol wrappers.
+        pymc_models = [cast(Any, model).model for model in self.models]
+        if self.num_models == 1:
+            return pymc_models[0]
+        return merge_models(
+            models=pymc_models, prefixes=self.prefixes, merge_on=self.merge_on
+        )
 
 
 def extract_response_distribution(


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->
Introduces functions and a wrapper class in `pytensor_utils.py` to merge multiple PyMC models with variable prefixing and shared variable support, enabling multi-model budget optimization. Updates `budget_optimizer.py` to use delayed imports to avoid circular dependencies. Adds tests for model merging and the new wrapper in `test_pytensor_utils.py`.
Combines multiple independent PyMC Models into a single Model.

### Example
As we move forward in causality, and discover new DAGs, a way to collect direct or indirect effects could be create different regressions, every one adjusting by the minimum set of variables. _Each regression will respond to the same DAG but will uncover different effects per channel depending on the adjustment_.

Nevertheless, we probably want to optimize all regressions together or we want to join the mode to make several operations. But how to? Well let's remember PyMC models are graphical generative model so, each model can be represent as a function graph, and their nodes/variables could be prefixed (e.g., model1_, model2_). Doing so, we could decide which variable or data will be the one to merge_on="some_var" and the variable is kept **unprefixed** and shared across the merged models. All outputs and coordinates are merged into a single function graph.

Imagine you have the following DAG:
```
digraph G {
  rankdir=LR; splines=true; nodesep=0.4; ranksep=0.5;
  node [shape=ellipse, fontsize=12];

  C1 -> X1; C1 -> Y;
  C2 -> X2; C2 -> Y;
  C3 -> X3; C3 -> Y;

  X1 -> X2; X2 -> X3;
  X1 -> Y;  X2 -> Y;  X3 -> Y;

  // styling
  {rank=same; C1; C2; C3}
  {rank=same; X1; X2; X3}
  Y [shape=doublecircle];
}
```

This structure makes the minimal sufficient sets different for each channel’s **direct** effect on Y:

- **For x1:** backdoor via C1; mediated paths via X2 to X3.  
  **Adjust:** C1,X2 (conditioning on X2 also blocks the X1 to X2 to X3 to Y path).

- **For X2:** backdoors via C2 and via X1 (since X1 to X2 and X1 to Y); mediated path via X3.  
  **Adjust:** C2, X1, X3.

- **For X3:** backdoors via C3 and via X2 (since X2 to X3 and X2 to Y).  
  **Adjust:** C_3, X_2.

Meaning, we need three models to uncover the effects:
```python
# Get x1 over Y
mask = np.array([True, False, False])
mmm_x1_effect = MMM(  # (Y ~ X1 + C1 + X2)
    date_column="date",
    target_column="Y",
    channel_columns=[
        "X1",
        "X2",
        "X3",
    ],  # always use all channels, but mask the ones that are not used
    control_columns=["X2", "C1"],
    adstock=NoAdstock(l_max=1),
    saturation=NoSaturation(
        priors={
            "beta": MaskedDist(
                Prior("HalfNormal", sigma=1.0, dims="channel"), mask=mask
            )
        }
    ),
)

# get x2 over Y
# make mask for channels making x1,x2 false
mask2 = np.array([False, True, False])
mmm_x2_effect = MMM(  # (Y ~ X2 + C2 + X1 + X3)
    date_column="date",
    target_column="Y",
    channel_columns=[
        "X1",
        "X2",
        "X3",
    ],  # always use all channels, but mask the ones that are not used
    control_columns=["X1", "C2", "X3"],
    adstock=NoAdstock(l_max=1),
    saturation=NoSaturation(
        priors={
            "beta": MaskedDist(
                Prior("HalfNormal", sigma=1.0, dims="channel"), mask=mask2
            )
        }
    ),
)

# get x3 over Y
# make mask for channels making x1,x2 false
mask3 = np.array([False, False, True])
mmm_x3_effect = MMM(  # (Y ~ X3 + C3 + X2)
    date_column="date",
    target_column="Y",
    channel_columns=[
        "X1",
        "X2",
        "X3",
    ],  # always use all channels, but mask the ones that are not used
    control_columns=["X2", "C3"],
    adstock=NoAdstock(l_max=1),
    saturation=NoSaturation(
        priors={
            "beta": MaskedDist(
                Prior("HalfNormal", sigma=1.0, dims="channel"), mask=mask3
            )
        }
    ),
)
```

As you can see we should be able to _zero out with mask the distributions to avoid calculate the contributions for the channels we don't want to adjust in the regression_. Nevertheless, even when channels are zero out given the priors and not consider during the sampling, the data input is the same for all.

We could merge based on it.

```python
optimizable_model1 = MultiDimensionalBudgetOptimizerWrapper(
    model=mmm_x1_effect, start_date="2026-01-01", end_date="2026-01-31"
)

optimizable_model2 = MultiDimensionalBudgetOptimizerWrapper(
    model=mmm_x2_effect, start_date="2026-01-01", end_date="2026-01-31"
)

optimizable_model3 = MultiDimensionalBudgetOptimizerWrapper(
    model=mmm_x3_effect, start_date="2026-01-01", end_date="2026-01-31"
)

multi_model = BuildMergedModel(
    models=[optimizable_model1, optimizable_model2, optimizable_model3],
    prefixes=["model1", "model2", "model3"],
    merge_on="channel_data",
)
```

And finally, optimize.

```python
optimizer = BudgetOptimizer(
    num_periods=multi_model.num_periods,
    model=multi_model,
    response_variable="total_media_contribution_original_scale",
)
```

This opens the door to make optimization of different effects (total, indirects or directs) together. Allows for multi-objective optimization. Every model could have a different target variable but the target depends on same inputs, and consequently we want to optimize A and B together.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->
