### PR TITLE
Adjusting calibration by costs to work with sample posterior predictive

### DIFF
--- a/data/config_files/multi_dimensional_hierarchical_with_arbitrary_effects_model.yml
+++ b/data/config_files/multi_dimensional_hierarchical_with_arbitrary_effects_model.yml
@@ -134,6 +134,7 @@ calibration:
                 - "data"
                 - "processed"
                 - "X.csv"
+          parse_dates: ["date"]
       calibration_data:
         class: pandas.DataFrame
         kwargs:
@@ -142,7 +143,6 @@ calibration:
             channel: ["channel_1", "channel_2"]
             cost_per_target: [30.0, 42.5]
             sigma: [2.0, 3.0]
-      cpt_variable_name: "cost_per_target"
       name_prefix: "example_cpt"
 
 

--- a/pymc_marketing/mmm/builders/yaml.py
+++ b/pymc_marketing/mmm/builders/yaml.py
@@ -96,7 +96,7 @@ def _apply_and_validate_calibration_steps(
             method(**resolved_kwargs)
         except Exception as err:  # pragma: no cover - re-raise with context
             raise RuntimeError(
-                f"Failed to apply calibration step '{method_name}' from YAML configuration."
+                f"Failed to apply calibration step '{method_name}' from YAML configuration: \n {err}"
             ) from err
 
 

--- a/pymc_marketing/mmm/multidimensional.py
+++ b/pymc_marketing/mmm/multidimensional.py
@@ -1614,22 +1614,6 @@ class MMM(RegressionModelBuilder):
             else:
                 data["target_data"] = target_values
 
-        # Handle optional spend data used for CPT calibration if available
-        if (
-            hasattr(self, "_calibration_spend_xarray")
-            and "channel_data_spend" in model.named_vars
-        ):
-            spend_values = self._calibration_spend_xarray._channel
-            # Align to new coords
-            reindex_coords = {"date": coords["date"], "channel": coords["channel"]}
-            for dim in self.dims:
-                reindex_coords[dim] = coords[dim]
-            spend_values = spend_values.reindex(reindex_coords, fill_value=0)
-            # Ensure no NaNs are passed into pm.Data updates
-            spend_values = spend_values.fillna(0)
-            original_dtype = model.named_vars["channel_data_spend"].type.dtype
-            data["channel_data_spend"] = spend_values.astype(original_dtype)
-
         self.new_updated_data = data
         self.new_updated_coords = coords
         self.new_updated_model = model
@@ -1971,7 +1955,6 @@ class MMM(RegressionModelBuilder):
         self,
         data: pd.DataFrame,
         calibration_data: pd.DataFrame,
-        cpt_variable_name: str = "cost_per_target",
         name_prefix: str = "cpt_calibration",
     ) -> None:
         """Calibrate cost-per-target using constraints via ``pm.Potential``.
@@ -2022,7 +2005,6 @@ class MMM(RegressionModelBuilder):
             mmm.add_cost_per_target_calibration(
                 data=spend_df,
                 calibration_data=calibration_df,
-                cpt_variable_name="cost_per_target",
                 name_prefix="cpt_calibration",
             )
         """
@@ -2039,15 +2021,43 @@ class MMM(RegressionModelBuilder):
                 )
 
         # Prepare spend data as xarray (original units)
-        spend_ds = self._create_xarray_from_pandas(
-            data=data,
-            date_column=self.date_column,
-            dims=self.dims,
-            metric_list=self.channel_columns,
-            metric_coordinate_name="channel",
-        ).transpose("date", *self.dims, "channel")
-        # Cache for predictive alignment
-        self._calibration_spend_xarray = spend_ds
+        spend_ds = (
+            self._create_xarray_from_pandas(
+                data=data,
+                date_column=self.date_column,
+                dims=self.dims,
+                metric_list=self.channel_columns,
+                metric_coordinate_name="channel",
+            )
+            .transpose("date", *self.dims, "channel")
+            .fillna(0)
+        )
+
+        spend_array = spend_ds._channel
+        # Compute expected shape from the model
+        channel_data_dims = self.model.named_vars_to_dims["channel_data"]
+        expected_shape = tuple(len(self.model.coords[dim]) for dim in channel_data_dims)
+
+        # Align spend array to the models dim order
+        spend_aligned = spend_array.transpose(*channel_data_dims)
+
+        # Now the check will fail when a coord (e.g., a country) is missing
+        if spend_aligned.shape != expected_shape:
+            raise ValueError(
+                "Spend data shape does not match channel data dims in the model: "
+                f"expected {expected_shape}, got {spend_aligned.shape}"
+            )
+
+        for dim in channel_data_dims:
+            spend_labels = np.asarray(spend_aligned.coords[dim].values)
+            model_labels = np.asarray(self.model.coords[dim])
+            if not np.array_equal(spend_labels, model_labels):
+                raise ValueError(
+                    f"Spend data coordinates for dim {dim!r} do not match model coords: "
+                    f"expected {model_labels.tolist()}, got {spend_labels.tolist()}"
+                )
+
+        spend_tensor = pt.as_tensor_variable(spend_aligned.values)
 
         with self.model:
             # Ensure original-scale contribution exists
@@ -2058,38 +2068,15 @@ class MMM(RegressionModelBuilder):
                     ]
                 )
 
-            # Create pm.Data for spend aligned to current model coords
-            spend_values = spend_ds._channel
-            # Reindex to model coords to ensure ordering matches
-            reindex_coords = {"date": self.model.coords["date"]}
-            for dim in self.dims:
-                reindex_coords[dim] = self.model.coords[dim]
-            reindex_coords["channel"] = self.model.coords["channel"]
-            spend_values = spend_values.reindex(reindex_coords, fill_value=0)
-            # Replace any existing NaNs in spend with zeros to satisfy pm.Data
-            spend_values = spend_values.fillna(0)
-
-            pm.Data(
-                name="channel_data_spend",
-                value=spend_values.values,
-                dims=("date", *self.dims, "channel"),
-            )
-
-            # Build cost_per_target deterministic safely (avoid division by ~0)
             denom = pt.clip(
                 self.model["channel_contribution_original_scale"], 1e-12, np.inf
             )
-            pm.Deterministic(
-                name=cpt_variable_name,
-                var=self.model["channel_data_spend"] / denom,
-                dims=("date", *self.dims, "channel"),
-            )
+            cpt_tensor = spend_tensor / denom
 
-        # Create one Potential per row in calibration_data
         add_cost_per_target_potentials(
             calibration_df=calibration_data,
             model=self.model,
-            cpt_variable_name=cpt_variable_name,
+            cpt_value=cpt_tensor,
             name_prefix=name_prefix,
         )
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->
Previous calibration was creating Data and Deterministic containers which will create issues at the time of out of sample.

Nevertheless, the containers are not needed because potential will not influence sample posterior predictive. I, keep the logic an signatures, align logic closer to lift test, removing containers and update all test suite.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1988.org.readthedocs.build/en/1988/

<!-- readthedocs-preview pymc-marketing end -->