### PR TITLE
Fix np.testing.assert_array_almost_equal argument names

### DIFF
--- a/tests/mmm/test_budget_optimizer.py
+++ b/tests/mmm/test_budget_optimizer.py
@@ -317,7 +317,7 @@ def test_allocate_budget_custom_minimize_args(
 
     kwargs = minimize_mock.call_args_list[0].kwargs
 
-    np.testing.assert_array_equal(x=kwargs["x0"], y=np.array([50.0, 50.0]))
+    np.testing.assert_array_equal(actual=kwargs["x0"], desired=np.array([50.0, 50.0]))
     assert kwargs["bounds"] == [(0.0, 50.0), (0.0, 50.0)]
     assert kwargs["method"] == minimize_kwargs["method"]
     assert kwargs["options"] == minimize_kwargs["options"]

--- a/tests/mmm/test_transformers.py
+++ b/tests/mmm/test_transformers.py
@@ -129,7 +129,7 @@ class TestsAdstockTransformers:
     def test_geometric_adstock_x_zero(self, mode):
         x = np.zeros(shape=(100))
         y = geometric_adstock(x=x, alpha=0.2, mode=mode)
-        np.testing.assert_array_equal(x=x, y=y.eval())
+        np.testing.assert_array_equal(actual=x, desired=y.eval())
 
     @pytest.mark.parametrize(
         "x, alpha, l_max",
@@ -180,7 +180,7 @@ class TestsAdstockTransformers:
     def test_delayed_adstock_x_zero(self):
         x = np.zeros(shape=(100))
         y = delayed_adstock(x=x, alpha=0.2, theta=2, l_max=4)
-        np.testing.assert_array_equal(x=x, y=y.eval())
+        np.testing.assert_array_equal(actual=x, desired=y.eval())
 
     @pytest.mark.parametrize(
         argnames="mode",
@@ -327,13 +327,13 @@ class TestSaturationTransformers:
     def test_logistic_saturation_lam_zero(self):
         x = np.ones(shape=(100))
         y = logistic_saturation(x=x, lam=0.0)
-        np.testing.assert_array_equal(x=np.zeros(shape=(100)), y=y.eval())
+        np.testing.assert_array_equal(actual=np.zeros(shape=(100)), desired=y.eval())
 
     def test_logistic_saturation_lam_one(self):
         x = np.ones(shape=(100))
         y = logistic_saturation(x=x, lam=1.0)
         np.testing.assert_array_equal(
-            x=((1 - np.e ** (-1)) / (1 + np.e ** (-1))) * x, y=y.eval()
+            actual=((1 - np.e ** (-1)) / (1 + np.e ** (-1))) * x, desired=y.eval()
         )
 
     @pytest.mark.parametrize(

--- a/tests/mmm/test_transformers.py
+++ b/tests/mmm/test_transformers.py
@@ -410,7 +410,7 @@ class TestSaturationTransformers:
     def test_tanh_saturation_inverse(self, x, b, c):
         y = tanh_saturation(x=x, b=b, c=c)
         y_inv = (b * c) * pt.arctanh(y / b)
-        np.testing.assert_array_almost_equal(x=x, y=y_inv.eval(), decimal=6)
+        np.testing.assert_array_almost_equal(actual=x, desired=y_inv.eval(), decimal=6)
 
     @pytest.mark.parametrize(
         "x, x0, gain, r",
@@ -442,7 +442,7 @@ class TestSaturationTransformers:
         b = (gain * x0) / r
         c = r / (gain * pt.arctanh(r))
         y_inv = (b * c) * pt.arctanh(y / b)
-        np.testing.assert_array_almost_equal(x=x, y=y_inv.eval(), decimal=6)
+        np.testing.assert_array_almost_equal(actual=x, desired=y_inv.eval(), decimal=6)
 
     @pytest.mark.parametrize(
         "x, b, c",


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->
Replaces deprecated 'x' and 'y' arguments with 'actual' and 'desired' in np.testing.assert_array_almost_equal calls for improved clarity and compatibility.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1949.org.readthedocs.build/en/1949/

<!-- readthedocs-preview pymc-marketing end -->