### PR TITLE
Add MaskedPrior class for masked variable creation

### DIFF
--- a/pymc_marketing/pytensor_utils.py
+++ b/pymc_marketing/pytensor_utils.py
@@ -27,6 +27,14 @@ try:
 except ImportError:
     from pymc.logprob.utils import rvs_in_graph
 
+import warnings
+
+import numpy as np
+import pymc as pm
+import xarray as xr
+from pymc_extras.deserialize import deserialize, register_deserialization
+from pymc_extras.prior import Prior
+
 
 def extract_response_distribution(
     pymc_model: Model,
@@ -106,3 +114,370 @@ def extract_response_distribution(
     )
 
     return response_distribution
+
+
+class MaskedPrior:
+    """Create variables from a prior over only the active entries of a boolean mask.
+
+    .. warning::
+        This class is experimental and its API may change in future versions.
+
+    Parameters
+    ----------
+    prior : Prior
+        Base prior whose variable is defined over `prior.dims`. Internally, the
+        variable is created only for the active entries given by `mask` and
+        then expanded back to the full shape with zeros at inactive positions.
+    mask : xarray.DataArray
+        Boolean array with the same dims and shape as `prior.dims` marking active
+        (True) and inactive (False) entries.
+    active_dim : str, optional
+        Name of the coordinate indexing the active subset. If not provided, a
+        name is generated as ``"non_null_dims:<dim1>_<dim2>_..."``. If an existing
+        coordinate with the same name has a different length, a suffix with the
+        active length is appended.
+
+    Examples
+    --------
+    Simple 1D masking.
+
+    .. code-block:: python
+
+        import numpy as np
+        import xarray as xr
+        import pymc as pm
+        from pymc_extras.prior import Prior
+        from pymc_marketing.pytensor_utils import MaskedPrior
+
+        coords = {"country": ["Venezuela", "Colombia"]}
+        mask = xr.DataArray(
+            [True, False],
+            dims=["country"],
+            coords={"country": coords["country"]},
+        )
+        intercept = Prior("Normal", mu=0, sigma=10, dims=("country",))
+        with pm.Model(coords=coords):
+            masked = MaskedPrior(intercept, mask)
+            intercept_full = masked.create_variable("intercept")
+
+    Nested parameter priors with dims remapped to the active subset.
+
+    .. code-block:: python
+
+        import numpy as np
+        import xarray as xr
+        import pymc as pm
+        from pymc_extras.prior import Prior
+        from pymc_marketing.pytensor_utils import MaskedPrior
+
+        coords = {"country": ["Venezuela", "Colombia"]}
+        mask = xr.DataArray(
+            [True, False],
+            dims=["country"],
+            coords={"country": coords["country"]},
+        )
+        intercept = Prior(
+            "Normal",
+            mu=Prior("HalfNormal", sigma=1, dims=("country",)),
+            sigma=10,
+            dims=("country",),
+        )
+        with pm.Model(coords=coords):
+            masked = MaskedPrior(intercept, mask)
+            intercept_full = masked.create_variable("intercept")
+
+    All entries masked (returns deterministic zeros with original dims).
+
+    .. code-block:: python
+
+        import numpy as np
+        import xarray as xr
+        import pymc as pm
+        from pymc_extras.prior import Prior
+        from pymc_marketing.pytensor_utils import MaskedPrior
+
+        coords = {"country": ["Venezuela", "Colombia"]}
+        mask = xr.DataArray(
+            [False, False],
+            dims=["country"],
+            coords={"country": coords["country"]},
+        )
+        prior = Prior("Normal", mu=0, sigma=10, dims=("country",))
+        with pm.Model(coords=coords):
+            masked = MaskedPrior(prior, mask)
+            zeros = masked.create_variable("intercept")
+
+    Apply over a saturation function priors:
+
+    .. code-block:: python
+
+        from pymc_marketing.mmm import LogisticSaturation
+        from pymc_marketing.pytensor_utils import MaskedPrior
+
+        coords = {
+            "country": ["Colombia", "Venezuela"],
+            "channel": ["x1", "x2", "x3", "x4"],
+        }
+
+        mask_excluded_x4_colombia = xr.DataArray(
+            [[True, False, True, False], [True, True, True, True]],
+            dims=["country", "channel"],
+            coords=coords,
+        )
+
+        saturation = LogisticSaturation(
+            priors={
+                "lam": MaskedPrior(
+                    Prior(
+                        "Gamma",
+                        mu=2,
+                        sigma=0.5,
+                        dims=("country", "channel"),
+                    ),
+                    mask=mask_excluded_x4_colombia,
+                ),
+                "beta": Prior(
+                    "Gamma",
+                    mu=3,
+                    sigma=0.5,
+                    dims=("country", "channel"),
+                ),
+            }
+        )
+
+        prior = saturation.sample_prior(coords=coords, random_seed=10)
+        curve = saturation.sample_curve(prior)
+        saturation.plot_curve(
+            curve,
+            subplot_kwargs={
+                "ncols": 4,
+                "figsize": (12, 18),
+            },
+        )
+
+    Masked likelihood over an arbitrary subset of entries (2D example over (date, country)):
+
+    .. code-block:: python
+
+        import numpy as np
+        import xarray as xr
+        import pymc as pm
+        from pymc_extras.prior import Prior
+        from pymc_marketing.pytensor_utils import MaskedPrior
+
+        coords = {
+            "date": np.array(["2021-01-01", "2021-01-02"], dtype="datetime64[D]"),
+            "country": ["Venezuela", "Colombia"],
+        }
+
+        mask = xr.DataArray(
+            [[True, False], [True, False]],
+            dims=["date", "country"],
+            coords={"date": coords["date"], "country": coords["country"]},
+        )
+
+        intercept = Prior("Normal", mu=0, sigma=10, dims=("country",))
+        likelihood = Prior(
+            "Normal", sigma=Prior("HalfNormal", sigma=1), dims=("date", "country")
+        )
+        observed = np.random.normal(0, 1, size=(2, 2))
+
+        with pm.Model(coords=coords):
+            mu = intercept.create_variable("intercept")
+            masked = MaskedPrior(likelihood, mask)
+            y = masked.create_likelihood_variable("y", mu=mu, observed=observed)
+    """
+
+    def __init__(self, prior: Prior, mask: xr.DataArray, active_dim: str | None = None):
+        self.prior = prior
+        self.mask = mask
+        self.dims = prior.dims
+        self.active_dim = active_dim or f"non_null_dims:{'_'.join(self.dims)}"
+        self._validate_mask()
+
+        warnings.warn(
+            "This class is experimental and its API may change in future versions.",
+            stacklevel=2,
+        )
+
+    def _validate_mask(self):
+        if tuple(self.mask.dims) != tuple(self.dims):
+            raise ValueError("mask dims must match prior.dims order")
+
+    def _remap_dims(self, factory):
+        # Depth-first remap of any nested VariableFactory with dims == parent dims
+        # This keeps internal subset checks (_param_dims_work) satisfied.
+        if hasattr(factory, "parameters"):
+            # Recurse on child parameters first
+            for key, value in list(factory.parameters.items()):
+                if hasattr(value, "create_variable") and hasattr(value, "dims"):
+                    factory.parameters[key] = self._remap_dims(value)
+
+        # Now remap this object's dims if they exactly match the masked dims
+        if hasattr(factory, "dims"):
+            dims = factory.dims
+            if isinstance(dims, str):
+                dims = (dims,)
+            if tuple(dims) == tuple(self.dims):
+                factory.dims = (self.active_dim,)
+
+        return factory
+
+    def create_variable(self, name: str):
+        """Create a deterministic variable with full dims using the active subset.
+
+        Creates an underlying variable over the active entries only and expands
+        it back to the full masked shape, filling inactive entries with zeros.
+
+        Parameters
+        ----------
+        name : str
+            Base name for the created variables.
+
+        Returns
+        -------
+        pt.TensorVariable
+            Deterministic variable with the original dims, zeros on inactive entries.
+        """
+        model = pm.modelcontext(None)
+        flat_mask = self.mask.values.ravel().astype(bool)
+        n_active = int(flat_mask.sum())
+
+        if n_active == 0:
+            return pm.Deterministic(name, pt.zeros(self.mask.shape), dims=self.dims)
+
+        # Ensure the coord exists and has the right length
+        if (
+            self.active_dim in model.coords
+            and len(model.coords[self.active_dim]) != n_active
+        ):
+            self.active_dim = f"{self.active_dim}__{n_active}"
+        model.add_coords({self.active_dim: np.arange(n_active)})
+
+        # Make a deep copy and remap dims depth-first before creating the RV
+        reduced = self._remap_dims(self.prior.deepcopy())
+
+        active_rv = reduced.create_variable(f"{name}_active")  # shape: (active_dim,)
+        flat_full = pt.zeros((self.mask.size,), dtype=active_rv.dtype)
+        full = flat_full[flat_mask].set(active_rv).reshape(self.mask.shape)
+        return pm.Deterministic(name, full, dims=self.dims)
+
+    def to_dict(self) -> dict:
+        """Serialize MaskedPrior to a JSON-serializable dictionary.
+
+        Returns
+        -------
+        dict
+            Dictionary containing the prior, mask, and active_dim.
+        """
+        # Store mask as a plain nested list of bools to avoid datetime coords serialization
+        mask_list = (
+            self.mask.values.astype(bool).tolist()
+            if hasattr(self.mask, "values")
+            else np.asarray(self.mask, dtype=bool).tolist()
+        )
+        return {
+            "class": "MaskedPrior",
+            "data": {
+                "prior": self.prior.to_dict()
+                if hasattr(self.prior, "to_dict")
+                else None,
+                "mask": mask_list,
+                "mask_dims": list(self.dims),
+                "active_dim": self.active_dim,
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "MaskedPrior":
+        """Deserialize MaskedPrior from dictionary created by ``to_dict``.
+
+        Parameters
+        ----------
+        data : dict
+            Dictionary produced by :meth:`to_dict`.
+
+        Returns
+        -------
+        MaskedPrior
+            Reconstructed instance.
+        """
+        payload = data["data"] if "data" in data else data
+        prior = (
+            deserialize(payload["prior"])
+            if isinstance(payload.get("prior"), dict)
+            else payload.get("prior")
+        )
+        mask_vals = payload.get("mask")
+        # Fallback to provided dims or infer from prior if available
+        mask_dims = payload.get("mask_dims") or (getattr(prior, "dims", None) or ())
+        mask_da = xr.DataArray(np.asarray(mask_vals, dtype=bool), dims=tuple(mask_dims))
+        active_dim = payload.get("active_dim")
+        return cls(prior=prior, mask=mask_da, active_dim=active_dim)
+
+    def create_likelihood_variable(
+        self, name: str, *, mu: pt.TensorLike, observed: pt.TensorLike
+    ):
+        """Create an observed variable over the active subset and expand to full dims.
+
+        Parameters
+        ----------
+        name : str
+            Base name for the created variables.
+        mu : pt.TensorLike
+            Mean/location parameter broadcastable to the masked shape.
+        observed : pt.TensorLike
+            Observations broadcastable to the masked shape.
+
+        Returns
+        -------
+        pt.TensorVariable
+            Deterministic variable over the full dims with observed RV on active entries.
+        """
+        model = pm.modelcontext(None)
+        flat_mask = self.mask.values.ravel().astype(bool)
+        n_active = int(flat_mask.sum())
+
+        if n_active == 0:
+            return pm.Deterministic(name, pt.zeros(self.mask.shape), dims=self.dims)
+
+        # Ensure the coord exists and has the right length
+        if (
+            self.active_dim in model.coords
+            and len(model.coords[self.active_dim]) != n_active
+        ):
+            self.active_dim = f"{self.active_dim}__{n_active}"
+        model.add_coords({self.active_dim: np.arange(n_active)})
+
+        # Remap dims on a deep copy so nested parameter priors match the active subset
+        reduced = self._remap_dims(self.prior.deepcopy())
+
+        # Broadcast mu/observed to full mask shape via arithmetic broadcasting, then select active entries
+        mu_tensor = pt.as_tensor_variable(mu)
+        mu_full = mu_tensor + pt.zeros(self.mask.shape, dtype=mu_tensor.dtype)
+        mu_active = mu_full.reshape((self.mask.size,))[flat_mask]
+
+        obs = observed.values if hasattr(observed, "values") else observed
+        obs_tensor = pt.as_tensor_variable(obs)
+        obs_full = obs_tensor + pt.zeros(self.mask.shape, dtype=obs_tensor.dtype)
+        obs_active = obs_full.reshape((self.mask.size,))[flat_mask]
+
+        # Create the masked observed RV over the active subset
+        active_name = f"{name}_active"
+        active_rv = reduced.create_likelihood_variable(
+            active_name, mu=mu_active, observed=obs_active
+        )
+
+        # Expand back to full shape for user-friendly access
+        flat_full = pt.zeros((self.mask.size,), dtype=active_rv.dtype)
+        full = flat_full[flat_mask].set(active_rv).reshape(self.mask.shape)
+        return pm.Deterministic(name, full, dims=self.dims)
+
+
+def _is_masked_prior_type(data: dict) -> bool:
+    return data.keys() == {"class", "data"} and data.get("class") == "MaskedPrior"
+
+
+register_deserialization(
+    is_type=_is_masked_prior_type, deserialize=MaskedPrior.from_dict
+)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->
Introduces the experimental MaskedPrior class to create variables and likelihoods over only the active entries of a boolean mask, expanding back to the full shape with zeros at inactive positions. Includes serialization/deserialization support and comprehensive tests for 1D, multidimensional, and integration with saturation functions and MMM fitting.

**What it does (in short)**
1. Wraps a Prior that is defined over named dims.
2. Applies a boolean mask to those dims to:
3. Build an “active” 1D RV only for unmasked positions (under a new active dim).
4. Scatter the active RV back to the original full grid and return a deterministic with the original dims.
5. Can also create masked likelihoods so only active positions contribute to the log-likelihood.

```python
import numpy as np
import pymc as pm
from pymc_extras.prior import Prior
from pymc_marketing.pytensor_utils import MaskedPrior

# Define a 3x4 grid
coords = {"row": [0, 1, 2], "col": [0, 1, 2, 3]}

# Create mask - only activate positions (0,0), (1,2), (2,3)
mask = np.array(
    [
        [True, False, False, False],
        [False, False, True, False],
        [False, False, False, True],
    ]
)

# Define prior over full grid
prior = Prior("Normal", mu=0, sigma=1, dims=("row", "col"))
masked_dist = MaskedPrior(prior, mask)

with pm.Model(coords=coords):
    # Create masked distribution
    coeff = masked_dist.create_variable("coeff")
```

Users can combine this to modify the params into their functions, such as `saturation` or `adstock`.

```python
LogisticSaturation(
    priors={
        "lam": MaskedPrior(
            Prior("HalfNormal", sigma=1.0, dims=("country", "region")),
            mask=mask,
        ),
        "beta": MaskedPrior(
            Prior("HalfNormal", sigma=1.0, dims=("country", "region")),
            mask=mask,
        ),
    }
)
```

If from the full grid, some panels are missing they can mask the likelihood as well to not sample on dates or combos dates-region-city which doesn't exist.

```python
mu_prior = Prior("Normal", mu=0.0, sigma=1.0, dims=("date", "geo"))
masked_mu = MaskedPrior(mu_prior, mask=mask)

observed = np.zeros((len(coords["date"]), len(coords["geo"])))

likelihood_prior = Prior(
    "Normal",
    sigma=Prior("HalfNormal", sigma=1.0),
    dims=("date", "geo"),
)
masked_lik = MaskedPrior(likelihood_prior, mask=mask)

with pm.Model(coords=coords):
    # Masked deterministic mean over full grid (zeros where mask is False)
    mu_full = masked_mu.create_variable("mu_full")

    # Build likelihood as a Prior and mask it, so both mu and observed are masked
    masked_lik.create_likelihood_variable(
        name="y",
        mu=mu_full,
        observed=observed,
    )
```

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->
