### PR TITLE
Hotfix - Fix dimension assertion for adding multidimensional event effects to multidimensional MMM

### DIFF
--- a/pymc_marketing/mmm/multidimensional.py
+++ b/pymc_marketing/mmm/multidimensional.py
@@ -490,7 +490,7 @@ class MMM(RegressionModelBuilder):
             If the event effect dimensions do not contain the prefix and model dimensions.
 
         """
-        if not set(effect.dims).issubset((prefix, self.dims)):
+        if not set(effect.dims).issubset((prefix, *self.dims)):
             raise ValueError(
                 f"Event effect dims {effect.dims} must contain {prefix} and {self.dims}"
             )

--- a/tests/mmm/test_multidimensional.py
+++ b/tests/mmm/test_multidimensional.py
@@ -813,12 +813,13 @@ def create_event_effect() -> Callable[[str], EventEffect]:
         prefix: str = "holiday",
         sigma_dims: str | None = None,
         effect_size: Prior | None = None,
+        dims: tuple[str] | str | None = None,
     ):
         basis = GaussianBasis()
         return EventEffect(
             basis=basis,
             effect_size=Prior("Normal"),
-            dims=(prefix,),
+            dims=dims or (prefix,),
         )
 
     return create
@@ -882,10 +883,14 @@ def test_mmm_with_events(
     )
     assert len(mmm.mu_effects) == 1
 
+    df_events_with_country = df_events.copy()
+    df_events_with_country["country"] = "A"
     mmm.add_events(
-        df_events,
+        df_events_with_country,
         prefix="another_event_type",
-        effect=create_event_effect(prefix="another_event_type"),
+        effect=create_event_effect(
+            prefix="another_event_type", dims=("country", "another_event_type")
+        ),
     )
     assert len(mmm.mu_effects) == 2
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
Adding events with a dimension other than the EventEffect prefix was failing dimension validation.

For example adding an event with dimension "country" to an MMM with the same dimension was failing.
<!--- Describe your changes in detail -->

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1969.org.readthedocs.build/en/1969/

<!-- readthedocs-preview pymc-marketing end -->