### PR TITLE
Translate to spanish certain notebooks!

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,7 +180,7 @@ The steps to follow to update the translatable sources are:
 1. Update the Spanish `.po` files
 
    ```bash
-   sphinx-intl update -p docs/gettext -l es
+   sphinx-intl update -p docs/gettext -l es --locale-dir locales
    ```
 
 ### Translated build preview

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.hsgp_kwargs.HSGPKwargs.model_copy.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.hsgp_kwargs.HSGPKwargs.model_copy.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,27 +21,27 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.hsgp_kwargs.HSGPKwargs.model_copy.rst:2
-#: 16aa0829f1544aa59bd418a247c80594
+#: 3c5fb11358bb4db38427f2dd1b0dc723
 msgid "HSGPKwargs.model\\_copy"
 msgstr ""
 
-#: df5adadcd572479483b7bc884afd4329 of pydantic.main.BaseModel.model_copy:2
+#: 105ca8aba82d4e6098544a1c2c0b8f43 of pydantic.main.BaseModel.model_copy:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: f19b92b632154f81b894ea8168e8c63f of pydantic.main.BaseModel.model_copy:3
-msgid "[`model_copy`](../concepts/serialization.md#model_copy)"
+#: b2d933cfb69c42309ac10f083c7a6a62 of pydantic.main.BaseModel.model_copy:3
+msgid "[`model_copy`](../concepts/models.md#model-copy)"
 msgstr ""
 
-#: cc12c00f9fd14d8fa37b75fef9544d68 of pydantic.main.BaseModel.model_copy:5
+#: 86940fb572f34c3a8b403971ed75c096 of pydantic.main.BaseModel.model_copy:5
 msgid "Returns a copy of the model."
 msgstr ""
 
-#: 501b1c5f3850469ab161bde90fb8cc2e of pydantic.main.BaseModel.model_copy:7
+#: 85758cde8f744f33807fc915f0c2c732 of pydantic.main.BaseModel.model_copy:7
 msgid "!!! note"
 msgstr ""
 
-#: cdd01caf0b6941bbaec008bc6265224d of pydantic.main.BaseModel.model_copy:8
+#: 1174d7433b7e4597b2c96a6550e1852b of pydantic.main.BaseModel.model_copy:8
 msgid ""
 "The underlying instance's [`__dict__`][object.__dict__] attribute is "
 "copied. This might have unexpected side effects if you store anything in "
@@ -49,28 +49,31 @@ msgid ""
 "properties][functools.cached_property])."
 msgstr ""
 
-#: e72e111d1c534286a9dbbb78a1043133 of pydantic.main.BaseModel.model_copy:12
+#: 33bddf90189d44cf9d7259c5a45fd43c of pydantic.main.BaseModel.model_copy:12
 msgid "Args:"
 msgstr ""
 
-#: a4d5ea3e0976453fb34dc260a0d5ec01 of pydantic.main.BaseModel.model_copy:13
+#: 9ca8a499600a4be4b0f26ad3bbd6327d of pydantic.main.BaseModel.model_copy:13
 msgid ""
 "update: Values to change/add in the new model. Note: the data is not "
 "validated"
 msgstr ""
 
-#: 0702e424b0b84edf8a0bdb311d6a7e7d of pydantic.main.BaseModel.model_copy:14
+#: 208f97d70d944503ba73cbe8e86fa842 of pydantic.main.BaseModel.model_copy:14
 msgid "before creating the new model. You should trust this data."
 msgstr ""
 
-#: 7c1eacb3201847f4a32598aa83e3f13f of pydantic.main.BaseModel.model_copy:15
+#: faa620b87ca34edeba9c1959c1630057 of pydantic.main.BaseModel.model_copy:15
 msgid "deep: Set to `True` to make a deep copy of the model."
 msgstr ""
 
-#: 9a5e1c4d822e4cc1a9b1b351a0ec00f0 of pydantic.main.BaseModel.model_copy:17
+#: 3ddab0cbec3342d28d0d06f0f911b413 of pydantic.main.BaseModel.model_copy:17
 msgid "Returns:"
 msgstr ""
 
-#: 58edab614af8416d9eb4e2ea1c8ecad5 of pydantic.main.BaseModel.model_copy:18
+#: 19c49114331f4e5485519addefe5c06e of pydantic.main.BaseModel.model_copy:18
 msgid "New model instance."
 msgstr ""
+
+#~ msgid "[`model_copy`](../concepts/serialization.md#model_copy)"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.hsgp_kwargs.HSGPKwargs.model_dump.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.hsgp_kwargs.HSGPKwargs.model_dump.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,40 +21,40 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.hsgp_kwargs.HSGPKwargs.model_dump.rst:2
-#: 1651c80b55d54ffbbe530f26308e20e9
+#: 915cb574fc034e44b8df4e898ea60177
 msgid "HSGPKwargs.model\\_dump"
 msgstr ""
 
-#: da4567a2e49d45549c3c9b9a48d437c8 of pydantic.main.BaseModel.model_dump:2
+#: c2946dbd73df4953a1622827b9c7f94b of pydantic.main.BaseModel.model_dump:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: e385a1a86edf44b9b537fad0b6c1de67 of pydantic.main.BaseModel.model_dump:3
-msgid "[`model_dump`](../concepts/serialization.md#modelmodel_dump)"
+#: 6dc9927da7ff4aed9b77ff5344bebde1 of pydantic.main.BaseModel.model_dump:3
+msgid "[`model_dump`](../concepts/serialization.md#python-mode)"
 msgstr ""
 
-#: f6d6fc5981c24907813bf46ee36d46ab of pydantic.main.BaseModel.model_dump:5
+#: 9e06fd2a30e3496aa79fbcf74dfe5611 of pydantic.main.BaseModel.model_dump:5
 msgid ""
 "Generate a dictionary representation of the model, optionally specifying "
 "which fields to include or exclude."
 msgstr ""
 
-#: ed0bce468ef34111a154146f0e5b6dba of pydantic.main.BaseModel.model_dump:7
+#: 578224dcabf14429b9d663da3d22ddf2 of pydantic.main.BaseModel.model_dump:7
 msgid "Args:"
 msgstr ""
 
-#: 6226f7d80dcc46eaa62afa83318bcbfb of pydantic.main.BaseModel.model_dump:8
+#: 04d836f225194982a5ed8bdab9ebc9da of pydantic.main.BaseModel.model_dump:8
 msgid "mode: The mode in which `to_python` should run."
 msgstr ""
 
-#: 3cad23ce8cee4d9e8770a975fbf84654 of pydantic.main.BaseModel.model_dump:9
+#: d6bba2ef23104b94999b9d347bcb7bab of pydantic.main.BaseModel.model_dump:9
 msgid ""
 "If mode is 'json', the output will only contain JSON serializable types. "
 "If mode is 'python', the output may contain non-JSON-serializable Python "
 "objects."
 msgstr ""
 
-#: e0ada6647e5a454e88e3678c046b513e of pydantic.main.BaseModel.model_dump:11
+#: d23e2c1727cc4919bd37aea96cb476ab of pydantic.main.BaseModel.model_dump:11
 msgid ""
 "include: A set of fields to include in the output. exclude: A set of "
 "fields to exclude from the output. context: Additional context to pass to"
@@ -62,41 +62,77 @@ msgid ""
 "dictionary key if defined. exclude_unset: Whether to exclude fields that "
 "have not been explicitly set. exclude_defaults: Whether to exclude fields"
 " that are set to their default value. exclude_none: Whether to exclude "
-"fields that have a value of `None`. round_trip: If True, dumped values "
-"should be valid as input for non-idempotent types such as Json[T]. "
-"warnings: How to handle serialization errors. False/\"none\" ignores "
-"them, True/\"warn\" logs errors,"
+"fields that have a value of `None`. exclude_computed_fields: Whether to "
+"exclude computed fields."
 msgstr ""
 
-#: 8b26c4ec3c3a407bae530d056e19dd1e of pydantic.main.BaseModel.model_dump:20
+#: 33265050b6a64e1682170780fe6ff575 of pydantic.main.BaseModel.model_dump:19
+msgid ""
+"While this can be useful for round-tripping, it is usually recommended tu"
+" use the dedicated `round_trip` parameter instead."
+msgstr ""
+
+#: 9e4b9f2b5a174e82b266953713507ef0 of pydantic.main.BaseModel.model_dump:21
+msgid ""
+"round_trip: If True, dumped values should be valid as input for non-"
+"idempotent types such as Json[T]. warnings: How to handle serialization "
+"errors. False/\"none\" ignores them, True/\"warn\" logs errors,"
+msgstr ""
+
+#: 4c89729c955e4d9e80bc293fed703d18 of pydantic.main.BaseModel.model_dump:23
 msgid ""
 "\"error\" raises a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError]."
 msgstr ""
 
-#: 3569cfaaedb247b5831b45a29786668e of pydantic.main.BaseModel.model_dump:21
+#: 765a346bd9e946e3ab25231bc4540772 of pydantic.main.BaseModel.model_dump:24
 msgid ""
 "fallback: A function to call when an unknown value is encountered. If not"
 " provided,"
 msgstr ""
 
-#: 0a0134730be749bc995358eace9ba44b of pydantic.main.BaseModel.model_dump:22
+#: def2b831d6ff4f088b1b62a5a0c1a2ab of pydantic.main.BaseModel.model_dump:25
 msgid ""
 "a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError] "
 "error is raised."
 msgstr ""
 
-#: 3a291419974d4d8cb42f1c2b978e24b2 of pydantic.main.BaseModel.model_dump:23
+#: 0b8065556c42457294ecdac22eeb1d99 of pydantic.main.BaseModel.model_dump:26
 msgid ""
 "serialize_as_any: Whether to serialize fields with duck-typing "
 "serialization behavior."
 msgstr ""
 
-#: 6e537ccb88664792a5e0d099f9be2831 of pydantic.main.BaseModel.model_dump:25
+#: fb9f49ebc0184bf2a90929f45634dcdc of pydantic.main.BaseModel.model_dump:28
 msgid "Returns:"
 msgstr ""
 
-#: ccb133cf5eb949e38f25f8f8b1ba041c of pydantic.main.BaseModel.model_dump:26
+#: d8c3438894a24cee9d2f156c58c75b79 of pydantic.main.BaseModel.model_dump:29
 msgid "A dictionary representation of the model."
 msgstr ""
+
+#~ msgid "[`model_dump`](../concepts/serialization.md#modelmodel_dump)"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "include: A set of fields to "
+#~ "include in the output. exclude: A "
+#~ "set of fields to exclude from the"
+#~ " output. context: Additional context to "
+#~ "pass to the serializer. by_alias: "
+#~ "Whether to use the field's alias "
+#~ "in the dictionary key if defined. "
+#~ "exclude_unset: Whether to exclude fields "
+#~ "that have not been explicitly set. "
+#~ "exclude_defaults: Whether to exclude fields"
+#~ " that are set to their default "
+#~ "value. exclude_none: Whether to exclude "
+#~ "fields that have a value of "
+#~ "`None`. round_trip: If True, dumped "
+#~ "values should be valid as input "
+#~ "for non-idempotent types such as "
+#~ "Json[T]. warnings: How to handle "
+#~ "serialization errors. False/\"none\" ignores "
+#~ "them, True/\"warn\" logs errors,"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.hsgp_kwargs.HSGPKwargs.model_dump_json.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.hsgp_kwargs.HSGPKwargs.model_dump_json.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,83 +21,133 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.hsgp_kwargs.HSGPKwargs.model_dump_json.rst:2
-#: 3d039d2e4fdd4b8ebdde31f7c7fe5aa7
+#: ad50a7c6e13f4506a1ea2c68721145af
 msgid "HSGPKwargs.model\\_dump\\_json"
 msgstr ""
 
-#: 8718146ed96940bab1f82e78dcf19beb of
+#: 961006978f204c21a06130582e9af97f of
 #: pydantic.main.BaseModel.model_dump_json:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 4f7885792ec8469ba0596d52f4210c1f of
+#: 4a768c6417b649eda77e9912676e9c10 of
 #: pydantic.main.BaseModel.model_dump_json:3
-msgid "[`model_dump_json`](../concepts/serialization.md#modelmodel_dump_json)"
+msgid "[`model_dump_json`](../concepts/serialization.md#json-mode)"
 msgstr ""
 
-#: 5fdd9786116b40cfb9a8553e5d869e3a of
+#: 521c7dde323949148dad4b881e0d5ab8 of
 #: pydantic.main.BaseModel.model_dump_json:5
 msgid ""
 "Generates a JSON representation of the model using Pydantic's `to_json` "
 "method."
 msgstr ""
 
-#: b3f878df69c545d6a77e4edca5f42707 of
+#: d78a103546e748d395d93ed8ae51ded8 of
 #: pydantic.main.BaseModel.model_dump_json:7
 msgid "Args:"
 msgstr ""
 
-#: bc6a84e389f8439eb739eadc7dd29aba of
+#: 0aa86d2cf4ad46a894239afa04172415 of
 #: pydantic.main.BaseModel.model_dump_json:8
 msgid ""
 "indent: Indentation to use in the JSON output. If None is passed, the "
-"output will be compact. include: Field(s) to include in the JSON output. "
-"exclude: Field(s) to exclude from the JSON output. context: Additional "
-"context to pass to the serializer. by_alias: Whether to serialize using "
-"field aliases. exclude_unset: Whether to exclude fields that have not "
-"been explicitly set. exclude_defaults: Whether to exclude fields that are"
-" set to their default value. exclude_none: Whether to exclude fields that"
-" have a value of `None`. round_trip: If True, dumped values should be "
-"valid as input for non-idempotent types such as Json[T]. warnings: How to"
-" handle serialization errors. False/\"none\" ignores them, True/\"warn\" "
-"logs errors,"
+"output will be compact. ensure_ascii: If `True`, the output is guaranteed"
+" to have all incoming non-ASCII characters escaped."
 msgstr ""
 
-#: 1d0747a2f2444fa49e9006c112a71da1 of
-#: pydantic.main.BaseModel.model_dump_json:18
+#: f3d595ef47b247359513a3a12ffb3da0 of
+#: pydantic.main.BaseModel.model_dump_json:10
+msgid "If `False` (the default), these characters will be output as-is."
+msgstr ""
+
+#: 48db4a6cbafc432881fd2acb4fb9de3e of
+#: pydantic.main.BaseModel.model_dump_json:11
+msgid ""
+"include: Field(s) to include in the JSON output. exclude: Field(s) to "
+"exclude from the JSON output. context: Additional context to pass to the "
+"serializer. by_alias: Whether to serialize using field aliases. "
+"exclude_unset: Whether to exclude fields that have not been explicitly "
+"set. exclude_defaults: Whether to exclude fields that are set to their "
+"default value. exclude_none: Whether to exclude fields that have a value "
+"of `None`. exclude_computed_fields: Whether to exclude computed fields."
+msgstr ""
+
+#: f5113bfbcc224e0cbfa411014b84ac9e of
+#: pydantic.main.BaseModel.model_dump_json:19
+msgid ""
+"While this can be useful for round-tripping, it is usually recommended to"
+" use the dedicated `round_trip` parameter instead."
+msgstr ""
+
+#: a7749b018af04a71a5f3dadba9c135e3 of
+#: pydantic.main.BaseModel.model_dump_json:21
+msgid ""
+"round_trip: If True, dumped values should be valid as input for non-"
+"idempotent types such as Json[T]. warnings: How to handle serialization "
+"errors. False/\"none\" ignores them, True/\"warn\" logs errors,"
+msgstr ""
+
+#: 156493dbf44e41a3a03fb93e12c6ef78 of
+#: pydantic.main.BaseModel.model_dump_json:23
 msgid ""
 "\"error\" raises a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError]."
 msgstr ""
 
-#: 254b66497d4e426caabf8e35aa790858 of
-#: pydantic.main.BaseModel.model_dump_json:19
+#: 677252ddb06444cbb37c9f2a85d56987 of
+#: pydantic.main.BaseModel.model_dump_json:24
 msgid ""
 "fallback: A function to call when an unknown value is encountered. If not"
 " provided,"
 msgstr ""
 
-#: 516b3293393e45daa362e069a2ca542a of
-#: pydantic.main.BaseModel.model_dump_json:20
+#: fb948d9ee45640ce9abfd423f30ab229 of
+#: pydantic.main.BaseModel.model_dump_json:25
 msgid ""
 "a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError] "
 "error is raised."
 msgstr ""
 
-#: 035411daf1074eafa935ee00c42c2e24 of
-#: pydantic.main.BaseModel.model_dump_json:21
+#: af0569cef03a44f0be9dec1c7894476d of
+#: pydantic.main.BaseModel.model_dump_json:26
 msgid ""
 "serialize_as_any: Whether to serialize fields with duck-typing "
 "serialization behavior."
 msgstr ""
 
-#: a9ab3e330b3342a7a97cdd1e9087d182 of
-#: pydantic.main.BaseModel.model_dump_json:23
+#: 68f73750b79a4e52ab2316097a166d04 of
+#: pydantic.main.BaseModel.model_dump_json:28
 msgid "Returns:"
 msgstr ""
 
-#: df21963cf4954eb6912c50d32d2e2e9e of
-#: pydantic.main.BaseModel.model_dump_json:24
+#: 0cb01dc06c674ed5b027921a40b977ca of
+#: pydantic.main.BaseModel.model_dump_json:29
 msgid "A JSON string representation of the model."
 msgstr ""
+
+#~ msgid "[`model_dump_json`](../concepts/serialization.md#modelmodel_dump_json)"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "indent: Indentation to use in the "
+#~ "JSON output. If None is passed, "
+#~ "the output will be compact. include: "
+#~ "Field(s) to include in the JSON "
+#~ "output. exclude: Field(s) to exclude "
+#~ "from the JSON output. context: "
+#~ "Additional context to pass to the "
+#~ "serializer. by_alias: Whether to serialize "
+#~ "using field aliases. exclude_unset: Whether"
+#~ " to exclude fields that have not "
+#~ "been explicitly set. exclude_defaults: Whether"
+#~ " to exclude fields that are set "
+#~ "to their default value. exclude_none: "
+#~ "Whether to exclude fields that have "
+#~ "a value of `None`. round_trip: If "
+#~ "True, dumped values should be valid "
+#~ "as input for non-idempotent types "
+#~ "such as Json[T]. warnings: How to "
+#~ "handle serialization errors. False/\"none\" "
+#~ "ignores them, True/\"warn\" logs errors,"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.hsgp_kwargs.HSGPKwargs.model_json_schema.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.hsgp_kwargs.HSGPKwargs.model_json_schema.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,44 +21,77 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.hsgp_kwargs.HSGPKwargs.model_json_schema.rst:2
-#: 59880f1ec0e44b15851073dee746f5f6
+#: 41bf49d229fa49d0abab10a91d726d27
 msgid "HSGPKwargs.model\\_json\\_schema"
 msgstr ""
 
-#: bea10d547dd14975ae2ab865aa54e4d9 of
+#: c45c34389c5b403b9534558dd9c224de of
 #: pydantic.main.BaseModel.model_json_schema:2
 msgid "Generates a JSON schema for a model class."
 msgstr ""
 
-#: e8575db7c86b4a0e810e7f08355c8419 of
+#: 017ae0c6520c4470b74501a09b333110 of
 #: pydantic.main.BaseModel.model_json_schema:4
 msgid "Args:"
 msgstr ""
 
-#: 1103fbfd0d7f4da78675ded918b27e9e of
+#: f7d4e82e52ba4b819f20186cb5a69192 of
 #: pydantic.main.BaseModel.model_json_schema:5
 msgid ""
 "by_alias: Whether to use attribute aliases or not. ref_template: The "
-"reference template. schema_generator: To override the logic used to "
-"generate the JSON schema, as a subclass of"
+"reference template. union_format: The format to use when combining "
+"schemas from unions together. Can be one of:"
 msgstr ""
 
-#: aad25e414a7c4ff9a5a2296528616ae0 of
-#: pydantic.main.BaseModel.model_json_schema:8
+#: 17d2a1bb54d245f2888df6d33fa50143 of
+#: pydantic.main.BaseModel.model_json_schema:9
+msgid ""
+"`'any_of'`: Use the [`anyOf`](https://json-schema.org/understanding-json-"
+"schema/reference/combining#anyOf)"
+msgstr ""
+
+#: 83b4754c2968488c8ec45a50f684ddc1 of
+#: pydantic.main.BaseModel.model_json_schema:10
+msgid ""
+"keyword to combine schemas (the default). - `'primitive_type_array'`: Use"
+" the [`type`](https://json-schema.org/understanding-json-"
+"schema/reference/type) keyword as an array of strings, containing each "
+"type of the combination. If any of the schemas is not a primitive type "
+"(`string`, `boolean`, `null`, `integer` or `number`) or contains "
+"constraints/metadata, falls back to `any_of`."
+msgstr ""
+
+#: 9f00d2e22f5c4806b7c0c67f1457f35e of
+#: pydantic.main.BaseModel.model_json_schema:15
+msgid ""
+"schema_generator: To override the logic used to generate the JSON schema,"
+" as a subclass of"
+msgstr ""
+
+#: 9d383691668046adb2b554701ec045a8 of
+#: pydantic.main.BaseModel.model_json_schema:16
 msgid "`GenerateJsonSchema` with your desired modifications"
 msgstr ""
 
-#: 0baa99c44bb143ebb651e34dd59ea4fb of
-#: pydantic.main.BaseModel.model_json_schema:9
+#: 60bbe1fc3055496fbe8edc8f61ea933b of
+#: pydantic.main.BaseModel.model_json_schema:17
 msgid "mode: The mode in which to generate the schema."
 msgstr ""
 
-#: 55d002d7f9334200a2fd1a737c91ab5c of
-#: pydantic.main.BaseModel.model_json_schema:11
+#: d3e8a6d305dd4d7ab026181c499089db of
+#: pydantic.main.BaseModel.model_json_schema:19
 msgid "Returns:"
 msgstr ""
 
-#: 0019958be8c64740b3fb0d5f22cd7c5b of
-#: pydantic.main.BaseModel.model_json_schema:12
+#: 07aabbe1b07f4d3da3cc1a88a70cc117 of
+#: pydantic.main.BaseModel.model_json_schema:20
 msgid "The JSON schema for the given model class."
 msgstr ""
+
+#~ msgid ""
+#~ "by_alias: Whether to use attribute "
+#~ "aliases or not. ref_template: The "
+#~ "reference template. schema_generator: To "
+#~ "override the logic used to generate "
+#~ "the JSON schema, as a subclass of"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.hsgp_kwargs.HSGPKwargs.model_validate.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.hsgp_kwargs.HSGPKwargs.model_validate.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,21 +21,33 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.hsgp_kwargs.HSGPKwargs.model_validate.rst:2
-#: 40e58e1ba9844e1f822da9b256a96b07
+#: 74aadac296cb4793b18f17264743291c
 msgid "HSGPKwargs.model\\_validate"
 msgstr ""
 
-#: b640d93575f24b849f280d89b8142ed2 of pydantic.main.BaseModel.model_validate:2
+#: 5551b0fff013427aa888c68abf475ae4 of pydantic.main.BaseModel.model_validate:2
 msgid "Validate a pydantic model instance."
 msgstr ""
 
-#: 5b14b951b84d465a98a5b9ffda3081cf of pydantic.main.BaseModel.model_validate:4
+#: 00de75d87d364b5996dcb341cd854978 of pydantic.main.BaseModel.model_validate:4
 msgid "Args:"
 msgstr ""
 
-#: 73bec722d4a148a8aaa4735887e654e4 of pydantic.main.BaseModel.model_validate:5
+#: e6ec0a28ca924af1b69e6deab19f0f87 of pydantic.main.BaseModel.model_validate:5
 msgid ""
 "obj: The object to validate. strict: Whether to enforce types strictly. "
+"extra: Whether to ignore, allow, or forbid extra data during model "
+"validation."
+msgstr ""
+
+#: 1f18b5815ecf4bfb800eb865943a8084 of pydantic.main.BaseModel.model_validate:8
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: 418ebfb505ee4b20b445bf85f9d25a20 of pydantic.main.BaseModel.model_validate:9
+msgid ""
 "from_attributes: Whether to extract data from object attributes. context:"
 " Additional context to pass to the validator. by_alias: Whether to use "
 "the field's alias when validating against the provided input data. "
@@ -43,22 +55,35 @@ msgid ""
 "provided input data."
 msgstr ""
 
-#: 6a7d2a40ec60451fa9d4a0670568d53d of
-#: pydantic.main.BaseModel.model_validate:12
+#: a9a1c62933be452dbcdb91ed1a565568 of
+#: pydantic.main.BaseModel.model_validate:14
 msgid "Raises:"
 msgstr ""
 
-#: b9595e5e5f954f80a5135c1aec45b0d7 of
-#: pydantic.main.BaseModel.model_validate:13
+#: 2ca51b18650c4a6296437605e7476a61 of
+#: pydantic.main.BaseModel.model_validate:15
 msgid "ValidationError: If the object could not be validated."
 msgstr ""
 
-#: 06082728fbd345d5bf45f98d9d4cf864 of
-#: pydantic.main.BaseModel.model_validate:15
+#: 7b1954cb96314913938553480d1a62a0 of
+#: pydantic.main.BaseModel.model_validate:17
 msgid "Returns:"
 msgstr ""
 
-#: 42705116108c4759a97525c7e9d9f17e of
-#: pydantic.main.BaseModel.model_validate:16
+#: 51a34d75fdba4dd08637fbea00c60ba8 of
+#: pydantic.main.BaseModel.model_validate:18
 msgid "The validated model instance."
 msgstr ""
+
+#~ msgid ""
+#~ "obj: The object to validate. strict: "
+#~ "Whether to enforce types strictly. "
+#~ "from_attributes: Whether to extract data "
+#~ "from object attributes. context: Additional"
+#~ " context to pass to the validator."
+#~ " by_alias: Whether to use the field's"
+#~ " alias when validating against the "
+#~ "provided input data. by_name: Whether to"
+#~ " use the field's name when validating"
+#~ " against the provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.hsgp_kwargs.HSGPKwargs.model_validate_json.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.hsgp_kwargs.HSGPKwargs.model_validate_json.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,58 +21,84 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.hsgp_kwargs.HSGPKwargs.model_validate_json.rst:2
-#: fe24537e71644a6fade5530ae1643709
+#: 91e372238a754e94a13c326018e1bea2
 msgid "HSGPKwargs.model\\_validate\\_json"
 msgstr ""
 
-#: f96e2778ba7d44b8875de916c8d8ff9f of
+#: 57d10918ee3e4349bd04f3ca26d5972e of
 #: pydantic.main.BaseModel.model_validate_json:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 725098aa12d64e10bb6ce975005cedd8 of
+#: cf27797a5b794f96836c37cd2012217b of
 #: pydantic.main.BaseModel.model_validate_json:3
 msgid "[JSON Parsing](../concepts/json.md#json-parsing)"
 msgstr ""
 
-#: 2e32412e80304aca8016b5acd15423da of
+#: 68132b6f2b2c4ba787c49e3916163596 of
 #: pydantic.main.BaseModel.model_validate_json:5
 msgid "Validate the given JSON data against the Pydantic model."
 msgstr ""
 
-#: e86c4406dad74feda7c75a5d0eea229c of
+#: eff82820467f4f9b81ef6cbfa7446c8f of
 #: pydantic.main.BaseModel.model_validate_json:7
 msgid "Args:"
 msgstr ""
 
-#: 403d553bfbee4901bc9a275d99dd412f of
+#: a890ed1b3c3c4420b628d3c4d0899d00 of
 #: pydantic.main.BaseModel.model_validate_json:8
 msgid ""
 "json_data: The JSON data to validate. strict: Whether to enforce types "
-"strictly. context: Extra variables to pass to the validator. by_alias: "
-"Whether to use the field's alias when validating against the provided "
-"input data. by_name: Whether to use the field's name when validating "
-"against the provided input data."
+"strictly. extra: Whether to ignore, allow, or forbid extra data during "
+"model validation."
 msgstr ""
 
-#: d19c7598264f4a068ef9c3e17d872bc8 of
-#: pydantic.main.BaseModel.model_validate_json:14
+#: 54f594843eed4df0b1e692f975125d5e of
+#: pydantic.main.BaseModel.model_validate_json:11
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: 1921176d1e164db8ad6434d2573fa23a of
+#: pydantic.main.BaseModel.model_validate_json:12
+msgid ""
+"context: Extra variables to pass to the validator. by_alias: Whether to "
+"use the field's alias when validating against the provided input data. "
+"by_name: Whether to use the field's name when validating against the "
+"provided input data."
+msgstr ""
+
+#: 704f61e507ea4027b55e311b12172389 of
+#: pydantic.main.BaseModel.model_validate_json:16
 msgid "Returns:"
 msgstr ""
 
-#: 2611fc7162954b7485b93fd2aa5561a1 of
-#: pydantic.main.BaseModel.model_validate_json:15
+#: 932e0db61e3742018e27bf79e769f33a of
+#: pydantic.main.BaseModel.model_validate_json:17
 msgid "The validated Pydantic model."
 msgstr ""
 
-#: 9485094a7f0440498c6a4cc5efd2f2b3 of
-#: pydantic.main.BaseModel.model_validate_json:17
+#: ca2c00681b21460dae931c2aa1291fb2 of
+#: pydantic.main.BaseModel.model_validate_json:19
 msgid "Raises:"
 msgstr ""
 
-#: c860647d47364293870dbf3e0fa14f84 of
-#: pydantic.main.BaseModel.model_validate_json:18
+#: 9f4b198c770f416c932e00278c60a171 of
+#: pydantic.main.BaseModel.model_validate_json:20
 msgid ""
 "ValidationError: If `json_data` is not a JSON string or the object could "
 "not be validated."
 msgstr ""
+
+#~ msgid ""
+#~ "json_data: The JSON data to validate."
+#~ " strict: Whether to enforce types "
+#~ "strictly. context: Extra variables to "
+#~ "pass to the validator. by_alias: Whether"
+#~ " to use the field's alias when "
+#~ "validating against the provided input "
+#~ "data. by_name: Whether to use the "
+#~ "field's name when validating against the"
+#~ " provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.hsgp_kwargs.HSGPKwargs.model_validate_strings.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.hsgp_kwargs.HSGPKwargs.model_validate_strings.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,36 +21,62 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.hsgp_kwargs.HSGPKwargs.model_validate_strings.rst:2
-#: b2f2c41c3519448f919521d678a752aa
+#: 9d415366631e40279ec60867c2199df5
 msgid "HSGPKwargs.model\\_validate\\_strings"
 msgstr ""
 
-#: d6cba62bba17424c869bfeaf850cda4c of
+#: d0254f826705478ebc68d42a300c98da of
 #: pydantic.main.BaseModel.model_validate_strings:2
 msgid "Validate the given object with string data against the Pydantic model."
 msgstr ""
 
-#: f85f71bb18734b1fafcfcba7873650f6 of
+#: c8f03bb7ecd440d4aa8e1a1031ebe602 of
 #: pydantic.main.BaseModel.model_validate_strings:4
 msgid "Args:"
 msgstr ""
 
-#: 833151a27a5d4c1b993f520f9043ed3a of
+#: 702d6d2a50eb4308a7552b5911f46f56 of
 #: pydantic.main.BaseModel.model_validate_strings:5
 msgid ""
 "obj: The object containing string data to validate. strict: Whether to "
-"enforce types strictly. context: Extra variables to pass to the "
-"validator. by_alias: Whether to use the field's alias when validating "
-"against the provided input data. by_name: Whether to use the field's name"
-" when validating against the provided input data."
+"enforce types strictly. extra: Whether to ignore, allow, or forbid extra "
+"data during model validation."
 msgstr ""
 
-#: b008aec0d16844828bc891bfd1914936 of
-#: pydantic.main.BaseModel.model_validate_strings:11
+#: 544eaa6914b94ae394bdab89790afe8f of
+#: pydantic.main.BaseModel.model_validate_strings:8
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: b10b2d8f7c004a20a564951a83a7295e of
+#: pydantic.main.BaseModel.model_validate_strings:9
+msgid ""
+"context: Extra variables to pass to the validator. by_alias: Whether to "
+"use the field's alias when validating against the provided input data. "
+"by_name: Whether to use the field's name when validating against the "
+"provided input data."
+msgstr ""
+
+#: 1a46caaca41d4aacb9afc580b62ca4c3 of
+#: pydantic.main.BaseModel.model_validate_strings:13
 msgid "Returns:"
 msgstr ""
 
-#: b11b64e52836447983fe1f2d8ad207ec of
-#: pydantic.main.BaseModel.model_validate_strings:12
+#: 401f740c866b4f56abf0a9c8748c2c1a of
+#: pydantic.main.BaseModel.model_validate_strings:14
 msgid "The validated Pydantic model."
 msgstr ""
+
+#~ msgid ""
+#~ "obj: The object containing string data"
+#~ " to validate. strict: Whether to "
+#~ "enforce types strictly. context: Extra "
+#~ "variables to pass to the validator. "
+#~ "by_alias: Whether to use the field's "
+#~ "alias when validating against the "
+#~ "provided input data. by_name: Whether to"
+#~ " use the field's name when validating"
+#~ " against the provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.additive_effect.EventAdditiveEffect.model_copy.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.additive_effect.EventAdditiveEffect.model_copy.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,27 +21,27 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.additive_effect.EventAdditiveEffect.model_copy.rst:2
-#: 0143ee49caa946abae17f20c6e788f2f
+#: 446499f633604e24a876dc660d421a4a
 msgid "EventAdditiveEffect.model\\_copy"
 msgstr ""
 
-#: 47bd3fe246a8445b92bf5b4611becfbf of pydantic.main.BaseModel.model_copy:2
+#: 258be161dac14d37bbf4fde6a99413b0 of pydantic.main.BaseModel.model_copy:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 77f9a685b4be41a1a9ef1761671b99fd of pydantic.main.BaseModel.model_copy:3
-msgid "[`model_copy`](../concepts/serialization.md#model_copy)"
+#: 2f8ab4e364e74d21a5b51b01fb0abbc9 of pydantic.main.BaseModel.model_copy:3
+msgid "[`model_copy`](../concepts/models.md#model-copy)"
 msgstr ""
 
-#: 5cf6161e08264962837483c9a1370efb of pydantic.main.BaseModel.model_copy:5
+#: a9832074b4f94b088b09b2cf00bc3938 of pydantic.main.BaseModel.model_copy:5
 msgid "Returns a copy of the model."
 msgstr ""
 
-#: fa03c71adda145b28436aedb8883c44d of pydantic.main.BaseModel.model_copy:7
+#: e8fdcb7f00474d5599d4abfe1a8d4226 of pydantic.main.BaseModel.model_copy:7
 msgid "!!! note"
 msgstr ""
 
-#: 35ab8ff4b2eb4cb8ba4735ff9ade0cb0 of pydantic.main.BaseModel.model_copy:8
+#: d6fde3c57cc14c08b0f839b05f47a755 of pydantic.main.BaseModel.model_copy:8
 msgid ""
 "The underlying instance's [`__dict__`][object.__dict__] attribute is "
 "copied. This might have unexpected side effects if you store anything in "
@@ -49,28 +49,31 @@ msgid ""
 "properties][functools.cached_property])."
 msgstr ""
 
-#: 86075a8ee90c42d38fe845900559cfe4 of pydantic.main.BaseModel.model_copy:12
+#: a05287ef30554aa28423de650a4a209a of pydantic.main.BaseModel.model_copy:12
 msgid "Args:"
 msgstr ""
 
-#: ae5694999b664852875712e05394e176 of pydantic.main.BaseModel.model_copy:13
+#: 081a332dafb044c3bbe90cea8796c2d8 of pydantic.main.BaseModel.model_copy:13
 msgid ""
 "update: Values to change/add in the new model. Note: the data is not "
 "validated"
 msgstr ""
 
-#: f4fb7716d06145eb8bdf87ebd5de91b1 of pydantic.main.BaseModel.model_copy:14
+#: a3f07c6addfa4eeeb99f287302418f85 of pydantic.main.BaseModel.model_copy:14
 msgid "before creating the new model. You should trust this data."
 msgstr ""
 
-#: 571a7411f8d04e0c9f08202d3ae02461 of pydantic.main.BaseModel.model_copy:15
+#: 1a5cc202059047d48bb6e7469da56e56 of pydantic.main.BaseModel.model_copy:15
 msgid "deep: Set to `True` to make a deep copy of the model."
 msgstr ""
 
-#: f94f8f6462514c89ab194009420c5a53 of pydantic.main.BaseModel.model_copy:17
+#: 3fc69505230840d883038cb3cab96fd9 of pydantic.main.BaseModel.model_copy:17
 msgid "Returns:"
 msgstr ""
 
-#: 4fb4aec8a5d44bd29dd7017a7485bd89 of pydantic.main.BaseModel.model_copy:18
+#: 95cdf908c15146d5a8a13dcf7fb9a19d of pydantic.main.BaseModel.model_copy:18
 msgid "New model instance."
 msgstr ""
+
+#~ msgid "[`model_copy`](../concepts/serialization.md#model_copy)"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.additive_effect.EventAdditiveEffect.model_dump.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.additive_effect.EventAdditiveEffect.model_dump.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,40 +21,40 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.additive_effect.EventAdditiveEffect.model_dump.rst:2
-#: 67bfaeb8a64145f0b507155aa74234e2
+#: 841eac559c0542c2a0a9db7211dd2e4c
 msgid "EventAdditiveEffect.model\\_dump"
 msgstr ""
 
-#: ed1bda8027194b17b6d65e66a86e1b80 of pydantic.main.BaseModel.model_dump:2
+#: 1c49409b7f84441795d7c134596c3d8e of pydantic.main.BaseModel.model_dump:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: b387fc3d0eb940bf9c34aabe80796a73 of pydantic.main.BaseModel.model_dump:3
-msgid "[`model_dump`](../concepts/serialization.md#modelmodel_dump)"
+#: cb39d271b0c24036abbc4849315dbf1d of pydantic.main.BaseModel.model_dump:3
+msgid "[`model_dump`](../concepts/serialization.md#python-mode)"
 msgstr ""
 
-#: d2a319717a80475682f25b57790513a8 of pydantic.main.BaseModel.model_dump:5
+#: ed013598bc0144f38cb02407c128c9f7 of pydantic.main.BaseModel.model_dump:5
 msgid ""
 "Generate a dictionary representation of the model, optionally specifying "
 "which fields to include or exclude."
 msgstr ""
 
-#: 67d977cd3ec444549095202c54ff0790 of pydantic.main.BaseModel.model_dump:7
+#: 2d42b678e2e445258d5cda82ea20f525 of pydantic.main.BaseModel.model_dump:7
 msgid "Args:"
 msgstr ""
 
-#: 3174a668d9ea4793a6829296b9565ad7 of pydantic.main.BaseModel.model_dump:8
+#: 071ee07939374486ae6789b059edf32f of pydantic.main.BaseModel.model_dump:8
 msgid "mode: The mode in which `to_python` should run."
 msgstr ""
 
-#: e41b9204d3b746fabb8a35f2a5be32ad of pydantic.main.BaseModel.model_dump:9
+#: fea918104dbe4ec795a8ddc7b0a0ec42 of pydantic.main.BaseModel.model_dump:9
 msgid ""
 "If mode is 'json', the output will only contain JSON serializable types. "
 "If mode is 'python', the output may contain non-JSON-serializable Python "
 "objects."
 msgstr ""
 
-#: 95518870ad4743b49f5d494031ab5d47 of pydantic.main.BaseModel.model_dump:11
+#: c587407a854f450d8ccc36f965472abc of pydantic.main.BaseModel.model_dump:11
 msgid ""
 "include: A set of fields to include in the output. exclude: A set of "
 "fields to exclude from the output. context: Additional context to pass to"
@@ -62,41 +62,77 @@ msgid ""
 "dictionary key if defined. exclude_unset: Whether to exclude fields that "
 "have not been explicitly set. exclude_defaults: Whether to exclude fields"
 " that are set to their default value. exclude_none: Whether to exclude "
-"fields that have a value of `None`. round_trip: If True, dumped values "
-"should be valid as input for non-idempotent types such as Json[T]. "
-"warnings: How to handle serialization errors. False/\"none\" ignores "
-"them, True/\"warn\" logs errors,"
+"fields that have a value of `None`. exclude_computed_fields: Whether to "
+"exclude computed fields."
 msgstr ""
 
-#: 593e840a83c44de5b9652ef773697f36 of pydantic.main.BaseModel.model_dump:20
+#: b38222fc5bb34dbeb8df0d929b0bb769 of pydantic.main.BaseModel.model_dump:19
+msgid ""
+"While this can be useful for round-tripping, it is usually recommended tu"
+" use the dedicated `round_trip` parameter instead."
+msgstr ""
+
+#: 38921fa2e7b447dda2a80e59d3d39a9a of pydantic.main.BaseModel.model_dump:21
+msgid ""
+"round_trip: If True, dumped values should be valid as input for non-"
+"idempotent types such as Json[T]. warnings: How to handle serialization "
+"errors. False/\"none\" ignores them, True/\"warn\" logs errors,"
+msgstr ""
+
+#: 1606635973de4926baabbde153d32c18 of pydantic.main.BaseModel.model_dump:23
 msgid ""
 "\"error\" raises a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError]."
 msgstr ""
 
-#: ffb687ecf9a8444c828188cae01e920f of pydantic.main.BaseModel.model_dump:21
+#: 05bdf02a216b48fc81b235d66e33639f of pydantic.main.BaseModel.model_dump:24
 msgid ""
 "fallback: A function to call when an unknown value is encountered. If not"
 " provided,"
 msgstr ""
 
-#: ae0552a2e56b4ec8bba8045ccbb8061a of pydantic.main.BaseModel.model_dump:22
+#: 3b4e01cfa9d64c1ea50a1f1eb42eea36 of pydantic.main.BaseModel.model_dump:25
 msgid ""
 "a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError] "
 "error is raised."
 msgstr ""
 
-#: 55ce7b86551c41e895a0d7fca1aeea09 of pydantic.main.BaseModel.model_dump:23
+#: e691d983322d4083ac2c7254c8d75c98 of pydantic.main.BaseModel.model_dump:26
 msgid ""
 "serialize_as_any: Whether to serialize fields with duck-typing "
 "serialization behavior."
 msgstr ""
 
-#: 1f55b34af4fd4fb8a68c77ffe4ca80ae of pydantic.main.BaseModel.model_dump:25
+#: 100b32c628234aa59bed7bfd418f9e14 of pydantic.main.BaseModel.model_dump:28
 msgid "Returns:"
 msgstr ""
 
-#: f2811e42e85643ac8369d4c81f93ede6 of pydantic.main.BaseModel.model_dump:26
+#: 8351ca3d453c4733b718babb8caa77dd of pydantic.main.BaseModel.model_dump:29
 msgid "A dictionary representation of the model."
 msgstr ""
+
+#~ msgid "[`model_dump`](../concepts/serialization.md#modelmodel_dump)"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "include: A set of fields to "
+#~ "include in the output. exclude: A "
+#~ "set of fields to exclude from the"
+#~ " output. context: Additional context to "
+#~ "pass to the serializer. by_alias: "
+#~ "Whether to use the field's alias "
+#~ "in the dictionary key if defined. "
+#~ "exclude_unset: Whether to exclude fields "
+#~ "that have not been explicitly set. "
+#~ "exclude_defaults: Whether to exclude fields"
+#~ " that are set to their default "
+#~ "value. exclude_none: Whether to exclude "
+#~ "fields that have a value of "
+#~ "`None`. round_trip: If True, dumped "
+#~ "values should be valid as input "
+#~ "for non-idempotent types such as "
+#~ "Json[T]. warnings: How to handle "
+#~ "serialization errors. False/\"none\" ignores "
+#~ "them, True/\"warn\" logs errors,"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.additive_effect.EventAdditiveEffect.model_dump_json.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.additive_effect.EventAdditiveEffect.model_dump_json.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,83 +21,133 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.additive_effect.EventAdditiveEffect.model_dump_json.rst:2
-#: 058607caaa71424c9ec75da5d03d0fc3
+#: 27037370a5da41c5b1a6ec9069f07257
 msgid "EventAdditiveEffect.model\\_dump\\_json"
 msgstr ""
 
-#: 86944ae013a54849940ea0033dedc108 of
+#: 5f6d0e6264124d2dadbebf987f8818c2 of
 #: pydantic.main.BaseModel.model_dump_json:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 7987cc1864ed4da68108f278999b02f5 of
+#: c31e62f5f0264c61b9c3493c03fed964 of
 #: pydantic.main.BaseModel.model_dump_json:3
-msgid "[`model_dump_json`](../concepts/serialization.md#modelmodel_dump_json)"
+msgid "[`model_dump_json`](../concepts/serialization.md#json-mode)"
 msgstr ""
 
-#: 120230152a37408e87abd41f24d55778 of
+#: 67174b54841541e288867c3ae25d2e0a of
 #: pydantic.main.BaseModel.model_dump_json:5
 msgid ""
 "Generates a JSON representation of the model using Pydantic's `to_json` "
 "method."
 msgstr ""
 
-#: fcdbbdf918d34e6dbd995e30cf33be0f of
+#: b92df006e0364c09b82f48a1064fffc3 of
 #: pydantic.main.BaseModel.model_dump_json:7
 msgid "Args:"
 msgstr ""
 
-#: 13b692140f9b4926b3d7e2289b53bc92 of
+#: 4c1814f201784672839ca8c72e83ffc1 of
 #: pydantic.main.BaseModel.model_dump_json:8
 msgid ""
 "indent: Indentation to use in the JSON output. If None is passed, the "
-"output will be compact. include: Field(s) to include in the JSON output. "
-"exclude: Field(s) to exclude from the JSON output. context: Additional "
-"context to pass to the serializer. by_alias: Whether to serialize using "
-"field aliases. exclude_unset: Whether to exclude fields that have not "
-"been explicitly set. exclude_defaults: Whether to exclude fields that are"
-" set to their default value. exclude_none: Whether to exclude fields that"
-" have a value of `None`. round_trip: If True, dumped values should be "
-"valid as input for non-idempotent types such as Json[T]. warnings: How to"
-" handle serialization errors. False/\"none\" ignores them, True/\"warn\" "
-"logs errors,"
+"output will be compact. ensure_ascii: If `True`, the output is guaranteed"
+" to have all incoming non-ASCII characters escaped."
 msgstr ""
 
-#: e9fee04807c44b7dbcafe78311a54d62 of
-#: pydantic.main.BaseModel.model_dump_json:18
+#: 0f0df63037dc4671a7e7cee3438dac20 of
+#: pydantic.main.BaseModel.model_dump_json:10
+msgid "If `False` (the default), these characters will be output as-is."
+msgstr ""
+
+#: e384a71f83b8402ca5cd5214ddd066a0 of
+#: pydantic.main.BaseModel.model_dump_json:11
+msgid ""
+"include: Field(s) to include in the JSON output. exclude: Field(s) to "
+"exclude from the JSON output. context: Additional context to pass to the "
+"serializer. by_alias: Whether to serialize using field aliases. "
+"exclude_unset: Whether to exclude fields that have not been explicitly "
+"set. exclude_defaults: Whether to exclude fields that are set to their "
+"default value. exclude_none: Whether to exclude fields that have a value "
+"of `None`. exclude_computed_fields: Whether to exclude computed fields."
+msgstr ""
+
+#: 14bc50ec0f504b468ecc438b7fc0c943 of
+#: pydantic.main.BaseModel.model_dump_json:19
+msgid ""
+"While this can be useful for round-tripping, it is usually recommended to"
+" use the dedicated `round_trip` parameter instead."
+msgstr ""
+
+#: 34c71ac5c828415a9512a6f50ff7ea5c of
+#: pydantic.main.BaseModel.model_dump_json:21
+msgid ""
+"round_trip: If True, dumped values should be valid as input for non-"
+"idempotent types such as Json[T]. warnings: How to handle serialization "
+"errors. False/\"none\" ignores them, True/\"warn\" logs errors,"
+msgstr ""
+
+#: 026ca2cffc3e40cc85bd7fd413a9185b of
+#: pydantic.main.BaseModel.model_dump_json:23
 msgid ""
 "\"error\" raises a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError]."
 msgstr ""
 
-#: 98a3c06e19ce4a6fa68410fcea63d042 of
-#: pydantic.main.BaseModel.model_dump_json:19
+#: fa3fb9878ca64966a9afcfefd933866b of
+#: pydantic.main.BaseModel.model_dump_json:24
 msgid ""
 "fallback: A function to call when an unknown value is encountered. If not"
 " provided,"
 msgstr ""
 
-#: 62e3904ac9634dd4b981fcd9608004f7 of
-#: pydantic.main.BaseModel.model_dump_json:20
+#: 6f05324f18a4435486c979f253ce5c49 of
+#: pydantic.main.BaseModel.model_dump_json:25
 msgid ""
 "a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError] "
 "error is raised."
 msgstr ""
 
-#: 25fd0f69ed03440bb2113f9f1fce57a6 of
-#: pydantic.main.BaseModel.model_dump_json:21
+#: 9d7c9e5ff3214255941328084041618c of
+#: pydantic.main.BaseModel.model_dump_json:26
 msgid ""
 "serialize_as_any: Whether to serialize fields with duck-typing "
 "serialization behavior."
 msgstr ""
 
-#: 72e2d2c71d224fef8cc06e18736a3d2b of
-#: pydantic.main.BaseModel.model_dump_json:23
+#: 67643595abc24281a4c2f19e0c4f795b of
+#: pydantic.main.BaseModel.model_dump_json:28
 msgid "Returns:"
 msgstr ""
 
-#: c4caf9e47c254fe086fe48b9c7e85953 of
-#: pydantic.main.BaseModel.model_dump_json:24
+#: ee273861eebd4661b7a04f5de74582dd of
+#: pydantic.main.BaseModel.model_dump_json:29
 msgid "A JSON string representation of the model."
 msgstr ""
+
+#~ msgid "[`model_dump_json`](../concepts/serialization.md#modelmodel_dump_json)"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "indent: Indentation to use in the "
+#~ "JSON output. If None is passed, "
+#~ "the output will be compact. include: "
+#~ "Field(s) to include in the JSON "
+#~ "output. exclude: Field(s) to exclude "
+#~ "from the JSON output. context: "
+#~ "Additional context to pass to the "
+#~ "serializer. by_alias: Whether to serialize "
+#~ "using field aliases. exclude_unset: Whether"
+#~ " to exclude fields that have not "
+#~ "been explicitly set. exclude_defaults: Whether"
+#~ " to exclude fields that are set "
+#~ "to their default value. exclude_none: "
+#~ "Whether to exclude fields that have "
+#~ "a value of `None`. round_trip: If "
+#~ "True, dumped values should be valid "
+#~ "as input for non-idempotent types "
+#~ "such as Json[T]. warnings: How to "
+#~ "handle serialization errors. False/\"none\" "
+#~ "ignores them, True/\"warn\" logs errors,"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.additive_effect.EventAdditiveEffect.model_json_schema.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.additive_effect.EventAdditiveEffect.model_json_schema.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,44 +21,77 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.additive_effect.EventAdditiveEffect.model_json_schema.rst:2
-#: 2d6220a4f90e4011b08f56b36f2ba1ca
+#: 801c474cfb0a4f44a1d433824c086abe
 msgid "EventAdditiveEffect.model\\_json\\_schema"
 msgstr ""
 
-#: b99aeac76f3442068bc2b647cc920849 of
+#: 8c6d16b7b3994a7d911eb2b8f5c58a04 of
 #: pydantic.main.BaseModel.model_json_schema:2
 msgid "Generates a JSON schema for a model class."
 msgstr ""
 
-#: beb8de7ea8e646e8857bd3facb0b0f87 of
+#: 33b600f26e4443489314f169c6b40667 of
 #: pydantic.main.BaseModel.model_json_schema:4
 msgid "Args:"
 msgstr ""
 
-#: d7d23b56a1ec4cf29084612ba683a936 of
+#: 194937e6f7dd4da999b62b68e8a9b64c of
 #: pydantic.main.BaseModel.model_json_schema:5
 msgid ""
 "by_alias: Whether to use attribute aliases or not. ref_template: The "
-"reference template. schema_generator: To override the logic used to "
-"generate the JSON schema, as a subclass of"
+"reference template. union_format: The format to use when combining "
+"schemas from unions together. Can be one of:"
 msgstr ""
 
-#: 9c52cca806da40a88c6f3ba58f8ddb55 of
-#: pydantic.main.BaseModel.model_json_schema:8
+#: dd483f14c42b4e1fafd55f76b9c14d45 of
+#: pydantic.main.BaseModel.model_json_schema:9
+msgid ""
+"`'any_of'`: Use the [`anyOf`](https://json-schema.org/understanding-json-"
+"schema/reference/combining#anyOf)"
+msgstr ""
+
+#: 46cff79bfc4c458bb7cf7ad39456815d of
+#: pydantic.main.BaseModel.model_json_schema:10
+msgid ""
+"keyword to combine schemas (the default). - `'primitive_type_array'`: Use"
+" the [`type`](https://json-schema.org/understanding-json-"
+"schema/reference/type) keyword as an array of strings, containing each "
+"type of the combination. If any of the schemas is not a primitive type "
+"(`string`, `boolean`, `null`, `integer` or `number`) or contains "
+"constraints/metadata, falls back to `any_of`."
+msgstr ""
+
+#: 0838212da9e14a638daae8d0b129e844 of
+#: pydantic.main.BaseModel.model_json_schema:15
+msgid ""
+"schema_generator: To override the logic used to generate the JSON schema,"
+" as a subclass of"
+msgstr ""
+
+#: 6e6ec50b2f974184a888c2b83a0215a0 of
+#: pydantic.main.BaseModel.model_json_schema:16
 msgid "`GenerateJsonSchema` with your desired modifications"
 msgstr ""
 
-#: 249d462c9772461f8ed6ae8a1d32536a of
-#: pydantic.main.BaseModel.model_json_schema:9
+#: 6c85af49b2974a85a0012e1ba2f4bfb9 of
+#: pydantic.main.BaseModel.model_json_schema:17
 msgid "mode: The mode in which to generate the schema."
 msgstr ""
 
-#: 220ca8400c7c40b2b5f5a95436b55528 of
-#: pydantic.main.BaseModel.model_json_schema:11
+#: 3a37a3dad7ed498faa4a5ffcc63ca58a of
+#: pydantic.main.BaseModel.model_json_schema:19
 msgid "Returns:"
 msgstr ""
 
-#: e52ecde4a2fc408c8a3a0dd2c4240c62 of
-#: pydantic.main.BaseModel.model_json_schema:12
+#: 606a936479374316acbd750fc4f427ee of
+#: pydantic.main.BaseModel.model_json_schema:20
 msgid "The JSON schema for the given model class."
 msgstr ""
+
+#~ msgid ""
+#~ "by_alias: Whether to use attribute "
+#~ "aliases or not. ref_template: The "
+#~ "reference template. schema_generator: To "
+#~ "override the logic used to generate "
+#~ "the JSON schema, as a subclass of"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.additive_effect.EventAdditiveEffect.model_validate.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.additive_effect.EventAdditiveEffect.model_validate.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,21 +21,33 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.additive_effect.EventAdditiveEffect.model_validate.rst:2
-#: 20c2025c4a074f4d8ab5c6acd0ef5cc0
+#: cb9ce3c1ee3d4be5bc9b915e37b3aacf
 msgid "EventAdditiveEffect.model\\_validate"
 msgstr ""
 
-#: 6f25aa1bbd6b4408ac1b2591369330d5 of pydantic.main.BaseModel.model_validate:2
+#: 37f4674ed3d341cb861134f8da497955 of pydantic.main.BaseModel.model_validate:2
 msgid "Validate a pydantic model instance."
 msgstr ""
 
-#: be6043e9335e43c4a87e3e1bf0231305 of pydantic.main.BaseModel.model_validate:4
+#: b5b3c0eea2a84560b36e2ffdebe2feaa of pydantic.main.BaseModel.model_validate:4
 msgid "Args:"
 msgstr ""
 
-#: f2cc61f7b8c840be86929039f69fb7c0 of pydantic.main.BaseModel.model_validate:5
+#: a0ac959f09ac4845a61bc77cd668b061 of pydantic.main.BaseModel.model_validate:5
 msgid ""
 "obj: The object to validate. strict: Whether to enforce types strictly. "
+"extra: Whether to ignore, allow, or forbid extra data during model "
+"validation."
+msgstr ""
+
+#: 54e98a0142ee43b29b0fcb55f6c6a8f7 of pydantic.main.BaseModel.model_validate:8
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: 5c0838bcd59a48f5b9cc8bbb238bc08e of pydantic.main.BaseModel.model_validate:9
+msgid ""
 "from_attributes: Whether to extract data from object attributes. context:"
 " Additional context to pass to the validator. by_alias: Whether to use "
 "the field's alias when validating against the provided input data. "
@@ -43,22 +55,35 @@ msgid ""
 "provided input data."
 msgstr ""
 
-#: 526eaaf9c32142ff98188cdee2814532 of
-#: pydantic.main.BaseModel.model_validate:12
+#: c5d3af63e24d4920babe0ed755900e74 of
+#: pydantic.main.BaseModel.model_validate:14
 msgid "Raises:"
 msgstr ""
 
-#: c3bca9a38f89401b92f7048dfce9c8fd of
-#: pydantic.main.BaseModel.model_validate:13
+#: 226268f677cb46748a470fbd7373730e of
+#: pydantic.main.BaseModel.model_validate:15
 msgid "ValidationError: If the object could not be validated."
 msgstr ""
 
-#: a3018c8261ab4ef1afcbb2c5aa9871dc of
-#: pydantic.main.BaseModel.model_validate:15
+#: 5c04816c29284a61b49ca1c3fd6dcfd8 of
+#: pydantic.main.BaseModel.model_validate:17
 msgid "Returns:"
 msgstr ""
 
-#: 64f22752654a4eb98f19c460daa00d72 of
-#: pydantic.main.BaseModel.model_validate:16
+#: 5fc88b83bde44fdca2bbed0ef8750ae7 of
+#: pydantic.main.BaseModel.model_validate:18
 msgid "The validated model instance."
 msgstr ""
+
+#~ msgid ""
+#~ "obj: The object to validate. strict: "
+#~ "Whether to enforce types strictly. "
+#~ "from_attributes: Whether to extract data "
+#~ "from object attributes. context: Additional"
+#~ " context to pass to the validator."
+#~ " by_alias: Whether to use the field's"
+#~ " alias when validating against the "
+#~ "provided input data. by_name: Whether to"
+#~ " use the field's name when validating"
+#~ " against the provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.additive_effect.EventAdditiveEffect.model_validate_json.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.additive_effect.EventAdditiveEffect.model_validate_json.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,58 +21,84 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.additive_effect.EventAdditiveEffect.model_validate_json.rst:2
-#: 66b5183dce6a4d3e9bf4d6c3945fa371
+#: 8da191ea78e24b3ebc529e285b9dba73
 msgid "EventAdditiveEffect.model\\_validate\\_json"
 msgstr ""
 
-#: aefe6148321342e78d35056a0de75d22 of
+#: 6d0a14cde3064795bfcc4822dd52ddc2 of
 #: pydantic.main.BaseModel.model_validate_json:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 42b669242cd245c9af0c3af6faa5fcd8 of
+#: b1f960144e9e4ea78bed01dcf4475589 of
 #: pydantic.main.BaseModel.model_validate_json:3
 msgid "[JSON Parsing](../concepts/json.md#json-parsing)"
 msgstr ""
 
-#: a98a922b6b4041779bfa715f90cfd018 of
+#: 61626ceb70e4409288e3f88900fb08f7 of
 #: pydantic.main.BaseModel.model_validate_json:5
 msgid "Validate the given JSON data against the Pydantic model."
 msgstr ""
 
-#: 68aaf61d2aee47099e3c04dbf8c858db of
+#: fa58a3113629404086d05b6afab3a0d4 of
 #: pydantic.main.BaseModel.model_validate_json:7
 msgid "Args:"
 msgstr ""
 
-#: 236d3f1f10634cfa9b6eb3efa3871f94 of
+#: 232f515088fd41a9899ca1be2f342f2e of
 #: pydantic.main.BaseModel.model_validate_json:8
 msgid ""
 "json_data: The JSON data to validate. strict: Whether to enforce types "
-"strictly. context: Extra variables to pass to the validator. by_alias: "
-"Whether to use the field's alias when validating against the provided "
-"input data. by_name: Whether to use the field's name when validating "
-"against the provided input data."
+"strictly. extra: Whether to ignore, allow, or forbid extra data during "
+"model validation."
 msgstr ""
 
-#: a52cde70d8de40da899ca930bb95e610 of
-#: pydantic.main.BaseModel.model_validate_json:14
+#: 41d318b18378437eb7b6c3df8edd1034 of
+#: pydantic.main.BaseModel.model_validate_json:11
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: 5e3a99fd517a4d468a56e586808ceb3d of
+#: pydantic.main.BaseModel.model_validate_json:12
+msgid ""
+"context: Extra variables to pass to the validator. by_alias: Whether to "
+"use the field's alias when validating against the provided input data. "
+"by_name: Whether to use the field's name when validating against the "
+"provided input data."
+msgstr ""
+
+#: 4311e890dcfe4967bb2e51a348384a46 of
+#: pydantic.main.BaseModel.model_validate_json:16
 msgid "Returns:"
 msgstr ""
 
-#: d9bef9e4eb674fb6b048287ab3315e60 of
-#: pydantic.main.BaseModel.model_validate_json:15
+#: 0a0189994c3343c3b8b05e52eefa9d43 of
+#: pydantic.main.BaseModel.model_validate_json:17
 msgid "The validated Pydantic model."
 msgstr ""
 
-#: e4ed3b4e599946dfa6de36a478fca088 of
-#: pydantic.main.BaseModel.model_validate_json:17
+#: 2002c4270a454181bdb765a0c26fd82f of
+#: pydantic.main.BaseModel.model_validate_json:19
 msgid "Raises:"
 msgstr ""
 
-#: 068939a71e2f43788fd96ba525a543f9 of
-#: pydantic.main.BaseModel.model_validate_json:18
+#: 7e82a31baf4b4f7d9b9c17fbc05c2baa of
+#: pydantic.main.BaseModel.model_validate_json:20
 msgid ""
 "ValidationError: If `json_data` is not a JSON string or the object could "
 "not be validated."
 msgstr ""
+
+#~ msgid ""
+#~ "json_data: The JSON data to validate."
+#~ " strict: Whether to enforce types "
+#~ "strictly. context: Extra variables to "
+#~ "pass to the validator. by_alias: Whether"
+#~ " to use the field's alias when "
+#~ "validating against the provided input "
+#~ "data. by_name: Whether to use the "
+#~ "field's name when validating against the"
+#~ " provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.additive_effect.EventAdditiveEffect.model_validate_strings.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.additive_effect.EventAdditiveEffect.model_validate_strings.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,36 +21,62 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.additive_effect.EventAdditiveEffect.model_validate_strings.rst:2
-#: 2a8507bb2c754ad59a08df5a69d7ecd9
+#: ac524212fc0b471d94cb9f2e586e9a80
 msgid "EventAdditiveEffect.model\\_validate\\_strings"
 msgstr ""
 
-#: fb48df99648d4bdbb71c22229426785d of
+#: cc559fe13e7a401d8aec174250ef6dee of
 #: pydantic.main.BaseModel.model_validate_strings:2
 msgid "Validate the given object with string data against the Pydantic model."
 msgstr ""
 
-#: e71834c72ecb403997713710deb9c152 of
+#: ec523d0120e44c13b318132c38e03e7d of
 #: pydantic.main.BaseModel.model_validate_strings:4
 msgid "Args:"
 msgstr ""
 
-#: c2165b4253904d329216b2d12a48b032 of
+#: 1c0527572f8248efa61a620776a43003 of
 #: pydantic.main.BaseModel.model_validate_strings:5
 msgid ""
 "obj: The object containing string data to validate. strict: Whether to "
-"enforce types strictly. context: Extra variables to pass to the "
-"validator. by_alias: Whether to use the field's alias when validating "
-"against the provided input data. by_name: Whether to use the field's name"
-" when validating against the provided input data."
+"enforce types strictly. extra: Whether to ignore, allow, or forbid extra "
+"data during model validation."
 msgstr ""
 
-#: bd6275d604534fc4a6677e59de2f8773 of
-#: pydantic.main.BaseModel.model_validate_strings:11
+#: 068a99f447d248a2bac2e3b3a77eedb1 of
+#: pydantic.main.BaseModel.model_validate_strings:8
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: e7afb2c1543948b3bb27eb41896a5ab2 of
+#: pydantic.main.BaseModel.model_validate_strings:9
+msgid ""
+"context: Extra variables to pass to the validator. by_alias: Whether to "
+"use the field's alias when validating against the provided input data. "
+"by_name: Whether to use the field's name when validating against the "
+"provided input data."
+msgstr ""
+
+#: bfb87a9826b44cceafb6ca50c2d19809 of
+#: pydantic.main.BaseModel.model_validate_strings:13
 msgid "Returns:"
 msgstr ""
 
-#: 741996ef3458456aa252854b5e390759 of
-#: pydantic.main.BaseModel.model_validate_strings:12
+#: bedc313a15134c35848fa77cb052416e of
+#: pydantic.main.BaseModel.model_validate_strings:14
 msgid "The validated Pydantic model."
 msgstr ""
+
+#~ msgid ""
+#~ "obj: The object containing string data"
+#~ " to validate. strict: Whether to "
+#~ "enforce types strictly. context: Extra "
+#~ "variables to pass to the validator. "
+#~ "by_alias: Whether to use the field's "
+#~ "alias when validating against the "
+#~ "provided input data. by_name: Whether to"
+#~ " use the field's name when validating"
+#~ " against the provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.budget_optimizer.BudgetOptimizer.model_copy.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.budget_optimizer.BudgetOptimizer.model_copy.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,27 +21,27 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.budget_optimizer.BudgetOptimizer.model_copy.rst:2
-#: 8988e27e06294f1bb5e7fe5ef1299862
+#: 9b366c1b580340f6a563d82596739d05
 msgid "BudgetOptimizer.model\\_copy"
 msgstr ""
 
-#: 59d8f57aff2b4acd858d5914921717eb of pydantic.main.BaseModel.model_copy:2
+#: 9fc71a0d8dc6431eb1d74c00d7dee57f of pydantic.main.BaseModel.model_copy:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: bed488c8cded4322b12c1b7a5779c481 of pydantic.main.BaseModel.model_copy:3
-msgid "[`model_copy`](../concepts/serialization.md#model_copy)"
+#: 946015a2e8544bcc9f6b065e7690bb50 of pydantic.main.BaseModel.model_copy:3
+msgid "[`model_copy`](../concepts/models.md#model-copy)"
 msgstr ""
 
-#: 637f77eeb1ac4715a01774c17b9f2e89 of pydantic.main.BaseModel.model_copy:5
+#: b21218458eab4a7987f3cf83334bd0b2 of pydantic.main.BaseModel.model_copy:5
 msgid "Returns a copy of the model."
 msgstr ""
 
-#: 1bd6e5df53ef4068a01e0f67342f44b1 of pydantic.main.BaseModel.model_copy:7
+#: d23bfc6c67a8490e8541289c62505fcf of pydantic.main.BaseModel.model_copy:7
 msgid "!!! note"
 msgstr ""
 
-#: 7ec1dae46ffd43bd9598ba4142d1005c of pydantic.main.BaseModel.model_copy:8
+#: 2d111523c80344e3b9de8c25f02159b6 of pydantic.main.BaseModel.model_copy:8
 msgid ""
 "The underlying instance's [`__dict__`][object.__dict__] attribute is "
 "copied. This might have unexpected side effects if you store anything in "
@@ -49,28 +49,31 @@ msgid ""
 "properties][functools.cached_property])."
 msgstr ""
 
-#: e516cc337b9548a68f07ccdaf07e6c99 of pydantic.main.BaseModel.model_copy:12
+#: de6f8631ae0c4f25acfdec349df20454 of pydantic.main.BaseModel.model_copy:12
 msgid "Args:"
 msgstr ""
 
-#: 26ba51bd2dee48fc99ba9488cae24652 of pydantic.main.BaseModel.model_copy:13
+#: 26f9e4ca98ec4ff3bef92af160c85cfd of pydantic.main.BaseModel.model_copy:13
 msgid ""
 "update: Values to change/add in the new model. Note: the data is not "
 "validated"
 msgstr ""
 
-#: 59dbe0a19c3e477a89fc23b0ff4281fb of pydantic.main.BaseModel.model_copy:14
+#: 3b19e1731a66479c8192dad8daabbc37 of pydantic.main.BaseModel.model_copy:14
 msgid "before creating the new model. You should trust this data."
 msgstr ""
 
-#: 8999a0a1b1644ce28533af03eec1e6d6 of pydantic.main.BaseModel.model_copy:15
+#: 76c480149bfa42cda3009036ec64483f of pydantic.main.BaseModel.model_copy:15
 msgid "deep: Set to `True` to make a deep copy of the model."
 msgstr ""
 
-#: 7cda3189ea834ce39823105559f6387b of pydantic.main.BaseModel.model_copy:17
+#: 9871348770d74a28925b4ef693b2badc of pydantic.main.BaseModel.model_copy:17
 msgid "Returns:"
 msgstr ""
 
-#: 1e2989300f1f4c9faa5eddd4048462de of pydantic.main.BaseModel.model_copy:18
+#: 5be2a508573a467e8815c11342aaeaa9 of pydantic.main.BaseModel.model_copy:18
 msgid "New model instance."
 msgstr ""
+
+#~ msgid "[`model_copy`](../concepts/serialization.md#model_copy)"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.budget_optimizer.BudgetOptimizer.model_dump.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.budget_optimizer.BudgetOptimizer.model_dump.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,40 +21,40 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.budget_optimizer.BudgetOptimizer.model_dump.rst:2
-#: e835979babd4433e89f411ca08db6d8a
+#: bcb16b7d5b034938a4fb0739f2265bda
 msgid "BudgetOptimizer.model\\_dump"
 msgstr ""
 
-#: 783cd835d29e430fb137b90cff5a609b of pydantic.main.BaseModel.model_dump:2
+#: 3ad884e107e44a5faf8a5ab69e57530e of pydantic.main.BaseModel.model_dump:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 87b8a62a48f749839c91c4159b0742f4 of pydantic.main.BaseModel.model_dump:3
-msgid "[`model_dump`](../concepts/serialization.md#modelmodel_dump)"
+#: 6b68f5369f3e4177a24ceeb320cff273 of pydantic.main.BaseModel.model_dump:3
+msgid "[`model_dump`](../concepts/serialization.md#python-mode)"
 msgstr ""
 
-#: f3499da2c89f4d9b849cc2ba7ff581df of pydantic.main.BaseModel.model_dump:5
+#: 1c2a153230094784adcdd622617a06d0 of pydantic.main.BaseModel.model_dump:5
 msgid ""
 "Generate a dictionary representation of the model, optionally specifying "
 "which fields to include or exclude."
 msgstr ""
 
-#: 6c81565a108644efa73b03c375844c64 of pydantic.main.BaseModel.model_dump:7
+#: 1307dab07c3044f19ff9d9e839f0fdd2 of pydantic.main.BaseModel.model_dump:7
 msgid "Args:"
 msgstr ""
 
-#: 8103e04afba34b49bca1d2764f55ead8 of pydantic.main.BaseModel.model_dump:8
+#: 3e39a5b259854a78804e46078d21a1c2 of pydantic.main.BaseModel.model_dump:8
 msgid "mode: The mode in which `to_python` should run."
 msgstr ""
 
-#: 8d727ad2cfa14cb7a7d8b6a885116577 of pydantic.main.BaseModel.model_dump:9
+#: 59167d8e122f4a8ebd2cffa9fc143afe of pydantic.main.BaseModel.model_dump:9
 msgid ""
 "If mode is 'json', the output will only contain JSON serializable types. "
 "If mode is 'python', the output may contain non-JSON-serializable Python "
 "objects."
 msgstr ""
 
-#: 15071b5dd6bb470f964c34d6883c94e4 of pydantic.main.BaseModel.model_dump:11
+#: 3bf63609578b4ce08a4bf80d68ae3545 of pydantic.main.BaseModel.model_dump:11
 msgid ""
 "include: A set of fields to include in the output. exclude: A set of "
 "fields to exclude from the output. context: Additional context to pass to"
@@ -62,41 +62,77 @@ msgid ""
 "dictionary key if defined. exclude_unset: Whether to exclude fields that "
 "have not been explicitly set. exclude_defaults: Whether to exclude fields"
 " that are set to their default value. exclude_none: Whether to exclude "
-"fields that have a value of `None`. round_trip: If True, dumped values "
-"should be valid as input for non-idempotent types such as Json[T]. "
-"warnings: How to handle serialization errors. False/\"none\" ignores "
-"them, True/\"warn\" logs errors,"
+"fields that have a value of `None`. exclude_computed_fields: Whether to "
+"exclude computed fields."
 msgstr ""
 
-#: ecff59304ed2415281adb9fcd55357c8 of pydantic.main.BaseModel.model_dump:20
+#: 3cadf9a1c12c4910a243ced5e6ef5d55 of pydantic.main.BaseModel.model_dump:19
+msgid ""
+"While this can be useful for round-tripping, it is usually recommended tu"
+" use the dedicated `round_trip` parameter instead."
+msgstr ""
+
+#: 206d179fe2d249eba83b6aa46bc380a4 of pydantic.main.BaseModel.model_dump:21
+msgid ""
+"round_trip: If True, dumped values should be valid as input for non-"
+"idempotent types such as Json[T]. warnings: How to handle serialization "
+"errors. False/\"none\" ignores them, True/\"warn\" logs errors,"
+msgstr ""
+
+#: 1514b1b2d9674894be92833f87c01454 of pydantic.main.BaseModel.model_dump:23
 msgid ""
 "\"error\" raises a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError]."
 msgstr ""
 
-#: ce24ec53397f451ba379744fa08945fc of pydantic.main.BaseModel.model_dump:21
+#: ce355d366a27422cbbd6d36f87676228 of pydantic.main.BaseModel.model_dump:24
 msgid ""
 "fallback: A function to call when an unknown value is encountered. If not"
 " provided,"
 msgstr ""
 
-#: 6c5e42093b814dd09972bd6ecfe5206d of pydantic.main.BaseModel.model_dump:22
+#: b0415f4cd824416b9eac6c2964486776 of pydantic.main.BaseModel.model_dump:25
 msgid ""
 "a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError] "
 "error is raised."
 msgstr ""
 
-#: 0a857238a0f84db78773a11335f75c7f of pydantic.main.BaseModel.model_dump:23
+#: 59a3396e7e0e401dbb01961429a649fd of pydantic.main.BaseModel.model_dump:26
 msgid ""
 "serialize_as_any: Whether to serialize fields with duck-typing "
 "serialization behavior."
 msgstr ""
 
-#: 3c6a47d5ab454b87be76206e58b258be of pydantic.main.BaseModel.model_dump:25
+#: 0421a12b35da41ff8a224590c1590ef4 of pydantic.main.BaseModel.model_dump:28
 msgid "Returns:"
 msgstr ""
 
-#: 1aba2935ed694ec1b46a95c4f998adc0 of pydantic.main.BaseModel.model_dump:26
+#: 56d98fe7e4944c08bd6d7110c607b804 of pydantic.main.BaseModel.model_dump:29
 msgid "A dictionary representation of the model."
 msgstr ""
+
+#~ msgid "[`model_dump`](../concepts/serialization.md#modelmodel_dump)"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "include: A set of fields to "
+#~ "include in the output. exclude: A "
+#~ "set of fields to exclude from the"
+#~ " output. context: Additional context to "
+#~ "pass to the serializer. by_alias: "
+#~ "Whether to use the field's alias "
+#~ "in the dictionary key if defined. "
+#~ "exclude_unset: Whether to exclude fields "
+#~ "that have not been explicitly set. "
+#~ "exclude_defaults: Whether to exclude fields"
+#~ " that are set to their default "
+#~ "value. exclude_none: Whether to exclude "
+#~ "fields that have a value of "
+#~ "`None`. round_trip: If True, dumped "
+#~ "values should be valid as input "
+#~ "for non-idempotent types such as "
+#~ "Json[T]. warnings: How to handle "
+#~ "serialization errors. False/\"none\" ignores "
+#~ "them, True/\"warn\" logs errors,"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.budget_optimizer.BudgetOptimizer.model_dump_json.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.budget_optimizer.BudgetOptimizer.model_dump_json.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,83 +21,133 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.budget_optimizer.BudgetOptimizer.model_dump_json.rst:2
-#: 8ff9cf4b8fd943fc94b981dcfffe6f45
+#: 763c9b26cb6c4714b34ac73264641c5c
 msgid "BudgetOptimizer.model\\_dump\\_json"
 msgstr ""
 
-#: fb53fc24f80b4fdba6e3491de56bd8b7 of
+#: 72b42f1fac8b4ae2bfcc5408d5d4500a of
 #: pydantic.main.BaseModel.model_dump_json:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 003f043907b145179cdf02c52e125f2d of
+#: 4645a14796a04490bef66f2b14a4e853 of
 #: pydantic.main.BaseModel.model_dump_json:3
-msgid "[`model_dump_json`](../concepts/serialization.md#modelmodel_dump_json)"
+msgid "[`model_dump_json`](../concepts/serialization.md#json-mode)"
 msgstr ""
 
-#: 9a213b85ed1b47b2b180dabed3e0070d of
+#: ae9e5a38bd1d43099a4cbf2464814328 of
 #: pydantic.main.BaseModel.model_dump_json:5
 msgid ""
 "Generates a JSON representation of the model using Pydantic's `to_json` "
 "method."
 msgstr ""
 
-#: 48b11543a40446c4b2d2e2e7816a499a of
+#: b730da3bb1304278b25e9f9239a127e3 of
 #: pydantic.main.BaseModel.model_dump_json:7
 msgid "Args:"
 msgstr ""
 
-#: 4c29f5bbb52e454cb6656899fd7d5795 of
+#: 25493f7c449c4cd180a44e406f837b3e of
 #: pydantic.main.BaseModel.model_dump_json:8
 msgid ""
 "indent: Indentation to use in the JSON output. If None is passed, the "
-"output will be compact. include: Field(s) to include in the JSON output. "
-"exclude: Field(s) to exclude from the JSON output. context: Additional "
-"context to pass to the serializer. by_alias: Whether to serialize using "
-"field aliases. exclude_unset: Whether to exclude fields that have not "
-"been explicitly set. exclude_defaults: Whether to exclude fields that are"
-" set to their default value. exclude_none: Whether to exclude fields that"
-" have a value of `None`. round_trip: If True, dumped values should be "
-"valid as input for non-idempotent types such as Json[T]. warnings: How to"
-" handle serialization errors. False/\"none\" ignores them, True/\"warn\" "
-"logs errors,"
+"output will be compact. ensure_ascii: If `True`, the output is guaranteed"
+" to have all incoming non-ASCII characters escaped."
 msgstr ""
 
-#: dcd823c8cdc74786a638619a37dfc041 of
-#: pydantic.main.BaseModel.model_dump_json:18
+#: 5660d2d0e632475eb8933b04c5bd665f of
+#: pydantic.main.BaseModel.model_dump_json:10
+msgid "If `False` (the default), these characters will be output as-is."
+msgstr ""
+
+#: 38cd7d6e48d54378974bbe4a3c473c36 of
+#: pydantic.main.BaseModel.model_dump_json:11
+msgid ""
+"include: Field(s) to include in the JSON output. exclude: Field(s) to "
+"exclude from the JSON output. context: Additional context to pass to the "
+"serializer. by_alias: Whether to serialize using field aliases. "
+"exclude_unset: Whether to exclude fields that have not been explicitly "
+"set. exclude_defaults: Whether to exclude fields that are set to their "
+"default value. exclude_none: Whether to exclude fields that have a value "
+"of `None`. exclude_computed_fields: Whether to exclude computed fields."
+msgstr ""
+
+#: 051c05d7a1b54b37a1138ed9ef59ae1a of
+#: pydantic.main.BaseModel.model_dump_json:19
+msgid ""
+"While this can be useful for round-tripping, it is usually recommended to"
+" use the dedicated `round_trip` parameter instead."
+msgstr ""
+
+#: 557ededbf1054e1497f76c8cfc01da74 of
+#: pydantic.main.BaseModel.model_dump_json:21
+msgid ""
+"round_trip: If True, dumped values should be valid as input for non-"
+"idempotent types such as Json[T]. warnings: How to handle serialization "
+"errors. False/\"none\" ignores them, True/\"warn\" logs errors,"
+msgstr ""
+
+#: 2383ca5c77494115b91becf777849bd7 of
+#: pydantic.main.BaseModel.model_dump_json:23
 msgid ""
 "\"error\" raises a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError]."
 msgstr ""
 
-#: 0fd030357e5e49448f8a7218186a1a39 of
-#: pydantic.main.BaseModel.model_dump_json:19
+#: e599cb6c0a534a1f8ed96c686b22ed58 of
+#: pydantic.main.BaseModel.model_dump_json:24
 msgid ""
 "fallback: A function to call when an unknown value is encountered. If not"
 " provided,"
 msgstr ""
 
-#: 8c1af9014d594cf8ae9a5bd6cd5575d9 of
-#: pydantic.main.BaseModel.model_dump_json:20
+#: 89ba410b6b214abfbfcb8941fc806af7 of
+#: pydantic.main.BaseModel.model_dump_json:25
 msgid ""
 "a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError] "
 "error is raised."
 msgstr ""
 
-#: a2ed4ff86d9b44668b75eca1e511b43c of
-#: pydantic.main.BaseModel.model_dump_json:21
+#: d427e9f920304de48c40c587e7d179ec of
+#: pydantic.main.BaseModel.model_dump_json:26
 msgid ""
 "serialize_as_any: Whether to serialize fields with duck-typing "
 "serialization behavior."
 msgstr ""
 
-#: acf840e8b85a44e3bb28a28114f8dae9 of
-#: pydantic.main.BaseModel.model_dump_json:23
+#: fcc4ce3f314b4720b6ae49acf37143fc of
+#: pydantic.main.BaseModel.model_dump_json:28
 msgid "Returns:"
 msgstr ""
 
-#: 2fd1ecfbf26744b99559aa3286859b5d of
-#: pydantic.main.BaseModel.model_dump_json:24
+#: e74bb54984324dde9ebd2e494fce9d90 of
+#: pydantic.main.BaseModel.model_dump_json:29
 msgid "A JSON string representation of the model."
 msgstr ""
+
+#~ msgid "[`model_dump_json`](../concepts/serialization.md#modelmodel_dump_json)"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "indent: Indentation to use in the "
+#~ "JSON output. If None is passed, "
+#~ "the output will be compact. include: "
+#~ "Field(s) to include in the JSON "
+#~ "output. exclude: Field(s) to exclude "
+#~ "from the JSON output. context: "
+#~ "Additional context to pass to the "
+#~ "serializer. by_alias: Whether to serialize "
+#~ "using field aliases. exclude_unset: Whether"
+#~ " to exclude fields that have not "
+#~ "been explicitly set. exclude_defaults: Whether"
+#~ " to exclude fields that are set "
+#~ "to their default value. exclude_none: "
+#~ "Whether to exclude fields that have "
+#~ "a value of `None`. round_trip: If "
+#~ "True, dumped values should be valid "
+#~ "as input for non-idempotent types "
+#~ "such as Json[T]. warnings: How to "
+#~ "handle serialization errors. False/\"none\" "
+#~ "ignores them, True/\"warn\" logs errors,"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.budget_optimizer.BudgetOptimizer.model_json_schema.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.budget_optimizer.BudgetOptimizer.model_json_schema.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,44 +21,77 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.budget_optimizer.BudgetOptimizer.model_json_schema.rst:2
-#: 98649f54d5b044c88a4f3a6b2a95033a
+#: b83f760a96ee44808d48187e587250e7
 msgid "BudgetOptimizer.model\\_json\\_schema"
 msgstr ""
 
-#: 838a1545fba4475395236082a193c7a4 of
+#: 93555ab0577d4499a16c0aa72e019b02 of
 #: pydantic.main.BaseModel.model_json_schema:2
 msgid "Generates a JSON schema for a model class."
 msgstr ""
 
-#: b46e3e5bc5f44b94a81c9718ae073e15 of
+#: a06e26a80bb848748d9f0537c2c2a197 of
 #: pydantic.main.BaseModel.model_json_schema:4
 msgid "Args:"
 msgstr ""
 
-#: 172642ec23174534a230590f0449dd95 of
+#: b0023663a99f4840ad40de4b1e2bcb00 of
 #: pydantic.main.BaseModel.model_json_schema:5
 msgid ""
 "by_alias: Whether to use attribute aliases or not. ref_template: The "
-"reference template. schema_generator: To override the logic used to "
-"generate the JSON schema, as a subclass of"
+"reference template. union_format: The format to use when combining "
+"schemas from unions together. Can be one of:"
 msgstr ""
 
-#: e7e4c12df1fc49ee898f4f857b57504f of
-#: pydantic.main.BaseModel.model_json_schema:8
+#: 4e3602f809994bb0b7a2d8ff03d2cb05 of
+#: pydantic.main.BaseModel.model_json_schema:9
+msgid ""
+"`'any_of'`: Use the [`anyOf`](https://json-schema.org/understanding-json-"
+"schema/reference/combining#anyOf)"
+msgstr ""
+
+#: f141ad3e6ccb49eb9e5f54a9f36b4f9c of
+#: pydantic.main.BaseModel.model_json_schema:10
+msgid ""
+"keyword to combine schemas (the default). - `'primitive_type_array'`: Use"
+" the [`type`](https://json-schema.org/understanding-json-"
+"schema/reference/type) keyword as an array of strings, containing each "
+"type of the combination. If any of the schemas is not a primitive type "
+"(`string`, `boolean`, `null`, `integer` or `number`) or contains "
+"constraints/metadata, falls back to `any_of`."
+msgstr ""
+
+#: af410b08c61a4b7a8bae3a2db65503db of
+#: pydantic.main.BaseModel.model_json_schema:15
+msgid ""
+"schema_generator: To override the logic used to generate the JSON schema,"
+" as a subclass of"
+msgstr ""
+
+#: 0701582466de42648c51881652768c0f of
+#: pydantic.main.BaseModel.model_json_schema:16
 msgid "`GenerateJsonSchema` with your desired modifications"
 msgstr ""
 
-#: e0784eff7d154b07a233286f189ad6db of
-#: pydantic.main.BaseModel.model_json_schema:9
+#: 3aaabe15086d488a826287cf361b93c6 of
+#: pydantic.main.BaseModel.model_json_schema:17
 msgid "mode: The mode in which to generate the schema."
 msgstr ""
 
-#: e40ecfa27db44c08a89a3f73b9dd4c64 of
-#: pydantic.main.BaseModel.model_json_schema:11
+#: 78c68a637eb24f79a8fbf3111f435174 of
+#: pydantic.main.BaseModel.model_json_schema:19
 msgid "Returns:"
 msgstr ""
 
-#: 00f8d5cd6b8f47fe8baa60210460a14e of
-#: pydantic.main.BaseModel.model_json_schema:12
+#: 6b1b6f6846d044ddb06dd966fda2e8c9 of
+#: pydantic.main.BaseModel.model_json_schema:20
 msgid "The JSON schema for the given model class."
 msgstr ""
+
+#~ msgid ""
+#~ "by_alias: Whether to use attribute "
+#~ "aliases or not. ref_template: The "
+#~ "reference template. schema_generator: To "
+#~ "override the logic used to generate "
+#~ "the JSON schema, as a subclass of"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.budget_optimizer.BudgetOptimizer.model_validate.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.budget_optimizer.BudgetOptimizer.model_validate.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,21 +21,33 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.budget_optimizer.BudgetOptimizer.model_validate.rst:2
-#: 06fa0d832c1649798d1143f1356619a8
+#: b0eb1104b49f446883ca6b7c88875e64
 msgid "BudgetOptimizer.model\\_validate"
 msgstr ""
 
-#: f2a6d2c3306c4fdf9bfeaceb7ee52b76 of pydantic.main.BaseModel.model_validate:2
+#: 2e482314813f4ab3919b340b5e74640f of pydantic.main.BaseModel.model_validate:2
 msgid "Validate a pydantic model instance."
 msgstr ""
 
-#: 93129ae5731d445fba095d823274b85f of pydantic.main.BaseModel.model_validate:4
+#: 55cd02b2ad7a43bc9c38bc147d2f5b99 of pydantic.main.BaseModel.model_validate:4
 msgid "Args:"
 msgstr ""
 
-#: 9917887270b14afabc1f37647b5adc90 of pydantic.main.BaseModel.model_validate:5
+#: a6004308963849608e3a946e2afd63de of pydantic.main.BaseModel.model_validate:5
 msgid ""
 "obj: The object to validate. strict: Whether to enforce types strictly. "
+"extra: Whether to ignore, allow, or forbid extra data during model "
+"validation."
+msgstr ""
+
+#: a458fcb51d5245a28eadec8346dea552 of pydantic.main.BaseModel.model_validate:8
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: 44a06a53dd1643c3b53912f762086dfa of pydantic.main.BaseModel.model_validate:9
+msgid ""
 "from_attributes: Whether to extract data from object attributes. context:"
 " Additional context to pass to the validator. by_alias: Whether to use "
 "the field's alias when validating against the provided input data. "
@@ -43,22 +55,35 @@ msgid ""
 "provided input data."
 msgstr ""
 
-#: 2fbd6b0677fa4abea72be65332dd5c25 of
-#: pydantic.main.BaseModel.model_validate:12
+#: 16da5ed4192445429e0ac98436b6ae03 of
+#: pydantic.main.BaseModel.model_validate:14
 msgid "Raises:"
 msgstr ""
 
-#: 276da98b54e544c09a31c3ea52c954d0 of
-#: pydantic.main.BaseModel.model_validate:13
+#: b17b9fd4c8a34439abf0e4fbf807b144 of
+#: pydantic.main.BaseModel.model_validate:15
 msgid "ValidationError: If the object could not be validated."
 msgstr ""
 
-#: 8bb5bec8a6e54abc9c530ed066d8a8ba of
-#: pydantic.main.BaseModel.model_validate:15
+#: b9ce64b17db744cebc393a8f93f015ef of
+#: pydantic.main.BaseModel.model_validate:17
 msgid "Returns:"
 msgstr ""
 
-#: 9f8ed03a2ca74af09ec39b98e778e58d of
-#: pydantic.main.BaseModel.model_validate:16
+#: 1a6a677b833c4a39b2e8b6c9b2fefd2a of
+#: pydantic.main.BaseModel.model_validate:18
 msgid "The validated model instance."
 msgstr ""
+
+#~ msgid ""
+#~ "obj: The object to validate. strict: "
+#~ "Whether to enforce types strictly. "
+#~ "from_attributes: Whether to extract data "
+#~ "from object attributes. context: Additional"
+#~ " context to pass to the validator."
+#~ " by_alias: Whether to use the field's"
+#~ " alias when validating against the "
+#~ "provided input data. by_name: Whether to"
+#~ " use the field's name when validating"
+#~ " against the provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.budget_optimizer.BudgetOptimizer.model_validate_json.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.budget_optimizer.BudgetOptimizer.model_validate_json.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,58 +21,84 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.budget_optimizer.BudgetOptimizer.model_validate_json.rst:2
-#: 4623496893324e37b6611f4514ec566d
+#: cce5522da7dc4ed280636a47c1c4948c
 msgid "BudgetOptimizer.model\\_validate\\_json"
 msgstr ""
 
-#: d693df85bed94edd8877874c7f4bc05b of
+#: 0415f28997084651aeb0d9357f609de3 of
 #: pydantic.main.BaseModel.model_validate_json:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: f23f9b8799214ba08800ae3a6c6729f6 of
+#: d0bae22dd2a14f48a3b4b0f1606b4068 of
 #: pydantic.main.BaseModel.model_validate_json:3
 msgid "[JSON Parsing](../concepts/json.md#json-parsing)"
 msgstr ""
 
-#: c30f8b2e5e594a4882e02be6f1d8f966 of
+#: 7c515c4f8ad045978f080938a4faebf3 of
 #: pydantic.main.BaseModel.model_validate_json:5
 msgid "Validate the given JSON data against the Pydantic model."
 msgstr ""
 
-#: 766007f79ee847e3b6cb39e1249085da of
+#: 6eb0ec1d5e834a368a6806866b0e7b3e of
 #: pydantic.main.BaseModel.model_validate_json:7
 msgid "Args:"
 msgstr ""
 
-#: e9303605d157491f93f46cc82bc507b0 of
+#: c108da31b4ed40e9bbc294a1ab93a416 of
 #: pydantic.main.BaseModel.model_validate_json:8
 msgid ""
 "json_data: The JSON data to validate. strict: Whether to enforce types "
-"strictly. context: Extra variables to pass to the validator. by_alias: "
-"Whether to use the field's alias when validating against the provided "
-"input data. by_name: Whether to use the field's name when validating "
-"against the provided input data."
+"strictly. extra: Whether to ignore, allow, or forbid extra data during "
+"model validation."
 msgstr ""
 
-#: 60620e0081434f668ca202d1a33e861b of
-#: pydantic.main.BaseModel.model_validate_json:14
+#: 7b76a16271b44ec280ec40f30e78d1db of
+#: pydantic.main.BaseModel.model_validate_json:11
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: 571b64bfce7a4e1d90e4823efc744630 of
+#: pydantic.main.BaseModel.model_validate_json:12
+msgid ""
+"context: Extra variables to pass to the validator. by_alias: Whether to "
+"use the field's alias when validating against the provided input data. "
+"by_name: Whether to use the field's name when validating against the "
+"provided input data."
+msgstr ""
+
+#: 372b87bf219349e98d71d20599516fea of
+#: pydantic.main.BaseModel.model_validate_json:16
 msgid "Returns:"
 msgstr ""
 
-#: a344e9a468ed4edc8f90b7448500a201 of
-#: pydantic.main.BaseModel.model_validate_json:15
+#: 20040a46851b4aa59572a7ab35b72b1d of
+#: pydantic.main.BaseModel.model_validate_json:17
 msgid "The validated Pydantic model."
 msgstr ""
 
-#: da87ad5d783a4c1ead05c041c6ab4f11 of
-#: pydantic.main.BaseModel.model_validate_json:17
+#: b4746c6c13924fdaa641ba1f765cb727 of
+#: pydantic.main.BaseModel.model_validate_json:19
 msgid "Raises:"
 msgstr ""
 
-#: ad1681ace9fc4265a5f297201416aa46 of
-#: pydantic.main.BaseModel.model_validate_json:18
+#: 090ed00ba9a44cdfbaaef29ec3212321 of
+#: pydantic.main.BaseModel.model_validate_json:20
 msgid ""
 "ValidationError: If `json_data` is not a JSON string or the object could "
 "not be validated."
 msgstr ""
+
+#~ msgid ""
+#~ "json_data: The JSON data to validate."
+#~ " strict: Whether to enforce types "
+#~ "strictly. context: Extra variables to "
+#~ "pass to the validator. by_alias: Whether"
+#~ " to use the field's alias when "
+#~ "validating against the provided input "
+#~ "data. by_name: Whether to use the "
+#~ "field's name when validating against the"
+#~ " provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.budget_optimizer.BudgetOptimizer.model_validate_strings.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.budget_optimizer.BudgetOptimizer.model_validate_strings.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,36 +21,62 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.budget_optimizer.BudgetOptimizer.model_validate_strings.rst:2
-#: 8a782efe7e73462cb36110225532fb1c
+#: 616c2d6a1d0941b2ab3f1811e3702cf1
 msgid "BudgetOptimizer.model\\_validate\\_strings"
 msgstr ""
 
-#: 5698b5ca26ce49339df5457338d65ce8 of
+#: a6a908cfbc194d249d92fd922c7c962f of
 #: pydantic.main.BaseModel.model_validate_strings:2
 msgid "Validate the given object with string data against the Pydantic model."
 msgstr ""
 
-#: 8a7fc54df073423daf351625f50691b6 of
+#: 44002d8b895345bdaf728b24f1989e74 of
 #: pydantic.main.BaseModel.model_validate_strings:4
 msgid "Args:"
 msgstr ""
 
-#: 575c37086fea49529a84cd3154f43850 of
+#: 8c29230c42e3473888433a6749b968dd of
 #: pydantic.main.BaseModel.model_validate_strings:5
 msgid ""
 "obj: The object containing string data to validate. strict: Whether to "
-"enforce types strictly. context: Extra variables to pass to the "
-"validator. by_alias: Whether to use the field's alias when validating "
-"against the provided input data. by_name: Whether to use the field's name"
-" when validating against the provided input data."
+"enforce types strictly. extra: Whether to ignore, allow, or forbid extra "
+"data during model validation."
 msgstr ""
 
-#: c22f01e95b824b3aad86d7ee967f06bf of
-#: pydantic.main.BaseModel.model_validate_strings:11
+#: 69f32ad60c8b4788ae82b8e8de00574b of
+#: pydantic.main.BaseModel.model_validate_strings:8
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: bcfb940de2af4d80a023e9cc7b88f259 of
+#: pydantic.main.BaseModel.model_validate_strings:9
+msgid ""
+"context: Extra variables to pass to the validator. by_alias: Whether to "
+"use the field's alias when validating against the provided input data. "
+"by_name: Whether to use the field's name when validating against the "
+"provided input data."
+msgstr ""
+
+#: 20121ba4eee34946a8bb3496ddcc3f5e of
+#: pydantic.main.BaseModel.model_validate_strings:13
 msgid "Returns:"
 msgstr ""
 
-#: 890ffcdb04c3402cbd678f92af168404 of
-#: pydantic.main.BaseModel.model_validate_strings:12
+#: 115dcb44d7ba40edbe015efa79046f0d of
+#: pydantic.main.BaseModel.model_validate_strings:14
 msgid "The validated Pydantic model."
 msgstr ""
+
+#~ msgid ""
+#~ "obj: The object containing string data"
+#~ " to validate. strict: Whether to "
+#~ "enforce types strictly. context: Extra "
+#~ "variables to pass to the validator. "
+#~ "by_alias: Whether to use the field's "
+#~ "alias when validating against the "
+#~ "provided input data. by_name: Whether to"
+#~ " use the field's name when validating"
+#~ " against the provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.events.EventEffect.model_copy.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.events.EventEffect.model_copy.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,27 +21,27 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.events.EventEffect.model_copy.rst:2
-#: e435407950d440df9efb1fb2b96aa2ff
+#: 2f7568287fd84130855d7981a64a0679
 msgid "EventEffect.model\\_copy"
 msgstr ""
 
-#: 9250f72ac6774631b058512a5656a512 of pydantic.main.BaseModel.model_copy:2
+#: 55c1d1a138a243578cda66b77bbd178f of pydantic.main.BaseModel.model_copy:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 17953a380ae043dd848e0e02c5ba3964 of pydantic.main.BaseModel.model_copy:3
-msgid "[`model_copy`](../concepts/serialization.md#model_copy)"
+#: b85ed13e26ff4b4ea93df91bf239215b of pydantic.main.BaseModel.model_copy:3
+msgid "[`model_copy`](../concepts/models.md#model-copy)"
 msgstr ""
 
-#: 0c3f968218db4ff2854d314c108fda8a of pydantic.main.BaseModel.model_copy:5
+#: fe5de28b1f0e423e933dfd11e924cc6b of pydantic.main.BaseModel.model_copy:5
 msgid "Returns a copy of the model."
 msgstr ""
 
-#: 9cc438718b504f998685e3c722473d4b of pydantic.main.BaseModel.model_copy:7
+#: 240d890de99544c09bfe644a74606fa8 of pydantic.main.BaseModel.model_copy:7
 msgid "!!! note"
 msgstr ""
 
-#: 79c4ff33b1304164bdefbb27e60d59f0 of pydantic.main.BaseModel.model_copy:8
+#: 0694f2f14d884beb8d9815d3d7d1298b of pydantic.main.BaseModel.model_copy:8
 msgid ""
 "The underlying instance's [`__dict__`][object.__dict__] attribute is "
 "copied. This might have unexpected side effects if you store anything in "
@@ -49,28 +49,31 @@ msgid ""
 "properties][functools.cached_property])."
 msgstr ""
 
-#: 7584e07994844f2db9c5af9d06714131 of pydantic.main.BaseModel.model_copy:12
+#: 045332f0dc024c5faa8eb23d211a9414 of pydantic.main.BaseModel.model_copy:12
 msgid "Args:"
 msgstr ""
 
-#: 4a97d6bc8b7f4b75b27d1495bef568de of pydantic.main.BaseModel.model_copy:13
+#: 3caeb420fc32451cbedfd186645d6637 of pydantic.main.BaseModel.model_copy:13
 msgid ""
 "update: Values to change/add in the new model. Note: the data is not "
 "validated"
 msgstr ""
 
-#: 3c475b9528af4a72930a724d5f465603 of pydantic.main.BaseModel.model_copy:14
+#: 18e466126a9f4394909fb6705c2104f4 of pydantic.main.BaseModel.model_copy:14
 msgid "before creating the new model. You should trust this data."
 msgstr ""
 
-#: 5c91f345e993473597ca3c9f44fccf36 of pydantic.main.BaseModel.model_copy:15
+#: 56ec5a3d787f44e6b67aa7b53cc6e46c of pydantic.main.BaseModel.model_copy:15
 msgid "deep: Set to `True` to make a deep copy of the model."
 msgstr ""
 
-#: c94a743f92044f34858008056193657c of pydantic.main.BaseModel.model_copy:17
+#: b2dd198491be4ba29489d57585932262 of pydantic.main.BaseModel.model_copy:17
 msgid "Returns:"
 msgstr ""
 
-#: 61efe4adc4d04ccaaf6d2ca0200d51d0 of pydantic.main.BaseModel.model_copy:18
+#: fa2d4d95539848318f208f1da93ba8f8 of pydantic.main.BaseModel.model_copy:18
 msgid "New model instance."
 msgstr ""
+
+#~ msgid "[`model_copy`](../concepts/serialization.md#model_copy)"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.events.EventEffect.model_dump.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.events.EventEffect.model_dump.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,40 +21,40 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.events.EventEffect.model_dump.rst:2
-#: df415d75f1144e4d8ca5adb33f8edef6
+#: 8a86246f26454b4aafcfe92f95456554
 msgid "EventEffect.model\\_dump"
 msgstr ""
 
-#: 7d7a84c26363454ead6884696e1d9fd9 of pydantic.main.BaseModel.model_dump:2
+#: 3bb6eca59cec4cb1a71295ca03a98a5d of pydantic.main.BaseModel.model_dump:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 50921dd5d9b346f0a0c921f6ff7eeec2 of pydantic.main.BaseModel.model_dump:3
-msgid "[`model_dump`](../concepts/serialization.md#modelmodel_dump)"
+#: 8b4968dcf7654b728ba86b363cdc783e of pydantic.main.BaseModel.model_dump:3
+msgid "[`model_dump`](../concepts/serialization.md#python-mode)"
 msgstr ""
 
-#: 2c2401c64ee24fa2aef23a81c4eab562 of pydantic.main.BaseModel.model_dump:5
+#: d047246f64bf4ac89002787dee57addf of pydantic.main.BaseModel.model_dump:5
 msgid ""
 "Generate a dictionary representation of the model, optionally specifying "
 "which fields to include or exclude."
 msgstr ""
 
-#: ddf4d4403feb457b9da5e714b11737eb of pydantic.main.BaseModel.model_dump:7
+#: 2a85a89b9c964107a28526740ec900d6 of pydantic.main.BaseModel.model_dump:7
 msgid "Args:"
 msgstr ""
 
-#: 067c7f21872a428fac25933520942f6d of pydantic.main.BaseModel.model_dump:8
+#: d37b57b761994372ba2ed65d125af956 of pydantic.main.BaseModel.model_dump:8
 msgid "mode: The mode in which `to_python` should run."
 msgstr ""
 
-#: 34a1615524624a3aa1f916c22d0df7cb of pydantic.main.BaseModel.model_dump:9
+#: cc3d71e6d79f4a1cb134b26cfbaf34d0 of pydantic.main.BaseModel.model_dump:9
 msgid ""
 "If mode is 'json', the output will only contain JSON serializable types. "
 "If mode is 'python', the output may contain non-JSON-serializable Python "
 "objects."
 msgstr ""
 
-#: 73475fe3280542bd8c907859f289779d of pydantic.main.BaseModel.model_dump:11
+#: 09faf6ea89c146a4a0c8cff976363800 of pydantic.main.BaseModel.model_dump:11
 msgid ""
 "include: A set of fields to include in the output. exclude: A set of "
 "fields to exclude from the output. context: Additional context to pass to"
@@ -62,41 +62,77 @@ msgid ""
 "dictionary key if defined. exclude_unset: Whether to exclude fields that "
 "have not been explicitly set. exclude_defaults: Whether to exclude fields"
 " that are set to their default value. exclude_none: Whether to exclude "
-"fields that have a value of `None`. round_trip: If True, dumped values "
-"should be valid as input for non-idempotent types such as Json[T]. "
-"warnings: How to handle serialization errors. False/\"none\" ignores "
-"them, True/\"warn\" logs errors,"
+"fields that have a value of `None`. exclude_computed_fields: Whether to "
+"exclude computed fields."
 msgstr ""
 
-#: 1a86a9e4edaa49f28df982ee0d04e6cb of pydantic.main.BaseModel.model_dump:20
+#: fc2ac22fd3dc4a4493fe986c8e9f7b79 of pydantic.main.BaseModel.model_dump:19
+msgid ""
+"While this can be useful for round-tripping, it is usually recommended tu"
+" use the dedicated `round_trip` parameter instead."
+msgstr ""
+
+#: 581654b78e004172ab35a6489fd46865 of pydantic.main.BaseModel.model_dump:21
+msgid ""
+"round_trip: If True, dumped values should be valid as input for non-"
+"idempotent types such as Json[T]. warnings: How to handle serialization "
+"errors. False/\"none\" ignores them, True/\"warn\" logs errors,"
+msgstr ""
+
+#: 235e3a9298984454869532a91b69d6dc of pydantic.main.BaseModel.model_dump:23
 msgid ""
 "\"error\" raises a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError]."
 msgstr ""
 
-#: 734d31679300498182a28ab8cd7c63ba of pydantic.main.BaseModel.model_dump:21
+#: 67fd31565d794834b1fa452139370b00 of pydantic.main.BaseModel.model_dump:24
 msgid ""
 "fallback: A function to call when an unknown value is encountered. If not"
 " provided,"
 msgstr ""
 
-#: 04f7993d68c0493f8f9b9e2e54bc90ff of pydantic.main.BaseModel.model_dump:22
+#: a29f5f2f51a441c684439fc35be72882 of pydantic.main.BaseModel.model_dump:25
 msgid ""
 "a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError] "
 "error is raised."
 msgstr ""
 
-#: ea9b1be3eb6f45559818ca77863bf42c of pydantic.main.BaseModel.model_dump:23
+#: 953e4181f22e4240af7c3ac86d7c1732 of pydantic.main.BaseModel.model_dump:26
 msgid ""
 "serialize_as_any: Whether to serialize fields with duck-typing "
 "serialization behavior."
 msgstr ""
 
-#: 8d30c925bccb46cda5a38e714753c1b8 of pydantic.main.BaseModel.model_dump:25
+#: 58899e7ba6fd481bb9aa27aaa64f1344 of pydantic.main.BaseModel.model_dump:28
 msgid "Returns:"
 msgstr ""
 
-#: 2d1e7186712c49aabd8d3010ca2a41cf of pydantic.main.BaseModel.model_dump:26
+#: ede8d885bd714e468b91b444faa8a78d of pydantic.main.BaseModel.model_dump:29
 msgid "A dictionary representation of the model."
 msgstr ""
+
+#~ msgid "[`model_dump`](../concepts/serialization.md#modelmodel_dump)"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "include: A set of fields to "
+#~ "include in the output. exclude: A "
+#~ "set of fields to exclude from the"
+#~ " output. context: Additional context to "
+#~ "pass to the serializer. by_alias: "
+#~ "Whether to use the field's alias "
+#~ "in the dictionary key if defined. "
+#~ "exclude_unset: Whether to exclude fields "
+#~ "that have not been explicitly set. "
+#~ "exclude_defaults: Whether to exclude fields"
+#~ " that are set to their default "
+#~ "value. exclude_none: Whether to exclude "
+#~ "fields that have a value of "
+#~ "`None`. round_trip: If True, dumped "
+#~ "values should be valid as input "
+#~ "for non-idempotent types such as "
+#~ "Json[T]. warnings: How to handle "
+#~ "serialization errors. False/\"none\" ignores "
+#~ "them, True/\"warn\" logs errors,"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.events.EventEffect.model_dump_json.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.events.EventEffect.model_dump_json.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,83 +21,133 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.events.EventEffect.model_dump_json.rst:2
-#: 11dad0ac3fb049da922f0049fad685f9
+#: adeb299781c9403eb6fc27dc060bd113
 msgid "EventEffect.model\\_dump\\_json"
 msgstr ""
 
-#: fa3da72bff27475b8537dc15bbf2d339 of
+#: a3b1e4186ceb404c8ed5b7fcec042f01 of
 #: pydantic.main.BaseModel.model_dump_json:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: fe5c121ceb9b456c8a86bff0b23ab83e of
+#: 79690c92c1954ab9a4604916a5d15708 of
 #: pydantic.main.BaseModel.model_dump_json:3
-msgid "[`model_dump_json`](../concepts/serialization.md#modelmodel_dump_json)"
+msgid "[`model_dump_json`](../concepts/serialization.md#json-mode)"
 msgstr ""
 
-#: f1d1696a5c90449b9c0b50112a3438f6 of
+#: f82dc939064f433f9a9766cade1438a6 of
 #: pydantic.main.BaseModel.model_dump_json:5
 msgid ""
 "Generates a JSON representation of the model using Pydantic's `to_json` "
 "method."
 msgstr ""
 
-#: a8913a5ac183467a86f8e772f8de2235 of
+#: 6a83cdd0f1f44071b403615439ca3f5d of
 #: pydantic.main.BaseModel.model_dump_json:7
 msgid "Args:"
 msgstr ""
 
-#: 42a7d2572a7349fc926485e70d54dc7d of
+#: efd3595789854a8da1270b9092b2a8bd of
 #: pydantic.main.BaseModel.model_dump_json:8
 msgid ""
 "indent: Indentation to use in the JSON output. If None is passed, the "
-"output will be compact. include: Field(s) to include in the JSON output. "
-"exclude: Field(s) to exclude from the JSON output. context: Additional "
-"context to pass to the serializer. by_alias: Whether to serialize using "
-"field aliases. exclude_unset: Whether to exclude fields that have not "
-"been explicitly set. exclude_defaults: Whether to exclude fields that are"
-" set to their default value. exclude_none: Whether to exclude fields that"
-" have a value of `None`. round_trip: If True, dumped values should be "
-"valid as input for non-idempotent types such as Json[T]. warnings: How to"
-" handle serialization errors. False/\"none\" ignores them, True/\"warn\" "
-"logs errors,"
+"output will be compact. ensure_ascii: If `True`, the output is guaranteed"
+" to have all incoming non-ASCII characters escaped."
 msgstr ""
 
-#: 37a2224dc96649fb8d7755317eab5dae of
-#: pydantic.main.BaseModel.model_dump_json:18
+#: bf6d0432a4a44d05ad1276858dd13556 of
+#: pydantic.main.BaseModel.model_dump_json:10
+msgid "If `False` (the default), these characters will be output as-is."
+msgstr ""
+
+#: 779a1a986aeb4b5bafe22979feb50909 of
+#: pydantic.main.BaseModel.model_dump_json:11
+msgid ""
+"include: Field(s) to include in the JSON output. exclude: Field(s) to "
+"exclude from the JSON output. context: Additional context to pass to the "
+"serializer. by_alias: Whether to serialize using field aliases. "
+"exclude_unset: Whether to exclude fields that have not been explicitly "
+"set. exclude_defaults: Whether to exclude fields that are set to their "
+"default value. exclude_none: Whether to exclude fields that have a value "
+"of `None`. exclude_computed_fields: Whether to exclude computed fields."
+msgstr ""
+
+#: 406a2e575c3f4527a3592d5c49e55445 of
+#: pydantic.main.BaseModel.model_dump_json:19
+msgid ""
+"While this can be useful for round-tripping, it is usually recommended to"
+" use the dedicated `round_trip` parameter instead."
+msgstr ""
+
+#: 39a31d5c758e415b94198af927b8b49e of
+#: pydantic.main.BaseModel.model_dump_json:21
+msgid ""
+"round_trip: If True, dumped values should be valid as input for non-"
+"idempotent types such as Json[T]. warnings: How to handle serialization "
+"errors. False/\"none\" ignores them, True/\"warn\" logs errors,"
+msgstr ""
+
+#: b60c157b0cd34e04abd8495f3cd3b065 of
+#: pydantic.main.BaseModel.model_dump_json:23
 msgid ""
 "\"error\" raises a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError]."
 msgstr ""
 
-#: 1bbbb1311cb0451581d6a8aaa719a687 of
-#: pydantic.main.BaseModel.model_dump_json:19
+#: 2788bd26b349416c9df0f1a7ba85740a of
+#: pydantic.main.BaseModel.model_dump_json:24
 msgid ""
 "fallback: A function to call when an unknown value is encountered. If not"
 " provided,"
 msgstr ""
 
-#: f66013f61a474c118e5a4bfd77d66cfc of
-#: pydantic.main.BaseModel.model_dump_json:20
+#: bd6f6b941c57459084fd7493a7f98b18 of
+#: pydantic.main.BaseModel.model_dump_json:25
 msgid ""
 "a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError] "
 "error is raised."
 msgstr ""
 
-#: 499db8b8721b4f009e2e8685cc8ce7fc of
-#: pydantic.main.BaseModel.model_dump_json:21
+#: 9744db12a403410882074b5fd8dee7bf of
+#: pydantic.main.BaseModel.model_dump_json:26
 msgid ""
 "serialize_as_any: Whether to serialize fields with duck-typing "
 "serialization behavior."
 msgstr ""
 
-#: a1a7df5ae533495fb8d1071b39ef8fd0 of
-#: pydantic.main.BaseModel.model_dump_json:23
+#: 89bef38cdabe42ac8b122dc7292d23a5 of
+#: pydantic.main.BaseModel.model_dump_json:28
 msgid "Returns:"
 msgstr ""
 
-#: 75f11efd0fd54d21b3203df13683a106 of
-#: pydantic.main.BaseModel.model_dump_json:24
+#: 8e8dd480260049e3a1bebdff13351a81 of
+#: pydantic.main.BaseModel.model_dump_json:29
 msgid "A JSON string representation of the model."
 msgstr ""
+
+#~ msgid "[`model_dump_json`](../concepts/serialization.md#modelmodel_dump_json)"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "indent: Indentation to use in the "
+#~ "JSON output. If None is passed, "
+#~ "the output will be compact. include: "
+#~ "Field(s) to include in the JSON "
+#~ "output. exclude: Field(s) to exclude "
+#~ "from the JSON output. context: "
+#~ "Additional context to pass to the "
+#~ "serializer. by_alias: Whether to serialize "
+#~ "using field aliases. exclude_unset: Whether"
+#~ " to exclude fields that have not "
+#~ "been explicitly set. exclude_defaults: Whether"
+#~ " to exclude fields that are set "
+#~ "to their default value. exclude_none: "
+#~ "Whether to exclude fields that have "
+#~ "a value of `None`. round_trip: If "
+#~ "True, dumped values should be valid "
+#~ "as input for non-idempotent types "
+#~ "such as Json[T]. warnings: How to "
+#~ "handle serialization errors. False/\"none\" "
+#~ "ignores them, True/\"warn\" logs errors,"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.events.EventEffect.model_json_schema.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.events.EventEffect.model_json_schema.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,44 +21,77 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.events.EventEffect.model_json_schema.rst:2
-#: 01584086726247f19f2772afa020cfaa
+#: 0848659958b443558d125dde35fc635d
 msgid "EventEffect.model\\_json\\_schema"
 msgstr ""
 
-#: b496fb6fb771403e8cd71a8cd12aa0a2 of
+#: 7619f24a18bb48efa1cf2b386cfd54f7 of
 #: pydantic.main.BaseModel.model_json_schema:2
 msgid "Generates a JSON schema for a model class."
 msgstr ""
 
-#: e196b1d7e2de48a482885e11d8e98f92 of
+#: 836b077253d340d398aa543e723ffb0c of
 #: pydantic.main.BaseModel.model_json_schema:4
 msgid "Args:"
 msgstr ""
 
-#: e8f7add9b58a498a812c2593d1e77560 of
+#: c2beb3f3425c4c439db6c1f70c0dfaac of
 #: pydantic.main.BaseModel.model_json_schema:5
 msgid ""
 "by_alias: Whether to use attribute aliases or not. ref_template: The "
-"reference template. schema_generator: To override the logic used to "
-"generate the JSON schema, as a subclass of"
+"reference template. union_format: The format to use when combining "
+"schemas from unions together. Can be one of:"
 msgstr ""
 
-#: 96ef1ea2614d4f13a2f00c8b864ad3e2 of
-#: pydantic.main.BaseModel.model_json_schema:8
+#: 54ef9dca9d8d4b48bad3c938b0e82931 of
+#: pydantic.main.BaseModel.model_json_schema:9
+msgid ""
+"`'any_of'`: Use the [`anyOf`](https://json-schema.org/understanding-json-"
+"schema/reference/combining#anyOf)"
+msgstr ""
+
+#: e0b7c0612fcb44f88a2701c610d52e46 of
+#: pydantic.main.BaseModel.model_json_schema:10
+msgid ""
+"keyword to combine schemas (the default). - `'primitive_type_array'`: Use"
+" the [`type`](https://json-schema.org/understanding-json-"
+"schema/reference/type) keyword as an array of strings, containing each "
+"type of the combination. If any of the schemas is not a primitive type "
+"(`string`, `boolean`, `null`, `integer` or `number`) or contains "
+"constraints/metadata, falls back to `any_of`."
+msgstr ""
+
+#: ed26ca39a2a74fc6bd35ab16579b2e22 of
+#: pydantic.main.BaseModel.model_json_schema:15
+msgid ""
+"schema_generator: To override the logic used to generate the JSON schema,"
+" as a subclass of"
+msgstr ""
+
+#: 71d372d9b9c94b33b8ce4595457f7f97 of
+#: pydantic.main.BaseModel.model_json_schema:16
 msgid "`GenerateJsonSchema` with your desired modifications"
 msgstr ""
 
-#: 632b9af796eb480786772c56799898fa of
-#: pydantic.main.BaseModel.model_json_schema:9
+#: 54a4359dcd4e43698dc23d1d5e370d20 of
+#: pydantic.main.BaseModel.model_json_schema:17
 msgid "mode: The mode in which to generate the schema."
 msgstr ""
 
-#: 3914d1823b404cc3b7529b7fc43b9eb3 of
-#: pydantic.main.BaseModel.model_json_schema:11
+#: b58e3629d0e1410a87452047548f376f of
+#: pydantic.main.BaseModel.model_json_schema:19
 msgid "Returns:"
 msgstr ""
 
-#: e6fe998db35a4d20a8b29ef422ef02e6 of
-#: pydantic.main.BaseModel.model_json_schema:12
+#: 4e9463a9ccc146aab0ddafb465e20532 of
+#: pydantic.main.BaseModel.model_json_schema:20
 msgid "The JSON schema for the given model class."
 msgstr ""
+
+#~ msgid ""
+#~ "by_alias: Whether to use attribute "
+#~ "aliases or not. ref_template: The "
+#~ "reference template. schema_generator: To "
+#~ "override the logic used to generate "
+#~ "the JSON schema, as a subclass of"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.events.EventEffect.model_validate.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.events.EventEffect.model_validate.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,21 +21,33 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.events.EventEffect.model_validate.rst:2
-#: e317d20c97354511959dee54156750d2
+#: cc1b4713d28141b891767e69160b26ad
 msgid "EventEffect.model\\_validate"
 msgstr ""
 
-#: db8a0e9f3f444919836fc8cb9f32e02a of pydantic.main.BaseModel.model_validate:2
+#: a8c6f4c3c487476283e6e6a9a5176329 of pydantic.main.BaseModel.model_validate:2
 msgid "Validate a pydantic model instance."
 msgstr ""
 
-#: a22f9f958cd742bf940ba9286850a015 of pydantic.main.BaseModel.model_validate:4
+#: a3662687e0e44849a1fa5f7f507f1033 of pydantic.main.BaseModel.model_validate:4
 msgid "Args:"
 msgstr ""
 
-#: 891ace70d9c24492b7b38f99bda71c3e of pydantic.main.BaseModel.model_validate:5
+#: f8e8f3ec336c40f5a37ea36b254a3bbd of pydantic.main.BaseModel.model_validate:5
 msgid ""
 "obj: The object to validate. strict: Whether to enforce types strictly. "
+"extra: Whether to ignore, allow, or forbid extra data during model "
+"validation."
+msgstr ""
+
+#: 083012a9e4794348971ed1e089deeb92 of pydantic.main.BaseModel.model_validate:8
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: dd5f363f9d4f4827a4f3d46227c99b07 of pydantic.main.BaseModel.model_validate:9
+msgid ""
 "from_attributes: Whether to extract data from object attributes. context:"
 " Additional context to pass to the validator. by_alias: Whether to use "
 "the field's alias when validating against the provided input data. "
@@ -43,22 +55,35 @@ msgid ""
 "provided input data."
 msgstr ""
 
-#: 38bd6a65da074612a6f0f6bc1718b155 of
-#: pydantic.main.BaseModel.model_validate:12
+#: 0e84f1a6566a4947aa5c7185471d3662 of
+#: pydantic.main.BaseModel.model_validate:14
 msgid "Raises:"
 msgstr ""
 
-#: 5d773ead70de47b7ad5570d9273b84d5 of
-#: pydantic.main.BaseModel.model_validate:13
+#: c46bb1e836554bebbf47185d12c73a6d of
+#: pydantic.main.BaseModel.model_validate:15
 msgid "ValidationError: If the object could not be validated."
 msgstr ""
 
-#: fdf1202f8a674c66a799b5ad0156859d of
-#: pydantic.main.BaseModel.model_validate:15
+#: 1957b4116124403b949cf60bee28bae6 of
+#: pydantic.main.BaseModel.model_validate:17
 msgid "Returns:"
 msgstr ""
 
-#: e8a4989f0f414605872af0e1ea49ba0d of
-#: pydantic.main.BaseModel.model_validate:16
+#: cf33b7fb8e5e461f9797d39823a77ed5 of
+#: pydantic.main.BaseModel.model_validate:18
 msgid "The validated model instance."
 msgstr ""
+
+#~ msgid ""
+#~ "obj: The object to validate. strict: "
+#~ "Whether to enforce types strictly. "
+#~ "from_attributes: Whether to extract data "
+#~ "from object attributes. context: Additional"
+#~ " context to pass to the validator."
+#~ " by_alias: Whether to use the field's"
+#~ " alias when validating against the "
+#~ "provided input data. by_name: Whether to"
+#~ " use the field's name when validating"
+#~ " against the provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.events.EventEffect.model_validate_json.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.events.EventEffect.model_validate_json.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,58 +21,84 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.events.EventEffect.model_validate_json.rst:2
-#: f735d8c8c1074342a334637c0081e702
+#: ad38334cd5eb465e8b0f191e3f307e23
 msgid "EventEffect.model\\_validate\\_json"
 msgstr ""
 
-#: 4e1e35f772774aff91308ec7c2cfffef of
+#: 12ad20b6392b4aa78a9001be330b0a13 of
 #: pydantic.main.BaseModel.model_validate_json:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 3fe0537dddc9469781ea77e9a9bbf4e0 of
+#: 7cddacb3bc6b464b853ec28491c6aaef of
 #: pydantic.main.BaseModel.model_validate_json:3
 msgid "[JSON Parsing](../concepts/json.md#json-parsing)"
 msgstr ""
 
-#: 58f8d417299b4178a01def5798895632 of
+#: f4a5f5ffd9ae487f8dd343ae680812b6 of
 #: pydantic.main.BaseModel.model_validate_json:5
 msgid "Validate the given JSON data against the Pydantic model."
 msgstr ""
 
-#: 8b99dfc4cfd14a0bb4abe0a5f54465cd of
+#: 911ba58218074fbdb54d1e78b9386bf9 of
 #: pydantic.main.BaseModel.model_validate_json:7
 msgid "Args:"
 msgstr ""
 
-#: ecb7ff56f37b4a538fcaf609add3ac10 of
+#: 5752c2a9573849f6b6037ca931e362a9 of
 #: pydantic.main.BaseModel.model_validate_json:8
 msgid ""
 "json_data: The JSON data to validate. strict: Whether to enforce types "
-"strictly. context: Extra variables to pass to the validator. by_alias: "
-"Whether to use the field's alias when validating against the provided "
-"input data. by_name: Whether to use the field's name when validating "
-"against the provided input data."
+"strictly. extra: Whether to ignore, allow, or forbid extra data during "
+"model validation."
 msgstr ""
 
-#: 84c91a110af147308c2049b583119a6a of
-#: pydantic.main.BaseModel.model_validate_json:14
+#: 70e8dd69218f405e84283de4d2e067c6 of
+#: pydantic.main.BaseModel.model_validate_json:11
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: db36c4f29d6049468dfbb7b2d2602e5e of
+#: pydantic.main.BaseModel.model_validate_json:12
+msgid ""
+"context: Extra variables to pass to the validator. by_alias: Whether to "
+"use the field's alias when validating against the provided input data. "
+"by_name: Whether to use the field's name when validating against the "
+"provided input data."
+msgstr ""
+
+#: ffc7bcec13dc487087f28623df9d2905 of
+#: pydantic.main.BaseModel.model_validate_json:16
 msgid "Returns:"
 msgstr ""
 
-#: 966d09fc269541bbb06f926e8959c526 of
-#: pydantic.main.BaseModel.model_validate_json:15
+#: 78e9c9a6f0644f539c70ed9b558a3d4b of
+#: pydantic.main.BaseModel.model_validate_json:17
 msgid "The validated Pydantic model."
 msgstr ""
 
-#: 4b63ee90e135432d8f608ad7ff731db3 of
-#: pydantic.main.BaseModel.model_validate_json:17
+#: 9c4c19e9c7e342b482c7b61512540873 of
+#: pydantic.main.BaseModel.model_validate_json:19
 msgid "Raises:"
 msgstr ""
 
-#: 2b8c300e12b24f5cae1e18f3ca4cca8a of
-#: pydantic.main.BaseModel.model_validate_json:18
+#: b41427e3b7ad426ab108daed489f51e3 of
+#: pydantic.main.BaseModel.model_validate_json:20
 msgid ""
 "ValidationError: If `json_data` is not a JSON string or the object could "
 "not be validated."
 msgstr ""
+
+#~ msgid ""
+#~ "json_data: The JSON data to validate."
+#~ " strict: Whether to enforce types "
+#~ "strictly. context: Extra variables to "
+#~ "pass to the validator. by_alias: Whether"
+#~ " to use the field's alias when "
+#~ "validating against the provided input "
+#~ "data. by_name: Whether to use the "
+#~ "field's name when validating against the"
+#~ " provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.events.EventEffect.model_validate_strings.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.events.EventEffect.model_validate_strings.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,36 +21,62 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.events.EventEffect.model_validate_strings.rst:2
-#: 0f971483a773407da1f22088c64964a3
+#: 9fa1bd036f414db0a50660d4cf8495a3
 msgid "EventEffect.model\\_validate\\_strings"
 msgstr ""
 
-#: 56e4afa72f904fab8236e3d9e4e823d6 of
+#: d17324de4b304747a4d926bbf717c62e of
 #: pydantic.main.BaseModel.model_validate_strings:2
 msgid "Validate the given object with string data against the Pydantic model."
 msgstr ""
 
-#: b2e6b2e2806d43008e94da1742f605fb of
+#: a55159737fbf436f9e5a4a36670acada of
 #: pydantic.main.BaseModel.model_validate_strings:4
 msgid "Args:"
 msgstr ""
 
-#: 0b046d12d7c64db3a677c677d9389909 of
+#: 4b03474e6f5843da99a655f1802b6e2b of
 #: pydantic.main.BaseModel.model_validate_strings:5
 msgid ""
 "obj: The object containing string data to validate. strict: Whether to "
-"enforce types strictly. context: Extra variables to pass to the "
-"validator. by_alias: Whether to use the field's alias when validating "
-"against the provided input data. by_name: Whether to use the field's name"
-" when validating against the provided input data."
+"enforce types strictly. extra: Whether to ignore, allow, or forbid extra "
+"data during model validation."
 msgstr ""
 
-#: aa431fcc12554a4eb3f5faacc23fd4a8 of
-#: pydantic.main.BaseModel.model_validate_strings:11
+#: fc2d648d29454ef3be81c59b4b84fdab of
+#: pydantic.main.BaseModel.model_validate_strings:8
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: d59b7999cb954b38b061fa810900f167 of
+#: pydantic.main.BaseModel.model_validate_strings:9
+msgid ""
+"context: Extra variables to pass to the validator. by_alias: Whether to "
+"use the field's alias when validating against the provided input data. "
+"by_name: Whether to use the field's name when validating against the "
+"provided input data."
+msgstr ""
+
+#: bf41f40b47974f6184e7cc8f6a006593 of
+#: pydantic.main.BaseModel.model_validate_strings:13
 msgid "Returns:"
 msgstr ""
 
-#: b5d989da88124a3694af7a87b4d87893 of
-#: pydantic.main.BaseModel.model_validate_strings:12
+#: deddd556d6e94ebe9b19498526b931a0 of
+#: pydantic.main.BaseModel.model_validate_strings:14
 msgid "The validated Pydantic model."
 msgstr ""
+
+#~ msgid ""
+#~ "obj: The object containing string data"
+#~ " to validate. strict: Whether to "
+#~ "enforce types strictly. context: Extra "
+#~ "variables to pass to the validator. "
+#~ "by_alias: Whether to use the field's "
+#~ "alias when validating against the "
+#~ "provided input data. by_name: Whether to"
+#~ " use the field's name when validating"
+#~ " against the provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.FourierBase.model_copy.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.FourierBase.model_copy.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,27 +21,27 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.fourier.FourierBase.model_copy.rst:2
-#: 97caa27e03614409a6abe716f004b00a
+#: e4bfeae25ed044f38b51f9712211b57c
 msgid "FourierBase.model\\_copy"
 msgstr ""
 
-#: dadb5defc0e54cf293a4f4e46ee5f37c of pydantic.main.BaseModel.model_copy:2
+#: 15f4e690ab504f2e966e1e7035c338ca of pydantic.main.BaseModel.model_copy:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 8d885cdb4f9e4f1e957618dae3d14718 of pydantic.main.BaseModel.model_copy:3
-msgid "[`model_copy`](../concepts/serialization.md#model_copy)"
+#: a29d454c660247e2a6b568fecf769ca2 of pydantic.main.BaseModel.model_copy:3
+msgid "[`model_copy`](../concepts/models.md#model-copy)"
 msgstr ""
 
-#: 5ecfd6839a054bb1a87f1f519233c4af of pydantic.main.BaseModel.model_copy:5
+#: 0dc9539bd1a0465389c1ef5dcba7064f of pydantic.main.BaseModel.model_copy:5
 msgid "Returns a copy of the model."
 msgstr ""
 
-#: 88dda0e651fa40c8a08590f7231958af of pydantic.main.BaseModel.model_copy:7
+#: c23c3051db894f049e0c4d6fb126e0cb of pydantic.main.BaseModel.model_copy:7
 msgid "!!! note"
 msgstr ""
 
-#: f05e4bb98b4b4d8db07fa10a4bad0383 of pydantic.main.BaseModel.model_copy:8
+#: 4758cbf70a95476a993e773b9a454445 of pydantic.main.BaseModel.model_copy:8
 msgid ""
 "The underlying instance's [`__dict__`][object.__dict__] attribute is "
 "copied. This might have unexpected side effects if you store anything in "
@@ -49,28 +49,31 @@ msgid ""
 "properties][functools.cached_property])."
 msgstr ""
 
-#: 7d8d2089262c48598de5b9acb70da544 of pydantic.main.BaseModel.model_copy:12
+#: 7b4695d441f8441aa81f2e4685a67549 of pydantic.main.BaseModel.model_copy:12
 msgid "Args:"
 msgstr ""
 
-#: fe15200b961a483eb761b331f166434b of pydantic.main.BaseModel.model_copy:13
+#: 6b6884bcf2ce4915ac78cbb650953821 of pydantic.main.BaseModel.model_copy:13
 msgid ""
 "update: Values to change/add in the new model. Note: the data is not "
 "validated"
 msgstr ""
 
-#: b16b709a98164c59b915b100c3f8dba8 of pydantic.main.BaseModel.model_copy:14
+#: 7fa3ecbcfaca4e82994905b6aeb9b2f3 of pydantic.main.BaseModel.model_copy:14
 msgid "before creating the new model. You should trust this data."
 msgstr ""
 
-#: 70ba65a2c9e94b589645346d74ad5be1 of pydantic.main.BaseModel.model_copy:15
+#: 97f3eac9b8224be6a9c563a6a63391c9 of pydantic.main.BaseModel.model_copy:15
 msgid "deep: Set to `True` to make a deep copy of the model."
 msgstr ""
 
-#: 0f4360b0330d462188298fc0c72dd39f of pydantic.main.BaseModel.model_copy:17
+#: 1dc634510b9f45c4ac203b047f0f139a of pydantic.main.BaseModel.model_copy:17
 msgid "Returns:"
 msgstr ""
 
-#: a243da59c2ec48b8b4ba3b6bd443530f of pydantic.main.BaseModel.model_copy:18
+#: 8e2574c8ead54c6a97770b998ccb49b1 of pydantic.main.BaseModel.model_copy:18
 msgid "New model instance."
 msgstr ""
+
+#~ msgid "[`model_copy`](../concepts/serialization.md#model_copy)"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.FourierBase.model_dump.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.FourierBase.model_dump.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,40 +21,40 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.fourier.FourierBase.model_dump.rst:2
-#: b1a48c562eee40caae5db26a77189ef4
+#: bb68bc914b73449f94c6c91c9bf9a66c
 msgid "FourierBase.model\\_dump"
 msgstr ""
 
-#: ef89c1dbbf924fffa1254d46185b187d of pydantic.main.BaseModel.model_dump:2
+#: b3601cc30e0b4348b2b496ac946f0275 of pydantic.main.BaseModel.model_dump:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: f93453a9976a4efe99cac8ac6766202a of pydantic.main.BaseModel.model_dump:3
-msgid "[`model_dump`](../concepts/serialization.md#modelmodel_dump)"
+#: 72a778af96b04ed49018644b5d0088fc of pydantic.main.BaseModel.model_dump:3
+msgid "[`model_dump`](../concepts/serialization.md#python-mode)"
 msgstr ""
 
-#: dc2180c7f1f34c7ea777651227906e7d of pydantic.main.BaseModel.model_dump:5
+#: e8f7bb16b7634045a8ca166226bc503d of pydantic.main.BaseModel.model_dump:5
 msgid ""
 "Generate a dictionary representation of the model, optionally specifying "
 "which fields to include or exclude."
 msgstr ""
 
-#: fcab7656ba974e4baea385123a713bce of pydantic.main.BaseModel.model_dump:7
+#: bd64ff72ca414b29a75e6162e465289b of pydantic.main.BaseModel.model_dump:7
 msgid "Args:"
 msgstr ""
 
-#: 582d265cc00e46509a9d7daa97115bf3 of pydantic.main.BaseModel.model_dump:8
+#: 852ab85932b040cfb3602c98ad79b13f of pydantic.main.BaseModel.model_dump:8
 msgid "mode: The mode in which `to_python` should run."
 msgstr ""
 
-#: dc7a4d2b0ba84fe28af3ddd1ed9a6abe of pydantic.main.BaseModel.model_dump:9
+#: 37829252216e4ab795f0c77a7d6bf893 of pydantic.main.BaseModel.model_dump:9
 msgid ""
 "If mode is 'json', the output will only contain JSON serializable types. "
 "If mode is 'python', the output may contain non-JSON-serializable Python "
 "objects."
 msgstr ""
 
-#: b0d0e467d1b74b49bb4ba171f619bb81 of pydantic.main.BaseModel.model_dump:11
+#: eef6bfb5b7a843da8b8bcde6f9f50911 of pydantic.main.BaseModel.model_dump:11
 msgid ""
 "include: A set of fields to include in the output. exclude: A set of "
 "fields to exclude from the output. context: Additional context to pass to"
@@ -62,41 +62,77 @@ msgid ""
 "dictionary key if defined. exclude_unset: Whether to exclude fields that "
 "have not been explicitly set. exclude_defaults: Whether to exclude fields"
 " that are set to their default value. exclude_none: Whether to exclude "
-"fields that have a value of `None`. round_trip: If True, dumped values "
-"should be valid as input for non-idempotent types such as Json[T]. "
-"warnings: How to handle serialization errors. False/\"none\" ignores "
-"them, True/\"warn\" logs errors,"
+"fields that have a value of `None`. exclude_computed_fields: Whether to "
+"exclude computed fields."
 msgstr ""
 
-#: 031bbd4418144b6893d12cd711d340a8 of pydantic.main.BaseModel.model_dump:20
+#: 52e1eab5b7174f03a2998f0f76253976 of pydantic.main.BaseModel.model_dump:19
+msgid ""
+"While this can be useful for round-tripping, it is usually recommended tu"
+" use the dedicated `round_trip` parameter instead."
+msgstr ""
+
+#: 9cfbc2957f2f47039f303c1dc6bb286f of pydantic.main.BaseModel.model_dump:21
+msgid ""
+"round_trip: If True, dumped values should be valid as input for non-"
+"idempotent types such as Json[T]. warnings: How to handle serialization "
+"errors. False/\"none\" ignores them, True/\"warn\" logs errors,"
+msgstr ""
+
+#: 1599a06bf35f4582b10b707b3deab5f1 of pydantic.main.BaseModel.model_dump:23
 msgid ""
 "\"error\" raises a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError]."
 msgstr ""
 
-#: ff354ffc2cad462e95a82288ccd7a5af of pydantic.main.BaseModel.model_dump:21
+#: 22c40f45a5564ec0898a63913b1c95c4 of pydantic.main.BaseModel.model_dump:24
 msgid ""
 "fallback: A function to call when an unknown value is encountered. If not"
 " provided,"
 msgstr ""
 
-#: b99490ffc43b4f5e92dc9db08a8faecf of pydantic.main.BaseModel.model_dump:22
+#: 520b59168dc6456fb4bfd6f0b9d32651 of pydantic.main.BaseModel.model_dump:25
 msgid ""
 "a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError] "
 "error is raised."
 msgstr ""
 
-#: 2a1ce7a0d3904ecca54cc96742c8ee8d of pydantic.main.BaseModel.model_dump:23
+#: 3614f7c4fa22422395dddedefc283b6b of pydantic.main.BaseModel.model_dump:26
 msgid ""
 "serialize_as_any: Whether to serialize fields with duck-typing "
 "serialization behavior."
 msgstr ""
 
-#: ca8b2e4645b34b01a2c5e605616f7eea of pydantic.main.BaseModel.model_dump:25
+#: 37eff1cc4e9b4f68b3fffbb0f80cafde of pydantic.main.BaseModel.model_dump:28
 msgid "Returns:"
 msgstr ""
 
-#: 8eea7343dd3547848f033b20181eb76a of pydantic.main.BaseModel.model_dump:26
+#: 140a23f7730143218a4a3862d2d0ce88 of pydantic.main.BaseModel.model_dump:29
 msgid "A dictionary representation of the model."
 msgstr ""
+
+#~ msgid "[`model_dump`](../concepts/serialization.md#modelmodel_dump)"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "include: A set of fields to "
+#~ "include in the output. exclude: A "
+#~ "set of fields to exclude from the"
+#~ " output. context: Additional context to "
+#~ "pass to the serializer. by_alias: "
+#~ "Whether to use the field's alias "
+#~ "in the dictionary key if defined. "
+#~ "exclude_unset: Whether to exclude fields "
+#~ "that have not been explicitly set. "
+#~ "exclude_defaults: Whether to exclude fields"
+#~ " that are set to their default "
+#~ "value. exclude_none: Whether to exclude "
+#~ "fields that have a value of "
+#~ "`None`. round_trip: If True, dumped "
+#~ "values should be valid as input "
+#~ "for non-idempotent types such as "
+#~ "Json[T]. warnings: How to handle "
+#~ "serialization errors. False/\"none\" ignores "
+#~ "them, True/\"warn\" logs errors,"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.FourierBase.model_dump_json.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.FourierBase.model_dump_json.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,83 +21,133 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.fourier.FourierBase.model_dump_json.rst:2
-#: 18ec4172d8584ce389bf84f60083a80f
+#: 31c113eb0ea44ea887a5bc949eb36847
 msgid "FourierBase.model\\_dump\\_json"
 msgstr ""
 
-#: 2e972c253f3048c9a13322f2171facf4 of
+#: 71d69546a6e242ad9d38c025a66986bb of
 #: pydantic.main.BaseModel.model_dump_json:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 195a632ed2e34413852121b04353dacf of
+#: 4466cf2e57d04a36a7ac50e4cd3fdc4a of
 #: pydantic.main.BaseModel.model_dump_json:3
-msgid "[`model_dump_json`](../concepts/serialization.md#modelmodel_dump_json)"
+msgid "[`model_dump_json`](../concepts/serialization.md#json-mode)"
 msgstr ""
 
-#: 12ccc94cc46649f9bfdaf0285d09dd42 of
+#: d96296f0e4bf410d8f5220a29548fea3 of
 #: pydantic.main.BaseModel.model_dump_json:5
 msgid ""
 "Generates a JSON representation of the model using Pydantic's `to_json` "
 "method."
 msgstr ""
 
-#: bc0314bc6ed24eb0ac81cbc1077fa125 of
+#: 03b51d3f04df4d47b0f004dd29e40ecc of
 #: pydantic.main.BaseModel.model_dump_json:7
 msgid "Args:"
 msgstr ""
 
-#: 8999ead38808491296257e79ef6ace4b of
+#: 0c8b0f7edc9045fbb574592a80c8ff10 of
 #: pydantic.main.BaseModel.model_dump_json:8
 msgid ""
 "indent: Indentation to use in the JSON output. If None is passed, the "
-"output will be compact. include: Field(s) to include in the JSON output. "
-"exclude: Field(s) to exclude from the JSON output. context: Additional "
-"context to pass to the serializer. by_alias: Whether to serialize using "
-"field aliases. exclude_unset: Whether to exclude fields that have not "
-"been explicitly set. exclude_defaults: Whether to exclude fields that are"
-" set to their default value. exclude_none: Whether to exclude fields that"
-" have a value of `None`. round_trip: If True, dumped values should be "
-"valid as input for non-idempotent types such as Json[T]. warnings: How to"
-" handle serialization errors. False/\"none\" ignores them, True/\"warn\" "
-"logs errors,"
+"output will be compact. ensure_ascii: If `True`, the output is guaranteed"
+" to have all incoming non-ASCII characters escaped."
 msgstr ""
 
-#: 03478944b24840099b7e46eaf10d0364 of
-#: pydantic.main.BaseModel.model_dump_json:18
+#: 8cf286c505c04678a85c13ce29cb3e27 of
+#: pydantic.main.BaseModel.model_dump_json:10
+msgid "If `False` (the default), these characters will be output as-is."
+msgstr ""
+
+#: cc950f05aed94c8097e46c0321bba5a5 of
+#: pydantic.main.BaseModel.model_dump_json:11
+msgid ""
+"include: Field(s) to include in the JSON output. exclude: Field(s) to "
+"exclude from the JSON output. context: Additional context to pass to the "
+"serializer. by_alias: Whether to serialize using field aliases. "
+"exclude_unset: Whether to exclude fields that have not been explicitly "
+"set. exclude_defaults: Whether to exclude fields that are set to their "
+"default value. exclude_none: Whether to exclude fields that have a value "
+"of `None`. exclude_computed_fields: Whether to exclude computed fields."
+msgstr ""
+
+#: 36e23e037b5345ecaef6b7cf09f0302d of
+#: pydantic.main.BaseModel.model_dump_json:19
+msgid ""
+"While this can be useful for round-tripping, it is usually recommended to"
+" use the dedicated `round_trip` parameter instead."
+msgstr ""
+
+#: 35537b7db4ef4a59b367642a1ea0fb5c of
+#: pydantic.main.BaseModel.model_dump_json:21
+msgid ""
+"round_trip: If True, dumped values should be valid as input for non-"
+"idempotent types such as Json[T]. warnings: How to handle serialization "
+"errors. False/\"none\" ignores them, True/\"warn\" logs errors,"
+msgstr ""
+
+#: cded85c87b8544ee8ab92859a8909ec4 of
+#: pydantic.main.BaseModel.model_dump_json:23
 msgid ""
 "\"error\" raises a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError]."
 msgstr ""
 
-#: 28d38ccdacb044199c85984e733ed2a5 of
-#: pydantic.main.BaseModel.model_dump_json:19
+#: 7c70ab5fdf8f4e989644c6f01eae0aad of
+#: pydantic.main.BaseModel.model_dump_json:24
 msgid ""
 "fallback: A function to call when an unknown value is encountered. If not"
 " provided,"
 msgstr ""
 
-#: 6c77276059584a519738d1bab8eab18e of
-#: pydantic.main.BaseModel.model_dump_json:20
+#: 11ade6db523d46ce951a668428d9e086 of
+#: pydantic.main.BaseModel.model_dump_json:25
 msgid ""
 "a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError] "
 "error is raised."
 msgstr ""
 
-#: 8364bb3dc9274c93a77f56e96f054080 of
-#: pydantic.main.BaseModel.model_dump_json:21
+#: 49bb03074b1347b6824c59005a7d9404 of
+#: pydantic.main.BaseModel.model_dump_json:26
 msgid ""
 "serialize_as_any: Whether to serialize fields with duck-typing "
 "serialization behavior."
 msgstr ""
 
-#: 4362bafe51344aa2a50b20860f4803d5 of
-#: pydantic.main.BaseModel.model_dump_json:23
+#: 95b04a2e89db48a1b89cc7ed4af2b006 of
+#: pydantic.main.BaseModel.model_dump_json:28
 msgid "Returns:"
 msgstr ""
 
-#: b925b48e07464789a0668001b97dd6b8 of
-#: pydantic.main.BaseModel.model_dump_json:24
+#: 1d3e626bc0b04b0580c57cd8dea53227 of
+#: pydantic.main.BaseModel.model_dump_json:29
 msgid "A JSON string representation of the model."
 msgstr ""
+
+#~ msgid "[`model_dump_json`](../concepts/serialization.md#modelmodel_dump_json)"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "indent: Indentation to use in the "
+#~ "JSON output. If None is passed, "
+#~ "the output will be compact. include: "
+#~ "Field(s) to include in the JSON "
+#~ "output. exclude: Field(s) to exclude "
+#~ "from the JSON output. context: "
+#~ "Additional context to pass to the "
+#~ "serializer. by_alias: Whether to serialize "
+#~ "using field aliases. exclude_unset: Whether"
+#~ " to exclude fields that have not "
+#~ "been explicitly set. exclude_defaults: Whether"
+#~ " to exclude fields that are set "
+#~ "to their default value. exclude_none: "
+#~ "Whether to exclude fields that have "
+#~ "a value of `None`. round_trip: If "
+#~ "True, dumped values should be valid "
+#~ "as input for non-idempotent types "
+#~ "such as Json[T]. warnings: How to "
+#~ "handle serialization errors. False/\"none\" "
+#~ "ignores them, True/\"warn\" logs errors,"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.FourierBase.model_json_schema.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.FourierBase.model_json_schema.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,44 +21,77 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.fourier.FourierBase.model_json_schema.rst:2
-#: 28f9852d5cbc4e3ebfc281baebb03339
+#: 712e852a83d04f08959faf3efe99645c
 msgid "FourierBase.model\\_json\\_schema"
 msgstr ""
 
-#: 18adab48b1ab41efb744164edd14f2c6 of
+#: 6592f7acb7924fae9f92de40cf5383d1 of
 #: pydantic.main.BaseModel.model_json_schema:2
 msgid "Generates a JSON schema for a model class."
 msgstr ""
 
-#: 653de4c1ac6849399918f2b141e4e4ff of
+#: fbb23ec03d15494cac013102d562aae5 of
 #: pydantic.main.BaseModel.model_json_schema:4
 msgid "Args:"
 msgstr ""
 
-#: cbbc3cd34c7d446abc64b55a3abebf15 of
+#: d4af69af88da46acb3652ff3992c5083 of
 #: pydantic.main.BaseModel.model_json_schema:5
 msgid ""
 "by_alias: Whether to use attribute aliases or not. ref_template: The "
-"reference template. schema_generator: To override the logic used to "
-"generate the JSON schema, as a subclass of"
+"reference template. union_format: The format to use when combining "
+"schemas from unions together. Can be one of:"
 msgstr ""
 
-#: aecd019d571945ef94e09879f7f5ae4e of
-#: pydantic.main.BaseModel.model_json_schema:8
+#: 099ef6ba6c974325b4b52124a50b1d40 of
+#: pydantic.main.BaseModel.model_json_schema:9
+msgid ""
+"`'any_of'`: Use the [`anyOf`](https://json-schema.org/understanding-json-"
+"schema/reference/combining#anyOf)"
+msgstr ""
+
+#: b1915a5404194497b9acb9f99414c280 of
+#: pydantic.main.BaseModel.model_json_schema:10
+msgid ""
+"keyword to combine schemas (the default). - `'primitive_type_array'`: Use"
+" the [`type`](https://json-schema.org/understanding-json-"
+"schema/reference/type) keyword as an array of strings, containing each "
+"type of the combination. If any of the schemas is not a primitive type "
+"(`string`, `boolean`, `null`, `integer` or `number`) or contains "
+"constraints/metadata, falls back to `any_of`."
+msgstr ""
+
+#: cb51a1935a9c44c381e069252b0ae0af of
+#: pydantic.main.BaseModel.model_json_schema:15
+msgid ""
+"schema_generator: To override the logic used to generate the JSON schema,"
+" as a subclass of"
+msgstr ""
+
+#: 39a7570eb97c40919d6d29d27ebe4bb6 of
+#: pydantic.main.BaseModel.model_json_schema:16
 msgid "`GenerateJsonSchema` with your desired modifications"
 msgstr ""
 
-#: f1cfd5942a194be6aa27672971dd43f3 of
-#: pydantic.main.BaseModel.model_json_schema:9
+#: a32495e3dcf848ce9efe6b03975c8f3f of
+#: pydantic.main.BaseModel.model_json_schema:17
 msgid "mode: The mode in which to generate the schema."
 msgstr ""
 
-#: d1a551dd5c964329938c105eb07a731c of
-#: pydantic.main.BaseModel.model_json_schema:11
+#: fa1c7f77b0f44cca9bd80626410968ca of
+#: pydantic.main.BaseModel.model_json_schema:19
 msgid "Returns:"
 msgstr ""
 
-#: 76fe26e91eaa46cdae84f7cd49967d67 of
-#: pydantic.main.BaseModel.model_json_schema:12
+#: 3980496560ae48c0be614f3a6bcf58f2 of
+#: pydantic.main.BaseModel.model_json_schema:20
 msgid "The JSON schema for the given model class."
 msgstr ""
+
+#~ msgid ""
+#~ "by_alias: Whether to use attribute "
+#~ "aliases or not. ref_template: The "
+#~ "reference template. schema_generator: To "
+#~ "override the logic used to generate "
+#~ "the JSON schema, as a subclass of"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.FourierBase.model_validate.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.FourierBase.model_validate.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,21 +21,33 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.fourier.FourierBase.model_validate.rst:2
-#: 317a2c89a583470daae6d4834e58bc6d
+#: 4cfd656bc862481b8eeaf61d31fee6c5
 msgid "FourierBase.model\\_validate"
 msgstr ""
 
-#: 957c13e652b148538ba087f318867775 of pydantic.main.BaseModel.model_validate:2
+#: 5a2f92caa5ca452eb0da7f54a7c36f8b of pydantic.main.BaseModel.model_validate:2
 msgid "Validate a pydantic model instance."
 msgstr ""
 
-#: b56938774f3e49ccbcf4879c651d24ed of pydantic.main.BaseModel.model_validate:4
+#: 1adb402e19a946fbb82866b364e56a92 of pydantic.main.BaseModel.model_validate:4
 msgid "Args:"
 msgstr ""
 
-#: 2c527ccbf7094a4aa82380796676a63a of pydantic.main.BaseModel.model_validate:5
+#: 1f9fad2e4cdc4bd687f266ee62f3ec14 of pydantic.main.BaseModel.model_validate:5
 msgid ""
 "obj: The object to validate. strict: Whether to enforce types strictly. "
+"extra: Whether to ignore, allow, or forbid extra data during model "
+"validation."
+msgstr ""
+
+#: d8b11c204fc2436baf36d3e91421ab64 of pydantic.main.BaseModel.model_validate:8
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: 9c2250b34eca45feae56b00d60816336 of pydantic.main.BaseModel.model_validate:9
+msgid ""
 "from_attributes: Whether to extract data from object attributes. context:"
 " Additional context to pass to the validator. by_alias: Whether to use "
 "the field's alias when validating against the provided input data. "
@@ -43,22 +55,35 @@ msgid ""
 "provided input data."
 msgstr ""
 
-#: de1415c4d6a048ec8e2b52e24235de8c of
-#: pydantic.main.BaseModel.model_validate:12
+#: dff37d7261314cb8ba1fc428f2265b05 of
+#: pydantic.main.BaseModel.model_validate:14
 msgid "Raises:"
 msgstr ""
 
-#: 4cf41228920e429fbeb1ff17af53b532 of
-#: pydantic.main.BaseModel.model_validate:13
+#: 3923e5a44b4d4e3c964dc96ce1ca586a of
+#: pydantic.main.BaseModel.model_validate:15
 msgid "ValidationError: If the object could not be validated."
 msgstr ""
 
-#: 868530e11c26437cbc42860800166c02 of
-#: pydantic.main.BaseModel.model_validate:15
+#: b2c0b537d90d40048a7699d215fbc00a of
+#: pydantic.main.BaseModel.model_validate:17
 msgid "Returns:"
 msgstr ""
 
-#: 0b1f033a70c644e7ad6fc03b16e716e4 of
-#: pydantic.main.BaseModel.model_validate:16
+#: f0ea85ee5a0e4ecc85c8df0876c947d7 of
+#: pydantic.main.BaseModel.model_validate:18
 msgid "The validated model instance."
 msgstr ""
+
+#~ msgid ""
+#~ "obj: The object to validate. strict: "
+#~ "Whether to enforce types strictly. "
+#~ "from_attributes: Whether to extract data "
+#~ "from object attributes. context: Additional"
+#~ " context to pass to the validator."
+#~ " by_alias: Whether to use the field's"
+#~ " alias when validating against the "
+#~ "provided input data. by_name: Whether to"
+#~ " use the field's name when validating"
+#~ " against the provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.FourierBase.model_validate_json.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.FourierBase.model_validate_json.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,58 +21,84 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.fourier.FourierBase.model_validate_json.rst:2
-#: 3bc6000406f44f3db26698b1fba9e112
+#: 5d9366c6df6543479eafcfeb2e43040f
 msgid "FourierBase.model\\_validate\\_json"
 msgstr ""
 
-#: 7dd3275deaa04f90a5cac1338f68d0b1 of
+#: 32e894e4e9d64429a785d3791fd86327 of
 #: pydantic.main.BaseModel.model_validate_json:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 1816c1dd9886420aa0ed8d6c39c94c66 of
+#: 647a89fa39124bdf810ab3dadea90dc0 of
 #: pydantic.main.BaseModel.model_validate_json:3
 msgid "[JSON Parsing](../concepts/json.md#json-parsing)"
 msgstr ""
 
-#: 199662f2a3a346a59654f66a57b0f2ea of
+#: 08de0b2ee997494087d114a4f2105f36 of
 #: pydantic.main.BaseModel.model_validate_json:5
 msgid "Validate the given JSON data against the Pydantic model."
 msgstr ""
 
-#: 035280c08a324cc9b561dc779cca8318 of
+#: 9558022ceed64367927b3dac014ee0a8 of
 #: pydantic.main.BaseModel.model_validate_json:7
 msgid "Args:"
 msgstr ""
 
-#: 770f49e96dc64669837bb7f0bb573f5b of
+#: 3ad030ed419746aaaefd88e9e11d5466 of
 #: pydantic.main.BaseModel.model_validate_json:8
 msgid ""
 "json_data: The JSON data to validate. strict: Whether to enforce types "
-"strictly. context: Extra variables to pass to the validator. by_alias: "
-"Whether to use the field's alias when validating against the provided "
-"input data. by_name: Whether to use the field's name when validating "
-"against the provided input data."
+"strictly. extra: Whether to ignore, allow, or forbid extra data during "
+"model validation."
 msgstr ""
 
-#: e328f7277a624c86b83af008e20c6954 of
-#: pydantic.main.BaseModel.model_validate_json:14
+#: d63c83fba2e547fc8089a0dc90a316e5 of
+#: pydantic.main.BaseModel.model_validate_json:11
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: 501825e5b7c844488e0f2553fbce8fd6 of
+#: pydantic.main.BaseModel.model_validate_json:12
+msgid ""
+"context: Extra variables to pass to the validator. by_alias: Whether to "
+"use the field's alias when validating against the provided input data. "
+"by_name: Whether to use the field's name when validating against the "
+"provided input data."
+msgstr ""
+
+#: 6d642990024a43bb91999c6c424ede46 of
+#: pydantic.main.BaseModel.model_validate_json:16
 msgid "Returns:"
 msgstr ""
 
-#: f6b327a5793346b3a25748cb890c78aa of
-#: pydantic.main.BaseModel.model_validate_json:15
+#: d72b350ed58945f2aab8a0117e827f48 of
+#: pydantic.main.BaseModel.model_validate_json:17
 msgid "The validated Pydantic model."
 msgstr ""
 
-#: 6516c69d702d438dbf9dbdd0c8d7a19d of
-#: pydantic.main.BaseModel.model_validate_json:17
+#: 982c1abc0515411fbc82e49a700637b9 of
+#: pydantic.main.BaseModel.model_validate_json:19
 msgid "Raises:"
 msgstr ""
 
-#: ee5d7a429db04a96b5a95670ae52f7f7 of
-#: pydantic.main.BaseModel.model_validate_json:18
+#: 4df2e46629ad4d93967030dbae00ad4b of
+#: pydantic.main.BaseModel.model_validate_json:20
 msgid ""
 "ValidationError: If `json_data` is not a JSON string or the object could "
 "not be validated."
 msgstr ""
+
+#~ msgid ""
+#~ "json_data: The JSON data to validate."
+#~ " strict: Whether to enforce types "
+#~ "strictly. context: Extra variables to "
+#~ "pass to the validator. by_alias: Whether"
+#~ " to use the field's alias when "
+#~ "validating against the provided input "
+#~ "data. by_name: Whether to use the "
+#~ "field's name when validating against the"
+#~ " provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.FourierBase.model_validate_strings.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.FourierBase.model_validate_strings.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,36 +21,62 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.fourier.FourierBase.model_validate_strings.rst:2
-#: 1050d221e6a34561aa9a6907ffb50c10
+#: e47670a0611541489848ba904a354127
 msgid "FourierBase.model\\_validate\\_strings"
 msgstr ""
 
-#: c91f0b0f8a454092b69023d6b69c02d3 of
+#: 90d48001edf7483bbcd12274e5965608 of
 #: pydantic.main.BaseModel.model_validate_strings:2
 msgid "Validate the given object with string data against the Pydantic model."
 msgstr ""
 
-#: 038fdc1d25e34b53a6b0588da773877c of
+#: f9a3212f2b6148239a78f7f65dc47a6d of
 #: pydantic.main.BaseModel.model_validate_strings:4
 msgid "Args:"
 msgstr ""
 
-#: c93f05b3c698495d9262ab330537edbd of
+#: 19661954306748ba80065f6336404a8b of
 #: pydantic.main.BaseModel.model_validate_strings:5
 msgid ""
 "obj: The object containing string data to validate. strict: Whether to "
-"enforce types strictly. context: Extra variables to pass to the "
-"validator. by_alias: Whether to use the field's alias when validating "
-"against the provided input data. by_name: Whether to use the field's name"
-" when validating against the provided input data."
+"enforce types strictly. extra: Whether to ignore, allow, or forbid extra "
+"data during model validation."
 msgstr ""
 
-#: c592c18193c04593a1afcdff8c1d46b0 of
-#: pydantic.main.BaseModel.model_validate_strings:11
+#: 7565b7c894f04973a62ec32059b12cf5 of
+#: pydantic.main.BaseModel.model_validate_strings:8
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: 92428e9a30b1496886702cfff8090345 of
+#: pydantic.main.BaseModel.model_validate_strings:9
+msgid ""
+"context: Extra variables to pass to the validator. by_alias: Whether to "
+"use the field's alias when validating against the provided input data. "
+"by_name: Whether to use the field's name when validating against the "
+"provided input data."
+msgstr ""
+
+#: 5dcba1ed3d45410fb4268e8601138f8d of
+#: pydantic.main.BaseModel.model_validate_strings:13
 msgid "Returns:"
 msgstr ""
 
-#: 1ade2407a8e842ce902edfcf9e78470f of
-#: pydantic.main.BaseModel.model_validate_strings:12
+#: 8d336ed6733f49a1a4073e1ed7a164b8 of
+#: pydantic.main.BaseModel.model_validate_strings:14
 msgid "The validated Pydantic model."
 msgstr ""
+
+#~ msgid ""
+#~ "obj: The object containing string data"
+#~ " to validate. strict: Whether to "
+#~ "enforce types strictly. context: Extra "
+#~ "variables to pass to the validator. "
+#~ "by_alias: Whether to use the field's "
+#~ "alias when validating against the "
+#~ "provided input data. by_name: Whether to"
+#~ " use the field's name when validating"
+#~ " against the provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.MonthlyFourier.model_copy.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.MonthlyFourier.model_copy.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,27 +21,27 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.fourier.MonthlyFourier.model_copy.rst:2
-#: d54302bb36de4951b24786a544298c72
+#: 634cad9be62545988967d0cb56db2fa5
 msgid "MonthlyFourier.model\\_copy"
 msgstr ""
 
-#: 6c39c9674fb04e519fef3d12417544f9 of pydantic.main.BaseModel.model_copy:2
+#: 5f6ace6524114c2fb3196c60717fed4e of pydantic.main.BaseModel.model_copy:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: a6331c1ce4c44f02b5e4d38d6e418f86 of pydantic.main.BaseModel.model_copy:3
-msgid "[`model_copy`](../concepts/serialization.md#model_copy)"
+#: 13c5f275f01e49249855663b123da2a2 of pydantic.main.BaseModel.model_copy:3
+msgid "[`model_copy`](../concepts/models.md#model-copy)"
 msgstr ""
 
-#: 518b5579fb8e4ab5b905cc58fdac306e of pydantic.main.BaseModel.model_copy:5
+#: 6314534cf13e4b7592ae4434dc87fdee of pydantic.main.BaseModel.model_copy:5
 msgid "Returns a copy of the model."
 msgstr ""
 
-#: ae9ff9b4b8b34c0582a1b44e7d4eba20 of pydantic.main.BaseModel.model_copy:7
+#: f592604ebfdc43629b0d8cb2cf7242ea of pydantic.main.BaseModel.model_copy:7
 msgid "!!! note"
 msgstr ""
 
-#: 1c5371593875445baf6349c83e2fc392 of pydantic.main.BaseModel.model_copy:8
+#: 66b648e1508c4dbd8449024dbf6b5926 of pydantic.main.BaseModel.model_copy:8
 msgid ""
 "The underlying instance's [`__dict__`][object.__dict__] attribute is "
 "copied. This might have unexpected side effects if you store anything in "
@@ -49,28 +49,31 @@ msgid ""
 "properties][functools.cached_property])."
 msgstr ""
 
-#: 922753fc97084e9d9fd16e86f0d1a0f5 of pydantic.main.BaseModel.model_copy:12
+#: 921d0cab86b24270a95e1271cfb0f97c of pydantic.main.BaseModel.model_copy:12
 msgid "Args:"
 msgstr ""
 
-#: e5184259cee54781b4c44e8a47c8828d of pydantic.main.BaseModel.model_copy:13
+#: 2fde4dfbe271486eadeab5d58b543db6 of pydantic.main.BaseModel.model_copy:13
 msgid ""
 "update: Values to change/add in the new model. Note: the data is not "
 "validated"
 msgstr ""
 
-#: 9db4e9e334c944158e788dbb7c0f24e9 of pydantic.main.BaseModel.model_copy:14
+#: a12d03d40e1b49f68be557f97f6ecf8d of pydantic.main.BaseModel.model_copy:14
 msgid "before creating the new model. You should trust this data."
 msgstr ""
 
-#: c3c786d498a84f93bc4799914b2d5507 of pydantic.main.BaseModel.model_copy:15
+#: da2510a1b4a945e49f52b953ecfb6761 of pydantic.main.BaseModel.model_copy:15
 msgid "deep: Set to `True` to make a deep copy of the model."
 msgstr ""
 
-#: 9d85fcfd013f4e83b91407ace04adb9c of pydantic.main.BaseModel.model_copy:17
+#: 23cf227d779346ccb95d0b8542c0034a of pydantic.main.BaseModel.model_copy:17
 msgid "Returns:"
 msgstr ""
 
-#: b10a02bb133c4bc282451474c73d144b of pydantic.main.BaseModel.model_copy:18
+#: 6f7937d8ac3942aab15c50cabc678822 of pydantic.main.BaseModel.model_copy:18
 msgid "New model instance."
 msgstr ""
+
+#~ msgid "[`model_copy`](../concepts/serialization.md#model_copy)"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.MonthlyFourier.model_dump.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.MonthlyFourier.model_dump.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,40 +21,40 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.fourier.MonthlyFourier.model_dump.rst:2
-#: b6fd6168ce95480386dfc0054cd75b0e
+#: cf9f995774674815b8202eda4b520308
 msgid "MonthlyFourier.model\\_dump"
 msgstr ""
 
-#: e64e67dc18354a1baf074f3ac6281c1f of pydantic.main.BaseModel.model_dump:2
+#: 6f4c0e00acba4567b85cc3904bcfdd28 of pydantic.main.BaseModel.model_dump:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 1016f3c43078436b90105f75aeb1ec20 of pydantic.main.BaseModel.model_dump:3
-msgid "[`model_dump`](../concepts/serialization.md#modelmodel_dump)"
+#: 1a166862f08d4eb29a273cafe4179dc1 of pydantic.main.BaseModel.model_dump:3
+msgid "[`model_dump`](../concepts/serialization.md#python-mode)"
 msgstr ""
 
-#: 0c516e3862a84fc1888ce3996f822d93 of pydantic.main.BaseModel.model_dump:5
+#: ac5ee6ab9a174cc895ff7e07220a5157 of pydantic.main.BaseModel.model_dump:5
 msgid ""
 "Generate a dictionary representation of the model, optionally specifying "
 "which fields to include or exclude."
 msgstr ""
 
-#: f4aefd547858404b8df095bbe4685998 of pydantic.main.BaseModel.model_dump:7
+#: 42ad72c17d8b4cf291da1de87bf3c760 of pydantic.main.BaseModel.model_dump:7
 msgid "Args:"
 msgstr ""
 
-#: f31b4b17b1fc4152bfdac3ae15525238 of pydantic.main.BaseModel.model_dump:8
+#: b7acb939e393436f823f245ca73f1045 of pydantic.main.BaseModel.model_dump:8
 msgid "mode: The mode in which `to_python` should run."
 msgstr ""
 
-#: cddf1a3b38e24b398108facfa28dada0 of pydantic.main.BaseModel.model_dump:9
+#: 18ef6904f3c246ce8c28b2bfdc184363 of pydantic.main.BaseModel.model_dump:9
 msgid ""
 "If mode is 'json', the output will only contain JSON serializable types. "
 "If mode is 'python', the output may contain non-JSON-serializable Python "
 "objects."
 msgstr ""
 
-#: 253bd38ce83142a09afd80de9456ab45 of pydantic.main.BaseModel.model_dump:11
+#: 026002ae4fdc41088c05c8aa312cef0b of pydantic.main.BaseModel.model_dump:11
 msgid ""
 "include: A set of fields to include in the output. exclude: A set of "
 "fields to exclude from the output. context: Additional context to pass to"
@@ -62,41 +62,77 @@ msgid ""
 "dictionary key if defined. exclude_unset: Whether to exclude fields that "
 "have not been explicitly set. exclude_defaults: Whether to exclude fields"
 " that are set to their default value. exclude_none: Whether to exclude "
-"fields that have a value of `None`. round_trip: If True, dumped values "
-"should be valid as input for non-idempotent types such as Json[T]. "
-"warnings: How to handle serialization errors. False/\"none\" ignores "
-"them, True/\"warn\" logs errors,"
+"fields that have a value of `None`. exclude_computed_fields: Whether to "
+"exclude computed fields."
 msgstr ""
 
-#: ad69680a003440b497219bd597b7fac2 of pydantic.main.BaseModel.model_dump:20
+#: a698bce8d3c2464494e81c7aa1743336 of pydantic.main.BaseModel.model_dump:19
+msgid ""
+"While this can be useful for round-tripping, it is usually recommended tu"
+" use the dedicated `round_trip` parameter instead."
+msgstr ""
+
+#: 9ec9c69ebf514ccbbcc051821b72237b of pydantic.main.BaseModel.model_dump:21
+msgid ""
+"round_trip: If True, dumped values should be valid as input for non-"
+"idempotent types such as Json[T]. warnings: How to handle serialization "
+"errors. False/\"none\" ignores them, True/\"warn\" logs errors,"
+msgstr ""
+
+#: fa1c4b2408ef457390331cdfb016a6b5 of pydantic.main.BaseModel.model_dump:23
 msgid ""
 "\"error\" raises a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError]."
 msgstr ""
 
-#: 22135c3bb1d9437880cf08960eb9a88d of pydantic.main.BaseModel.model_dump:21
+#: 2bbf51a23ec040afb6990216e7c41211 of pydantic.main.BaseModel.model_dump:24
 msgid ""
 "fallback: A function to call when an unknown value is encountered. If not"
 " provided,"
 msgstr ""
 
-#: 07e1f1076d0c4d78929fd82be2b8e5dd of pydantic.main.BaseModel.model_dump:22
+#: 95ec117cab6d4c4993110e0f953740ea of pydantic.main.BaseModel.model_dump:25
 msgid ""
 "a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError] "
 "error is raised."
 msgstr ""
 
-#: 941589ea619342c1ae99becf198d23c2 of pydantic.main.BaseModel.model_dump:23
+#: 2d3a3e30bab1431b92d43241f7592e29 of pydantic.main.BaseModel.model_dump:26
 msgid ""
 "serialize_as_any: Whether to serialize fields with duck-typing "
 "serialization behavior."
 msgstr ""
 
-#: 43f34112e02c4f59af688fdde41fc80e of pydantic.main.BaseModel.model_dump:25
+#: fcc2203f5d7b4a1590ba0273f612ebc7 of pydantic.main.BaseModel.model_dump:28
 msgid "Returns:"
 msgstr ""
 
-#: 9ff654d08d86424fac6e8bdc00056017 of pydantic.main.BaseModel.model_dump:26
+#: 561db26148b74ee7b03a8755a64aa75b of pydantic.main.BaseModel.model_dump:29
 msgid "A dictionary representation of the model."
 msgstr ""
+
+#~ msgid "[`model_dump`](../concepts/serialization.md#modelmodel_dump)"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "include: A set of fields to "
+#~ "include in the output. exclude: A "
+#~ "set of fields to exclude from the"
+#~ " output. context: Additional context to "
+#~ "pass to the serializer. by_alias: "
+#~ "Whether to use the field's alias "
+#~ "in the dictionary key if defined. "
+#~ "exclude_unset: Whether to exclude fields "
+#~ "that have not been explicitly set. "
+#~ "exclude_defaults: Whether to exclude fields"
+#~ " that are set to their default "
+#~ "value. exclude_none: Whether to exclude "
+#~ "fields that have a value of "
+#~ "`None`. round_trip: If True, dumped "
+#~ "values should be valid as input "
+#~ "for non-idempotent types such as "
+#~ "Json[T]. warnings: How to handle "
+#~ "serialization errors. False/\"none\" ignores "
+#~ "them, True/\"warn\" logs errors,"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.MonthlyFourier.model_dump_json.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.MonthlyFourier.model_dump_json.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,83 +21,133 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.fourier.MonthlyFourier.model_dump_json.rst:2
-#: db4dde9d2b654e358d8faa9db13c64c1
+#: 7510418d1e4d44f090cab965d5ed9acb
 msgid "MonthlyFourier.model\\_dump\\_json"
 msgstr ""
 
-#: 455926c8273e4e9d947cb8b2a01f6b5a of
+#: d2018aa90402410e8e5dfc75a950b46a of
 #: pydantic.main.BaseModel.model_dump_json:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: e38d1d0f28b54adeb00cbf7a3e36faab of
+#: 016fea27050444e29cb25d41fcd939d0 of
 #: pydantic.main.BaseModel.model_dump_json:3
-msgid "[`model_dump_json`](../concepts/serialization.md#modelmodel_dump_json)"
+msgid "[`model_dump_json`](../concepts/serialization.md#json-mode)"
 msgstr ""
 
-#: 2a3edd5cac8b460c830b8593c259716e of
+#: d9267bad64394463b976a4070b1511cd of
 #: pydantic.main.BaseModel.model_dump_json:5
 msgid ""
 "Generates a JSON representation of the model using Pydantic's `to_json` "
 "method."
 msgstr ""
 
-#: 94bc4e6333f84fb39ed9f42bbfa1cf40 of
+#: 87794f6e0d1842e2a86b9f7dcb0c97dd of
 #: pydantic.main.BaseModel.model_dump_json:7
 msgid "Args:"
 msgstr ""
 
-#: fba1092ed6aa47a5bdd271387b626a82 of
+#: 20bc1371a946402eb25a5816f58eab61 of
 #: pydantic.main.BaseModel.model_dump_json:8
 msgid ""
 "indent: Indentation to use in the JSON output. If None is passed, the "
-"output will be compact. include: Field(s) to include in the JSON output. "
-"exclude: Field(s) to exclude from the JSON output. context: Additional "
-"context to pass to the serializer. by_alias: Whether to serialize using "
-"field aliases. exclude_unset: Whether to exclude fields that have not "
-"been explicitly set. exclude_defaults: Whether to exclude fields that are"
-" set to their default value. exclude_none: Whether to exclude fields that"
-" have a value of `None`. round_trip: If True, dumped values should be "
-"valid as input for non-idempotent types such as Json[T]. warnings: How to"
-" handle serialization errors. False/\"none\" ignores them, True/\"warn\" "
-"logs errors,"
+"output will be compact. ensure_ascii: If `True`, the output is guaranteed"
+" to have all incoming non-ASCII characters escaped."
 msgstr ""
 
-#: 710082ac7ee2402dad95d82116013b85 of
-#: pydantic.main.BaseModel.model_dump_json:18
+#: 8c340d47c7074c47a15c36cb98c11b34 of
+#: pydantic.main.BaseModel.model_dump_json:10
+msgid "If `False` (the default), these characters will be output as-is."
+msgstr ""
+
+#: fb584f262ef548a0a5c7ffd1a1480bad of
+#: pydantic.main.BaseModel.model_dump_json:11
+msgid ""
+"include: Field(s) to include in the JSON output. exclude: Field(s) to "
+"exclude from the JSON output. context: Additional context to pass to the "
+"serializer. by_alias: Whether to serialize using field aliases. "
+"exclude_unset: Whether to exclude fields that have not been explicitly "
+"set. exclude_defaults: Whether to exclude fields that are set to their "
+"default value. exclude_none: Whether to exclude fields that have a value "
+"of `None`. exclude_computed_fields: Whether to exclude computed fields."
+msgstr ""
+
+#: ff8faf553e1a44419148dba1a57b179a of
+#: pydantic.main.BaseModel.model_dump_json:19
+msgid ""
+"While this can be useful for round-tripping, it is usually recommended to"
+" use the dedicated `round_trip` parameter instead."
+msgstr ""
+
+#: 0b33e82ecc2e4becae583654daae8559 of
+#: pydantic.main.BaseModel.model_dump_json:21
+msgid ""
+"round_trip: If True, dumped values should be valid as input for non-"
+"idempotent types such as Json[T]. warnings: How to handle serialization "
+"errors. False/\"none\" ignores them, True/\"warn\" logs errors,"
+msgstr ""
+
+#: d914bb4fa5e746159b3388739b5b7fa4 of
+#: pydantic.main.BaseModel.model_dump_json:23
 msgid ""
 "\"error\" raises a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError]."
 msgstr ""
 
-#: b9b10930b5d94a2c946941331906af3b of
-#: pydantic.main.BaseModel.model_dump_json:19
+#: 935e5c01368a47ab878753fe9a3688d1 of
+#: pydantic.main.BaseModel.model_dump_json:24
 msgid ""
 "fallback: A function to call when an unknown value is encountered. If not"
 " provided,"
 msgstr ""
 
-#: 745eaefccc944711bbd27a7214a62abf of
-#: pydantic.main.BaseModel.model_dump_json:20
+#: af5a13f298ad49bf943fc9eb26957263 of
+#: pydantic.main.BaseModel.model_dump_json:25
 msgid ""
 "a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError] "
 "error is raised."
 msgstr ""
 
-#: 6783c9ece0394f2ebfd9e357b926330a of
-#: pydantic.main.BaseModel.model_dump_json:21
+#: c0396182cc164127b908040953b32ad5 of
+#: pydantic.main.BaseModel.model_dump_json:26
 msgid ""
 "serialize_as_any: Whether to serialize fields with duck-typing "
 "serialization behavior."
 msgstr ""
 
-#: a8ba1e4166d449f1b8c96625e075de29 of
-#: pydantic.main.BaseModel.model_dump_json:23
+#: a8cab85e072a41bca071938bdbca8aa4 of
+#: pydantic.main.BaseModel.model_dump_json:28
 msgid "Returns:"
 msgstr ""
 
-#: 67d94527ba614a1cac86eb68e8c677e8 of
-#: pydantic.main.BaseModel.model_dump_json:24
+#: 886cc359cb5e4b1bbd90e2b25b367185 of
+#: pydantic.main.BaseModel.model_dump_json:29
 msgid "A JSON string representation of the model."
 msgstr ""
+
+#~ msgid "[`model_dump_json`](../concepts/serialization.md#modelmodel_dump_json)"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "indent: Indentation to use in the "
+#~ "JSON output. If None is passed, "
+#~ "the output will be compact. include: "
+#~ "Field(s) to include in the JSON "
+#~ "output. exclude: Field(s) to exclude "
+#~ "from the JSON output. context: "
+#~ "Additional context to pass to the "
+#~ "serializer. by_alias: Whether to serialize "
+#~ "using field aliases. exclude_unset: Whether"
+#~ " to exclude fields that have not "
+#~ "been explicitly set. exclude_defaults: Whether"
+#~ " to exclude fields that are set "
+#~ "to their default value. exclude_none: "
+#~ "Whether to exclude fields that have "
+#~ "a value of `None`. round_trip: If "
+#~ "True, dumped values should be valid "
+#~ "as input for non-idempotent types "
+#~ "such as Json[T]. warnings: How to "
+#~ "handle serialization errors. False/\"none\" "
+#~ "ignores them, True/\"warn\" logs errors,"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.MonthlyFourier.model_json_schema.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.MonthlyFourier.model_json_schema.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,44 +21,77 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.fourier.MonthlyFourier.model_json_schema.rst:2
-#: 4a4097634d8e4677a5d4712497f6bf99
+#: 9d0ac3f325ee43c4a9166fecc0d5c68b
 msgid "MonthlyFourier.model\\_json\\_schema"
 msgstr ""
 
-#: 2bd873104b5d422ba98c4fa364216296 of
+#: 5f829c69a13045a2b0c4ce060dc98288 of
 #: pydantic.main.BaseModel.model_json_schema:2
 msgid "Generates a JSON schema for a model class."
 msgstr ""
 
-#: 048b79e3c75045069b56fbb8a9dfe016 of
+#: d725ff3c624b4438961610b1b982edb9 of
 #: pydantic.main.BaseModel.model_json_schema:4
 msgid "Args:"
 msgstr ""
 
-#: 3b00c371a1eb4333b09d25c6efb68456 of
+#: 087272dfbbad4629b4cf3dc5e655bf44 of
 #: pydantic.main.BaseModel.model_json_schema:5
 msgid ""
 "by_alias: Whether to use attribute aliases or not. ref_template: The "
-"reference template. schema_generator: To override the logic used to "
-"generate the JSON schema, as a subclass of"
+"reference template. union_format: The format to use when combining "
+"schemas from unions together. Can be one of:"
 msgstr ""
 
-#: 276ae344393547329f134c4a7947d68d of
-#: pydantic.main.BaseModel.model_json_schema:8
+#: ed3964536e064738bb5fad83f138487f of
+#: pydantic.main.BaseModel.model_json_schema:9
+msgid ""
+"`'any_of'`: Use the [`anyOf`](https://json-schema.org/understanding-json-"
+"schema/reference/combining#anyOf)"
+msgstr ""
+
+#: ec9c15f51ddc410cbbf3b431740e98c9 of
+#: pydantic.main.BaseModel.model_json_schema:10
+msgid ""
+"keyword to combine schemas (the default). - `'primitive_type_array'`: Use"
+" the [`type`](https://json-schema.org/understanding-json-"
+"schema/reference/type) keyword as an array of strings, containing each "
+"type of the combination. If any of the schemas is not a primitive type "
+"(`string`, `boolean`, `null`, `integer` or `number`) or contains "
+"constraints/metadata, falls back to `any_of`."
+msgstr ""
+
+#: e6ab792fd48242669864f3cd372895ee of
+#: pydantic.main.BaseModel.model_json_schema:15
+msgid ""
+"schema_generator: To override the logic used to generate the JSON schema,"
+" as a subclass of"
+msgstr ""
+
+#: e53ef04c2e4442d6a36e52cef48ec166 of
+#: pydantic.main.BaseModel.model_json_schema:16
 msgid "`GenerateJsonSchema` with your desired modifications"
 msgstr ""
 
-#: 52cd217fd4794957bcf9d02dd8a0e427 of
-#: pydantic.main.BaseModel.model_json_schema:9
+#: 9abf3f9d8fc84455adc1bf9c2c6065c9 of
+#: pydantic.main.BaseModel.model_json_schema:17
 msgid "mode: The mode in which to generate the schema."
 msgstr ""
 
-#: ff9718c7f4ac43b88ae6638d359f6d31 of
-#: pydantic.main.BaseModel.model_json_schema:11
+#: be97a72601ed479f8e0c5260c6c73f4f of
+#: pydantic.main.BaseModel.model_json_schema:19
 msgid "Returns:"
 msgstr ""
 
-#: 16f9fa2dd0de40848066682c88f0b1ab of
-#: pydantic.main.BaseModel.model_json_schema:12
+#: c30c030556b54acf8ffbb52c49310985 of
+#: pydantic.main.BaseModel.model_json_schema:20
 msgid "The JSON schema for the given model class."
 msgstr ""
+
+#~ msgid ""
+#~ "by_alias: Whether to use attribute "
+#~ "aliases or not. ref_template: The "
+#~ "reference template. schema_generator: To "
+#~ "override the logic used to generate "
+#~ "the JSON schema, as a subclass of"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.MonthlyFourier.model_validate.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.MonthlyFourier.model_validate.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,21 +21,33 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.fourier.MonthlyFourier.model_validate.rst:2
-#: ebc261f0f62947729ce6218c4fb6e635
+#: d9a31ec7d09d4e89b003883c48e2d522
 msgid "MonthlyFourier.model\\_validate"
 msgstr ""
 
-#: 03a46b594d214cd691a4c96a73c12be5 of pydantic.main.BaseModel.model_validate:2
+#: 7ceb1aa4be8940faa30088a4f2e2dc88 of pydantic.main.BaseModel.model_validate:2
 msgid "Validate a pydantic model instance."
 msgstr ""
 
-#: 52c0cd24a97e42378133d0f97cea42cf of pydantic.main.BaseModel.model_validate:4
+#: 163fbe11d43e4c0484583de78888c0b3 of pydantic.main.BaseModel.model_validate:4
 msgid "Args:"
 msgstr ""
 
-#: b0905bbacfbf4a2c989b93559300dcc5 of pydantic.main.BaseModel.model_validate:5
+#: b0a22dbab4bf4a4a83a13e4ec50970c0 of pydantic.main.BaseModel.model_validate:5
 msgid ""
 "obj: The object to validate. strict: Whether to enforce types strictly. "
+"extra: Whether to ignore, allow, or forbid extra data during model "
+"validation."
+msgstr ""
+
+#: 7da14b8ab2ac4921bcd549203f4f049b of pydantic.main.BaseModel.model_validate:8
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: fe301915e290424492322ea14e3daa25 of pydantic.main.BaseModel.model_validate:9
+msgid ""
 "from_attributes: Whether to extract data from object attributes. context:"
 " Additional context to pass to the validator. by_alias: Whether to use "
 "the field's alias when validating against the provided input data. "
@@ -43,22 +55,35 @@ msgid ""
 "provided input data."
 msgstr ""
 
-#: d6fe3c3146444ff9981dbcf4816563f6 of
-#: pydantic.main.BaseModel.model_validate:12
+#: da5c720f034f4e389eff28159233e75d of
+#: pydantic.main.BaseModel.model_validate:14
 msgid "Raises:"
 msgstr ""
 
-#: bfad681bedf2415299fd4f80ef3bae87 of
-#: pydantic.main.BaseModel.model_validate:13
+#: 02f61d6242484de0b28af4a50caaa79c of
+#: pydantic.main.BaseModel.model_validate:15
 msgid "ValidationError: If the object could not be validated."
 msgstr ""
 
-#: 32c3860af46d4bd6841f40bf9f9f3857 of
-#: pydantic.main.BaseModel.model_validate:15
+#: bf0abfa37ea647d1a1f714970970c969 of
+#: pydantic.main.BaseModel.model_validate:17
 msgid "Returns:"
 msgstr ""
 
-#: afc25bac689f4e38aa1eb3756729025a of
-#: pydantic.main.BaseModel.model_validate:16
+#: 5bbd95f5b63e4d9e952bcfe46ccfcf8a of
+#: pydantic.main.BaseModel.model_validate:18
 msgid "The validated model instance."
 msgstr ""
+
+#~ msgid ""
+#~ "obj: The object to validate. strict: "
+#~ "Whether to enforce types strictly. "
+#~ "from_attributes: Whether to extract data "
+#~ "from object attributes. context: Additional"
+#~ " context to pass to the validator."
+#~ " by_alias: Whether to use the field's"
+#~ " alias when validating against the "
+#~ "provided input data. by_name: Whether to"
+#~ " use the field's name when validating"
+#~ " against the provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.MonthlyFourier.model_validate_json.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.MonthlyFourier.model_validate_json.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,58 +21,84 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.fourier.MonthlyFourier.model_validate_json.rst:2
-#: a60a5e8ed5044e71867907f69a6f86ed
+#: a931aa48ccf1498da4bf839d863e72d1
 msgid "MonthlyFourier.model\\_validate\\_json"
 msgstr ""
 
-#: efdcff54c34d4d97900cf25504e726d4 of
+#: d1d04f5c80db4565a879b520f666cefb of
 #: pydantic.main.BaseModel.model_validate_json:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: c9bf16534ab9431b9264e6b7f8c7efce of
+#: 9629cf69afc24985b1b586d7b015eead of
 #: pydantic.main.BaseModel.model_validate_json:3
 msgid "[JSON Parsing](../concepts/json.md#json-parsing)"
 msgstr ""
 
-#: 9db0ac7f11364d12ac778b0825fb0d81 of
+#: 95872eb635c74f0ab4f2f5a404d34874 of
 #: pydantic.main.BaseModel.model_validate_json:5
 msgid "Validate the given JSON data against the Pydantic model."
 msgstr ""
 
-#: ab92b88a47f54c0db08792949aef74db of
+#: 965d988ef39a4ac59a874b26c63c4020 of
 #: pydantic.main.BaseModel.model_validate_json:7
 msgid "Args:"
 msgstr ""
 
-#: b5f42556155c439d9a5107df221fc7f4 of
+#: 064bf0ebf45c4fcd89722a6e86759619 of
 #: pydantic.main.BaseModel.model_validate_json:8
 msgid ""
 "json_data: The JSON data to validate. strict: Whether to enforce types "
-"strictly. context: Extra variables to pass to the validator. by_alias: "
-"Whether to use the field's alias when validating against the provided "
-"input data. by_name: Whether to use the field's name when validating "
-"against the provided input data."
+"strictly. extra: Whether to ignore, allow, or forbid extra data during "
+"model validation."
 msgstr ""
 
-#: 46ec1ef74b7b43218b35b5c5737fc4ac of
-#: pydantic.main.BaseModel.model_validate_json:14
+#: c41f1812c8b241b6b16a0c3cf708d568 of
+#: pydantic.main.BaseModel.model_validate_json:11
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: 8eed646f68544a63962636ffaee95ebb of
+#: pydantic.main.BaseModel.model_validate_json:12
+msgid ""
+"context: Extra variables to pass to the validator. by_alias: Whether to "
+"use the field's alias when validating against the provided input data. "
+"by_name: Whether to use the field's name when validating against the "
+"provided input data."
+msgstr ""
+
+#: 4601624f47844a0fac7b2a7ee0ee971a of
+#: pydantic.main.BaseModel.model_validate_json:16
 msgid "Returns:"
 msgstr ""
 
-#: 258caa66182146a1b9c25a0394f2d3b2 of
-#: pydantic.main.BaseModel.model_validate_json:15
+#: eecbece5c8ce4d4fa699d71fc9e3bfad of
+#: pydantic.main.BaseModel.model_validate_json:17
 msgid "The validated Pydantic model."
 msgstr ""
 
-#: 2f4a25d6a7744a37bd1a86c3a43cfc65 of
-#: pydantic.main.BaseModel.model_validate_json:17
+#: b7590a803ea546e8ad5a89fce51d73ec of
+#: pydantic.main.BaseModel.model_validate_json:19
 msgid "Raises:"
 msgstr ""
 
-#: 691a8dfe772346938cc0ac0d2c97f756 of
-#: pydantic.main.BaseModel.model_validate_json:18
+#: 3cea6a92ad8b48ada45735358d1c2a58 of
+#: pydantic.main.BaseModel.model_validate_json:20
 msgid ""
 "ValidationError: If `json_data` is not a JSON string or the object could "
 "not be validated."
 msgstr ""
+
+#~ msgid ""
+#~ "json_data: The JSON data to validate."
+#~ " strict: Whether to enforce types "
+#~ "strictly. context: Extra variables to "
+#~ "pass to the validator. by_alias: Whether"
+#~ " to use the field's alias when "
+#~ "validating against the provided input "
+#~ "data. by_name: Whether to use the "
+#~ "field's name when validating against the"
+#~ " provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.MonthlyFourier.model_validate_strings.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.MonthlyFourier.model_validate_strings.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,36 +21,62 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.fourier.MonthlyFourier.model_validate_strings.rst:2
-#: f69593fe7edb40b1955d97e74c2b1f53
+#: 78067d9900644481855241d7eca91d53
 msgid "MonthlyFourier.model\\_validate\\_strings"
 msgstr ""
 
-#: b53c6d5c34df4310aa9928d10c40c7c3 of
+#: 8715d263b2644b07bf313cf3a6bd61f8 of
 #: pydantic.main.BaseModel.model_validate_strings:2
 msgid "Validate the given object with string data against the Pydantic model."
 msgstr ""
 
-#: 90f6a6983fd348de9d240abc8c344768 of
+#: c3272739bc54477b86550c7b3ab0f5c8 of
 #: pydantic.main.BaseModel.model_validate_strings:4
 msgid "Args:"
 msgstr ""
 
-#: a45ace06e9784ea8a41772e72fd4394a of
+#: 5ac43acc7fb249a29588838a352f9046 of
 #: pydantic.main.BaseModel.model_validate_strings:5
 msgid ""
 "obj: The object containing string data to validate. strict: Whether to "
-"enforce types strictly. context: Extra variables to pass to the "
-"validator. by_alias: Whether to use the field's alias when validating "
-"against the provided input data. by_name: Whether to use the field's name"
-" when validating against the provided input data."
+"enforce types strictly. extra: Whether to ignore, allow, or forbid extra "
+"data during model validation."
 msgstr ""
 
-#: dd0960d152554341bc8f55c76c4ec987 of
-#: pydantic.main.BaseModel.model_validate_strings:11
+#: 4288b9af6e8b41e1830e16d0c90254c5 of
+#: pydantic.main.BaseModel.model_validate_strings:8
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: ad5a967739dd48f2b8839bb963810b69 of
+#: pydantic.main.BaseModel.model_validate_strings:9
+msgid ""
+"context: Extra variables to pass to the validator. by_alias: Whether to "
+"use the field's alias when validating against the provided input data. "
+"by_name: Whether to use the field's name when validating against the "
+"provided input data."
+msgstr ""
+
+#: 345aa77e535a401e93ad7ff721f5f754 of
+#: pydantic.main.BaseModel.model_validate_strings:13
 msgid "Returns:"
 msgstr ""
 
-#: 9fb3dfea958d424c972234e32c0a966d of
-#: pydantic.main.BaseModel.model_validate_strings:12
+#: ce82a80e44a2436ba931d5fdee1ae8ab of
+#: pydantic.main.BaseModel.model_validate_strings:14
 msgid "The validated Pydantic model."
 msgstr ""
+
+#~ msgid ""
+#~ "obj: The object containing string data"
+#~ " to validate. strict: Whether to "
+#~ "enforce types strictly. context: Extra "
+#~ "variables to pass to the validator. "
+#~ "by_alias: Whether to use the field's "
+#~ "alias when validating against the "
+#~ "provided input data. by_name: Whether to"
+#~ " use the field's name when validating"
+#~ " against the provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.WeeklyFourier.model_copy.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.WeeklyFourier.model_copy.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,27 +21,27 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.fourier.WeeklyFourier.model_copy.rst:2
-#: a0071c1521f54dd3a4a532fa1381cd63
+#: 36a1967e38724ae99516fef8af75e221
 msgid "WeeklyFourier.model\\_copy"
 msgstr ""
 
-#: 0ce3ab5304d64261a47795641ec18441 of pydantic.main.BaseModel.model_copy:2
+#: c2f4a70cfd2a4108b2e9e77c1baeb639 of pydantic.main.BaseModel.model_copy:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 4c5b11a219b5489e9c4384bee41cbf47 of pydantic.main.BaseModel.model_copy:3
-msgid "[`model_copy`](../concepts/serialization.md#model_copy)"
+#: 86c842a7e4dc4584aefdd507bf10833d of pydantic.main.BaseModel.model_copy:3
+msgid "[`model_copy`](../concepts/models.md#model-copy)"
 msgstr ""
 
-#: d9295646edd04a67b90a5d0834a74060 of pydantic.main.BaseModel.model_copy:5
+#: b434240226fb42b0bf7c66b33fa1626e of pydantic.main.BaseModel.model_copy:5
 msgid "Returns a copy of the model."
 msgstr ""
 
-#: c6fa515617ce457ba8461a28c02a275f of pydantic.main.BaseModel.model_copy:7
+#: 3f736b1842b5445197c0220c85f99c26 of pydantic.main.BaseModel.model_copy:7
 msgid "!!! note"
 msgstr ""
 
-#: efefc19ebdeb449380af5a8649ee376d of pydantic.main.BaseModel.model_copy:8
+#: 2767563bbd4a40748621b0562c751b28 of pydantic.main.BaseModel.model_copy:8
 msgid ""
 "The underlying instance's [`__dict__`][object.__dict__] attribute is "
 "copied. This might have unexpected side effects if you store anything in "
@@ -49,28 +49,31 @@ msgid ""
 "properties][functools.cached_property])."
 msgstr ""
 
-#: cf54acaa7d60484cb771097667ac4c09 of pydantic.main.BaseModel.model_copy:12
+#: a634083f849a404aa0bad51e4a0a1640 of pydantic.main.BaseModel.model_copy:12
 msgid "Args:"
 msgstr ""
 
-#: 8ba4d5be7e614df998f341970b2eb393 of pydantic.main.BaseModel.model_copy:13
+#: 60cefa06ba6e4d128d7479801c77ada5 of pydantic.main.BaseModel.model_copy:13
 msgid ""
 "update: Values to change/add in the new model. Note: the data is not "
 "validated"
 msgstr ""
 
-#: b94c2a9aa3264b55a21f40dacc91ee15 of pydantic.main.BaseModel.model_copy:14
+#: 9dd7da15df504c9697809d85cff3817b of pydantic.main.BaseModel.model_copy:14
 msgid "before creating the new model. You should trust this data."
 msgstr ""
 
-#: 129521a7871c40cf8df16c7d3460ac58 of pydantic.main.BaseModel.model_copy:15
+#: 01213aab54dc4181a706e96fb6a7fd18 of pydantic.main.BaseModel.model_copy:15
 msgid "deep: Set to `True` to make a deep copy of the model."
 msgstr ""
 
-#: c0e8a041901044d8a475b48cae6087de of pydantic.main.BaseModel.model_copy:17
+#: ac13334c3f3943deb6c3e2a769003851 of pydantic.main.BaseModel.model_copy:17
 msgid "Returns:"
 msgstr ""
 
-#: 6255cf73430545c9a7a121dc16fc6bd8 of pydantic.main.BaseModel.model_copy:18
+#: 514b29f2ae0c4450b7eded61939cf411 of pydantic.main.BaseModel.model_copy:18
 msgid "New model instance."
 msgstr ""
+
+#~ msgid "[`model_copy`](../concepts/serialization.md#model_copy)"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.WeeklyFourier.model_dump.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.WeeklyFourier.model_dump.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,40 +21,40 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.fourier.WeeklyFourier.model_dump.rst:2
-#: 80ae9f41df7b4937af90ac1c6ded886c
+#: 3da37158f61d434089e71808841bf85d
 msgid "WeeklyFourier.model\\_dump"
 msgstr ""
 
-#: 0ffd3a0a805e4999a836e1700c40f822 of pydantic.main.BaseModel.model_dump:2
+#: 93affad4d6f4498d8652ec5855a48023 of pydantic.main.BaseModel.model_dump:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 81e00de855ec455c871b6538816d9b6e of pydantic.main.BaseModel.model_dump:3
-msgid "[`model_dump`](../concepts/serialization.md#modelmodel_dump)"
+#: 617e088f5b284feaa7178eade63e6dc8 of pydantic.main.BaseModel.model_dump:3
+msgid "[`model_dump`](../concepts/serialization.md#python-mode)"
 msgstr ""
 
-#: 0762bfb670834dadbd48e6e88ce1f7b9 of pydantic.main.BaseModel.model_dump:5
+#: dc235a5d07bc4a94a4cd469cbaa7e628 of pydantic.main.BaseModel.model_dump:5
 msgid ""
 "Generate a dictionary representation of the model, optionally specifying "
 "which fields to include or exclude."
 msgstr ""
 
-#: 741feb792bcf41dba75fc39ad793f6d7 of pydantic.main.BaseModel.model_dump:7
+#: d63341edcbc441e0bd1d4e50fccb0297 of pydantic.main.BaseModel.model_dump:7
 msgid "Args:"
 msgstr ""
 
-#: 0970caf613dd45b3a231d5de99f02b44 of pydantic.main.BaseModel.model_dump:8
+#: 653c2d9ad482465893bd4fe1fc71e6a8 of pydantic.main.BaseModel.model_dump:8
 msgid "mode: The mode in which `to_python` should run."
 msgstr ""
 
-#: 20aef14a908741f08a3691a2352e906e of pydantic.main.BaseModel.model_dump:9
+#: 58adec3e8a5c4bcbb7e183c291000847 of pydantic.main.BaseModel.model_dump:9
 msgid ""
 "If mode is 'json', the output will only contain JSON serializable types. "
 "If mode is 'python', the output may contain non-JSON-serializable Python "
 "objects."
 msgstr ""
 
-#: fe1a80224da446e9bae81c8aebe0ab82 of pydantic.main.BaseModel.model_dump:11
+#: 441181a30a8e456d821811d158055dab of pydantic.main.BaseModel.model_dump:11
 msgid ""
 "include: A set of fields to include in the output. exclude: A set of "
 "fields to exclude from the output. context: Additional context to pass to"
@@ -62,41 +62,77 @@ msgid ""
 "dictionary key if defined. exclude_unset: Whether to exclude fields that "
 "have not been explicitly set. exclude_defaults: Whether to exclude fields"
 " that are set to their default value. exclude_none: Whether to exclude "
-"fields that have a value of `None`. round_trip: If True, dumped values "
-"should be valid as input for non-idempotent types such as Json[T]. "
-"warnings: How to handle serialization errors. False/\"none\" ignores "
-"them, True/\"warn\" logs errors,"
+"fields that have a value of `None`. exclude_computed_fields: Whether to "
+"exclude computed fields."
 msgstr ""
 
-#: d50fe2e493794e71aabaf335abb08ce9 of pydantic.main.BaseModel.model_dump:20
+#: 620c6d0acc4b4f8ba1d60e2d3e83b403 of pydantic.main.BaseModel.model_dump:19
+msgid ""
+"While this can be useful for round-tripping, it is usually recommended tu"
+" use the dedicated `round_trip` parameter instead."
+msgstr ""
+
+#: bb2233be994241f9a409ce72a2ff85b8 of pydantic.main.BaseModel.model_dump:21
+msgid ""
+"round_trip: If True, dumped values should be valid as input for non-"
+"idempotent types such as Json[T]. warnings: How to handle serialization "
+"errors. False/\"none\" ignores them, True/\"warn\" logs errors,"
+msgstr ""
+
+#: fffcdaff9f644d68ac5265a84363b661 of pydantic.main.BaseModel.model_dump:23
 msgid ""
 "\"error\" raises a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError]."
 msgstr ""
 
-#: 853ac8db8d774acb94874d29efd59c9f of pydantic.main.BaseModel.model_dump:21
+#: 40001dcb9a1d4788b2cbc529e916ea0b of pydantic.main.BaseModel.model_dump:24
 msgid ""
 "fallback: A function to call when an unknown value is encountered. If not"
 " provided,"
 msgstr ""
 
-#: 01bcc95b27a040b58db9d40ad45fafef of pydantic.main.BaseModel.model_dump:22
+#: c48bfce8b46b4bf0af9b174e23c1bab6 of pydantic.main.BaseModel.model_dump:25
 msgid ""
 "a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError] "
 "error is raised."
 msgstr ""
 
-#: 35573078a68c446b8cd00596dd0040c3 of pydantic.main.BaseModel.model_dump:23
+#: 338fb6e8831b4e9e9fdd1f0c6df2e394 of pydantic.main.BaseModel.model_dump:26
 msgid ""
 "serialize_as_any: Whether to serialize fields with duck-typing "
 "serialization behavior."
 msgstr ""
 
-#: 06b1f9ab9ee44844940b44d66233b26b of pydantic.main.BaseModel.model_dump:25
+#: 103c12a108a648a09d94cecfd893aa1f of pydantic.main.BaseModel.model_dump:28
 msgid "Returns:"
 msgstr ""
 
-#: 32cb90e6b9e047e581411f63a6e1901f of pydantic.main.BaseModel.model_dump:26
+#: 8d67a56264d04255b9dfdc20e9e3270d of pydantic.main.BaseModel.model_dump:29
 msgid "A dictionary representation of the model."
 msgstr ""
+
+#~ msgid "[`model_dump`](../concepts/serialization.md#modelmodel_dump)"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "include: A set of fields to "
+#~ "include in the output. exclude: A "
+#~ "set of fields to exclude from the"
+#~ " output. context: Additional context to "
+#~ "pass to the serializer. by_alias: "
+#~ "Whether to use the field's alias "
+#~ "in the dictionary key if defined. "
+#~ "exclude_unset: Whether to exclude fields "
+#~ "that have not been explicitly set. "
+#~ "exclude_defaults: Whether to exclude fields"
+#~ " that are set to their default "
+#~ "value. exclude_none: Whether to exclude "
+#~ "fields that have a value of "
+#~ "`None`. round_trip: If True, dumped "
+#~ "values should be valid as input "
+#~ "for non-idempotent types such as "
+#~ "Json[T]. warnings: How to handle "
+#~ "serialization errors. False/\"none\" ignores "
+#~ "them, True/\"warn\" logs errors,"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.WeeklyFourier.model_dump_json.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.WeeklyFourier.model_dump_json.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,83 +21,133 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.fourier.WeeklyFourier.model_dump_json.rst:2
-#: 0e63a536d7b44d4ea630f33392b025f0
+#: be9d652132044cb387cd51d5d5735da0
 msgid "WeeklyFourier.model\\_dump\\_json"
 msgstr ""
 
-#: 9395ad6a2e4c4bdf814d1774b06edfaf of
+#: 30c29553c6ba451c8850e371b252b920 of
 #: pydantic.main.BaseModel.model_dump_json:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 0e689949b424448aa6b3c8b1f55e4465 of
+#: b80bad699cd749cdb065d73425ef7ea3 of
 #: pydantic.main.BaseModel.model_dump_json:3
-msgid "[`model_dump_json`](../concepts/serialization.md#modelmodel_dump_json)"
+msgid "[`model_dump_json`](../concepts/serialization.md#json-mode)"
 msgstr ""
 
-#: de4e93ce6ce64c42a3185563383d7ff1 of
+#: bc667c7139ff4287b96a926a4aed6621 of
 #: pydantic.main.BaseModel.model_dump_json:5
 msgid ""
 "Generates a JSON representation of the model using Pydantic's `to_json` "
 "method."
 msgstr ""
 
-#: 0d224fdac85f4e6eb1dc02a710349fc6 of
+#: e7b68608b89c4f7ab6166f2430ded9c3 of
 #: pydantic.main.BaseModel.model_dump_json:7
 msgid "Args:"
 msgstr ""
 
-#: a94d29542929427ebba5796ee1c9dde9 of
+#: e9bc18801dc24fbab2a17bec874fa8b0 of
 #: pydantic.main.BaseModel.model_dump_json:8
 msgid ""
 "indent: Indentation to use in the JSON output. If None is passed, the "
-"output will be compact. include: Field(s) to include in the JSON output. "
-"exclude: Field(s) to exclude from the JSON output. context: Additional "
-"context to pass to the serializer. by_alias: Whether to serialize using "
-"field aliases. exclude_unset: Whether to exclude fields that have not "
-"been explicitly set. exclude_defaults: Whether to exclude fields that are"
-" set to their default value. exclude_none: Whether to exclude fields that"
-" have a value of `None`. round_trip: If True, dumped values should be "
-"valid as input for non-idempotent types such as Json[T]. warnings: How to"
-" handle serialization errors. False/\"none\" ignores them, True/\"warn\" "
-"logs errors,"
+"output will be compact. ensure_ascii: If `True`, the output is guaranteed"
+" to have all incoming non-ASCII characters escaped."
 msgstr ""
 
-#: 18491554e5e04ad780da5be3061583f6 of
-#: pydantic.main.BaseModel.model_dump_json:18
+#: b0cd0fcafbdd44828c65813ba4a093fd of
+#: pydantic.main.BaseModel.model_dump_json:10
+msgid "If `False` (the default), these characters will be output as-is."
+msgstr ""
+
+#: de2b67e7e1b14d88907446b68702144a of
+#: pydantic.main.BaseModel.model_dump_json:11
+msgid ""
+"include: Field(s) to include in the JSON output. exclude: Field(s) to "
+"exclude from the JSON output. context: Additional context to pass to the "
+"serializer. by_alias: Whether to serialize using field aliases. "
+"exclude_unset: Whether to exclude fields that have not been explicitly "
+"set. exclude_defaults: Whether to exclude fields that are set to their "
+"default value. exclude_none: Whether to exclude fields that have a value "
+"of `None`. exclude_computed_fields: Whether to exclude computed fields."
+msgstr ""
+
+#: b37af5cc80294207b436f4bc142371d9 of
+#: pydantic.main.BaseModel.model_dump_json:19
+msgid ""
+"While this can be useful for round-tripping, it is usually recommended to"
+" use the dedicated `round_trip` parameter instead."
+msgstr ""
+
+#: 7920885ccc4d48139509c1e364226aa1 of
+#: pydantic.main.BaseModel.model_dump_json:21
+msgid ""
+"round_trip: If True, dumped values should be valid as input for non-"
+"idempotent types such as Json[T]. warnings: How to handle serialization "
+"errors. False/\"none\" ignores them, True/\"warn\" logs errors,"
+msgstr ""
+
+#: 2b79d1676b3442e6b65ca20609b00ca7 of
+#: pydantic.main.BaseModel.model_dump_json:23
 msgid ""
 "\"error\" raises a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError]."
 msgstr ""
 
-#: 94eabc6da59b4ddebaa663808994787d of
-#: pydantic.main.BaseModel.model_dump_json:19
+#: 5ce64866b8af4eb0bb6546d02b0b9cb9 of
+#: pydantic.main.BaseModel.model_dump_json:24
 msgid ""
 "fallback: A function to call when an unknown value is encountered. If not"
 " provided,"
 msgstr ""
 
-#: b82c216d5f0e41ae8ab0d2dc390e0b2b of
-#: pydantic.main.BaseModel.model_dump_json:20
+#: 6e4cea6a0f204790a02e13d7c08772e1 of
+#: pydantic.main.BaseModel.model_dump_json:25
 msgid ""
 "a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError] "
 "error is raised."
 msgstr ""
 
-#: e60acd5ca23e44e08e69d27cfbfef2bd of
-#: pydantic.main.BaseModel.model_dump_json:21
+#: 8e5310938ee54e20952bc4571fb247e8 of
+#: pydantic.main.BaseModel.model_dump_json:26
 msgid ""
 "serialize_as_any: Whether to serialize fields with duck-typing "
 "serialization behavior."
 msgstr ""
 
-#: d16ac86611da485b83e44875da1167df of
-#: pydantic.main.BaseModel.model_dump_json:23
+#: 9b74782f645d4ba2ba1db7b5b782cea3 of
+#: pydantic.main.BaseModel.model_dump_json:28
 msgid "Returns:"
 msgstr ""
 
-#: a904a7637836488b8ba1157dea08f13b of
-#: pydantic.main.BaseModel.model_dump_json:24
+#: bccfb1c01a284469be968f4dd73c9b05 of
+#: pydantic.main.BaseModel.model_dump_json:29
 msgid "A JSON string representation of the model."
 msgstr ""
+
+#~ msgid "[`model_dump_json`](../concepts/serialization.md#modelmodel_dump_json)"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "indent: Indentation to use in the "
+#~ "JSON output. If None is passed, "
+#~ "the output will be compact. include: "
+#~ "Field(s) to include in the JSON "
+#~ "output. exclude: Field(s) to exclude "
+#~ "from the JSON output. context: "
+#~ "Additional context to pass to the "
+#~ "serializer. by_alias: Whether to serialize "
+#~ "using field aliases. exclude_unset: Whether"
+#~ " to exclude fields that have not "
+#~ "been explicitly set. exclude_defaults: Whether"
+#~ " to exclude fields that are set "
+#~ "to their default value. exclude_none: "
+#~ "Whether to exclude fields that have "
+#~ "a value of `None`. round_trip: If "
+#~ "True, dumped values should be valid "
+#~ "as input for non-idempotent types "
+#~ "such as Json[T]. warnings: How to "
+#~ "handle serialization errors. False/\"none\" "
+#~ "ignores them, True/\"warn\" logs errors,"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.WeeklyFourier.model_json_schema.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.WeeklyFourier.model_json_schema.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,44 +21,77 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.fourier.WeeklyFourier.model_json_schema.rst:2
-#: f16ffea91fe64a8dba527fd759eaec81
+#: 1d844fcf73d14f9aa50441e9446a4b26
 msgid "WeeklyFourier.model\\_json\\_schema"
 msgstr ""
 
-#: c50202d059a34063b31c430f7d05433e of
+#: bc5bacfbed3e491b8ce2acab73c045e4 of
 #: pydantic.main.BaseModel.model_json_schema:2
 msgid "Generates a JSON schema for a model class."
 msgstr ""
 
-#: 3841a79596474b73912971a80e02f48d of
+#: 483817483fc64bbd9fa94525dd0887f2 of
 #: pydantic.main.BaseModel.model_json_schema:4
 msgid "Args:"
 msgstr ""
 
-#: 62573ae55b434a75ad7f811b87f72ff0 of
+#: 3435bc66a719445cb46e40b8772613a7 of
 #: pydantic.main.BaseModel.model_json_schema:5
 msgid ""
 "by_alias: Whether to use attribute aliases or not. ref_template: The "
-"reference template. schema_generator: To override the logic used to "
-"generate the JSON schema, as a subclass of"
+"reference template. union_format: The format to use when combining "
+"schemas from unions together. Can be one of:"
 msgstr ""
 
-#: 424ed8e10a3041718a78e619286bdb04 of
-#: pydantic.main.BaseModel.model_json_schema:8
+#: 80295b85dd2b46acbeace2cbf38c4a33 of
+#: pydantic.main.BaseModel.model_json_schema:9
+msgid ""
+"`'any_of'`: Use the [`anyOf`](https://json-schema.org/understanding-json-"
+"schema/reference/combining#anyOf)"
+msgstr ""
+
+#: 6357c6f5ae3a45858ef6d0c98209fdcb of
+#: pydantic.main.BaseModel.model_json_schema:10
+msgid ""
+"keyword to combine schemas (the default). - `'primitive_type_array'`: Use"
+" the [`type`](https://json-schema.org/understanding-json-"
+"schema/reference/type) keyword as an array of strings, containing each "
+"type of the combination. If any of the schemas is not a primitive type "
+"(`string`, `boolean`, `null`, `integer` or `number`) or contains "
+"constraints/metadata, falls back to `any_of`."
+msgstr ""
+
+#: 3f2307033bcd47dd9e973566920cb17c of
+#: pydantic.main.BaseModel.model_json_schema:15
+msgid ""
+"schema_generator: To override the logic used to generate the JSON schema,"
+" as a subclass of"
+msgstr ""
+
+#: dcd6897fed1841cd8c73165d50363e17 of
+#: pydantic.main.BaseModel.model_json_schema:16
 msgid "`GenerateJsonSchema` with your desired modifications"
 msgstr ""
 
-#: 3fbcd2833972454fa6fb5926806fb149 of
-#: pydantic.main.BaseModel.model_json_schema:9
+#: 1c894d91ab1144c2b27d248d44525077 of
+#: pydantic.main.BaseModel.model_json_schema:17
 msgid "mode: The mode in which to generate the schema."
 msgstr ""
 
-#: aaa71b2a19374512b762d1efa1eaa4ce of
-#: pydantic.main.BaseModel.model_json_schema:11
+#: 66effcb1294041c9b4d1e798537a631f of
+#: pydantic.main.BaseModel.model_json_schema:19
 msgid "Returns:"
 msgstr ""
 
-#: d4063f861b5f421a9a4cc77a5d7144ee of
-#: pydantic.main.BaseModel.model_json_schema:12
+#: 42c79b404ab14498a97602fd51d1065a of
+#: pydantic.main.BaseModel.model_json_schema:20
 msgid "The JSON schema for the given model class."
 msgstr ""
+
+#~ msgid ""
+#~ "by_alias: Whether to use attribute "
+#~ "aliases or not. ref_template: The "
+#~ "reference template. schema_generator: To "
+#~ "override the logic used to generate "
+#~ "the JSON schema, as a subclass of"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.WeeklyFourier.model_validate.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.WeeklyFourier.model_validate.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,21 +21,33 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.fourier.WeeklyFourier.model_validate.rst:2
-#: 50b8872eda6140268f4318ad829ca3cf
+#: 65adbc60683b4f5593b5f11a7b489fcb
 msgid "WeeklyFourier.model\\_validate"
 msgstr ""
 
-#: 1c0f9a70650442adbe6cf9ea45d7b753 of pydantic.main.BaseModel.model_validate:2
+#: 6680f7ab8fb44ee89e1e12ad2a05b720 of pydantic.main.BaseModel.model_validate:2
 msgid "Validate a pydantic model instance."
 msgstr ""
 
-#: e0e396855dd648cfacace5b3ee627415 of pydantic.main.BaseModel.model_validate:4
+#: 96ccfcf95a104a7fb1c4b60a2fc489d4 of pydantic.main.BaseModel.model_validate:4
 msgid "Args:"
 msgstr ""
 
-#: 8c9c511333b94138bd7cb4cb06d51e6d of pydantic.main.BaseModel.model_validate:5
+#: bc1b0d18b09a4419b831d592a15f31b9 of pydantic.main.BaseModel.model_validate:5
 msgid ""
 "obj: The object to validate. strict: Whether to enforce types strictly. "
+"extra: Whether to ignore, allow, or forbid extra data during model "
+"validation."
+msgstr ""
+
+#: b8bd10cff3bb494297f3b35344b5216c of pydantic.main.BaseModel.model_validate:8
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: b120ae89b4d34fd3affb7714b420d464 of pydantic.main.BaseModel.model_validate:9
+msgid ""
 "from_attributes: Whether to extract data from object attributes. context:"
 " Additional context to pass to the validator. by_alias: Whether to use "
 "the field's alias when validating against the provided input data. "
@@ -43,22 +55,35 @@ msgid ""
 "provided input data."
 msgstr ""
 
-#: 1784a359835942bbb4b3ea903a4a2cd3 of
-#: pydantic.main.BaseModel.model_validate:12
+#: affd252440fc4643adc249b6b4e4e91c of
+#: pydantic.main.BaseModel.model_validate:14
 msgid "Raises:"
 msgstr ""
 
-#: c756cd5f38c94663bb4c155b94d895ff of
-#: pydantic.main.BaseModel.model_validate:13
+#: 6ead2da3d22c49e992eb7954e2d99018 of
+#: pydantic.main.BaseModel.model_validate:15
 msgid "ValidationError: If the object could not be validated."
 msgstr ""
 
-#: af3411762c3f4bdebc932d38c1e4aa95 of
-#: pydantic.main.BaseModel.model_validate:15
+#: 99cd407db9a94a15868d1f368f956356 of
+#: pydantic.main.BaseModel.model_validate:17
 msgid "Returns:"
 msgstr ""
 
-#: 8ce1fb83c3674eb6ab64ff7b9aa9f55a of
-#: pydantic.main.BaseModel.model_validate:16
+#: cf649480cc524b72841e70765d842ff1 of
+#: pydantic.main.BaseModel.model_validate:18
 msgid "The validated model instance."
 msgstr ""
+
+#~ msgid ""
+#~ "obj: The object to validate. strict: "
+#~ "Whether to enforce types strictly. "
+#~ "from_attributes: Whether to extract data "
+#~ "from object attributes. context: Additional"
+#~ " context to pass to the validator."
+#~ " by_alias: Whether to use the field's"
+#~ " alias when validating against the "
+#~ "provided input data. by_name: Whether to"
+#~ " use the field's name when validating"
+#~ " against the provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.WeeklyFourier.model_validate_json.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.WeeklyFourier.model_validate_json.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,58 +21,84 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.fourier.WeeklyFourier.model_validate_json.rst:2
-#: bcd0c79123c84f479a442e2269609adf
+#: fe3dc86cea864afbb4ca093f089fb9cc
 msgid "WeeklyFourier.model\\_validate\\_json"
 msgstr ""
 
-#: 93e35feeaad04391b02fb59a40a35716 of
+#: e134a5e7d86d4f098251ac0e25c880ed of
 #: pydantic.main.BaseModel.model_validate_json:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 9e114033b28c4a54bf444fdfbd5e46a8 of
+#: fdec845673674f0484979d73ea01f42d of
 #: pydantic.main.BaseModel.model_validate_json:3
 msgid "[JSON Parsing](../concepts/json.md#json-parsing)"
 msgstr ""
 
-#: fff17f13811b4992b07b05f3d86e325e of
+#: b28598590ebe43faa559ff61fb319ae1 of
 #: pydantic.main.BaseModel.model_validate_json:5
 msgid "Validate the given JSON data against the Pydantic model."
 msgstr ""
 
-#: 01ed58b17d8d45f8b637c85722657a61 of
+#: ad58eda01f3347e591cd5474714b51cc of
 #: pydantic.main.BaseModel.model_validate_json:7
 msgid "Args:"
 msgstr ""
 
-#: ce04a7fbf90e4d4e93d029b37b97460e of
+#: 810c690aa4424a9e948a40e8c2dfc958 of
 #: pydantic.main.BaseModel.model_validate_json:8
 msgid ""
 "json_data: The JSON data to validate. strict: Whether to enforce types "
-"strictly. context: Extra variables to pass to the validator. by_alias: "
-"Whether to use the field's alias when validating against the provided "
-"input data. by_name: Whether to use the field's name when validating "
-"against the provided input data."
+"strictly. extra: Whether to ignore, allow, or forbid extra data during "
+"model validation."
 msgstr ""
 
-#: 2d6272479d8b45cf9095c6310ce1af81 of
-#: pydantic.main.BaseModel.model_validate_json:14
+#: 07ca9e558d49444bb74b003d95dbd1ec of
+#: pydantic.main.BaseModel.model_validate_json:11
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: 14c54c7f243e4e3aa2bf9992a62e3b13 of
+#: pydantic.main.BaseModel.model_validate_json:12
+msgid ""
+"context: Extra variables to pass to the validator. by_alias: Whether to "
+"use the field's alias when validating against the provided input data. "
+"by_name: Whether to use the field's name when validating against the "
+"provided input data."
+msgstr ""
+
+#: 5cb2e9f653dd4cf08034bddb762192a7 of
+#: pydantic.main.BaseModel.model_validate_json:16
 msgid "Returns:"
 msgstr ""
 
-#: b279f769fbfa4ecdb9c37adb61ff9cd6 of
-#: pydantic.main.BaseModel.model_validate_json:15
+#: 7315f1bf6b85412e87d9e7b51b3b3d4a of
+#: pydantic.main.BaseModel.model_validate_json:17
 msgid "The validated Pydantic model."
 msgstr ""
 
-#: 784deb39a66448b0973a25409ca8d463 of
-#: pydantic.main.BaseModel.model_validate_json:17
+#: aa91316149ed4b3698cffdbdad978295 of
+#: pydantic.main.BaseModel.model_validate_json:19
 msgid "Raises:"
 msgstr ""
 
-#: c44efe389001458196c846ad5c1e585e of
-#: pydantic.main.BaseModel.model_validate_json:18
+#: 2440c80d22094c15b6254ab894abd53c of
+#: pydantic.main.BaseModel.model_validate_json:20
 msgid ""
 "ValidationError: If `json_data` is not a JSON string or the object could "
 "not be validated."
 msgstr ""
+
+#~ msgid ""
+#~ "json_data: The JSON data to validate."
+#~ " strict: Whether to enforce types "
+#~ "strictly. context: Extra variables to "
+#~ "pass to the validator. by_alias: Whether"
+#~ " to use the field's alias when "
+#~ "validating against the provided input "
+#~ "data. by_name: Whether to use the "
+#~ "field's name when validating against the"
+#~ " provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.WeeklyFourier.model_validate_strings.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.WeeklyFourier.model_validate_strings.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,36 +21,62 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.fourier.WeeklyFourier.model_validate_strings.rst:2
-#: 25e03d1dba17474c939cc5ad7f224e35
+#: 2e9e3c43d08447f0b3a49f07b4162d51
 msgid "WeeklyFourier.model\\_validate\\_strings"
 msgstr ""
 
-#: 2f55e4a46e18458181304805ce2ce7d8 of
+#: 6c81f15ad41c434ca02360fc78bb873e of
 #: pydantic.main.BaseModel.model_validate_strings:2
 msgid "Validate the given object with string data against the Pydantic model."
 msgstr ""
 
-#: 299951c24ad740ca9cc4b10dce5a09f9 of
+#: 067126e5262e43b99b9b73afc6a54c79 of
 #: pydantic.main.BaseModel.model_validate_strings:4
 msgid "Args:"
 msgstr ""
 
-#: 247476908b384cf9bfe56247fd2409ee of
+#: befca9f06a6f494ab5499f476a73fb0a of
 #: pydantic.main.BaseModel.model_validate_strings:5
 msgid ""
 "obj: The object containing string data to validate. strict: Whether to "
-"enforce types strictly. context: Extra variables to pass to the "
-"validator. by_alias: Whether to use the field's alias when validating "
-"against the provided input data. by_name: Whether to use the field's name"
-" when validating against the provided input data."
+"enforce types strictly. extra: Whether to ignore, allow, or forbid extra "
+"data during model validation."
 msgstr ""
 
-#: d3ef54f125c4409da37dd09b40d25f2a of
-#: pydantic.main.BaseModel.model_validate_strings:11
+#: b88741a530d4407aa60f1eb1f4a255bd of
+#: pydantic.main.BaseModel.model_validate_strings:8
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: 8a76b54b3893420a853956b91f0ec6ac of
+#: pydantic.main.BaseModel.model_validate_strings:9
+msgid ""
+"context: Extra variables to pass to the validator. by_alias: Whether to "
+"use the field's alias when validating against the provided input data. "
+"by_name: Whether to use the field's name when validating against the "
+"provided input data."
+msgstr ""
+
+#: e4da974892e14452a4e2a944ab62c286 of
+#: pydantic.main.BaseModel.model_validate_strings:13
 msgid "Returns:"
 msgstr ""
 
-#: 75996c5c3f714900a776f08a9734d779 of
-#: pydantic.main.BaseModel.model_validate_strings:12
+#: 8078bb72a3354a699b41ce333f1d4a42 of
+#: pydantic.main.BaseModel.model_validate_strings:14
 msgid "The validated Pydantic model."
 msgstr ""
+
+#~ msgid ""
+#~ "obj: The object containing string data"
+#~ " to validate. strict: Whether to "
+#~ "enforce types strictly. context: Extra "
+#~ "variables to pass to the validator. "
+#~ "by_alias: Whether to use the field's "
+#~ "alias when validating against the "
+#~ "provided input data. by_name: Whether to"
+#~ " use the field's name when validating"
+#~ " against the provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.YearlyFourier.model_copy.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.YearlyFourier.model_copy.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,27 +21,27 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.fourier.YearlyFourier.model_copy.rst:2
-#: 7e63a00a1ee24b1db9c1bcb03fde5f4b
+#: 75c84b1836494e4a9d667bbea430a38b
 msgid "YearlyFourier.model\\_copy"
 msgstr ""
 
-#: 3827468ef3ad4137bc6abc7bbd81666d of pydantic.main.BaseModel.model_copy:2
+#: 494ccf7753a84f7db586cc2c8d20df05 of pydantic.main.BaseModel.model_copy:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 8318e23c4ac44607b95f864f591783c2 of pydantic.main.BaseModel.model_copy:3
-msgid "[`model_copy`](../concepts/serialization.md#model_copy)"
+#: 71f038f61cbb4ab2970df28e898d5714 of pydantic.main.BaseModel.model_copy:3
+msgid "[`model_copy`](../concepts/models.md#model-copy)"
 msgstr ""
 
-#: a27e6e27afec444992d4c97083000c0c of pydantic.main.BaseModel.model_copy:5
+#: 8aa82e7907cd4abf8d784c908256f8ca of pydantic.main.BaseModel.model_copy:5
 msgid "Returns a copy of the model."
 msgstr ""
 
-#: 712e63c7ac8e48659b62e16a51458ea8 of pydantic.main.BaseModel.model_copy:7
+#: efc74c4d22bb421786ada01544cb5642 of pydantic.main.BaseModel.model_copy:7
 msgid "!!! note"
 msgstr ""
 
-#: d9f9c9e291024f1f9e61eaf12cfe1436 of pydantic.main.BaseModel.model_copy:8
+#: 11cf001a2214468587ba91dad842c195 of pydantic.main.BaseModel.model_copy:8
 msgid ""
 "The underlying instance's [`__dict__`][object.__dict__] attribute is "
 "copied. This might have unexpected side effects if you store anything in "
@@ -49,28 +49,31 @@ msgid ""
 "properties][functools.cached_property])."
 msgstr ""
 
-#: 55379ee9677a48c68514876bd5c42c76 of pydantic.main.BaseModel.model_copy:12
+#: e537f462c70b4fb18e781f8fdc05421c of pydantic.main.BaseModel.model_copy:12
 msgid "Args:"
 msgstr ""
 
-#: 9c3dfd11994341b68e05b2c1310fe949 of pydantic.main.BaseModel.model_copy:13
+#: 16d2cadf2fc2414fac5cd6f89f93e5b9 of pydantic.main.BaseModel.model_copy:13
 msgid ""
 "update: Values to change/add in the new model. Note: the data is not "
 "validated"
 msgstr ""
 
-#: ba9f5a9dfbb640caab98e8d67ed008cf of pydantic.main.BaseModel.model_copy:14
+#: f38819b453cd4f8ab780ccbeff1618b5 of pydantic.main.BaseModel.model_copy:14
 msgid "before creating the new model. You should trust this data."
 msgstr ""
 
-#: da49acd8780e4a919b943b433317a053 of pydantic.main.BaseModel.model_copy:15
+#: 6f4a09e9af70441b81f12eccfcd01c84 of pydantic.main.BaseModel.model_copy:15
 msgid "deep: Set to `True` to make a deep copy of the model."
 msgstr ""
 
-#: 2ea1a5333c03440e954b3f9413be3840 of pydantic.main.BaseModel.model_copy:17
+#: 83a56e8954df4f809d594f8a717eaba1 of pydantic.main.BaseModel.model_copy:17
 msgid "Returns:"
 msgstr ""
 
-#: 65c8fe64252a4ac1804a44fbaeba9ad9 of pydantic.main.BaseModel.model_copy:18
+#: 6cfcc6a3403447e0b6487397e4bcab32 of pydantic.main.BaseModel.model_copy:18
 msgid "New model instance."
 msgstr ""
+
+#~ msgid "[`model_copy`](../concepts/serialization.md#model_copy)"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.YearlyFourier.model_dump.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.YearlyFourier.model_dump.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,40 +21,40 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.fourier.YearlyFourier.model_dump.rst:2
-#: da5ac87a8b5a46538f5d7107ab4e5359
+#: d8410e9590cc40e4af9d4604d4c7ba30
 msgid "YearlyFourier.model\\_dump"
 msgstr ""
 
-#: 974e86cf5c8a4e78ac27551df3c2d81e of pydantic.main.BaseModel.model_dump:2
+#: 088da7a7660c4351a6e62b4e167618b2 of pydantic.main.BaseModel.model_dump:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: f9f5fd4b85c3466ca981dd26ce2294fd of pydantic.main.BaseModel.model_dump:3
-msgid "[`model_dump`](../concepts/serialization.md#modelmodel_dump)"
+#: 9fc956c700c34d4cb2b87334b5e36d84 of pydantic.main.BaseModel.model_dump:3
+msgid "[`model_dump`](../concepts/serialization.md#python-mode)"
 msgstr ""
 
-#: cd0a058590394ca293eea1cf4de0d5e8 of pydantic.main.BaseModel.model_dump:5
+#: 136ae025703141dfab45dabf47c54807 of pydantic.main.BaseModel.model_dump:5
 msgid ""
 "Generate a dictionary representation of the model, optionally specifying "
 "which fields to include or exclude."
 msgstr ""
 
-#: b91a57cc35a940b8b1c3614e9e2793e6 of pydantic.main.BaseModel.model_dump:7
+#: 15cb01edd7944e6da434e3f20aee3a3f of pydantic.main.BaseModel.model_dump:7
 msgid "Args:"
 msgstr ""
 
-#: 5ac0edf72cbb4b9abd0400393166e905 of pydantic.main.BaseModel.model_dump:8
+#: 5f5e05ee66b044619b3bf01b4ba077be of pydantic.main.BaseModel.model_dump:8
 msgid "mode: The mode in which `to_python` should run."
 msgstr ""
 
-#: 093d095b07574402a985e26d0ceaa6b5 of pydantic.main.BaseModel.model_dump:9
+#: 220d74aad8d0487494f0f231351afd03 of pydantic.main.BaseModel.model_dump:9
 msgid ""
 "If mode is 'json', the output will only contain JSON serializable types. "
 "If mode is 'python', the output may contain non-JSON-serializable Python "
 "objects."
 msgstr ""
 
-#: 1b255babafce49e0a01f8d3b41588616 of pydantic.main.BaseModel.model_dump:11
+#: 8686aa86222b47359326d836ee6e63fa of pydantic.main.BaseModel.model_dump:11
 msgid ""
 "include: A set of fields to include in the output. exclude: A set of "
 "fields to exclude from the output. context: Additional context to pass to"
@@ -62,41 +62,77 @@ msgid ""
 "dictionary key if defined. exclude_unset: Whether to exclude fields that "
 "have not been explicitly set. exclude_defaults: Whether to exclude fields"
 " that are set to their default value. exclude_none: Whether to exclude "
-"fields that have a value of `None`. round_trip: If True, dumped values "
-"should be valid as input for non-idempotent types such as Json[T]. "
-"warnings: How to handle serialization errors. False/\"none\" ignores "
-"them, True/\"warn\" logs errors,"
+"fields that have a value of `None`. exclude_computed_fields: Whether to "
+"exclude computed fields."
 msgstr ""
 
-#: 0b11ee5020c04f37ae5b6efedd3e5dbd of pydantic.main.BaseModel.model_dump:20
+#: e2112211e435444c9503e3b1db0268c1 of pydantic.main.BaseModel.model_dump:19
+msgid ""
+"While this can be useful for round-tripping, it is usually recommended tu"
+" use the dedicated `round_trip` parameter instead."
+msgstr ""
+
+#: c366b3cbdb644f35bfbb357268a784db of pydantic.main.BaseModel.model_dump:21
+msgid ""
+"round_trip: If True, dumped values should be valid as input for non-"
+"idempotent types such as Json[T]. warnings: How to handle serialization "
+"errors. False/\"none\" ignores them, True/\"warn\" logs errors,"
+msgstr ""
+
+#: 725bd2843e5648d589f9f25a0f683af1 of pydantic.main.BaseModel.model_dump:23
 msgid ""
 "\"error\" raises a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError]."
 msgstr ""
 
-#: 742a2c020c7a4fa78d1d8c6333e77e32 of pydantic.main.BaseModel.model_dump:21
+#: d5e32211b5d245d393a842665015650f of pydantic.main.BaseModel.model_dump:24
 msgid ""
 "fallback: A function to call when an unknown value is encountered. If not"
 " provided,"
 msgstr ""
 
-#: 8841060b50c44d7a9d89de265756f3a8 of pydantic.main.BaseModel.model_dump:22
+#: b0810bf3fba94ab2aac1c4aad47246ed of pydantic.main.BaseModel.model_dump:25
 msgid ""
 "a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError] "
 "error is raised."
 msgstr ""
 
-#: a3e1d5e5033a4670830feabf6dc65bcd of pydantic.main.BaseModel.model_dump:23
+#: 89f1dcdd3f5f43a585e2af5dab5d8c50 of pydantic.main.BaseModel.model_dump:26
 msgid ""
 "serialize_as_any: Whether to serialize fields with duck-typing "
 "serialization behavior."
 msgstr ""
 
-#: abe55f75b1d644d39273e9d7ab75109f of pydantic.main.BaseModel.model_dump:25
+#: 320843ffce2c41888199a5ef3c71808e of pydantic.main.BaseModel.model_dump:28
 msgid "Returns:"
 msgstr ""
 
-#: fbfc6ed4a8324f87a3d42a15878f77ae of pydantic.main.BaseModel.model_dump:26
+#: beaddd1e454b4a5799c298c82110ad5f of pydantic.main.BaseModel.model_dump:29
 msgid "A dictionary representation of the model."
 msgstr ""
+
+#~ msgid "[`model_dump`](../concepts/serialization.md#modelmodel_dump)"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "include: A set of fields to "
+#~ "include in the output. exclude: A "
+#~ "set of fields to exclude from the"
+#~ " output. context: Additional context to "
+#~ "pass to the serializer. by_alias: "
+#~ "Whether to use the field's alias "
+#~ "in the dictionary key if defined. "
+#~ "exclude_unset: Whether to exclude fields "
+#~ "that have not been explicitly set. "
+#~ "exclude_defaults: Whether to exclude fields"
+#~ " that are set to their default "
+#~ "value. exclude_none: Whether to exclude "
+#~ "fields that have a value of "
+#~ "`None`. round_trip: If True, dumped "
+#~ "values should be valid as input "
+#~ "for non-idempotent types such as "
+#~ "Json[T]. warnings: How to handle "
+#~ "serialization errors. False/\"none\" ignores "
+#~ "them, True/\"warn\" logs errors,"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.YearlyFourier.model_dump_json.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.YearlyFourier.model_dump_json.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,83 +21,133 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.fourier.YearlyFourier.model_dump_json.rst:2
-#: 6f62b61a738447a1a941daa5488f6f62
+#: 6d67a1888b37435b9a591a5346c6d4a3
 msgid "YearlyFourier.model\\_dump\\_json"
 msgstr ""
 
-#: 9dfad0d2fbe049f49f4223fe2df79e6e of
+#: d44072596c86480cb5b87e3fca766752 of
 #: pydantic.main.BaseModel.model_dump_json:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: d9b9eb6650c64ca3aaf1778f8bb457ee of
+#: 652f8e2300394c4ab40139e6bd428a63 of
 #: pydantic.main.BaseModel.model_dump_json:3
-msgid "[`model_dump_json`](../concepts/serialization.md#modelmodel_dump_json)"
+msgid "[`model_dump_json`](../concepts/serialization.md#json-mode)"
 msgstr ""
 
-#: a8adceb7b5a54941b63cfdc0b8e3b388 of
+#: c45b04bf3c4e4196a6a509166c200dbf of
 #: pydantic.main.BaseModel.model_dump_json:5
 msgid ""
 "Generates a JSON representation of the model using Pydantic's `to_json` "
 "method."
 msgstr ""
 
-#: c0f5a4c22bf64c11a2db56a3c755bd74 of
+#: 6304b05dc5494b678e77906fec9ee56e of
 #: pydantic.main.BaseModel.model_dump_json:7
 msgid "Args:"
 msgstr ""
 
-#: 5c8d03884b844c25a799a1ba517eb443 of
+#: c2617eb470194bde9d1eb26572d8bb93 of
 #: pydantic.main.BaseModel.model_dump_json:8
 msgid ""
 "indent: Indentation to use in the JSON output. If None is passed, the "
-"output will be compact. include: Field(s) to include in the JSON output. "
-"exclude: Field(s) to exclude from the JSON output. context: Additional "
-"context to pass to the serializer. by_alias: Whether to serialize using "
-"field aliases. exclude_unset: Whether to exclude fields that have not "
-"been explicitly set. exclude_defaults: Whether to exclude fields that are"
-" set to their default value. exclude_none: Whether to exclude fields that"
-" have a value of `None`. round_trip: If True, dumped values should be "
-"valid as input for non-idempotent types such as Json[T]. warnings: How to"
-" handle serialization errors. False/\"none\" ignores them, True/\"warn\" "
-"logs errors,"
+"output will be compact. ensure_ascii: If `True`, the output is guaranteed"
+" to have all incoming non-ASCII characters escaped."
 msgstr ""
 
-#: 043aef9e14154f9eb659dfeb8b1e06d1 of
-#: pydantic.main.BaseModel.model_dump_json:18
+#: dd08013612ea494c987a483e0db69c42 of
+#: pydantic.main.BaseModel.model_dump_json:10
+msgid "If `False` (the default), these characters will be output as-is."
+msgstr ""
+
+#: c727d500c32c41929cf1313c5f48c04f of
+#: pydantic.main.BaseModel.model_dump_json:11
+msgid ""
+"include: Field(s) to include in the JSON output. exclude: Field(s) to "
+"exclude from the JSON output. context: Additional context to pass to the "
+"serializer. by_alias: Whether to serialize using field aliases. "
+"exclude_unset: Whether to exclude fields that have not been explicitly "
+"set. exclude_defaults: Whether to exclude fields that are set to their "
+"default value. exclude_none: Whether to exclude fields that have a value "
+"of `None`. exclude_computed_fields: Whether to exclude computed fields."
+msgstr ""
+
+#: 339012755b0d404abc97b065d878abd0 of
+#: pydantic.main.BaseModel.model_dump_json:19
+msgid ""
+"While this can be useful for round-tripping, it is usually recommended to"
+" use the dedicated `round_trip` parameter instead."
+msgstr ""
+
+#: 4d7c835157424808a115f195159bcf2d of
+#: pydantic.main.BaseModel.model_dump_json:21
+msgid ""
+"round_trip: If True, dumped values should be valid as input for non-"
+"idempotent types such as Json[T]. warnings: How to handle serialization "
+"errors. False/\"none\" ignores them, True/\"warn\" logs errors,"
+msgstr ""
+
+#: 36d6aed38118419faa12306658ba959a of
+#: pydantic.main.BaseModel.model_dump_json:23
 msgid ""
 "\"error\" raises a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError]."
 msgstr ""
 
-#: 18e6a2768acf44cca335c3b04b128a8c of
-#: pydantic.main.BaseModel.model_dump_json:19
+#: 9026b62940744116bd795609c1a6ed35 of
+#: pydantic.main.BaseModel.model_dump_json:24
 msgid ""
 "fallback: A function to call when an unknown value is encountered. If not"
 " provided,"
 msgstr ""
 
-#: 549fc53e7c3140a689d922336d481a71 of
-#: pydantic.main.BaseModel.model_dump_json:20
+#: 5f9dd78d30834dc49d8928b32cf1b66c of
+#: pydantic.main.BaseModel.model_dump_json:25
 msgid ""
 "a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError] "
 "error is raised."
 msgstr ""
 
-#: a1bb4cdaa87f4d8aac26b9cc48b2228b of
-#: pydantic.main.BaseModel.model_dump_json:21
+#: 882e1740107447dd899be0f8b097635b of
+#: pydantic.main.BaseModel.model_dump_json:26
 msgid ""
 "serialize_as_any: Whether to serialize fields with duck-typing "
 "serialization behavior."
 msgstr ""
 
-#: b2413f57d6404aaab40bfea72d1b0c3e of
-#: pydantic.main.BaseModel.model_dump_json:23
+#: 2096f7b0ee9b41ff83eaabf863eb3de3 of
+#: pydantic.main.BaseModel.model_dump_json:28
 msgid "Returns:"
 msgstr ""
 
-#: 8233fe67cdde400e803a72e8268c8f50 of
-#: pydantic.main.BaseModel.model_dump_json:24
+#: c0a5106bd1aa4d26af12855f49ab55a5 of
+#: pydantic.main.BaseModel.model_dump_json:29
 msgid "A JSON string representation of the model."
 msgstr ""
+
+#~ msgid "[`model_dump_json`](../concepts/serialization.md#modelmodel_dump_json)"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "indent: Indentation to use in the "
+#~ "JSON output. If None is passed, "
+#~ "the output will be compact. include: "
+#~ "Field(s) to include in the JSON "
+#~ "output. exclude: Field(s) to exclude "
+#~ "from the JSON output. context: "
+#~ "Additional context to pass to the "
+#~ "serializer. by_alias: Whether to serialize "
+#~ "using field aliases. exclude_unset: Whether"
+#~ " to exclude fields that have not "
+#~ "been explicitly set. exclude_defaults: Whether"
+#~ " to exclude fields that are set "
+#~ "to their default value. exclude_none: "
+#~ "Whether to exclude fields that have "
+#~ "a value of `None`. round_trip: If "
+#~ "True, dumped values should be valid "
+#~ "as input for non-idempotent types "
+#~ "such as Json[T]. warnings: How to "
+#~ "handle serialization errors. False/\"none\" "
+#~ "ignores them, True/\"warn\" logs errors,"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.YearlyFourier.model_json_schema.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.YearlyFourier.model_json_schema.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,44 +21,77 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.fourier.YearlyFourier.model_json_schema.rst:2
-#: ae95f14f93ba4297a478b0393bafdd51
+#: 9219b181f29d49c98d7ac8fbfb0a3498
 msgid "YearlyFourier.model\\_json\\_schema"
 msgstr ""
 
-#: d825297f4a994cccbdeabdf8228d1457 of
+#: aa3e943eff554daa9cf639d14056796a of
 #: pydantic.main.BaseModel.model_json_schema:2
 msgid "Generates a JSON schema for a model class."
 msgstr ""
 
-#: 81b8414fb8d74a388a42b0503fe0d93e of
+#: 1606b9c12f3e439b90e2ef0cbf9a4820 of
 #: pydantic.main.BaseModel.model_json_schema:4
 msgid "Args:"
 msgstr ""
 
-#: 08d31efd1f5e42339c0ef35f64002734 of
+#: b8932ffcb7544f40a4241547e5a8e546 of
 #: pydantic.main.BaseModel.model_json_schema:5
 msgid ""
 "by_alias: Whether to use attribute aliases or not. ref_template: The "
-"reference template. schema_generator: To override the logic used to "
-"generate the JSON schema, as a subclass of"
+"reference template. union_format: The format to use when combining "
+"schemas from unions together. Can be one of:"
 msgstr ""
 
-#: f871d1f9ec264d0c9188275f8ede5a5a of
-#: pydantic.main.BaseModel.model_json_schema:8
+#: 6f8c162c04854767aa1bad88488fd03a of
+#: pydantic.main.BaseModel.model_json_schema:9
+msgid ""
+"`'any_of'`: Use the [`anyOf`](https://json-schema.org/understanding-json-"
+"schema/reference/combining#anyOf)"
+msgstr ""
+
+#: afca4e2fe8244bbd9412306f88d9cf9a of
+#: pydantic.main.BaseModel.model_json_schema:10
+msgid ""
+"keyword to combine schemas (the default). - `'primitive_type_array'`: Use"
+" the [`type`](https://json-schema.org/understanding-json-"
+"schema/reference/type) keyword as an array of strings, containing each "
+"type of the combination. If any of the schemas is not a primitive type "
+"(`string`, `boolean`, `null`, `integer` or `number`) or contains "
+"constraints/metadata, falls back to `any_of`."
+msgstr ""
+
+#: 42c7dda18f3947acb06c9059b63c698b of
+#: pydantic.main.BaseModel.model_json_schema:15
+msgid ""
+"schema_generator: To override the logic used to generate the JSON schema,"
+" as a subclass of"
+msgstr ""
+
+#: 601febf9404d4efd85fdfc428c63789e of
+#: pydantic.main.BaseModel.model_json_schema:16
 msgid "`GenerateJsonSchema` with your desired modifications"
 msgstr ""
 
-#: 3a59bfb18e6044b1afc2341956eaaa51 of
-#: pydantic.main.BaseModel.model_json_schema:9
+#: 719b95792b944e36a364253e3f180e1b of
+#: pydantic.main.BaseModel.model_json_schema:17
 msgid "mode: The mode in which to generate the schema."
 msgstr ""
 
-#: 307d9b0b2390423da744763181b21655 of
-#: pydantic.main.BaseModel.model_json_schema:11
+#: b085c062933247a586577288ae64efe5 of
+#: pydantic.main.BaseModel.model_json_schema:19
 msgid "Returns:"
 msgstr ""
 
-#: d28a7388605649a9904d64ff4f65f163 of
-#: pydantic.main.BaseModel.model_json_schema:12
+#: 85a16db5967b4f3e906a4af08b4e6731 of
+#: pydantic.main.BaseModel.model_json_schema:20
 msgid "The JSON schema for the given model class."
 msgstr ""
+
+#~ msgid ""
+#~ "by_alias: Whether to use attribute "
+#~ "aliases or not. ref_template: The "
+#~ "reference template. schema_generator: To "
+#~ "override the logic used to generate "
+#~ "the JSON schema, as a subclass of"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.YearlyFourier.model_validate.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.YearlyFourier.model_validate.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,21 +21,33 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.fourier.YearlyFourier.model_validate.rst:2
-#: 46ec43b7272f476aacf6fcad9e08161f
+#: 6ca000305b844c738afb1ebffc0bb7a4
 msgid "YearlyFourier.model\\_validate"
 msgstr ""
 
-#: 13dfac39d1494be9a8e1088ce1e92f34 of pydantic.main.BaseModel.model_validate:2
+#: 9130d252fefe45cc85ce08b14b2ae7b4 of pydantic.main.BaseModel.model_validate:2
 msgid "Validate a pydantic model instance."
 msgstr ""
 
-#: f12eb8ebf4784d99b4ab7e844dabcd89 of pydantic.main.BaseModel.model_validate:4
+#: b4baccd08dce41bb89979a42d40f6e08 of pydantic.main.BaseModel.model_validate:4
 msgid "Args:"
 msgstr ""
 
-#: 0ae05c478dcc4e7b9867da97847e2773 of pydantic.main.BaseModel.model_validate:5
+#: ad53d73a912547d7a73019cde7b15214 of pydantic.main.BaseModel.model_validate:5
 msgid ""
 "obj: The object to validate. strict: Whether to enforce types strictly. "
+"extra: Whether to ignore, allow, or forbid extra data during model "
+"validation."
+msgstr ""
+
+#: 834bc4d887754c4c844a7c16effd5ba1 of pydantic.main.BaseModel.model_validate:8
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: cd017fb5b17b4429871f9a91b21474d9 of pydantic.main.BaseModel.model_validate:9
+msgid ""
 "from_attributes: Whether to extract data from object attributes. context:"
 " Additional context to pass to the validator. by_alias: Whether to use "
 "the field's alias when validating against the provided input data. "
@@ -43,22 +55,35 @@ msgid ""
 "provided input data."
 msgstr ""
 
-#: 94783f31d7ba48b0a86323c62f6441f8 of
-#: pydantic.main.BaseModel.model_validate:12
+#: 30ec9c60227f4887bfe2666c4ea89f93 of
+#: pydantic.main.BaseModel.model_validate:14
 msgid "Raises:"
 msgstr ""
 
-#: 50749ae747284b4baba48a9da9f64016 of
-#: pydantic.main.BaseModel.model_validate:13
+#: da345bcb1862401499fcb25c56c74375 of
+#: pydantic.main.BaseModel.model_validate:15
 msgid "ValidationError: If the object could not be validated."
 msgstr ""
 
-#: 1ef3078c98a043e9b3a0b1d9b8a3c0c9 of
-#: pydantic.main.BaseModel.model_validate:15
+#: 8858a98180a64d54b2548ba8532c952e of
+#: pydantic.main.BaseModel.model_validate:17
 msgid "Returns:"
 msgstr ""
 
-#: bae610eadb58463a929fc173e36c4c2d of
-#: pydantic.main.BaseModel.model_validate:16
+#: 83d8859d3b0f46f2a93aa3095e0c2d9d of
+#: pydantic.main.BaseModel.model_validate:18
 msgid "The validated model instance."
 msgstr ""
+
+#~ msgid ""
+#~ "obj: The object to validate. strict: "
+#~ "Whether to enforce types strictly. "
+#~ "from_attributes: Whether to extract data "
+#~ "from object attributes. context: Additional"
+#~ " context to pass to the validator."
+#~ " by_alias: Whether to use the field's"
+#~ " alias when validating against the "
+#~ "provided input data. by_name: Whether to"
+#~ " use the field's name when validating"
+#~ " against the provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.YearlyFourier.model_validate_json.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.YearlyFourier.model_validate_json.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,58 +21,84 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.fourier.YearlyFourier.model_validate_json.rst:2
-#: 074b998d8bc94e558b7ec45828ff822e
+#: 471b288d0b1841cd903b6968fcff3286
 msgid "YearlyFourier.model\\_validate\\_json"
 msgstr ""
 
-#: 76d6d13cefd14f20b053af128c2cb32e of
+#: 6958e395816b46c5a03220283db10498 of
 #: pydantic.main.BaseModel.model_validate_json:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 614f3235326d4cc7b518eae8440874e2 of
+#: 4dadbecc8e5742f5a2f67b149924b8b0 of
 #: pydantic.main.BaseModel.model_validate_json:3
 msgid "[JSON Parsing](../concepts/json.md#json-parsing)"
 msgstr ""
 
-#: ba697ef27e8b4efea423cc5004f4559d of
+#: d4d9ce44b9df4eafa62598cb5ea0ab45 of
 #: pydantic.main.BaseModel.model_validate_json:5
 msgid "Validate the given JSON data against the Pydantic model."
 msgstr ""
 
-#: 604603d0271041b2b9289eac11c489e3 of
+#: c094407c4a8148f1bb5650840911970b of
 #: pydantic.main.BaseModel.model_validate_json:7
 msgid "Args:"
 msgstr ""
 
-#: 75fab81286424ace83fc20a5906525d0 of
+#: 6c848fb593eb4639aa3b18aeb040d5bb of
 #: pydantic.main.BaseModel.model_validate_json:8
 msgid ""
 "json_data: The JSON data to validate. strict: Whether to enforce types "
-"strictly. context: Extra variables to pass to the validator. by_alias: "
-"Whether to use the field's alias when validating against the provided "
-"input data. by_name: Whether to use the field's name when validating "
-"against the provided input data."
+"strictly. extra: Whether to ignore, allow, or forbid extra data during "
+"model validation."
 msgstr ""
 
-#: 8cf40d7e75824687982a7a0ab8be93a6 of
-#: pydantic.main.BaseModel.model_validate_json:14
+#: 9c143478bd7c4bfcb1ec777a9b8d1995 of
+#: pydantic.main.BaseModel.model_validate_json:11
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: cf116079604449b7bc87f02f646fdb52 of
+#: pydantic.main.BaseModel.model_validate_json:12
+msgid ""
+"context: Extra variables to pass to the validator. by_alias: Whether to "
+"use the field's alias when validating against the provided input data. "
+"by_name: Whether to use the field's name when validating against the "
+"provided input data."
+msgstr ""
+
+#: 93403dcd3ff14d69b9a715883ca42b27 of
+#: pydantic.main.BaseModel.model_validate_json:16
 msgid "Returns:"
 msgstr ""
 
-#: 8938e3def96549cf8df18a23714a7f95 of
-#: pydantic.main.BaseModel.model_validate_json:15
+#: f6b60e2e3acf4ea68adb4d8392419df3 of
+#: pydantic.main.BaseModel.model_validate_json:17
 msgid "The validated Pydantic model."
 msgstr ""
 
-#: 06bb3f573acf4fb593f4bb06916ea5c2 of
-#: pydantic.main.BaseModel.model_validate_json:17
+#: db72fade696f433b93c442be68f714b1 of
+#: pydantic.main.BaseModel.model_validate_json:19
 msgid "Raises:"
 msgstr ""
 
-#: fba3c01949324843aef6756d8554753f of
-#: pydantic.main.BaseModel.model_validate_json:18
+#: 7e711a6b5fa14205818abad23dbe44d1 of
+#: pydantic.main.BaseModel.model_validate_json:20
 msgid ""
 "ValidationError: If `json_data` is not a JSON string or the object could "
 "not be validated."
 msgstr ""
+
+#~ msgid ""
+#~ "json_data: The JSON data to validate."
+#~ " strict: Whether to enforce types "
+#~ "strictly. context: Extra variables to "
+#~ "pass to the validator. by_alias: Whether"
+#~ " to use the field's alias when "
+#~ "validating against the provided input "
+#~ "data. by_name: Whether to use the "
+#~ "field's name when validating against the"
+#~ " provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.YearlyFourier.model_validate_strings.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.fourier.YearlyFourier.model_validate_strings.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,36 +21,62 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.fourier.YearlyFourier.model_validate_strings.rst:2
-#: b3af2b22fc79483aa6884d101019bfc3
+#: 373fb5714e8c4e0e98200a5c421700fb
 msgid "YearlyFourier.model\\_validate\\_strings"
 msgstr ""
 
-#: 3ff1f30dc89c46dcb2cdda91b8f34cba of
+#: a5cf91dcb530411a8b7d7f1b26aa88da of
 #: pydantic.main.BaseModel.model_validate_strings:2
 msgid "Validate the given object with string data against the Pydantic model."
 msgstr ""
 
-#: d44cbd346a2a458fb41ce186d4e01fef of
+#: 84c31dabc4244253b8ec187c681a9e7e of
 #: pydantic.main.BaseModel.model_validate_strings:4
 msgid "Args:"
 msgstr ""
 
-#: 0b8dcf97af3c445298f6c2992c7ae092 of
+#: d71888d000184b94b8caf486b9e02597 of
 #: pydantic.main.BaseModel.model_validate_strings:5
 msgid ""
 "obj: The object containing string data to validate. strict: Whether to "
-"enforce types strictly. context: Extra variables to pass to the "
-"validator. by_alias: Whether to use the field's alias when validating "
-"against the provided input data. by_name: Whether to use the field's name"
-" when validating against the provided input data."
+"enforce types strictly. extra: Whether to ignore, allow, or forbid extra "
+"data during model validation."
 msgstr ""
 
-#: de2e5ce4c72140f595cf0be0a9fb7c0d of
-#: pydantic.main.BaseModel.model_validate_strings:11
+#: af5fb753797840058600b8998102c37e of
+#: pydantic.main.BaseModel.model_validate_strings:8
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: 1fb69485852a4f1ebbf5451a236a2914 of
+#: pydantic.main.BaseModel.model_validate_strings:9
+msgid ""
+"context: Extra variables to pass to the validator. by_alias: Whether to "
+"use the field's alias when validating against the provided input data. "
+"by_name: Whether to use the field's name when validating against the "
+"provided input data."
+msgstr ""
+
+#: c4c6b3cc7d314ec8bc49784d940f9455 of
+#: pydantic.main.BaseModel.model_validate_strings:13
 msgid "Returns:"
 msgstr ""
 
-#: 10843a35a106482ebd9939cb3edfcf40 of
-#: pydantic.main.BaseModel.model_validate_strings:12
+#: ff3d5d68d189402ab7c7a6d267de361e of
+#: pydantic.main.BaseModel.model_validate_strings:14
 msgid "The validated Pydantic model."
 msgstr ""
+
+#~ msgid ""
+#~ "obj: The object containing string data"
+#~ " to validate. strict: Whether to "
+#~ "enforce types strictly. context: Extra "
+#~ "variables to pass to the validator. "
+#~ "by_alias: Whether to use the field's "
+#~ "alias when validating against the "
+#~ "provided input data. by_name: Whether to"
+#~ " use the field's name when validating"
+#~ " against the provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGP.model_copy.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGP.model_copy.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,27 +21,27 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGP.model_copy.rst:2
-#: c5a67c7673fe42c4b3d9162dfcab800c
+#: 93c1eca579a14465929cc74204a848c8
 msgid "HSGP.model\\_copy"
 msgstr ""
 
-#: b63d2bc4f01d49969085042eeb929139 of pydantic.main.BaseModel.model_copy:2
+#: 0e61a08fbdf848d3b25c9199d3639e38 of pydantic.main.BaseModel.model_copy:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 6e4fa5ded3fc467ba2a4c62312a96b73 of pydantic.main.BaseModel.model_copy:3
-msgid "[`model_copy`](../concepts/serialization.md#model_copy)"
+#: 79f2c284535f4d7585d5cf438c5eaf57 of pydantic.main.BaseModel.model_copy:3
+msgid "[`model_copy`](../concepts/models.md#model-copy)"
 msgstr ""
 
-#: 9a2e2c30feeb46a6b6951ea842237aaf of pydantic.main.BaseModel.model_copy:5
+#: ddb3a039f2964514b01ec2ee72705467 of pydantic.main.BaseModel.model_copy:5
 msgid "Returns a copy of the model."
 msgstr ""
 
-#: a08ef640a248459f870f5e315d230025 of pydantic.main.BaseModel.model_copy:7
+#: 833d160ef91d439395a675f8f6314cc4 of pydantic.main.BaseModel.model_copy:7
 msgid "!!! note"
 msgstr ""
 
-#: 2d316bced2784e80b84a7d3372cacc3f of pydantic.main.BaseModel.model_copy:8
+#: a78ca3ff28a4418ca422ef75bc9bef1b of pydantic.main.BaseModel.model_copy:8
 msgid ""
 "The underlying instance's [`__dict__`][object.__dict__] attribute is "
 "copied. This might have unexpected side effects if you store anything in "
@@ -49,28 +49,31 @@ msgid ""
 "properties][functools.cached_property])."
 msgstr ""
 
-#: 181255b76e014ebab864e9b831e9aec8 of pydantic.main.BaseModel.model_copy:12
+#: 8031d009f20d455881dfe71ee21e4815 of pydantic.main.BaseModel.model_copy:12
 msgid "Args:"
 msgstr ""
 
-#: c640086fe1404883bd5adf11655e8928 of pydantic.main.BaseModel.model_copy:13
+#: d5e679890d604d3fa49608b523846a50 of pydantic.main.BaseModel.model_copy:13
 msgid ""
 "update: Values to change/add in the new model. Note: the data is not "
 "validated"
 msgstr ""
 
-#: ee6fdb5489154b32b5862f90d0cde153 of pydantic.main.BaseModel.model_copy:14
+#: d8b3da4605224028bf1d400b7496c830 of pydantic.main.BaseModel.model_copy:14
 msgid "before creating the new model. You should trust this data."
 msgstr ""
 
-#: f3ebfb2e1eb34681b2443657e55b711d of pydantic.main.BaseModel.model_copy:15
+#: 230b04138e9e4ccfbcf4a45869d9974c of pydantic.main.BaseModel.model_copy:15
 msgid "deep: Set to `True` to make a deep copy of the model."
 msgstr ""
 
-#: 96bb8b13c6264e5a91f3935b8c236777 of pydantic.main.BaseModel.model_copy:17
+#: c374314bd4fe4561b49fba5c392a5d98 of pydantic.main.BaseModel.model_copy:17
 msgid "Returns:"
 msgstr ""
 
-#: 1edce4d964db4c7cbe40920bd5e250a2 of pydantic.main.BaseModel.model_copy:18
+#: 3250663548374e13b096600d50f53cf4 of pydantic.main.BaseModel.model_copy:18
 msgid "New model instance."
 msgstr ""
+
+#~ msgid "[`model_copy`](../concepts/serialization.md#model_copy)"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGP.model_dump.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGP.model_dump.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,40 +21,40 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGP.model_dump.rst:2
-#: ff7515bf4d5f42548f7e018ff39b3d29
+#: 973326daeb2a49a5bcd29f59e94a09e6
 msgid "HSGP.model\\_dump"
 msgstr ""
 
-#: 45dfbc33b73d4ae2b71782f63d8c61b7 of pydantic.main.BaseModel.model_dump:2
+#: 269c448985f74f28bc42487a55df7353 of pydantic.main.BaseModel.model_dump:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: a7ecf2c237974688bb7e38a5e94d00f9 of pydantic.main.BaseModel.model_dump:3
-msgid "[`model_dump`](../concepts/serialization.md#modelmodel_dump)"
+#: d3f5d9aa64cb4519a02c387db582fee7 of pydantic.main.BaseModel.model_dump:3
+msgid "[`model_dump`](../concepts/serialization.md#python-mode)"
 msgstr ""
 
-#: a6e05607725b4211b2931f71af8ad79a of pydantic.main.BaseModel.model_dump:5
+#: 9152396e7c3149dfaa4bad95259cdf97 of pydantic.main.BaseModel.model_dump:5
 msgid ""
 "Generate a dictionary representation of the model, optionally specifying "
 "which fields to include or exclude."
 msgstr ""
 
-#: 2f3bb4d410284d029b063d272b6619f1 of pydantic.main.BaseModel.model_dump:7
+#: ba2e7a6b9add47f9a9432767e6208f42 of pydantic.main.BaseModel.model_dump:7
 msgid "Args:"
 msgstr ""
 
-#: 4e953f2f2fb54d51b9b5ff1c2bfbd417 of pydantic.main.BaseModel.model_dump:8
+#: 2bbf1ea4da7846ec8d075f5e3951c3ad of pydantic.main.BaseModel.model_dump:8
 msgid "mode: The mode in which `to_python` should run."
 msgstr ""
 
-#: 018087f2b5604be1ae5a67f83b89c58c of pydantic.main.BaseModel.model_dump:9
+#: 0edd63b7391440eeb2a3467966735221 of pydantic.main.BaseModel.model_dump:9
 msgid ""
 "If mode is 'json', the output will only contain JSON serializable types. "
 "If mode is 'python', the output may contain non-JSON-serializable Python "
 "objects."
 msgstr ""
 
-#: 64bb8ef24048458cb4a1cea809398076 of pydantic.main.BaseModel.model_dump:11
+#: 89af4557b82346cfa779603fd1eaa624 of pydantic.main.BaseModel.model_dump:11
 msgid ""
 "include: A set of fields to include in the output. exclude: A set of "
 "fields to exclude from the output. context: Additional context to pass to"
@@ -62,41 +62,77 @@ msgid ""
 "dictionary key if defined. exclude_unset: Whether to exclude fields that "
 "have not been explicitly set. exclude_defaults: Whether to exclude fields"
 " that are set to their default value. exclude_none: Whether to exclude "
-"fields that have a value of `None`. round_trip: If True, dumped values "
-"should be valid as input for non-idempotent types such as Json[T]. "
-"warnings: How to handle serialization errors. False/\"none\" ignores "
-"them, True/\"warn\" logs errors,"
+"fields that have a value of `None`. exclude_computed_fields: Whether to "
+"exclude computed fields."
 msgstr ""
 
-#: ac051ec597d3486894b3929ca261ad7f of pydantic.main.BaseModel.model_dump:20
+#: 79c842961dfc4a069f49c36ee697b110 of pydantic.main.BaseModel.model_dump:19
+msgid ""
+"While this can be useful for round-tripping, it is usually recommended tu"
+" use the dedicated `round_trip` parameter instead."
+msgstr ""
+
+#: 6c344ce8771e4d32b23edd7a6d3f6a65 of pydantic.main.BaseModel.model_dump:21
+msgid ""
+"round_trip: If True, dumped values should be valid as input for non-"
+"idempotent types such as Json[T]. warnings: How to handle serialization "
+"errors. False/\"none\" ignores them, True/\"warn\" logs errors,"
+msgstr ""
+
+#: 4ccf936fc4ba4fb48a7418eec33b8a3f of pydantic.main.BaseModel.model_dump:23
 msgid ""
 "\"error\" raises a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError]."
 msgstr ""
 
-#: 04b4ccbe77e04bd5b2db1cf210e7b64c of pydantic.main.BaseModel.model_dump:21
+#: 7bd607a801864a08bd5a1e285f43b933 of pydantic.main.BaseModel.model_dump:24
 msgid ""
 "fallback: A function to call when an unknown value is encountered. If not"
 " provided,"
 msgstr ""
 
-#: 62eea347fdab44f3ac4d65766569b946 of pydantic.main.BaseModel.model_dump:22
+#: 6e0c98c0e0404f0fbc8cead30a5736e1 of pydantic.main.BaseModel.model_dump:25
 msgid ""
 "a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError] "
 "error is raised."
 msgstr ""
 
-#: 986e6cad6e6849ceb8c50b2efa552fb4 of pydantic.main.BaseModel.model_dump:23
+#: d841fb99002a4555939d65b4b46c2281 of pydantic.main.BaseModel.model_dump:26
 msgid ""
 "serialize_as_any: Whether to serialize fields with duck-typing "
 "serialization behavior."
 msgstr ""
 
-#: 854e74503fe24d2a845ee2d467224667 of pydantic.main.BaseModel.model_dump:25
+#: 0c32591dc8cd46548780db722b392adc of pydantic.main.BaseModel.model_dump:28
 msgid "Returns:"
 msgstr ""
 
-#: bc65b89011a34a5fbf89da50cb40d91d of pydantic.main.BaseModel.model_dump:26
+#: e00dfa71bc7e4fc983db2688772b195d of pydantic.main.BaseModel.model_dump:29
 msgid "A dictionary representation of the model."
 msgstr ""
+
+#~ msgid "[`model_dump`](../concepts/serialization.md#modelmodel_dump)"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "include: A set of fields to "
+#~ "include in the output. exclude: A "
+#~ "set of fields to exclude from the"
+#~ " output. context: Additional context to "
+#~ "pass to the serializer. by_alias: "
+#~ "Whether to use the field's alias "
+#~ "in the dictionary key if defined. "
+#~ "exclude_unset: Whether to exclude fields "
+#~ "that have not been explicitly set. "
+#~ "exclude_defaults: Whether to exclude fields"
+#~ " that are set to their default "
+#~ "value. exclude_none: Whether to exclude "
+#~ "fields that have a value of "
+#~ "`None`. round_trip: If True, dumped "
+#~ "values should be valid as input "
+#~ "for non-idempotent types such as "
+#~ "Json[T]. warnings: How to handle "
+#~ "serialization errors. False/\"none\" ignores "
+#~ "them, True/\"warn\" logs errors,"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGP.model_dump_json.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGP.model_dump_json.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,83 +21,133 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGP.model_dump_json.rst:2
-#: f64715166bca43e89e73b457bb3da1fa
+#: a934b11f08b44abb8a226438045a9879
 msgid "HSGP.model\\_dump\\_json"
 msgstr ""
 
-#: 386d74152fcb401e9a1080f090efd079 of
+#: 4914381976934f2e922e13ba09b3d8cc of
 #: pydantic.main.BaseModel.model_dump_json:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 6c7fd9bff912490d9535c9ac56d1a9bc of
+#: 86907de2c3374d7c96936556a96e5789 of
 #: pydantic.main.BaseModel.model_dump_json:3
-msgid "[`model_dump_json`](../concepts/serialization.md#modelmodel_dump_json)"
+msgid "[`model_dump_json`](../concepts/serialization.md#json-mode)"
 msgstr ""
 
-#: 7ab2a6f1d5bd473f99d40466df0843a4 of
+#: 445180bb34ff43789a46d1b780621eba of
 #: pydantic.main.BaseModel.model_dump_json:5
 msgid ""
 "Generates a JSON representation of the model using Pydantic's `to_json` "
 "method."
 msgstr ""
 
-#: a2787037f95c414582e0642d4583110f of
+#: 3e382202b2b54955b83785990db9bbec of
 #: pydantic.main.BaseModel.model_dump_json:7
 msgid "Args:"
 msgstr ""
 
-#: 0dd88398b02848999627b7c481c9f9bd of
+#: 6d295d62eb4a4c849a091de6dd3384ee of
 #: pydantic.main.BaseModel.model_dump_json:8
 msgid ""
 "indent: Indentation to use in the JSON output. If None is passed, the "
-"output will be compact. include: Field(s) to include in the JSON output. "
-"exclude: Field(s) to exclude from the JSON output. context: Additional "
-"context to pass to the serializer. by_alias: Whether to serialize using "
-"field aliases. exclude_unset: Whether to exclude fields that have not "
-"been explicitly set. exclude_defaults: Whether to exclude fields that are"
-" set to their default value. exclude_none: Whether to exclude fields that"
-" have a value of `None`. round_trip: If True, dumped values should be "
-"valid as input for non-idempotent types such as Json[T]. warnings: How to"
-" handle serialization errors. False/\"none\" ignores them, True/\"warn\" "
-"logs errors,"
+"output will be compact. ensure_ascii: If `True`, the output is guaranteed"
+" to have all incoming non-ASCII characters escaped."
 msgstr ""
 
-#: 01b622f4ac8e4073ba12202d6a2e11d0 of
-#: pydantic.main.BaseModel.model_dump_json:18
+#: 0422a4a837e54ffda02c3f3c45df59b3 of
+#: pydantic.main.BaseModel.model_dump_json:10
+msgid "If `False` (the default), these characters will be output as-is."
+msgstr ""
+
+#: 078eb9278fde48e6a2e20e3755bfd3c5 of
+#: pydantic.main.BaseModel.model_dump_json:11
+msgid ""
+"include: Field(s) to include in the JSON output. exclude: Field(s) to "
+"exclude from the JSON output. context: Additional context to pass to the "
+"serializer. by_alias: Whether to serialize using field aliases. "
+"exclude_unset: Whether to exclude fields that have not been explicitly "
+"set. exclude_defaults: Whether to exclude fields that are set to their "
+"default value. exclude_none: Whether to exclude fields that have a value "
+"of `None`. exclude_computed_fields: Whether to exclude computed fields."
+msgstr ""
+
+#: d7b9a9b2c0c74996b293e76303677a16 of
+#: pydantic.main.BaseModel.model_dump_json:19
+msgid ""
+"While this can be useful for round-tripping, it is usually recommended to"
+" use the dedicated `round_trip` parameter instead."
+msgstr ""
+
+#: 90ba7627d53148ce85b009dfd3b17c51 of
+#: pydantic.main.BaseModel.model_dump_json:21
+msgid ""
+"round_trip: If True, dumped values should be valid as input for non-"
+"idempotent types such as Json[T]. warnings: How to handle serialization "
+"errors. False/\"none\" ignores them, True/\"warn\" logs errors,"
+msgstr ""
+
+#: 30d22d58af654180bc94a81b7aef2555 of
+#: pydantic.main.BaseModel.model_dump_json:23
 msgid ""
 "\"error\" raises a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError]."
 msgstr ""
 
-#: 952dcddb379849b2a4fa48838111a59f of
-#: pydantic.main.BaseModel.model_dump_json:19
+#: 1bb0e455abdc46b69a5bbd8aa4eb62d6 of
+#: pydantic.main.BaseModel.model_dump_json:24
 msgid ""
 "fallback: A function to call when an unknown value is encountered. If not"
 " provided,"
 msgstr ""
 
-#: 9d13ef2d0d0c465486014c497d1f224d of
-#: pydantic.main.BaseModel.model_dump_json:20
+#: d873f40566ca4deabdcac4cda660bf49 of
+#: pydantic.main.BaseModel.model_dump_json:25
 msgid ""
 "a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError] "
 "error is raised."
 msgstr ""
 
-#: aca401d40f304900b95283ab62149d7f of
-#: pydantic.main.BaseModel.model_dump_json:21
+#: 443e4ed3fc364c1f9e2485fa9c6fe485 of
+#: pydantic.main.BaseModel.model_dump_json:26
 msgid ""
 "serialize_as_any: Whether to serialize fields with duck-typing "
 "serialization behavior."
 msgstr ""
 
-#: d8703e1af8de430dacc3ef25253cf470 of
-#: pydantic.main.BaseModel.model_dump_json:23
+#: 0fcf4674a196480ba6b8d01ff9d274bd of
+#: pydantic.main.BaseModel.model_dump_json:28
 msgid "Returns:"
 msgstr ""
 
-#: 9b999c3f8b4b40d8b3a2e8d3347d9de2 of
-#: pydantic.main.BaseModel.model_dump_json:24
+#: a2584a8025d04ee6bff3302179677f00 of
+#: pydantic.main.BaseModel.model_dump_json:29
 msgid "A JSON string representation of the model."
 msgstr ""
+
+#~ msgid "[`model_dump_json`](../concepts/serialization.md#modelmodel_dump_json)"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "indent: Indentation to use in the "
+#~ "JSON output. If None is passed, "
+#~ "the output will be compact. include: "
+#~ "Field(s) to include in the JSON "
+#~ "output. exclude: Field(s) to exclude "
+#~ "from the JSON output. context: "
+#~ "Additional context to pass to the "
+#~ "serializer. by_alias: Whether to serialize "
+#~ "using field aliases. exclude_unset: Whether"
+#~ " to exclude fields that have not "
+#~ "been explicitly set. exclude_defaults: Whether"
+#~ " to exclude fields that are set "
+#~ "to their default value. exclude_none: "
+#~ "Whether to exclude fields that have "
+#~ "a value of `None`. round_trip: If "
+#~ "True, dumped values should be valid "
+#~ "as input for non-idempotent types "
+#~ "such as Json[T]. warnings: How to "
+#~ "handle serialization errors. False/\"none\" "
+#~ "ignores them, True/\"warn\" logs errors,"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGP.model_json_schema.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGP.model_json_schema.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,44 +21,77 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGP.model_json_schema.rst:2
-#: a4added0c58941fd992cfa1238a46b86
+#: 81b448bcd74b48bdbe47bb1df5ca199c
 msgid "HSGP.model\\_json\\_schema"
 msgstr ""
 
-#: 318fa47ad2764f739b441cdfa1b037d2 of
+#: fb3cde14334147729979bbd734601c4e of
 #: pydantic.main.BaseModel.model_json_schema:2
 msgid "Generates a JSON schema for a model class."
 msgstr ""
 
-#: 6ae4c42b79304bd8bab31f1d92b2f202 of
+#: 9215ed0b06ba4260a556fa2aedd4f796 of
 #: pydantic.main.BaseModel.model_json_schema:4
 msgid "Args:"
 msgstr ""
 
-#: 3598307053f74d5aba04ef3f9a415f98 of
+#: 61b425b00f4b4cdaa0e694a8084df054 of
 #: pydantic.main.BaseModel.model_json_schema:5
 msgid ""
 "by_alias: Whether to use attribute aliases or not. ref_template: The "
-"reference template. schema_generator: To override the logic used to "
-"generate the JSON schema, as a subclass of"
+"reference template. union_format: The format to use when combining "
+"schemas from unions together. Can be one of:"
 msgstr ""
 
-#: c9d3ea32e55c49a8abe0239c667b7f2a of
-#: pydantic.main.BaseModel.model_json_schema:8
+#: 7041a29e7d6b4f47a0aa14c6a81f034d of
+#: pydantic.main.BaseModel.model_json_schema:9
+msgid ""
+"`'any_of'`: Use the [`anyOf`](https://json-schema.org/understanding-json-"
+"schema/reference/combining#anyOf)"
+msgstr ""
+
+#: b4f91a6c06884346bc73033fd01d6ddc of
+#: pydantic.main.BaseModel.model_json_schema:10
+msgid ""
+"keyword to combine schemas (the default). - `'primitive_type_array'`: Use"
+" the [`type`](https://json-schema.org/understanding-json-"
+"schema/reference/type) keyword as an array of strings, containing each "
+"type of the combination. If any of the schemas is not a primitive type "
+"(`string`, `boolean`, `null`, `integer` or `number`) or contains "
+"constraints/metadata, falls back to `any_of`."
+msgstr ""
+
+#: bacd1e25507e40f3a30804ce3c27244d of
+#: pydantic.main.BaseModel.model_json_schema:15
+msgid ""
+"schema_generator: To override the logic used to generate the JSON schema,"
+" as a subclass of"
+msgstr ""
+
+#: 49cf906ee6b244d18411313c5b7310cf of
+#: pydantic.main.BaseModel.model_json_schema:16
 msgid "`GenerateJsonSchema` with your desired modifications"
 msgstr ""
 
-#: 66d2a0fafdb04a60abbc18f93c3b6f66 of
-#: pydantic.main.BaseModel.model_json_schema:9
+#: 6451acb5943c4264b4849b1b13fc1df6 of
+#: pydantic.main.BaseModel.model_json_schema:17
 msgid "mode: The mode in which to generate the schema."
 msgstr ""
 
-#: 601d7eedcee4499781366c38f5d476ac of
-#: pydantic.main.BaseModel.model_json_schema:11
+#: 90dac30c5622494688ce5585eefd87e3 of
+#: pydantic.main.BaseModel.model_json_schema:19
 msgid "Returns:"
 msgstr ""
 
-#: 07dd1d904ceb483cb41e6f3a6f56030f of
-#: pydantic.main.BaseModel.model_json_schema:12
+#: ef546083267d46b898010f408969bc62 of
+#: pydantic.main.BaseModel.model_json_schema:20
 msgid "The JSON schema for the given model class."
 msgstr ""
+
+#~ msgid ""
+#~ "by_alias: Whether to use attribute "
+#~ "aliases or not. ref_template: The "
+#~ "reference template. schema_generator: To "
+#~ "override the logic used to generate "
+#~ "the JSON schema, as a subclass of"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGP.model_validate.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGP.model_validate.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,21 +21,33 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGP.model_validate.rst:2
-#: 261dcdf2b85a4b8e945b8d0f6dde7300
+#: 032abf44ca314860bfbf237f5213783d
 msgid "HSGP.model\\_validate"
 msgstr ""
 
-#: b5a78d62b7af4e95b0d24e35ae1f6b9c of pydantic.main.BaseModel.model_validate:2
+#: b5f382ef97e8451982ab3852c6eeebe6 of pydantic.main.BaseModel.model_validate:2
 msgid "Validate a pydantic model instance."
 msgstr ""
 
-#: d7747594d62c4188b6e61aa8462f383c of pydantic.main.BaseModel.model_validate:4
+#: c6008b6e6ced4c4cb8e1e6be8db8ea0e of pydantic.main.BaseModel.model_validate:4
 msgid "Args:"
 msgstr ""
 
-#: 8721e7f1cf3d4d2b9e9d0454a21e6a4a of pydantic.main.BaseModel.model_validate:5
+#: 8a88ed55f4404892b311a644ebd043df of pydantic.main.BaseModel.model_validate:5
 msgid ""
 "obj: The object to validate. strict: Whether to enforce types strictly. "
+"extra: Whether to ignore, allow, or forbid extra data during model "
+"validation."
+msgstr ""
+
+#: 690f69ced6a2494f826e28538cc34495 of pydantic.main.BaseModel.model_validate:8
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: 05208455c0a3444dba828197610d9217 of pydantic.main.BaseModel.model_validate:9
+msgid ""
 "from_attributes: Whether to extract data from object attributes. context:"
 " Additional context to pass to the validator. by_alias: Whether to use "
 "the field's alias when validating against the provided input data. "
@@ -43,22 +55,35 @@ msgid ""
 "provided input data."
 msgstr ""
 
-#: 30fb18869ec4464b9fa971a1b5d00ad0 of
-#: pydantic.main.BaseModel.model_validate:12
+#: cec64c08a1994ee6b44b490a93f45090 of
+#: pydantic.main.BaseModel.model_validate:14
 msgid "Raises:"
 msgstr ""
 
-#: 450d7854e4a546e0a7e9bd8f0311f9ae of
-#: pydantic.main.BaseModel.model_validate:13
+#: a4f3a21950c94cf3ab331524b7dea667 of
+#: pydantic.main.BaseModel.model_validate:15
 msgid "ValidationError: If the object could not be validated."
 msgstr ""
 
-#: c34a492a6ca74d63a98379974df51076 of
-#: pydantic.main.BaseModel.model_validate:15
+#: ff76082a7c38494b94f106008e298bf2 of
+#: pydantic.main.BaseModel.model_validate:17
 msgid "Returns:"
 msgstr ""
 
-#: 310e44eb6a184845b097664abdcb005a of
-#: pydantic.main.BaseModel.model_validate:16
+#: 3cb2d085beec40d1a910fcafff02118b of
+#: pydantic.main.BaseModel.model_validate:18
 msgid "The validated model instance."
 msgstr ""
+
+#~ msgid ""
+#~ "obj: The object to validate. strict: "
+#~ "Whether to enforce types strictly. "
+#~ "from_attributes: Whether to extract data "
+#~ "from object attributes. context: Additional"
+#~ " context to pass to the validator."
+#~ " by_alias: Whether to use the field's"
+#~ " alias when validating against the "
+#~ "provided input data. by_name: Whether to"
+#~ " use the field's name when validating"
+#~ " against the provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGP.model_validate_json.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGP.model_validate_json.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,58 +21,84 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGP.model_validate_json.rst:2
-#: 0b8e6d2b7af84e559e21a14c2354355e
+#: afc5fdb9526c4e5899bc641e1b864348
 msgid "HSGP.model\\_validate\\_json"
 msgstr ""
 
-#: 063a1323ff914c58ae6a1a5872b8f0d9 of
+#: 04281e45306442f4b1e4d2ba79bf98a3 of
 #: pydantic.main.BaseModel.model_validate_json:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 0b5c597795b4458b82fa72817624e20c of
+#: 7dfcd76d23244ee8bf95ade4dedfab77 of
 #: pydantic.main.BaseModel.model_validate_json:3
 msgid "[JSON Parsing](../concepts/json.md#json-parsing)"
 msgstr ""
 
-#: f1c2d891a86b4b348a96445e5f79669d of
+#: da14ea87a40d47d38e5c0b31fc5cb76f of
 #: pydantic.main.BaseModel.model_validate_json:5
 msgid "Validate the given JSON data against the Pydantic model."
 msgstr ""
 
-#: b8b7e5ca395d43799e201819cbfa6e7a of
+#: e3da19a9805e49e5b6279942a7e05277 of
 #: pydantic.main.BaseModel.model_validate_json:7
 msgid "Args:"
 msgstr ""
 
-#: 5174b234575e45308e44195517bde5a4 of
+#: 782cb9dcb66b492d89ecb49c9fdf180f of
 #: pydantic.main.BaseModel.model_validate_json:8
 msgid ""
 "json_data: The JSON data to validate. strict: Whether to enforce types "
-"strictly. context: Extra variables to pass to the validator. by_alias: "
-"Whether to use the field's alias when validating against the provided "
-"input data. by_name: Whether to use the field's name when validating "
-"against the provided input data."
+"strictly. extra: Whether to ignore, allow, or forbid extra data during "
+"model validation."
 msgstr ""
 
-#: fb2ad3af3ab948e5860baebfb7079ac2 of
-#: pydantic.main.BaseModel.model_validate_json:14
+#: 020556f16f5b407594d7e917b41ebdbf of
+#: pydantic.main.BaseModel.model_validate_json:11
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: b37833b3f38f4f259fa047d7dbc11f69 of
+#: pydantic.main.BaseModel.model_validate_json:12
+msgid ""
+"context: Extra variables to pass to the validator. by_alias: Whether to "
+"use the field's alias when validating against the provided input data. "
+"by_name: Whether to use the field's name when validating against the "
+"provided input data."
+msgstr ""
+
+#: 424fd45ce0ff41138086e1d1acb4fc83 of
+#: pydantic.main.BaseModel.model_validate_json:16
 msgid "Returns:"
 msgstr ""
 
-#: ebc031fb6123461d84b0967e3fbcac5a of
-#: pydantic.main.BaseModel.model_validate_json:15
+#: 1c33f00ecc3b44daba0243738c70abb1 of
+#: pydantic.main.BaseModel.model_validate_json:17
 msgid "The validated Pydantic model."
 msgstr ""
 
-#: d8ad992d230c44a6b2c3f196b1c48639 of
-#: pydantic.main.BaseModel.model_validate_json:17
+#: d36a9e3d45cc4bb6a2b6f5bd5803f018 of
+#: pydantic.main.BaseModel.model_validate_json:19
 msgid "Raises:"
 msgstr ""
 
-#: 72623b2237144da4843a8a70b6457997 of
-#: pydantic.main.BaseModel.model_validate_json:18
+#: 298c1c8736f14a879bcfe0044b88c1da of
+#: pydantic.main.BaseModel.model_validate_json:20
 msgid ""
 "ValidationError: If `json_data` is not a JSON string or the object could "
 "not be validated."
 msgstr ""
+
+#~ msgid ""
+#~ "json_data: The JSON data to validate."
+#~ " strict: Whether to enforce types "
+#~ "strictly. context: Extra variables to "
+#~ "pass to the validator. by_alias: Whether"
+#~ " to use the field's alias when "
+#~ "validating against the provided input "
+#~ "data. by_name: Whether to use the "
+#~ "field's name when validating against the"
+#~ " provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGP.model_validate_strings.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGP.model_validate_strings.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,36 +21,62 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGP.model_validate_strings.rst:2
-#: 955760116fde4626a35a06b971fb765e
+#: a93d082c915b46339cd70fa2a9cc7f74
 msgid "HSGP.model\\_validate\\_strings"
 msgstr ""
 
-#: 2c9b3f58a05e48a0ab5f04af74d2f3ee of
+#: 81c2d5022cd540cdb7cd37845f2d0906 of
 #: pydantic.main.BaseModel.model_validate_strings:2
 msgid "Validate the given object with string data against the Pydantic model."
 msgstr ""
 
-#: dc7d2996f467498fad3d1087dc214820 of
+#: 7d871e52dd0d47bcb7c7754c3e1e1fa7 of
 #: pydantic.main.BaseModel.model_validate_strings:4
 msgid "Args:"
 msgstr ""
 
-#: ae46748ea2f0485aba16aac98fcbcb57 of
+#: ad2b786e84b9495d89c4707128180bbe of
 #: pydantic.main.BaseModel.model_validate_strings:5
 msgid ""
 "obj: The object containing string data to validate. strict: Whether to "
-"enforce types strictly. context: Extra variables to pass to the "
-"validator. by_alias: Whether to use the field's alias when validating "
-"against the provided input data. by_name: Whether to use the field's name"
-" when validating against the provided input data."
+"enforce types strictly. extra: Whether to ignore, allow, or forbid extra "
+"data during model validation."
 msgstr ""
 
-#: 6089187f925c4947a49b16a1966673ce of
-#: pydantic.main.BaseModel.model_validate_strings:11
+#: a2a1878279a741b7b406b29acdc836de of
+#: pydantic.main.BaseModel.model_validate_strings:8
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: 6835a8a4f8ec405eafe849ca5da4b607 of
+#: pydantic.main.BaseModel.model_validate_strings:9
+msgid ""
+"context: Extra variables to pass to the validator. by_alias: Whether to "
+"use the field's alias when validating against the provided input data. "
+"by_name: Whether to use the field's name when validating against the "
+"provided input data."
+msgstr ""
+
+#: d9ba5490f1a540269f1588d4b430b950 of
+#: pydantic.main.BaseModel.model_validate_strings:13
 msgid "Returns:"
 msgstr ""
 
-#: 74d566b44a1a4e1681e4781611aa61a8 of
-#: pydantic.main.BaseModel.model_validate_strings:12
+#: 126ac9c3f39f4f28a31ff62cb2d21951 of
+#: pydantic.main.BaseModel.model_validate_strings:14
 msgid "The validated Pydantic model."
 msgstr ""
+
+#~ msgid ""
+#~ "obj: The object containing string data"
+#~ " to validate. strict: Whether to "
+#~ "enforce types strictly. context: Extra "
+#~ "variables to pass to the validator. "
+#~ "by_alias: Whether to use the field's "
+#~ "alias when validating against the "
+#~ "provided input data. by_name: Whether to"
+#~ " use the field's name when validating"
+#~ " against the provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPBase.model_copy.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPBase.model_copy.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,27 +21,27 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPBase.model_copy.rst:2
-#: cf98fbb844e24d1d8c8d0f5f183c82bf
+#: 41339b53755545ab81ea9fb7c80a81f1
 msgid "HSGPBase.model\\_copy"
 msgstr ""
 
-#: b05183753314401ea5e4029a86ad3abf of pydantic.main.BaseModel.model_copy:2
+#: 4de6ba29646c4841b2e7e0e6c3300966 of pydantic.main.BaseModel.model_copy:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 65086e18bec742be8c77e3e0addf4215 of pydantic.main.BaseModel.model_copy:3
-msgid "[`model_copy`](../concepts/serialization.md#model_copy)"
+#: 6e1d906cf9d94474bedc0587241058ef of pydantic.main.BaseModel.model_copy:3
+msgid "[`model_copy`](../concepts/models.md#model-copy)"
 msgstr ""
 
-#: 1bf61cd7fb9b413bb5dfaed701cf6e82 of pydantic.main.BaseModel.model_copy:5
+#: 1a8749e0f0284e78a544032de61ab6b3 of pydantic.main.BaseModel.model_copy:5
 msgid "Returns a copy of the model."
 msgstr ""
 
-#: ba49276722464eae8fae2257764f9651 of pydantic.main.BaseModel.model_copy:7
+#: 410ca5a000fc461eb6ea88755bfa49f5 of pydantic.main.BaseModel.model_copy:7
 msgid "!!! note"
 msgstr ""
 
-#: 823cf9b1105a475caf2f0bfc89a13258 of pydantic.main.BaseModel.model_copy:8
+#: 9f6a2c7596434acf85fb55ce43e2c920 of pydantic.main.BaseModel.model_copy:8
 msgid ""
 "The underlying instance's [`__dict__`][object.__dict__] attribute is "
 "copied. This might have unexpected side effects if you store anything in "
@@ -49,28 +49,31 @@ msgid ""
 "properties][functools.cached_property])."
 msgstr ""
 
-#: 78a159acf12d47f6a283cb9eb1ab193b of pydantic.main.BaseModel.model_copy:12
+#: d9eb91a945234aa5aeb88894ad3a8397 of pydantic.main.BaseModel.model_copy:12
 msgid "Args:"
 msgstr ""
 
-#: 6bdf3fe9961f42ef99afdd10deb2f4a4 of pydantic.main.BaseModel.model_copy:13
+#: 596ca19123c143278cf229e47560e1e8 of pydantic.main.BaseModel.model_copy:13
 msgid ""
 "update: Values to change/add in the new model. Note: the data is not "
 "validated"
 msgstr ""
 
-#: 2069d98c24bd4b28843633c33ce5e9dc of pydantic.main.BaseModel.model_copy:14
+#: 7cd49947058e472caa3cb1659b3cc70a of pydantic.main.BaseModel.model_copy:14
 msgid "before creating the new model. You should trust this data."
 msgstr ""
 
-#: 0ad37639817e4c1dab101f8734cd8f29 of pydantic.main.BaseModel.model_copy:15
+#: 4769a6b4077141488e341678f7c8d1cf of pydantic.main.BaseModel.model_copy:15
 msgid "deep: Set to `True` to make a deep copy of the model."
 msgstr ""
 
-#: a005a2aa05754b6ea2347ce22839b348 of pydantic.main.BaseModel.model_copy:17
+#: 24bc2f6bb121423c83b8942b81927ac3 of pydantic.main.BaseModel.model_copy:17
 msgid "Returns:"
 msgstr ""
 
-#: 90ef1fcdcd29449ebe6000b38296c296 of pydantic.main.BaseModel.model_copy:18
+#: 2e766771a68f49f686139511227005d3 of pydantic.main.BaseModel.model_copy:18
 msgid "New model instance."
 msgstr ""
+
+#~ msgid "[`model_copy`](../concepts/serialization.md#model_copy)"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPBase.model_dump.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPBase.model_dump.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,40 +21,40 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPBase.model_dump.rst:2
-#: 99cbdc24ae76465d90eed64fc163f7dd
+#: db2631dcf983464e9aa75f9df5aaa7c6
 msgid "HSGPBase.model\\_dump"
 msgstr ""
 
-#: c1158b44c18c4efca3230d66924231f6 of pydantic.main.BaseModel.model_dump:2
+#: 03bd5685078f4cf4bab1caf2de27f4d6 of pydantic.main.BaseModel.model_dump:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 9a7699a6551c466db63551714fa4f418 of pydantic.main.BaseModel.model_dump:3
-msgid "[`model_dump`](../concepts/serialization.md#modelmodel_dump)"
+#: 9b2a334bb0404f928f4b8c3e0251739a of pydantic.main.BaseModel.model_dump:3
+msgid "[`model_dump`](../concepts/serialization.md#python-mode)"
 msgstr ""
 
-#: 1193ec5491414504b1a4afee89f4626d of pydantic.main.BaseModel.model_dump:5
+#: c79c78503faa40bab1db0c556ef681c8 of pydantic.main.BaseModel.model_dump:5
 msgid ""
 "Generate a dictionary representation of the model, optionally specifying "
 "which fields to include or exclude."
 msgstr ""
 
-#: d2ab54eec1da4b4e87377f6a222ccbd5 of pydantic.main.BaseModel.model_dump:7
+#: 33c6eebf61854ca48135e4e4308d2dd3 of pydantic.main.BaseModel.model_dump:7
 msgid "Args:"
 msgstr ""
 
-#: b2f18a2f5a174ce885f7bd20c76f7bdb of pydantic.main.BaseModel.model_dump:8
+#: 59514a1c971345b0b806674bb55ab4d0 of pydantic.main.BaseModel.model_dump:8
 msgid "mode: The mode in which `to_python` should run."
 msgstr ""
 
-#: 8bd9c4565c6347058b2b62738e5f38d4 of pydantic.main.BaseModel.model_dump:9
+#: d5b5e829770047ae837b88dc9dce7688 of pydantic.main.BaseModel.model_dump:9
 msgid ""
 "If mode is 'json', the output will only contain JSON serializable types. "
 "If mode is 'python', the output may contain non-JSON-serializable Python "
 "objects."
 msgstr ""
 
-#: 2300d7a900014278b247583887055b26 of pydantic.main.BaseModel.model_dump:11
+#: 510dd7bffd9043d9b6070197481ca017 of pydantic.main.BaseModel.model_dump:11
 msgid ""
 "include: A set of fields to include in the output. exclude: A set of "
 "fields to exclude from the output. context: Additional context to pass to"
@@ -62,41 +62,77 @@ msgid ""
 "dictionary key if defined. exclude_unset: Whether to exclude fields that "
 "have not been explicitly set. exclude_defaults: Whether to exclude fields"
 " that are set to their default value. exclude_none: Whether to exclude "
-"fields that have a value of `None`. round_trip: If True, dumped values "
-"should be valid as input for non-idempotent types such as Json[T]. "
-"warnings: How to handle serialization errors. False/\"none\" ignores "
-"them, True/\"warn\" logs errors,"
+"fields that have a value of `None`. exclude_computed_fields: Whether to "
+"exclude computed fields."
 msgstr ""
 
-#: fdb2ea1be6654570b9b2adb9d70c507a of pydantic.main.BaseModel.model_dump:20
+#: c4733f087c4d45cdb73ea34f1c1074f9 of pydantic.main.BaseModel.model_dump:19
+msgid ""
+"While this can be useful for round-tripping, it is usually recommended tu"
+" use the dedicated `round_trip` parameter instead."
+msgstr ""
+
+#: 422b24b8a2fa4a75b8a8f75a6188e2a1 of pydantic.main.BaseModel.model_dump:21
+msgid ""
+"round_trip: If True, dumped values should be valid as input for non-"
+"idempotent types such as Json[T]. warnings: How to handle serialization "
+"errors. False/\"none\" ignores them, True/\"warn\" logs errors,"
+msgstr ""
+
+#: 093e4db7fb8b4c7187f94d053b6c9665 of pydantic.main.BaseModel.model_dump:23
 msgid ""
 "\"error\" raises a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError]."
 msgstr ""
 
-#: fbffb1831dfe443f8247bbce70ee52a4 of pydantic.main.BaseModel.model_dump:21
+#: ab14a064165a4130a88f0f975aaf2e11 of pydantic.main.BaseModel.model_dump:24
 msgid ""
 "fallback: A function to call when an unknown value is encountered. If not"
 " provided,"
 msgstr ""
 
-#: bb1df9f888424b49bb33993762691abe of pydantic.main.BaseModel.model_dump:22
+#: 650897df71084ab58ccdc2fb12d4c4f9 of pydantic.main.BaseModel.model_dump:25
 msgid ""
 "a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError] "
 "error is raised."
 msgstr ""
 
-#: 0c173f204b354226957a0df82c6865a6 of pydantic.main.BaseModel.model_dump:23
+#: df9709809e2642f1aa4e37540b52f631 of pydantic.main.BaseModel.model_dump:26
 msgid ""
 "serialize_as_any: Whether to serialize fields with duck-typing "
 "serialization behavior."
 msgstr ""
 
-#: 4756de73c6af40a2a73995cc01d7877e of pydantic.main.BaseModel.model_dump:25
+#: da7fcdd693f546edbd9790a55cb24035 of pydantic.main.BaseModel.model_dump:28
 msgid "Returns:"
 msgstr ""
 
-#: d6c6ff6745fd45878bf912a0d5300d24 of pydantic.main.BaseModel.model_dump:26
+#: b07e14a4a24244499b306ce40e79e39d of pydantic.main.BaseModel.model_dump:29
 msgid "A dictionary representation of the model."
 msgstr ""
+
+#~ msgid "[`model_dump`](../concepts/serialization.md#modelmodel_dump)"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "include: A set of fields to "
+#~ "include in the output. exclude: A "
+#~ "set of fields to exclude from the"
+#~ " output. context: Additional context to "
+#~ "pass to the serializer. by_alias: "
+#~ "Whether to use the field's alias "
+#~ "in the dictionary key if defined. "
+#~ "exclude_unset: Whether to exclude fields "
+#~ "that have not been explicitly set. "
+#~ "exclude_defaults: Whether to exclude fields"
+#~ " that are set to their default "
+#~ "value. exclude_none: Whether to exclude "
+#~ "fields that have a value of "
+#~ "`None`. round_trip: If True, dumped "
+#~ "values should be valid as input "
+#~ "for non-idempotent types such as "
+#~ "Json[T]. warnings: How to handle "
+#~ "serialization errors. False/\"none\" ignores "
+#~ "them, True/\"warn\" logs errors,"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPBase.model_dump_json.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPBase.model_dump_json.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,83 +21,133 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPBase.model_dump_json.rst:2
-#: b8e40e832482405ca60274b3db450949
+#: 6980a9b8e3a641a5a452290793e63eb1
 msgid "HSGPBase.model\\_dump\\_json"
 msgstr ""
 
-#: e5d8e17bcf434271968178ce328c0aa0 of
+#: 9003025ce2cf482cb7507f91edfc5106 of
 #: pydantic.main.BaseModel.model_dump_json:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 6e6758d4783142e0b832d4572ee4c98c of
+#: 87171c10a9f2451fb405dbed1d6f3e0e of
 #: pydantic.main.BaseModel.model_dump_json:3
-msgid "[`model_dump_json`](../concepts/serialization.md#modelmodel_dump_json)"
+msgid "[`model_dump_json`](../concepts/serialization.md#json-mode)"
 msgstr ""
 
-#: e02b589505604c5587d8f50b4bf04ff9 of
+#: d307b06fa0fe4bf4a6f7f7669b4ba395 of
 #: pydantic.main.BaseModel.model_dump_json:5
 msgid ""
 "Generates a JSON representation of the model using Pydantic's `to_json` "
 "method."
 msgstr ""
 
-#: c9b9671537cc45f98eba9ecc0e6c2843 of
+#: 2fd030a991484b4aaa1cac18e7f565a1 of
 #: pydantic.main.BaseModel.model_dump_json:7
 msgid "Args:"
 msgstr ""
 
-#: f8b6950529e0406e904aecaecb116bb2 of
+#: d89de4c3c47645c99188b3dbaa8c36b1 of
 #: pydantic.main.BaseModel.model_dump_json:8
 msgid ""
 "indent: Indentation to use in the JSON output. If None is passed, the "
-"output will be compact. include: Field(s) to include in the JSON output. "
-"exclude: Field(s) to exclude from the JSON output. context: Additional "
-"context to pass to the serializer. by_alias: Whether to serialize using "
-"field aliases. exclude_unset: Whether to exclude fields that have not "
-"been explicitly set. exclude_defaults: Whether to exclude fields that are"
-" set to their default value. exclude_none: Whether to exclude fields that"
-" have a value of `None`. round_trip: If True, dumped values should be "
-"valid as input for non-idempotent types such as Json[T]. warnings: How to"
-" handle serialization errors. False/\"none\" ignores them, True/\"warn\" "
-"logs errors,"
+"output will be compact. ensure_ascii: If `True`, the output is guaranteed"
+" to have all incoming non-ASCII characters escaped."
 msgstr ""
 
-#: b3a3d78ffc774094820d77ff4cda2a50 of
-#: pydantic.main.BaseModel.model_dump_json:18
+#: a16cbf1b6c0940219b1660d56e4175c3 of
+#: pydantic.main.BaseModel.model_dump_json:10
+msgid "If `False` (the default), these characters will be output as-is."
+msgstr ""
+
+#: 88453a103ad74e6ca51d45eeec8e14de of
+#: pydantic.main.BaseModel.model_dump_json:11
+msgid ""
+"include: Field(s) to include in the JSON output. exclude: Field(s) to "
+"exclude from the JSON output. context: Additional context to pass to the "
+"serializer. by_alias: Whether to serialize using field aliases. "
+"exclude_unset: Whether to exclude fields that have not been explicitly "
+"set. exclude_defaults: Whether to exclude fields that are set to their "
+"default value. exclude_none: Whether to exclude fields that have a value "
+"of `None`. exclude_computed_fields: Whether to exclude computed fields."
+msgstr ""
+
+#: dee9b52c45cb406fb8faca824b24808e of
+#: pydantic.main.BaseModel.model_dump_json:19
+msgid ""
+"While this can be useful for round-tripping, it is usually recommended to"
+" use the dedicated `round_trip` parameter instead."
+msgstr ""
+
+#: fc0214c82dc8437fa3a7d9a44b702a1e of
+#: pydantic.main.BaseModel.model_dump_json:21
+msgid ""
+"round_trip: If True, dumped values should be valid as input for non-"
+"idempotent types such as Json[T]. warnings: How to handle serialization "
+"errors. False/\"none\" ignores them, True/\"warn\" logs errors,"
+msgstr ""
+
+#: d8501d48be694532a9015ab7115e5f4b of
+#: pydantic.main.BaseModel.model_dump_json:23
 msgid ""
 "\"error\" raises a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError]."
 msgstr ""
 
-#: f3fd0cb878ea4ccaac99ed47b182b7dc of
-#: pydantic.main.BaseModel.model_dump_json:19
+#: 040a0762fbec48b990b505d33a57348e of
+#: pydantic.main.BaseModel.model_dump_json:24
 msgid ""
 "fallback: A function to call when an unknown value is encountered. If not"
 " provided,"
 msgstr ""
 
-#: c04f76ab88f844a180c6b52f58b7182f of
-#: pydantic.main.BaseModel.model_dump_json:20
+#: 0d9e610bf24e4f82948fff0231e52101 of
+#: pydantic.main.BaseModel.model_dump_json:25
 msgid ""
 "a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError] "
 "error is raised."
 msgstr ""
 
-#: 82070fbe39ae49f191a622d151ae194b of
-#: pydantic.main.BaseModel.model_dump_json:21
+#: b27760eb48194fafa64415749dce5c50 of
+#: pydantic.main.BaseModel.model_dump_json:26
 msgid ""
 "serialize_as_any: Whether to serialize fields with duck-typing "
 "serialization behavior."
 msgstr ""
 
-#: 17c7442ef4244d83b019a83e574ddc54 of
-#: pydantic.main.BaseModel.model_dump_json:23
+#: 464f74e088e54d3aa352bd96a618b54a of
+#: pydantic.main.BaseModel.model_dump_json:28
 msgid "Returns:"
 msgstr ""
 
-#: c34163d934b94b628a9545493e5c704b of
-#: pydantic.main.BaseModel.model_dump_json:24
+#: 1e6d13a020bb4b79b129f259569334ed of
+#: pydantic.main.BaseModel.model_dump_json:29
 msgid "A JSON string representation of the model."
 msgstr ""
+
+#~ msgid "[`model_dump_json`](../concepts/serialization.md#modelmodel_dump_json)"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "indent: Indentation to use in the "
+#~ "JSON output. If None is passed, "
+#~ "the output will be compact. include: "
+#~ "Field(s) to include in the JSON "
+#~ "output. exclude: Field(s) to exclude "
+#~ "from the JSON output. context: "
+#~ "Additional context to pass to the "
+#~ "serializer. by_alias: Whether to serialize "
+#~ "using field aliases. exclude_unset: Whether"
+#~ " to exclude fields that have not "
+#~ "been explicitly set. exclude_defaults: Whether"
+#~ " to exclude fields that are set "
+#~ "to their default value. exclude_none: "
+#~ "Whether to exclude fields that have "
+#~ "a value of `None`. round_trip: If "
+#~ "True, dumped values should be valid "
+#~ "as input for non-idempotent types "
+#~ "such as Json[T]. warnings: How to "
+#~ "handle serialization errors. False/\"none\" "
+#~ "ignores them, True/\"warn\" logs errors,"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPBase.model_json_schema.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPBase.model_json_schema.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,44 +21,77 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPBase.model_json_schema.rst:2
-#: 765110e63297411ca2ff30b86ad60ff6
+#: 8625b46791c34aa5a4160ded4f6c00b6
 msgid "HSGPBase.model\\_json\\_schema"
 msgstr ""
 
-#: cf97f9a4cd8e49a78118685139146912 of
+#: 552e3f6303204ed9bf9dd03933049908 of
 #: pydantic.main.BaseModel.model_json_schema:2
 msgid "Generates a JSON schema for a model class."
 msgstr ""
 
-#: 66592e458f7845e0bd8bb93d72c16e91 of
+#: 1c39c98775f546ed9b2e7bd4176a2f70 of
 #: pydantic.main.BaseModel.model_json_schema:4
 msgid "Args:"
 msgstr ""
 
-#: cc73a5598fd14a86bce26861a2e95d5d of
+#: 2b5e16e7992b4a2e926cc1959fc26d4e of
 #: pydantic.main.BaseModel.model_json_schema:5
 msgid ""
 "by_alias: Whether to use attribute aliases or not. ref_template: The "
-"reference template. schema_generator: To override the logic used to "
-"generate the JSON schema, as a subclass of"
+"reference template. union_format: The format to use when combining "
+"schemas from unions together. Can be one of:"
 msgstr ""
 
-#: e026df437a594d8fbbb4ba12eadef9e1 of
-#: pydantic.main.BaseModel.model_json_schema:8
+#: 48e285be67214e08ac4a4803c629fca4 of
+#: pydantic.main.BaseModel.model_json_schema:9
+msgid ""
+"`'any_of'`: Use the [`anyOf`](https://json-schema.org/understanding-json-"
+"schema/reference/combining#anyOf)"
+msgstr ""
+
+#: bdda25a0c8364b58bc1484c9847fca9f of
+#: pydantic.main.BaseModel.model_json_schema:10
+msgid ""
+"keyword to combine schemas (the default). - `'primitive_type_array'`: Use"
+" the [`type`](https://json-schema.org/understanding-json-"
+"schema/reference/type) keyword as an array of strings, containing each "
+"type of the combination. If any of the schemas is not a primitive type "
+"(`string`, `boolean`, `null`, `integer` or `number`) or contains "
+"constraints/metadata, falls back to `any_of`."
+msgstr ""
+
+#: 39aa201728e2463880af30902d7f0968 of
+#: pydantic.main.BaseModel.model_json_schema:15
+msgid ""
+"schema_generator: To override the logic used to generate the JSON schema,"
+" as a subclass of"
+msgstr ""
+
+#: 4e66e61f3353451f82c05dc2a8b00d71 of
+#: pydantic.main.BaseModel.model_json_schema:16
 msgid "`GenerateJsonSchema` with your desired modifications"
 msgstr ""
 
-#: f039c412448d4d3d82b140a88bf1c1ef of
-#: pydantic.main.BaseModel.model_json_schema:9
+#: 738ceed2d22744b8a024ceabfe581867 of
+#: pydantic.main.BaseModel.model_json_schema:17
 msgid "mode: The mode in which to generate the schema."
 msgstr ""
 
-#: 83ed2fc9f1374e5483818d43835dafae of
-#: pydantic.main.BaseModel.model_json_schema:11
+#: a7a5bbbed53d4d6dbacfc6ce6ac2bb94 of
+#: pydantic.main.BaseModel.model_json_schema:19
 msgid "Returns:"
 msgstr ""
 
-#: 71b68097d8b044779fa216efa6681023 of
-#: pydantic.main.BaseModel.model_json_schema:12
+#: 3dee8fc341ce4f14a204429f693ce867 of
+#: pydantic.main.BaseModel.model_json_schema:20
 msgid "The JSON schema for the given model class."
 msgstr ""
+
+#~ msgid ""
+#~ "by_alias: Whether to use attribute "
+#~ "aliases or not. ref_template: The "
+#~ "reference template. schema_generator: To "
+#~ "override the logic used to generate "
+#~ "the JSON schema, as a subclass of"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPBase.model_validate.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPBase.model_validate.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,21 +21,33 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPBase.model_validate.rst:2
-#: faf60bbb0fcb4b7aaad4e6fdd2bbad71
+#: 059c4c1683614f8fb6412f8584906dde
 msgid "HSGPBase.model\\_validate"
 msgstr ""
 
-#: 47080c16ded540b2a5f48bb8d1ae53dc of pydantic.main.BaseModel.model_validate:2
+#: ac32bc0f77884a1cbbd3fc9e562b8eef of pydantic.main.BaseModel.model_validate:2
 msgid "Validate a pydantic model instance."
 msgstr ""
 
-#: aa0d407035684384b2097e7aa9266a82 of pydantic.main.BaseModel.model_validate:4
+#: 8163b580575347d99bcdef8a9a70d650 of pydantic.main.BaseModel.model_validate:4
 msgid "Args:"
 msgstr ""
 
-#: d6c5202cc5c54e6ba3ed23736bd02dbe of pydantic.main.BaseModel.model_validate:5
+#: 3cbbe9c47bc94d08ab47efba42a546e3 of pydantic.main.BaseModel.model_validate:5
 msgid ""
 "obj: The object to validate. strict: Whether to enforce types strictly. "
+"extra: Whether to ignore, allow, or forbid extra data during model "
+"validation."
+msgstr ""
+
+#: b984f54b1f894fff96dfab2c40421a1f of pydantic.main.BaseModel.model_validate:8
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: fedea93ccd9d437e8e8432a5fdce2d03 of pydantic.main.BaseModel.model_validate:9
+msgid ""
 "from_attributes: Whether to extract data from object attributes. context:"
 " Additional context to pass to the validator. by_alias: Whether to use "
 "the field's alias when validating against the provided input data. "
@@ -43,22 +55,35 @@ msgid ""
 "provided input data."
 msgstr ""
 
-#: 459b373c782544e1a2f48c4dfd6b5c5b of
-#: pydantic.main.BaseModel.model_validate:12
+#: 2dbaf79d7bb446019520b731d93cabc5 of
+#: pydantic.main.BaseModel.model_validate:14
 msgid "Raises:"
 msgstr ""
 
-#: 6fe841e2ded14b48bb6e6bc7056343bf of
-#: pydantic.main.BaseModel.model_validate:13
+#: 9c9b9e34016240f5b767176fabbd138d of
+#: pydantic.main.BaseModel.model_validate:15
 msgid "ValidationError: If the object could not be validated."
 msgstr ""
 
-#: 05f5aa4a928e4cb0a6265f30dcdad597 of
-#: pydantic.main.BaseModel.model_validate:15
+#: 2e2d44008d8a4cf8bb42a1f519175639 of
+#: pydantic.main.BaseModel.model_validate:17
 msgid "Returns:"
 msgstr ""
 
-#: 0d37db7a38f14484955158a1632600d6 of
-#: pydantic.main.BaseModel.model_validate:16
+#: 79dd0c1b8a25460dbd108648b1f1c0c7 of
+#: pydantic.main.BaseModel.model_validate:18
 msgid "The validated model instance."
 msgstr ""
+
+#~ msgid ""
+#~ "obj: The object to validate. strict: "
+#~ "Whether to enforce types strictly. "
+#~ "from_attributes: Whether to extract data "
+#~ "from object attributes. context: Additional"
+#~ " context to pass to the validator."
+#~ " by_alias: Whether to use the field's"
+#~ " alias when validating against the "
+#~ "provided input data. by_name: Whether to"
+#~ " use the field's name when validating"
+#~ " against the provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPBase.model_validate_json.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPBase.model_validate_json.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,58 +21,84 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPBase.model_validate_json.rst:2
-#: 7cd40327ccf84f63933291eb16568b59
+#: 1c09bcc3cbb148e58013ed06b301630d
 msgid "HSGPBase.model\\_validate\\_json"
 msgstr ""
 
-#: 2345b8268fc041a5a8d5ee6250d0cea0 of
+#: 8019dfe39c204b69a5cc6c9d9f7b3498 of
 #: pydantic.main.BaseModel.model_validate_json:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 1522ced796ea43cea6d4799da0d7b90c of
+#: 9058f37051c6429f972cc7b4f9a63e86 of
 #: pydantic.main.BaseModel.model_validate_json:3
 msgid "[JSON Parsing](../concepts/json.md#json-parsing)"
 msgstr ""
 
-#: 44c12e89433841beacac02101578dd99 of
+#: 3ec7e375cd3645578c4335c433cadd94 of
 #: pydantic.main.BaseModel.model_validate_json:5
 msgid "Validate the given JSON data against the Pydantic model."
 msgstr ""
 
-#: 540a86eca74749cfa6b15c7ecfcaf429 of
+#: e40ae265e29d4670b0328e6e9217ac90 of
 #: pydantic.main.BaseModel.model_validate_json:7
 msgid "Args:"
 msgstr ""
 
-#: 80c3d71492a84ccf88c4de62ae4508e3 of
+#: dd3f368c34f543cd8e50f098df626418 of
 #: pydantic.main.BaseModel.model_validate_json:8
 msgid ""
 "json_data: The JSON data to validate. strict: Whether to enforce types "
-"strictly. context: Extra variables to pass to the validator. by_alias: "
-"Whether to use the field's alias when validating against the provided "
-"input data. by_name: Whether to use the field's name when validating "
-"against the provided input data."
+"strictly. extra: Whether to ignore, allow, or forbid extra data during "
+"model validation."
 msgstr ""
 
-#: 886a9d957b994c78b71497e6b240251f of
-#: pydantic.main.BaseModel.model_validate_json:14
+#: 29894951ab74419a83376b39946fa8dd of
+#: pydantic.main.BaseModel.model_validate_json:11
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: 5bb50d09d93e4e51be414c1625129ad8 of
+#: pydantic.main.BaseModel.model_validate_json:12
+msgid ""
+"context: Extra variables to pass to the validator. by_alias: Whether to "
+"use the field's alias when validating against the provided input data. "
+"by_name: Whether to use the field's name when validating against the "
+"provided input data."
+msgstr ""
+
+#: f360db23f3f24cf1a41cf6ef0168049d of
+#: pydantic.main.BaseModel.model_validate_json:16
 msgid "Returns:"
 msgstr ""
 
-#: 814872ca9bd1424a8bab977233f7d8ae of
-#: pydantic.main.BaseModel.model_validate_json:15
+#: 5d21d2de33614d6caa39357dfae211d0 of
+#: pydantic.main.BaseModel.model_validate_json:17
 msgid "The validated Pydantic model."
 msgstr ""
 
-#: 966ab141ce6d49acb4e9f6ef8000c5da of
-#: pydantic.main.BaseModel.model_validate_json:17
+#: 2a2e8d0437fe431db097f052120bb1e5 of
+#: pydantic.main.BaseModel.model_validate_json:19
 msgid "Raises:"
 msgstr ""
 
-#: 70743b2d59a64b769b7a61c48aa4ac4f of
-#: pydantic.main.BaseModel.model_validate_json:18
+#: ffa5baea04f9445a9aef11ba1458a19b of
+#: pydantic.main.BaseModel.model_validate_json:20
 msgid ""
 "ValidationError: If `json_data` is not a JSON string or the object could "
 "not be validated."
 msgstr ""
+
+#~ msgid ""
+#~ "json_data: The JSON data to validate."
+#~ " strict: Whether to enforce types "
+#~ "strictly. context: Extra variables to "
+#~ "pass to the validator. by_alias: Whether"
+#~ " to use the field's alias when "
+#~ "validating against the provided input "
+#~ "data. by_name: Whether to use the "
+#~ "field's name when validating against the"
+#~ " provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPBase.model_validate_strings.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPBase.model_validate_strings.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,36 +21,62 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPBase.model_validate_strings.rst:2
-#: cd6ebaa8a6be4fada155cd7230f84dbe
+#: c444e1249ebd40fdac8c9c428cacdbf9
 msgid "HSGPBase.model\\_validate\\_strings"
 msgstr ""
 
-#: e78f1eb222594d468ad450bfa7287816 of
+#: c58f1099fcd541faa92f0692ad2d7c31 of
 #: pydantic.main.BaseModel.model_validate_strings:2
 msgid "Validate the given object with string data against the Pydantic model."
 msgstr ""
 
-#: 84038500ea0248d4ba4d28d3c5d276b5 of
+#: 2536ef8ec58d406980ac0dcad9c3b71b of
 #: pydantic.main.BaseModel.model_validate_strings:4
 msgid "Args:"
 msgstr ""
 
-#: c29963ae5bb846d091d4d2c8475d4172 of
+#: 75e8b13175684ab4a10934f8b58ce7f1 of
 #: pydantic.main.BaseModel.model_validate_strings:5
 msgid ""
 "obj: The object containing string data to validate. strict: Whether to "
-"enforce types strictly. context: Extra variables to pass to the "
-"validator. by_alias: Whether to use the field's alias when validating "
-"against the provided input data. by_name: Whether to use the field's name"
-" when validating against the provided input data."
+"enforce types strictly. extra: Whether to ignore, allow, or forbid extra "
+"data during model validation."
 msgstr ""
 
-#: b18b137a51974af39db94574df07e6f4 of
-#: pydantic.main.BaseModel.model_validate_strings:11
+#: 64e2d92532c84745a89d38311ac5309b of
+#: pydantic.main.BaseModel.model_validate_strings:8
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: 569a43aedc3749c5a5a5a7464d0d10da of
+#: pydantic.main.BaseModel.model_validate_strings:9
+msgid ""
+"context: Extra variables to pass to the validator. by_alias: Whether to "
+"use the field's alias when validating against the provided input data. "
+"by_name: Whether to use the field's name when validating against the "
+"provided input data."
+msgstr ""
+
+#: c5c56caae57e4475b7fbe92363f454f4 of
+#: pydantic.main.BaseModel.model_validate_strings:13
 msgid "Returns:"
 msgstr ""
 
-#: ab40d985be864db7bb10a74ab2a46357 of
-#: pydantic.main.BaseModel.model_validate_strings:12
+#: 3f78bd2c69c64d649326c9afc4fd2253 of
+#: pydantic.main.BaseModel.model_validate_strings:14
 msgid "The validated Pydantic model."
 msgstr ""
+
+#~ msgid ""
+#~ "obj: The object containing string data"
+#~ " to validate. strict: Whether to "
+#~ "enforce types strictly. context: Extra "
+#~ "variables to pass to the validator. "
+#~ "by_alias: Whether to use the field's "
+#~ "alias when validating against the "
+#~ "provided input data. by_name: Whether to"
+#~ " use the field's name when validating"
+#~ " against the provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPPeriodic.model_copy.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPPeriodic.model_copy.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,27 +21,27 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPPeriodic.model_copy.rst:2
-#: 2f8d220e68ba4053be8c676e727a7851
+#: b458b3738f094543a1a737adf83ae9df
 msgid "HSGPPeriodic.model\\_copy"
 msgstr ""
 
-#: 3a74f9215c464e0a8bc0b5aaa6d6a2e2 of pydantic.main.BaseModel.model_copy:2
+#: 8f0d211a5a7d4bc8bb7278067a8c59a2 of pydantic.main.BaseModel.model_copy:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 6b7912c812124585b2ea7c8a48ab8e78 of pydantic.main.BaseModel.model_copy:3
-msgid "[`model_copy`](../concepts/serialization.md#model_copy)"
+#: 339defb74fa647a8a77dcdcdf426ba8f of pydantic.main.BaseModel.model_copy:3
+msgid "[`model_copy`](../concepts/models.md#model-copy)"
 msgstr ""
 
-#: 1695b304186a4cf091d2006917aa1398 of pydantic.main.BaseModel.model_copy:5
+#: 3c47fa94860348ae9d894be65d1b4e22 of pydantic.main.BaseModel.model_copy:5
 msgid "Returns a copy of the model."
 msgstr ""
 
-#: 711491162f3d4340820334b74cb0110c of pydantic.main.BaseModel.model_copy:7
+#: f6e5b648c42945949d1f8569dedc8dcc of pydantic.main.BaseModel.model_copy:7
 msgid "!!! note"
 msgstr ""
 
-#: 98f21dddd2934ba9b000b81a76af7485 of pydantic.main.BaseModel.model_copy:8
+#: fae96b603f484752a03411d38c562daa of pydantic.main.BaseModel.model_copy:8
 msgid ""
 "The underlying instance's [`__dict__`][object.__dict__] attribute is "
 "copied. This might have unexpected side effects if you store anything in "
@@ -49,28 +49,31 @@ msgid ""
 "properties][functools.cached_property])."
 msgstr ""
 
-#: 91c82ef9fdd04d51960e6904d3bbd4e7 of pydantic.main.BaseModel.model_copy:12
+#: e617f657086d4ae9b3d3b70cccc15872 of pydantic.main.BaseModel.model_copy:12
 msgid "Args:"
 msgstr ""
 
-#: 14edc43179fb40969ff24fd9792b9d89 of pydantic.main.BaseModel.model_copy:13
+#: 65b1efea60134413900cb357e305c4e0 of pydantic.main.BaseModel.model_copy:13
 msgid ""
 "update: Values to change/add in the new model. Note: the data is not "
 "validated"
 msgstr ""
 
-#: 6c06c0194b7b45528ccfb90f89c8d1d8 of pydantic.main.BaseModel.model_copy:14
+#: bda1a01652f64ee6a771206125034008 of pydantic.main.BaseModel.model_copy:14
 msgid "before creating the new model. You should trust this data."
 msgstr ""
 
-#: 39b627371f5a4e15a5b2270081428bed of pydantic.main.BaseModel.model_copy:15
+#: e29ec9e636a844229335202afcb9f9c2 of pydantic.main.BaseModel.model_copy:15
 msgid "deep: Set to `True` to make a deep copy of the model."
 msgstr ""
 
-#: 7f237e57533d4640a7f268d8ca0c9462 of pydantic.main.BaseModel.model_copy:17
+#: 8165566b70114a4eaf0ddb85ef7a729b of pydantic.main.BaseModel.model_copy:17
 msgid "Returns:"
 msgstr ""
 
-#: a70d1d01b9714874ba87965f32f4f657 of pydantic.main.BaseModel.model_copy:18
+#: 23106b49d1b3445ab9573480fa359f94 of pydantic.main.BaseModel.model_copy:18
 msgid "New model instance."
 msgstr ""
+
+#~ msgid "[`model_copy`](../concepts/serialization.md#model_copy)"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPPeriodic.model_dump.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPPeriodic.model_dump.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,40 +21,40 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPPeriodic.model_dump.rst:2
-#: dad1bffafa16433d86d2b68254ee91ac
+#: 9e32471cf4844167a6f5992cd46ae099
 msgid "HSGPPeriodic.model\\_dump"
 msgstr ""
 
-#: e5aef5ec6784460197389f7536487ea2 of pydantic.main.BaseModel.model_dump:2
+#: 07114cef6c7845108544a55a9311b60e of pydantic.main.BaseModel.model_dump:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: cd4f4eb5843f49068942412a5f3b0715 of pydantic.main.BaseModel.model_dump:3
-msgid "[`model_dump`](../concepts/serialization.md#modelmodel_dump)"
+#: 5090011e727d4213b64dd6ff9698fd62 of pydantic.main.BaseModel.model_dump:3
+msgid "[`model_dump`](../concepts/serialization.md#python-mode)"
 msgstr ""
 
-#: 1fc400a39d3a4b6c927264594f8d0883 of pydantic.main.BaseModel.model_dump:5
+#: 624a6a73172140ff8f7f822fead1fe42 of pydantic.main.BaseModel.model_dump:5
 msgid ""
 "Generate a dictionary representation of the model, optionally specifying "
 "which fields to include or exclude."
 msgstr ""
 
-#: 704009bf701e4704a34e9aef846c9561 of pydantic.main.BaseModel.model_dump:7
+#: 4454040f60a8411d8f240973540ab34d of pydantic.main.BaseModel.model_dump:7
 msgid "Args:"
 msgstr ""
 
-#: 50f0f8d395bc4c68bd87003ff1278928 of pydantic.main.BaseModel.model_dump:8
+#: 010587ec5f0c4884851a99e566ec6975 of pydantic.main.BaseModel.model_dump:8
 msgid "mode: The mode in which `to_python` should run."
 msgstr ""
 
-#: f017ba915bb84f21bd837f331b4bdb32 of pydantic.main.BaseModel.model_dump:9
+#: bbb62023576741a296773938c9bff66f of pydantic.main.BaseModel.model_dump:9
 msgid ""
 "If mode is 'json', the output will only contain JSON serializable types. "
 "If mode is 'python', the output may contain non-JSON-serializable Python "
 "objects."
 msgstr ""
 
-#: 6426b1bb98a84fafa0ea2e4dee0f1228 of pydantic.main.BaseModel.model_dump:11
+#: 52cbc946c14a4a74be91d110f360819c of pydantic.main.BaseModel.model_dump:11
 msgid ""
 "include: A set of fields to include in the output. exclude: A set of "
 "fields to exclude from the output. context: Additional context to pass to"
@@ -62,41 +62,77 @@ msgid ""
 "dictionary key if defined. exclude_unset: Whether to exclude fields that "
 "have not been explicitly set. exclude_defaults: Whether to exclude fields"
 " that are set to their default value. exclude_none: Whether to exclude "
-"fields that have a value of `None`. round_trip: If True, dumped values "
-"should be valid as input for non-idempotent types such as Json[T]. "
-"warnings: How to handle serialization errors. False/\"none\" ignores "
-"them, True/\"warn\" logs errors,"
+"fields that have a value of `None`. exclude_computed_fields: Whether to "
+"exclude computed fields."
 msgstr ""
 
-#: 4ac10ea1acc942959ce18469a09a9b94 of pydantic.main.BaseModel.model_dump:20
+#: bab1b3220fda413baf7904572ae06f47 of pydantic.main.BaseModel.model_dump:19
+msgid ""
+"While this can be useful for round-tripping, it is usually recommended tu"
+" use the dedicated `round_trip` parameter instead."
+msgstr ""
+
+#: 87a5a263a8be4218ad4892241dee7cb0 of pydantic.main.BaseModel.model_dump:21
+msgid ""
+"round_trip: If True, dumped values should be valid as input for non-"
+"idempotent types such as Json[T]. warnings: How to handle serialization "
+"errors. False/\"none\" ignores them, True/\"warn\" logs errors,"
+msgstr ""
+
+#: 5c28cda1f46642bc9174acc6a0fecd7f of pydantic.main.BaseModel.model_dump:23
 msgid ""
 "\"error\" raises a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError]."
 msgstr ""
 
-#: 1b966fcb3328428280180e515e68274e of pydantic.main.BaseModel.model_dump:21
+#: 183cf6eb327241d18bdb5f66cbb87236 of pydantic.main.BaseModel.model_dump:24
 msgid ""
 "fallback: A function to call when an unknown value is encountered. If not"
 " provided,"
 msgstr ""
 
-#: dd6978f14fb0423db8b3e9ce08426cb0 of pydantic.main.BaseModel.model_dump:22
+#: 9b70019321d346a790d73ee7f338b41b of pydantic.main.BaseModel.model_dump:25
 msgid ""
 "a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError] "
 "error is raised."
 msgstr ""
 
-#: f8b91e5e93eb4c878bb04db6e5ce0dc9 of pydantic.main.BaseModel.model_dump:23
+#: 7be1465a2f684310babb61908ba11d56 of pydantic.main.BaseModel.model_dump:26
 msgid ""
 "serialize_as_any: Whether to serialize fields with duck-typing "
 "serialization behavior."
 msgstr ""
 
-#: 927cef0ba49649258396690d04a0c2e2 of pydantic.main.BaseModel.model_dump:25
+#: a12949331105465883d1737ec1b1adc2 of pydantic.main.BaseModel.model_dump:28
 msgid "Returns:"
 msgstr ""
 
-#: 82eae776ba824489837acf2b9ec3ca04 of pydantic.main.BaseModel.model_dump:26
+#: ba3be2f47e2248308765425c2128bd6d of pydantic.main.BaseModel.model_dump:29
 msgid "A dictionary representation of the model."
 msgstr ""
+
+#~ msgid "[`model_dump`](../concepts/serialization.md#modelmodel_dump)"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "include: A set of fields to "
+#~ "include in the output. exclude: A "
+#~ "set of fields to exclude from the"
+#~ " output. context: Additional context to "
+#~ "pass to the serializer. by_alias: "
+#~ "Whether to use the field's alias "
+#~ "in the dictionary key if defined. "
+#~ "exclude_unset: Whether to exclude fields "
+#~ "that have not been explicitly set. "
+#~ "exclude_defaults: Whether to exclude fields"
+#~ " that are set to their default "
+#~ "value. exclude_none: Whether to exclude "
+#~ "fields that have a value of "
+#~ "`None`. round_trip: If True, dumped "
+#~ "values should be valid as input "
+#~ "for non-idempotent types such as "
+#~ "Json[T]. warnings: How to handle "
+#~ "serialization errors. False/\"none\" ignores "
+#~ "them, True/\"warn\" logs errors,"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPPeriodic.model_dump_json.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPPeriodic.model_dump_json.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,83 +21,133 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPPeriodic.model_dump_json.rst:2
-#: a2cd745c1ce246f7999cc4052e34d6ad
+#: a27cf1c859734ee1b0a68a239f845366
 msgid "HSGPPeriodic.model\\_dump\\_json"
 msgstr ""
 
-#: 83115d831ffe4b528f2f9c916b6fdc9f of
+#: aca229e930ff431d932983c73b600b09 of
 #: pydantic.main.BaseModel.model_dump_json:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 7f37e6a140484226b12f23d28ee4e8b5 of
+#: 6b0425ae183b4cf7ac9b26b2080ab53b of
 #: pydantic.main.BaseModel.model_dump_json:3
-msgid "[`model_dump_json`](../concepts/serialization.md#modelmodel_dump_json)"
+msgid "[`model_dump_json`](../concepts/serialization.md#json-mode)"
 msgstr ""
 
-#: 7b0422e253814cd3bdb1eb37a53694d7 of
+#: 95fb3f05c90d4217815571c7d27d9c38 of
 #: pydantic.main.BaseModel.model_dump_json:5
 msgid ""
 "Generates a JSON representation of the model using Pydantic's `to_json` "
 "method."
 msgstr ""
 
-#: e77deecf89de41f18d70fdb09b4903e7 of
+#: 4bb590be1c894a29b341a659ab9776d5 of
 #: pydantic.main.BaseModel.model_dump_json:7
 msgid "Args:"
 msgstr ""
 
-#: ad345bc1e6a44e34ac04b9873d823463 of
+#: d89713323ec64e9198ce452924208feb of
 #: pydantic.main.BaseModel.model_dump_json:8
 msgid ""
 "indent: Indentation to use in the JSON output. If None is passed, the "
-"output will be compact. include: Field(s) to include in the JSON output. "
-"exclude: Field(s) to exclude from the JSON output. context: Additional "
-"context to pass to the serializer. by_alias: Whether to serialize using "
-"field aliases. exclude_unset: Whether to exclude fields that have not "
-"been explicitly set. exclude_defaults: Whether to exclude fields that are"
-" set to their default value. exclude_none: Whether to exclude fields that"
-" have a value of `None`. round_trip: If True, dumped values should be "
-"valid as input for non-idempotent types such as Json[T]. warnings: How to"
-" handle serialization errors. False/\"none\" ignores them, True/\"warn\" "
-"logs errors,"
+"output will be compact. ensure_ascii: If `True`, the output is guaranteed"
+" to have all incoming non-ASCII characters escaped."
 msgstr ""
 
-#: cc0a8542b98c462ba5baa7139ee414b8 of
-#: pydantic.main.BaseModel.model_dump_json:18
+#: cc2f295cea87465db9e37ff03ccc5061 of
+#: pydantic.main.BaseModel.model_dump_json:10
+msgid "If `False` (the default), these characters will be output as-is."
+msgstr ""
+
+#: c91d342c124040ad9411fe1f85bbac23 of
+#: pydantic.main.BaseModel.model_dump_json:11
+msgid ""
+"include: Field(s) to include in the JSON output. exclude: Field(s) to "
+"exclude from the JSON output. context: Additional context to pass to the "
+"serializer. by_alias: Whether to serialize using field aliases. "
+"exclude_unset: Whether to exclude fields that have not been explicitly "
+"set. exclude_defaults: Whether to exclude fields that are set to their "
+"default value. exclude_none: Whether to exclude fields that have a value "
+"of `None`. exclude_computed_fields: Whether to exclude computed fields."
+msgstr ""
+
+#: 846f7ee12c7e46c286c84477a12b6042 of
+#: pydantic.main.BaseModel.model_dump_json:19
+msgid ""
+"While this can be useful for round-tripping, it is usually recommended to"
+" use the dedicated `round_trip` parameter instead."
+msgstr ""
+
+#: 93f01ca11d214cffbab5fe2d43b5ace8 of
+#: pydantic.main.BaseModel.model_dump_json:21
+msgid ""
+"round_trip: If True, dumped values should be valid as input for non-"
+"idempotent types such as Json[T]. warnings: How to handle serialization "
+"errors. False/\"none\" ignores them, True/\"warn\" logs errors,"
+msgstr ""
+
+#: f350703811d348dea204ae2a24b4636b of
+#: pydantic.main.BaseModel.model_dump_json:23
 msgid ""
 "\"error\" raises a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError]."
 msgstr ""
 
-#: e082775661274ea3a942013095c96052 of
-#: pydantic.main.BaseModel.model_dump_json:19
+#: c186734a14fd4ca5ac8d194947d03e4c of
+#: pydantic.main.BaseModel.model_dump_json:24
 msgid ""
 "fallback: A function to call when an unknown value is encountered. If not"
 " provided,"
 msgstr ""
 
-#: ccfb234c70f8406f87918ff7813712af of
-#: pydantic.main.BaseModel.model_dump_json:20
+#: fbf308fdb97644bfa42375d7de947a28 of
+#: pydantic.main.BaseModel.model_dump_json:25
 msgid ""
 "a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError] "
 "error is raised."
 msgstr ""
 
-#: 2fa44bf924de45a8bdd5763f1e5bc225 of
-#: pydantic.main.BaseModel.model_dump_json:21
+#: c251e236dd8e449abbbd25d6860a996a of
+#: pydantic.main.BaseModel.model_dump_json:26
 msgid ""
 "serialize_as_any: Whether to serialize fields with duck-typing "
 "serialization behavior."
 msgstr ""
 
-#: 3782af5ca1ec47078f7e60b116e6734b of
-#: pydantic.main.BaseModel.model_dump_json:23
+#: 73ef465927444e8aa2e8b03908cbb401 of
+#: pydantic.main.BaseModel.model_dump_json:28
 msgid "Returns:"
 msgstr ""
 
-#: c8e198d8d8a04011823624c4b6cdff9b of
-#: pydantic.main.BaseModel.model_dump_json:24
+#: e3a5796536404e68ae3a584aed922ecb of
+#: pydantic.main.BaseModel.model_dump_json:29
 msgid "A JSON string representation of the model."
 msgstr ""
+
+#~ msgid "[`model_dump_json`](../concepts/serialization.md#modelmodel_dump_json)"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "indent: Indentation to use in the "
+#~ "JSON output. If None is passed, "
+#~ "the output will be compact. include: "
+#~ "Field(s) to include in the JSON "
+#~ "output. exclude: Field(s) to exclude "
+#~ "from the JSON output. context: "
+#~ "Additional context to pass to the "
+#~ "serializer. by_alias: Whether to serialize "
+#~ "using field aliases. exclude_unset: Whether"
+#~ " to exclude fields that have not "
+#~ "been explicitly set. exclude_defaults: Whether"
+#~ " to exclude fields that are set "
+#~ "to their default value. exclude_none: "
+#~ "Whether to exclude fields that have "
+#~ "a value of `None`. round_trip: If "
+#~ "True, dumped values should be valid "
+#~ "as input for non-idempotent types "
+#~ "such as Json[T]. warnings: How to "
+#~ "handle serialization errors. False/\"none\" "
+#~ "ignores them, True/\"warn\" logs errors,"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPPeriodic.model_json_schema.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPPeriodic.model_json_schema.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,44 +21,77 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPPeriodic.model_json_schema.rst:2
-#: 0006ef9a14dc4a18863bb70363cea595
+#: ebb6981d15734e0e82cad68f1475565b
 msgid "HSGPPeriodic.model\\_json\\_schema"
 msgstr ""
 
-#: 89f8a4dce3b14af3877d59abc2713bcb of
+#: f42688c906394f37bb37d4036ed50306 of
 #: pydantic.main.BaseModel.model_json_schema:2
 msgid "Generates a JSON schema for a model class."
 msgstr ""
 
-#: f1cca107d0b449c299e9c906ee2716e1 of
+#: 89db75705eb84815abccd4b0cc0de052 of
 #: pydantic.main.BaseModel.model_json_schema:4
 msgid "Args:"
 msgstr ""
 
-#: 5ea998b574c4499fb46b62a5bff69d2d of
+#: 5cb383560cf3418e84fd03d62c732c39 of
 #: pydantic.main.BaseModel.model_json_schema:5
 msgid ""
 "by_alias: Whether to use attribute aliases or not. ref_template: The "
-"reference template. schema_generator: To override the logic used to "
-"generate the JSON schema, as a subclass of"
+"reference template. union_format: The format to use when combining "
+"schemas from unions together. Can be one of:"
 msgstr ""
 
-#: bce87b1fb7d647e09b6a38cf28aacc6f of
-#: pydantic.main.BaseModel.model_json_schema:8
+#: 8b6dfaec200e45ef91592836c8bf6be9 of
+#: pydantic.main.BaseModel.model_json_schema:9
+msgid ""
+"`'any_of'`: Use the [`anyOf`](https://json-schema.org/understanding-json-"
+"schema/reference/combining#anyOf)"
+msgstr ""
+
+#: 1dd8d565cb8741d9b09c8cb99b82ec9a of
+#: pydantic.main.BaseModel.model_json_schema:10
+msgid ""
+"keyword to combine schemas (the default). - `'primitive_type_array'`: Use"
+" the [`type`](https://json-schema.org/understanding-json-"
+"schema/reference/type) keyword as an array of strings, containing each "
+"type of the combination. If any of the schemas is not a primitive type "
+"(`string`, `boolean`, `null`, `integer` or `number`) or contains "
+"constraints/metadata, falls back to `any_of`."
+msgstr ""
+
+#: d7272ad92f5648c3b8f512fac9559431 of
+#: pydantic.main.BaseModel.model_json_schema:15
+msgid ""
+"schema_generator: To override the logic used to generate the JSON schema,"
+" as a subclass of"
+msgstr ""
+
+#: 0670b353bd4a49f9a910790e29e2c8d2 of
+#: pydantic.main.BaseModel.model_json_schema:16
 msgid "`GenerateJsonSchema` with your desired modifications"
 msgstr ""
 
-#: e9860dc096934ac1b70aaa715f8ce882 of
-#: pydantic.main.BaseModel.model_json_schema:9
+#: 8ced14af454149609c47e5cda03be804 of
+#: pydantic.main.BaseModel.model_json_schema:17
 msgid "mode: The mode in which to generate the schema."
 msgstr ""
 
-#: 46e41f6ae0f6476b84e32bd22d50be16 of
-#: pydantic.main.BaseModel.model_json_schema:11
+#: 4e1f5c3fafd343f198e1bf67bf6c8fb4 of
+#: pydantic.main.BaseModel.model_json_schema:19
 msgid "Returns:"
 msgstr ""
 
-#: a00067ccfff040e7b76b0fc7e77bfa1e of
-#: pydantic.main.BaseModel.model_json_schema:12
+#: ca1f1b088fd94b5caa08cbd8a1ee627a of
+#: pydantic.main.BaseModel.model_json_schema:20
 msgid "The JSON schema for the given model class."
 msgstr ""
+
+#~ msgid ""
+#~ "by_alias: Whether to use attribute "
+#~ "aliases or not. ref_template: The "
+#~ "reference template. schema_generator: To "
+#~ "override the logic used to generate "
+#~ "the JSON schema, as a subclass of"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPPeriodic.model_validate.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPPeriodic.model_validate.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,21 +21,33 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPPeriodic.model_validate.rst:2
-#: a33be93399664ed4818723fc691a744c
+#: 505aaab6467c41768be082593d4598f8
 msgid "HSGPPeriodic.model\\_validate"
 msgstr ""
 
-#: f4bd0b5616a340678a385866dbbddd41 of pydantic.main.BaseModel.model_validate:2
+#: 560675564d6840cda885b8f5d47d3f09 of pydantic.main.BaseModel.model_validate:2
 msgid "Validate a pydantic model instance."
 msgstr ""
 
-#: a4ca2a6df71c418eb73cee5e31bf93d1 of pydantic.main.BaseModel.model_validate:4
+#: 167c73f1d149458e97111618f143f06b of pydantic.main.BaseModel.model_validate:4
 msgid "Args:"
 msgstr ""
 
-#: cdec3c4d2d8d44f8a11771c9c2fb3712 of pydantic.main.BaseModel.model_validate:5
+#: ddb956df035145cb9c62702a6a4d8a96 of pydantic.main.BaseModel.model_validate:5
 msgid ""
 "obj: The object to validate. strict: Whether to enforce types strictly. "
+"extra: Whether to ignore, allow, or forbid extra data during model "
+"validation."
+msgstr ""
+
+#: 22ecb28b28954481bb7808b1cc5eb378 of pydantic.main.BaseModel.model_validate:8
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: e0ee6cfabba24027a5ca5bf6bd415004 of pydantic.main.BaseModel.model_validate:9
+msgid ""
 "from_attributes: Whether to extract data from object attributes. context:"
 " Additional context to pass to the validator. by_alias: Whether to use "
 "the field's alias when validating against the provided input data. "
@@ -43,22 +55,35 @@ msgid ""
 "provided input data."
 msgstr ""
 
-#: 8d0802a26612483da23b803453e01b53 of
-#: pydantic.main.BaseModel.model_validate:12
+#: 31f0afd4112a444295b4d8c4b6b21825 of
+#: pydantic.main.BaseModel.model_validate:14
 msgid "Raises:"
 msgstr ""
 
-#: 508bfb61241a45568283f78c21a3d131 of
-#: pydantic.main.BaseModel.model_validate:13
+#: b7f0aebcacea4377b03c7cdef20c6ec3 of
+#: pydantic.main.BaseModel.model_validate:15
 msgid "ValidationError: If the object could not be validated."
 msgstr ""
 
-#: 1fc2af79ec3e472ea07f2097a7263806 of
-#: pydantic.main.BaseModel.model_validate:15
+#: 445fa84fdb234e4599887de0aab31459 of
+#: pydantic.main.BaseModel.model_validate:17
 msgid "Returns:"
 msgstr ""
 
-#: e51fe9ca186746a6b45c37209c1f610a of
-#: pydantic.main.BaseModel.model_validate:16
+#: f5dc58b3560a411c8c33f9beb1b792aa of
+#: pydantic.main.BaseModel.model_validate:18
 msgid "The validated model instance."
 msgstr ""
+
+#~ msgid ""
+#~ "obj: The object to validate. strict: "
+#~ "Whether to enforce types strictly. "
+#~ "from_attributes: Whether to extract data "
+#~ "from object attributes. context: Additional"
+#~ " context to pass to the validator."
+#~ " by_alias: Whether to use the field's"
+#~ " alias when validating against the "
+#~ "provided input data. by_name: Whether to"
+#~ " use the field's name when validating"
+#~ " against the provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPPeriodic.model_validate_json.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPPeriodic.model_validate_json.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,58 +21,84 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPPeriodic.model_validate_json.rst:2
-#: 179add2f1bd34b9d8e172f47724a2ac2
+#: ffd5013b39da47989a3706ddedaedd47
 msgid "HSGPPeriodic.model\\_validate\\_json"
 msgstr ""
 
-#: dc91f540d22742b6a9add35dfade11fb of
+#: 38e4b5a480fe436a95caa81d293dae6b of
 #: pydantic.main.BaseModel.model_validate_json:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: ce1fcde14345423fa20363d92b02ae28 of
+#: e6448fd9f2fa4a3c81d5852860fa241e of
 #: pydantic.main.BaseModel.model_validate_json:3
 msgid "[JSON Parsing](../concepts/json.md#json-parsing)"
 msgstr ""
 
-#: 85ceedcc26204464a502a4f6c8d69726 of
+#: 4bf6467e874647a488119e23733438ba of
 #: pydantic.main.BaseModel.model_validate_json:5
 msgid "Validate the given JSON data against the Pydantic model."
 msgstr ""
 
-#: 6bd404a7634443839b49aec1ff7759c9 of
+#: 57008e17f03c4f7baaa7a3b091a9bedf of
 #: pydantic.main.BaseModel.model_validate_json:7
 msgid "Args:"
 msgstr ""
 
-#: baaf9dc8d59345bc96a30bdcf8b679e1 of
+#: 9a2d8d503993438ebd8e14d982e1d147 of
 #: pydantic.main.BaseModel.model_validate_json:8
 msgid ""
 "json_data: The JSON data to validate. strict: Whether to enforce types "
-"strictly. context: Extra variables to pass to the validator. by_alias: "
-"Whether to use the field's alias when validating against the provided "
-"input data. by_name: Whether to use the field's name when validating "
-"against the provided input data."
+"strictly. extra: Whether to ignore, allow, or forbid extra data during "
+"model validation."
 msgstr ""
 
-#: 3e7969bf49894404bedc5fa788790dae of
-#: pydantic.main.BaseModel.model_validate_json:14
+#: 8646138242ef4485bd874e6d6b4f4558 of
+#: pydantic.main.BaseModel.model_validate_json:11
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: f6c7eb58a54744c1b1fa443f7e3c67cf of
+#: pydantic.main.BaseModel.model_validate_json:12
+msgid ""
+"context: Extra variables to pass to the validator. by_alias: Whether to "
+"use the field's alias when validating against the provided input data. "
+"by_name: Whether to use the field's name when validating against the "
+"provided input data."
+msgstr ""
+
+#: 0c0bca01e41b4125b68fee4d744ae64d of
+#: pydantic.main.BaseModel.model_validate_json:16
 msgid "Returns:"
 msgstr ""
 
-#: ac43b76f2b484d9fbe969baebbbfcfd0 of
-#: pydantic.main.BaseModel.model_validate_json:15
+#: b09df011c5a2455b9fe7b09f39fd437b of
+#: pydantic.main.BaseModel.model_validate_json:17
 msgid "The validated Pydantic model."
 msgstr ""
 
-#: 73a2a50bb8ec4aa0a4c9cb4bbb80da1b of
-#: pydantic.main.BaseModel.model_validate_json:17
+#: fe744cd9267c481c834b4d137ef69cae of
+#: pydantic.main.BaseModel.model_validate_json:19
 msgid "Raises:"
 msgstr ""
 
-#: 2db8128487ed4459ad688500ed56ff40 of
-#: pydantic.main.BaseModel.model_validate_json:18
+#: 4ce3e900a21e44b49c48bd5ec6dceb85 of
+#: pydantic.main.BaseModel.model_validate_json:20
 msgid ""
 "ValidationError: If `json_data` is not a JSON string or the object could "
 "not be validated."
 msgstr ""
+
+#~ msgid ""
+#~ "json_data: The JSON data to validate."
+#~ " strict: Whether to enforce types "
+#~ "strictly. context: Extra variables to "
+#~ "pass to the validator. by_alias: Whether"
+#~ " to use the field's alias when "
+#~ "validating against the provided input "
+#~ "data. by_name: Whether to use the "
+#~ "field's name when validating against the"
+#~ " provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPPeriodic.model_validate_strings.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPPeriodic.model_validate_strings.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,36 +21,62 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.hsgp.HSGPPeriodic.model_validate_strings.rst:2
-#: d7ebbeb8eef74c54b672eae384de33bd
+#: 5b4b1d14d73349c894182862539d605e
 msgid "HSGPPeriodic.model\\_validate\\_strings"
 msgstr ""
 
-#: 623e17bf877549a5a8f418db6aee6959 of
+#: 5eed9e0fe61d475eae4a8903851565db of
 #: pydantic.main.BaseModel.model_validate_strings:2
 msgid "Validate the given object with string data against the Pydantic model."
 msgstr ""
 
-#: 3ca6a654f1e546328b8e4a3c36f2d847 of
+#: 2ab44b4b02414dd6a85f124e4ff96a9b of
 #: pydantic.main.BaseModel.model_validate_strings:4
 msgid "Args:"
 msgstr ""
 
-#: 46d7ea63185a4e32a4450736f8ff71e2 of
+#: 0698079962574709b4d1ea7d464724a5 of
 #: pydantic.main.BaseModel.model_validate_strings:5
 msgid ""
 "obj: The object containing string data to validate. strict: Whether to "
-"enforce types strictly. context: Extra variables to pass to the "
-"validator. by_alias: Whether to use the field's alias when validating "
-"against the provided input data. by_name: Whether to use the field's name"
-" when validating against the provided input data."
+"enforce types strictly. extra: Whether to ignore, allow, or forbid extra "
+"data during model validation."
 msgstr ""
 
-#: 0966f2bedebc4c56803ac9be901b4b47 of
-#: pydantic.main.BaseModel.model_validate_strings:11
+#: f3a7c02bd6ad4eb28a452bee997a944a of
+#: pydantic.main.BaseModel.model_validate_strings:8
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: feeb4b25e101473f8fbf9ca50efe0a0b of
+#: pydantic.main.BaseModel.model_validate_strings:9
+msgid ""
+"context: Extra variables to pass to the validator. by_alias: Whether to "
+"use the field's alias when validating against the provided input data. "
+"by_name: Whether to use the field's name when validating against the "
+"provided input data."
+msgstr ""
+
+#: 98153fec0b574c7893038a8a74165630 of
+#: pydantic.main.BaseModel.model_validate_strings:13
 msgid "Returns:"
 msgstr ""
 
-#: 2ed2a42e9d1549bdbcd630cd4c4a6c06 of
-#: pydantic.main.BaseModel.model_validate_strings:12
+#: 76888c74fedc4a31a5e0dfb13f9b2b0d of
+#: pydantic.main.BaseModel.model_validate_strings:14
 msgid "The validated Pydantic model."
 msgstr ""
+
+#~ msgid ""
+#~ "obj: The object containing string data"
+#~ " to validate. strict: Whether to "
+#~ "enforce types strictly. context: Extra "
+#~ "variables to pass to the validator. "
+#~ "by_alias: Whether to use the field's "
+#~ "alias when validating against the "
+#~ "provided input data. by_name: Whether to"
+#~ " use the field's name when validating"
+#~ " against the provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.SoftPlusHSGP.model_copy.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.SoftPlusHSGP.model_copy.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,27 +21,27 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.hsgp.SoftPlusHSGP.model_copy.rst:2
-#: 86ba782b114c4323903eb62ba9578162
+#: 08321fb7fa51465e9b0002d7a2fcc58f
 msgid "SoftPlusHSGP.model\\_copy"
 msgstr ""
 
-#: f9aa221e04274ccf9ed4ec3102bb75ce of pydantic.main.BaseModel.model_copy:2
+#: c708688e28e04a5ea6caabbb21654f07 of pydantic.main.BaseModel.model_copy:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 200cadadb39d47c89038b5f567303ed3 of pydantic.main.BaseModel.model_copy:3
-msgid "[`model_copy`](../concepts/serialization.md#model_copy)"
+#: 0df69f84dcec4bbbba4883f455e6d3a4 of pydantic.main.BaseModel.model_copy:3
+msgid "[`model_copy`](../concepts/models.md#model-copy)"
 msgstr ""
 
-#: aed1865404ec451799a7f223e948607b of pydantic.main.BaseModel.model_copy:5
+#: 51f8d96e3caa4718b890e6deb0d53b66 of pydantic.main.BaseModel.model_copy:5
 msgid "Returns a copy of the model."
 msgstr ""
 
-#: aea63a936974455e841a30fa7c4e5ccf of pydantic.main.BaseModel.model_copy:7
+#: 2462cb9ea1354ebd9fb962239159a921 of pydantic.main.BaseModel.model_copy:7
 msgid "!!! note"
 msgstr ""
 
-#: 9fd24e949f37457eaae40a7bdef17a48 of pydantic.main.BaseModel.model_copy:8
+#: 90b36f28d14f4412babd96b54e579660 of pydantic.main.BaseModel.model_copy:8
 msgid ""
 "The underlying instance's [`__dict__`][object.__dict__] attribute is "
 "copied. This might have unexpected side effects if you store anything in "
@@ -49,28 +49,31 @@ msgid ""
 "properties][functools.cached_property])."
 msgstr ""
 
-#: 280263e33e7c4a54b5e8a9d72bfbec9a of pydantic.main.BaseModel.model_copy:12
+#: 7bb2b1cc4a314349885fddeb3aa4fc75 of pydantic.main.BaseModel.model_copy:12
 msgid "Args:"
 msgstr ""
 
-#: 2063b1a8d8574c77be3afcdacb072f5a of pydantic.main.BaseModel.model_copy:13
+#: 14d20c4ec2d048b990d79d4178d354c6 of pydantic.main.BaseModel.model_copy:13
 msgid ""
 "update: Values to change/add in the new model. Note: the data is not "
 "validated"
 msgstr ""
 
-#: d2294dab9e9947318d879f5abb5b80ff of pydantic.main.BaseModel.model_copy:14
+#: 6a753d0498f542acbb12de2110d23658 of pydantic.main.BaseModel.model_copy:14
 msgid "before creating the new model. You should trust this data."
 msgstr ""
 
-#: e9c3ada7893d4294ac3553622f732957 of pydantic.main.BaseModel.model_copy:15
+#: 46c38d5e3bf146a4ab45f7b82d72229f of pydantic.main.BaseModel.model_copy:15
 msgid "deep: Set to `True` to make a deep copy of the model."
 msgstr ""
 
-#: b27286bbdeef4088afdbabb0869c1590 of pydantic.main.BaseModel.model_copy:17
+#: faa0961bff50418c92205a74a6caee2f of pydantic.main.BaseModel.model_copy:17
 msgid "Returns:"
 msgstr ""
 
-#: 272cd139759d4b2f9ae313f6030d5019 of pydantic.main.BaseModel.model_copy:18
+#: 40a672e19f8e49d3b6ec678cdff40a3a of pydantic.main.BaseModel.model_copy:18
 msgid "New model instance."
 msgstr ""
+
+#~ msgid "[`model_copy`](../concepts/serialization.md#model_copy)"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.SoftPlusHSGP.model_dump.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.SoftPlusHSGP.model_dump.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,40 +21,40 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.hsgp.SoftPlusHSGP.model_dump.rst:2
-#: bbda7b54185540f79886a80790e59ff2
+#: 37b852f789634a4aa53c4e46302ca0b1
 msgid "SoftPlusHSGP.model\\_dump"
 msgstr ""
 
-#: 4ae1d545378940cdae3d18bb56ce46c4 of pydantic.main.BaseModel.model_dump:2
+#: 24186066cf6043f89cfb467a667f4e17 of pydantic.main.BaseModel.model_dump:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 6f118908e23b479cbcb6491d1677c4e7 of pydantic.main.BaseModel.model_dump:3
-msgid "[`model_dump`](../concepts/serialization.md#modelmodel_dump)"
+#: 021a11f644504a8f9b2a5bb32609a62f of pydantic.main.BaseModel.model_dump:3
+msgid "[`model_dump`](../concepts/serialization.md#python-mode)"
 msgstr ""
 
-#: ba98bee830f04b6b8584071178ca7ff8 of pydantic.main.BaseModel.model_dump:5
+#: a5552dee6bde49d09cbdfba386b01f15 of pydantic.main.BaseModel.model_dump:5
 msgid ""
 "Generate a dictionary representation of the model, optionally specifying "
 "which fields to include or exclude."
 msgstr ""
 
-#: 6b31568300784c2a9e18a1af30f0066c of pydantic.main.BaseModel.model_dump:7
+#: 62a727e2f0a9461681411170259ef589 of pydantic.main.BaseModel.model_dump:7
 msgid "Args:"
 msgstr ""
 
-#: eccd122805f148e685b211870809c31c of pydantic.main.BaseModel.model_dump:8
+#: 70773ec425264c7f969a3c90db88a158 of pydantic.main.BaseModel.model_dump:8
 msgid "mode: The mode in which `to_python` should run."
 msgstr ""
 
-#: 91ed04194376414eae54937b7109a048 of pydantic.main.BaseModel.model_dump:9
+#: d917543d81c74946a4a794231c7d3499 of pydantic.main.BaseModel.model_dump:9
 msgid ""
 "If mode is 'json', the output will only contain JSON serializable types. "
 "If mode is 'python', the output may contain non-JSON-serializable Python "
 "objects."
 msgstr ""
 
-#: 77bbfd68ae67426188b57548b87d855f of pydantic.main.BaseModel.model_dump:11
+#: adf305c622b24c48bb0afa8b7604287d of pydantic.main.BaseModel.model_dump:11
 msgid ""
 "include: A set of fields to include in the output. exclude: A set of "
 "fields to exclude from the output. context: Additional context to pass to"
@@ -62,41 +62,77 @@ msgid ""
 "dictionary key if defined. exclude_unset: Whether to exclude fields that "
 "have not been explicitly set. exclude_defaults: Whether to exclude fields"
 " that are set to their default value. exclude_none: Whether to exclude "
-"fields that have a value of `None`. round_trip: If True, dumped values "
-"should be valid as input for non-idempotent types such as Json[T]. "
-"warnings: How to handle serialization errors. False/\"none\" ignores "
-"them, True/\"warn\" logs errors,"
+"fields that have a value of `None`. exclude_computed_fields: Whether to "
+"exclude computed fields."
 msgstr ""
 
-#: ce392fe885b64917a3afba5e93083c0a of pydantic.main.BaseModel.model_dump:20
+#: 92de220efebc4aae9fed04afdce58028 of pydantic.main.BaseModel.model_dump:19
+msgid ""
+"While this can be useful for round-tripping, it is usually recommended tu"
+" use the dedicated `round_trip` parameter instead."
+msgstr ""
+
+#: 3e2e1be3e973424593e24e05b184ea46 of pydantic.main.BaseModel.model_dump:21
+msgid ""
+"round_trip: If True, dumped values should be valid as input for non-"
+"idempotent types such as Json[T]. warnings: How to handle serialization "
+"errors. False/\"none\" ignores them, True/\"warn\" logs errors,"
+msgstr ""
+
+#: f7cbc0e90a4f4348a84f643c5b6730f5 of pydantic.main.BaseModel.model_dump:23
 msgid ""
 "\"error\" raises a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError]."
 msgstr ""
 
-#: 81177dd744b346dbaaae749d1a98787b of pydantic.main.BaseModel.model_dump:21
+#: d4ed8b20f1a34c66a4fd644f2850e3ec of pydantic.main.BaseModel.model_dump:24
 msgid ""
 "fallback: A function to call when an unknown value is encountered. If not"
 " provided,"
 msgstr ""
 
-#: 91305965927c4f818992c786a2725cad of pydantic.main.BaseModel.model_dump:22
+#: 5dc0a9d84dca4dcab32a3ac6733000b1 of pydantic.main.BaseModel.model_dump:25
 msgid ""
 "a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError] "
 "error is raised."
 msgstr ""
 
-#: b448e8d59a8d4823a1b6a24acb1582fa of pydantic.main.BaseModel.model_dump:23
+#: 9b7af086e90e4e61a46d4641fe56fbd7 of pydantic.main.BaseModel.model_dump:26
 msgid ""
 "serialize_as_any: Whether to serialize fields with duck-typing "
 "serialization behavior."
 msgstr ""
 
-#: 30e4b4a509d945378d8e02dbc38a279b of pydantic.main.BaseModel.model_dump:25
+#: a8614f5299b342ee8699dc421411821c of pydantic.main.BaseModel.model_dump:28
 msgid "Returns:"
 msgstr ""
 
-#: de45cc48a88b4498a913a2a96bc84b40 of pydantic.main.BaseModel.model_dump:26
+#: 25fb213ac6fa4067915396b6d9213966 of pydantic.main.BaseModel.model_dump:29
 msgid "A dictionary representation of the model."
 msgstr ""
+
+#~ msgid "[`model_dump`](../concepts/serialization.md#modelmodel_dump)"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "include: A set of fields to "
+#~ "include in the output. exclude: A "
+#~ "set of fields to exclude from the"
+#~ " output. context: Additional context to "
+#~ "pass to the serializer. by_alias: "
+#~ "Whether to use the field's alias "
+#~ "in the dictionary key if defined. "
+#~ "exclude_unset: Whether to exclude fields "
+#~ "that have not been explicitly set. "
+#~ "exclude_defaults: Whether to exclude fields"
+#~ " that are set to their default "
+#~ "value. exclude_none: Whether to exclude "
+#~ "fields that have a value of "
+#~ "`None`. round_trip: If True, dumped "
+#~ "values should be valid as input "
+#~ "for non-idempotent types such as "
+#~ "Json[T]. warnings: How to handle "
+#~ "serialization errors. False/\"none\" ignores "
+#~ "them, True/\"warn\" logs errors,"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.SoftPlusHSGP.model_dump_json.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.SoftPlusHSGP.model_dump_json.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,83 +21,133 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.hsgp.SoftPlusHSGP.model_dump_json.rst:2
-#: 022dac0f9b2b466ea03936593515b8ce
+#: d80c41f038314747b89beedb9cbbb10a
 msgid "SoftPlusHSGP.model\\_dump\\_json"
 msgstr ""
 
-#: 19634152cd33491ba65132e64e1af029 of
+#: 2b88d8d95ade47da980f73e0cb274892 of
 #: pydantic.main.BaseModel.model_dump_json:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 7a839a256f1745f092a8df5e34aae62b of
+#: f2923b7b57854f29be66a8da4bd874a2 of
 #: pydantic.main.BaseModel.model_dump_json:3
-msgid "[`model_dump_json`](../concepts/serialization.md#modelmodel_dump_json)"
+msgid "[`model_dump_json`](../concepts/serialization.md#json-mode)"
 msgstr ""
 
-#: cd56ee596c674a708c9cc74a9f4fe873 of
+#: 6a02987839c14719bc425ad0338bda18 of
 #: pydantic.main.BaseModel.model_dump_json:5
 msgid ""
 "Generates a JSON representation of the model using Pydantic's `to_json` "
 "method."
 msgstr ""
 
-#: df10289ac8324ae8bbf03a1ef5003a64 of
+#: 1fd889ca230b4d5d85d784eec16bc167 of
 #: pydantic.main.BaseModel.model_dump_json:7
 msgid "Args:"
 msgstr ""
 
-#: 430fc7924c16444b98412baa85ce24fc of
+#: cbeb25af8c8241c59db3945c81a630df of
 #: pydantic.main.BaseModel.model_dump_json:8
 msgid ""
 "indent: Indentation to use in the JSON output. If None is passed, the "
-"output will be compact. include: Field(s) to include in the JSON output. "
-"exclude: Field(s) to exclude from the JSON output. context: Additional "
-"context to pass to the serializer. by_alias: Whether to serialize using "
-"field aliases. exclude_unset: Whether to exclude fields that have not "
-"been explicitly set. exclude_defaults: Whether to exclude fields that are"
-" set to their default value. exclude_none: Whether to exclude fields that"
-" have a value of `None`. round_trip: If True, dumped values should be "
-"valid as input for non-idempotent types such as Json[T]. warnings: How to"
-" handle serialization errors. False/\"none\" ignores them, True/\"warn\" "
-"logs errors,"
+"output will be compact. ensure_ascii: If `True`, the output is guaranteed"
+" to have all incoming non-ASCII characters escaped."
 msgstr ""
 
-#: 558eded5db1b40e0b4ca9ada21232840 of
-#: pydantic.main.BaseModel.model_dump_json:18
+#: bf0dd25ee1554cac89a064af756827ca of
+#: pydantic.main.BaseModel.model_dump_json:10
+msgid "If `False` (the default), these characters will be output as-is."
+msgstr ""
+
+#: 94b08906795b416bb250ced9c69e1183 of
+#: pydantic.main.BaseModel.model_dump_json:11
+msgid ""
+"include: Field(s) to include in the JSON output. exclude: Field(s) to "
+"exclude from the JSON output. context: Additional context to pass to the "
+"serializer. by_alias: Whether to serialize using field aliases. "
+"exclude_unset: Whether to exclude fields that have not been explicitly "
+"set. exclude_defaults: Whether to exclude fields that are set to their "
+"default value. exclude_none: Whether to exclude fields that have a value "
+"of `None`. exclude_computed_fields: Whether to exclude computed fields."
+msgstr ""
+
+#: 9ccf4bec1e4b4e22a77e56a53de26f08 of
+#: pydantic.main.BaseModel.model_dump_json:19
+msgid ""
+"While this can be useful for round-tripping, it is usually recommended to"
+" use the dedicated `round_trip` parameter instead."
+msgstr ""
+
+#: 703e4876a50d4e7fa9de501e24a072ab of
+#: pydantic.main.BaseModel.model_dump_json:21
+msgid ""
+"round_trip: If True, dumped values should be valid as input for non-"
+"idempotent types such as Json[T]. warnings: How to handle serialization "
+"errors. False/\"none\" ignores them, True/\"warn\" logs errors,"
+msgstr ""
+
+#: a9c697cd489143d4b5671b204f174a7e of
+#: pydantic.main.BaseModel.model_dump_json:23
 msgid ""
 "\"error\" raises a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError]."
 msgstr ""
 
-#: 3e3adeba0836429cba372349762e0c9b of
-#: pydantic.main.BaseModel.model_dump_json:19
+#: 45b659eee71d47fe84388e0197afdccc of
+#: pydantic.main.BaseModel.model_dump_json:24
 msgid ""
 "fallback: A function to call when an unknown value is encountered. If not"
 " provided,"
 msgstr ""
 
-#: 6f56e07932a9497da56668ecf85e9492 of
-#: pydantic.main.BaseModel.model_dump_json:20
+#: 9244705d69f94a258f7c42f5f8d3255e of
+#: pydantic.main.BaseModel.model_dump_json:25
 msgid ""
 "a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError] "
 "error is raised."
 msgstr ""
 
-#: beb1cac2eecb4fbd8326ee4abc51b34f of
-#: pydantic.main.BaseModel.model_dump_json:21
+#: 74278a59b58f4073ab88aab4e9377442 of
+#: pydantic.main.BaseModel.model_dump_json:26
 msgid ""
 "serialize_as_any: Whether to serialize fields with duck-typing "
 "serialization behavior."
 msgstr ""
 
-#: fb7a373bf26840f9a65d5f0fdc20813c of
-#: pydantic.main.BaseModel.model_dump_json:23
+#: 96b29e761599445ea1700708c0f62698 of
+#: pydantic.main.BaseModel.model_dump_json:28
 msgid "Returns:"
 msgstr ""
 
-#: e3c841cb0eb04221bba1a40cf77be6ec of
-#: pydantic.main.BaseModel.model_dump_json:24
+#: 95a91ece83f340c992998d964e77a878 of
+#: pydantic.main.BaseModel.model_dump_json:29
 msgid "A JSON string representation of the model."
 msgstr ""
+
+#~ msgid "[`model_dump_json`](../concepts/serialization.md#modelmodel_dump_json)"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "indent: Indentation to use in the "
+#~ "JSON output. If None is passed, "
+#~ "the output will be compact. include: "
+#~ "Field(s) to include in the JSON "
+#~ "output. exclude: Field(s) to exclude "
+#~ "from the JSON output. context: "
+#~ "Additional context to pass to the "
+#~ "serializer. by_alias: Whether to serialize "
+#~ "using field aliases. exclude_unset: Whether"
+#~ " to exclude fields that have not "
+#~ "been explicitly set. exclude_defaults: Whether"
+#~ " to exclude fields that are set "
+#~ "to their default value. exclude_none: "
+#~ "Whether to exclude fields that have "
+#~ "a value of `None`. round_trip: If "
+#~ "True, dumped values should be valid "
+#~ "as input for non-idempotent types "
+#~ "such as Json[T]. warnings: How to "
+#~ "handle serialization errors. False/\"none\" "
+#~ "ignores them, True/\"warn\" logs errors,"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.SoftPlusHSGP.model_json_schema.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.SoftPlusHSGP.model_json_schema.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,44 +21,77 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.hsgp.SoftPlusHSGP.model_json_schema.rst:2
-#: f5d55a2558d04291ab30da788f5b7518
+#: 161a25dd610645c99a0125f7c100ced6
 msgid "SoftPlusHSGP.model\\_json\\_schema"
 msgstr ""
 
-#: 039b5f0d68284c55b994571d5d233836 of
+#: c9dc335bab5146c38cff7154bb666da5 of
 #: pydantic.main.BaseModel.model_json_schema:2
 msgid "Generates a JSON schema for a model class."
 msgstr ""
 
-#: efdc9fdbfd33451f9cbcc623e8c16295 of
+#: e2ae3a04cb694730bc7a88d102f7e135 of
 #: pydantic.main.BaseModel.model_json_schema:4
 msgid "Args:"
 msgstr ""
 
-#: c2c4b8e9b018419fa876a8f8e80f20a4 of
+#: 6d9b521307de4d5f88b333ca76009095 of
 #: pydantic.main.BaseModel.model_json_schema:5
 msgid ""
 "by_alias: Whether to use attribute aliases or not. ref_template: The "
-"reference template. schema_generator: To override the logic used to "
-"generate the JSON schema, as a subclass of"
+"reference template. union_format: The format to use when combining "
+"schemas from unions together. Can be one of:"
 msgstr ""
 
-#: 8beaea1c6a9d49c7b16b421f1cb5e5f0 of
-#: pydantic.main.BaseModel.model_json_schema:8
+#: 6db0535ccb5b4d4c9b4a3e08ce912e4e of
+#: pydantic.main.BaseModel.model_json_schema:9
+msgid ""
+"`'any_of'`: Use the [`anyOf`](https://json-schema.org/understanding-json-"
+"schema/reference/combining#anyOf)"
+msgstr ""
+
+#: 508e078658c743d7b6572bbf63cb92fc of
+#: pydantic.main.BaseModel.model_json_schema:10
+msgid ""
+"keyword to combine schemas (the default). - `'primitive_type_array'`: Use"
+" the [`type`](https://json-schema.org/understanding-json-"
+"schema/reference/type) keyword as an array of strings, containing each "
+"type of the combination. If any of the schemas is not a primitive type "
+"(`string`, `boolean`, `null`, `integer` or `number`) or contains "
+"constraints/metadata, falls back to `any_of`."
+msgstr ""
+
+#: 2cb1861d94eb41898106d88b20733bae of
+#: pydantic.main.BaseModel.model_json_schema:15
+msgid ""
+"schema_generator: To override the logic used to generate the JSON schema,"
+" as a subclass of"
+msgstr ""
+
+#: ae2388a4a1c746e383766537460a9b41 of
+#: pydantic.main.BaseModel.model_json_schema:16
 msgid "`GenerateJsonSchema` with your desired modifications"
 msgstr ""
 
-#: 181874600ae34a67a6fdadbb3a94ae9a of
-#: pydantic.main.BaseModel.model_json_schema:9
+#: 2f339b9016234c3785a7c8de8fbbda0a of
+#: pydantic.main.BaseModel.model_json_schema:17
 msgid "mode: The mode in which to generate the schema."
 msgstr ""
 
-#: 9ed4354835c2447aa70dc2a6d5c4fd9e of
-#: pydantic.main.BaseModel.model_json_schema:11
+#: fe2d84c2c29549b4ab0f27585680011d of
+#: pydantic.main.BaseModel.model_json_schema:19
 msgid "Returns:"
 msgstr ""
 
-#: 1b083b7ff26144bf9358de25d6b5b920 of
-#: pydantic.main.BaseModel.model_json_schema:12
+#: ae5f737b8f084db382b143385a85902d of
+#: pydantic.main.BaseModel.model_json_schema:20
 msgid "The JSON schema for the given model class."
 msgstr ""
+
+#~ msgid ""
+#~ "by_alias: Whether to use attribute "
+#~ "aliases or not. ref_template: The "
+#~ "reference template. schema_generator: To "
+#~ "override the logic used to generate "
+#~ "the JSON schema, as a subclass of"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.SoftPlusHSGP.model_validate.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.SoftPlusHSGP.model_validate.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,21 +21,33 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.hsgp.SoftPlusHSGP.model_validate.rst:2
-#: 9ea72c91f93847afb8a892153a5d3dbf
+#: 010fa00a930845c09c69e934f8de6c48
 msgid "SoftPlusHSGP.model\\_validate"
 msgstr ""
 
-#: b7b89ed10e5b41c6993d3ddaa4378aef of pydantic.main.BaseModel.model_validate:2
+#: d21e85114dfb4a1c9949fa700d9b5850 of pydantic.main.BaseModel.model_validate:2
 msgid "Validate a pydantic model instance."
 msgstr ""
 
-#: 10c81df4429d4b5c8602ba4942ec54f8 of pydantic.main.BaseModel.model_validate:4
+#: 849a2e26c74740af8ad095c20974e0f5 of pydantic.main.BaseModel.model_validate:4
 msgid "Args:"
 msgstr ""
 
-#: 137f58cf226649c6a2a8af3e717ea6f7 of pydantic.main.BaseModel.model_validate:5
+#: 4ad153f497e147da93702971225608de of pydantic.main.BaseModel.model_validate:5
 msgid ""
 "obj: The object to validate. strict: Whether to enforce types strictly. "
+"extra: Whether to ignore, allow, or forbid extra data during model "
+"validation."
+msgstr ""
+
+#: 3f4bf39ed3e248e2ae549c538d1373b4 of pydantic.main.BaseModel.model_validate:8
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: a02110cda424410a921b704483c1ad87 of pydantic.main.BaseModel.model_validate:9
+msgid ""
 "from_attributes: Whether to extract data from object attributes. context:"
 " Additional context to pass to the validator. by_alias: Whether to use "
 "the field's alias when validating against the provided input data. "
@@ -43,22 +55,35 @@ msgid ""
 "provided input data."
 msgstr ""
 
-#: e243374e024c49e88d90b77f597d2584 of
-#: pydantic.main.BaseModel.model_validate:12
+#: 63149732b0e6413c866051348b6841b4 of
+#: pydantic.main.BaseModel.model_validate:14
 msgid "Raises:"
 msgstr ""
 
-#: 9c3d5e92b20d4e068c265b15822f6a7d of
-#: pydantic.main.BaseModel.model_validate:13
+#: 234ab615242b48cdac96a8be07bffd1b of
+#: pydantic.main.BaseModel.model_validate:15
 msgid "ValidationError: If the object could not be validated."
 msgstr ""
 
-#: ae7e62a6e2d14b319d5567a42e6a0878 of
-#: pydantic.main.BaseModel.model_validate:15
+#: bf47ef8159e24cc397db0610a672dc1f of
+#: pydantic.main.BaseModel.model_validate:17
 msgid "Returns:"
 msgstr ""
 
-#: 828af146902d4e8f88cf664cc6317ddb of
-#: pydantic.main.BaseModel.model_validate:16
+#: d8c1798e0bda4e4caac568bc5fd27f0a of
+#: pydantic.main.BaseModel.model_validate:18
 msgid "The validated model instance."
 msgstr ""
+
+#~ msgid ""
+#~ "obj: The object to validate. strict: "
+#~ "Whether to enforce types strictly. "
+#~ "from_attributes: Whether to extract data "
+#~ "from object attributes. context: Additional"
+#~ " context to pass to the validator."
+#~ " by_alias: Whether to use the field's"
+#~ " alias when validating against the "
+#~ "provided input data. by_name: Whether to"
+#~ " use the field's name when validating"
+#~ " against the provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.SoftPlusHSGP.model_validate_json.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.SoftPlusHSGP.model_validate_json.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,58 +21,84 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.hsgp.SoftPlusHSGP.model_validate_json.rst:2
-#: 57438a7086a8476abab1d7f4e97adb10
+#: 4742984c4be64ad0b0697f2ed0e02fd9
 msgid "SoftPlusHSGP.model\\_validate\\_json"
 msgstr ""
 
-#: e0babcb4c4794cdbb5f9f8756928f5d6 of
+#: 26a10211b72b49ba98ed6449fe21aa30 of
 #: pydantic.main.BaseModel.model_validate_json:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: eaaaa94140834f6897c0e0f2523daa52 of
+#: ce36db09d7554daa8a3d64aa2b564d09 of
 #: pydantic.main.BaseModel.model_validate_json:3
 msgid "[JSON Parsing](../concepts/json.md#json-parsing)"
 msgstr ""
 
-#: 80dba4acbc7b429e9a36cfb541ced430 of
+#: 05a3b3b4b1cf4b9aa6c36c794f3ee3b9 of
 #: pydantic.main.BaseModel.model_validate_json:5
 msgid "Validate the given JSON data against the Pydantic model."
 msgstr ""
 
-#: adde68fd9bc84ffcb4e6ad627ed2912c of
+#: 7bb4446da1e348e9987d2bec99b3d70f of
 #: pydantic.main.BaseModel.model_validate_json:7
 msgid "Args:"
 msgstr ""
 
-#: 1fce249657eb48e688014509b11ad696 of
+#: 4d7faa2592ea4a9eb91b849ae38f7a8c of
 #: pydantic.main.BaseModel.model_validate_json:8
 msgid ""
 "json_data: The JSON data to validate. strict: Whether to enforce types "
-"strictly. context: Extra variables to pass to the validator. by_alias: "
-"Whether to use the field's alias when validating against the provided "
-"input data. by_name: Whether to use the field's name when validating "
-"against the provided input data."
+"strictly. extra: Whether to ignore, allow, or forbid extra data during "
+"model validation."
 msgstr ""
 
-#: d372930857bb48b5b512aa7f3a89f109 of
-#: pydantic.main.BaseModel.model_validate_json:14
+#: dcaf1a38e1cc45bfb08fbed2dec1d95d of
+#: pydantic.main.BaseModel.model_validate_json:11
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: f1438a6eea6645368a535afd9c345d0c of
+#: pydantic.main.BaseModel.model_validate_json:12
+msgid ""
+"context: Extra variables to pass to the validator. by_alias: Whether to "
+"use the field's alias when validating against the provided input data. "
+"by_name: Whether to use the field's name when validating against the "
+"provided input data."
+msgstr ""
+
+#: cf242b6fc1b8406bbcb2261c0345b665 of
+#: pydantic.main.BaseModel.model_validate_json:16
 msgid "Returns:"
 msgstr ""
 
-#: 7b49218a6bce4487aed435d061347490 of
-#: pydantic.main.BaseModel.model_validate_json:15
+#: b0557b1789a745cba18581c1717538b0 of
+#: pydantic.main.BaseModel.model_validate_json:17
 msgid "The validated Pydantic model."
 msgstr ""
 
-#: 490d57ed886d49dcac81ab783604de58 of
-#: pydantic.main.BaseModel.model_validate_json:17
+#: b72d8965504b4d3482b432fc80c3abe5 of
+#: pydantic.main.BaseModel.model_validate_json:19
 msgid "Raises:"
 msgstr ""
 
-#: 67ae2d70d36d4ff2b801505a83f64e5d of
-#: pydantic.main.BaseModel.model_validate_json:18
+#: 1c6934a417fe46609995aac4ad7596b8 of
+#: pydantic.main.BaseModel.model_validate_json:20
 msgid ""
 "ValidationError: If `json_data` is not a JSON string or the object could "
 "not be validated."
 msgstr ""
+
+#~ msgid ""
+#~ "json_data: The JSON data to validate."
+#~ " strict: Whether to enforce types "
+#~ "strictly. context: Extra variables to "
+#~ "pass to the validator. by_alias: Whether"
+#~ " to use the field's alias when "
+#~ "validating against the provided input "
+#~ "data. by_name: Whether to use the "
+#~ "field's name when validating against the"
+#~ " provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.SoftPlusHSGP.model_validate_strings.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.hsgp.SoftPlusHSGP.model_validate_strings.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,36 +21,62 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.hsgp.SoftPlusHSGP.model_validate_strings.rst:2
-#: c0dc086947f6407cab4d4268749a4eac
+#: 10367657b1bf48378298dc253c8a1e40
 msgid "SoftPlusHSGP.model\\_validate\\_strings"
 msgstr ""
 
-#: b3a82dbb15314ff69f6b553267d8f541 of
+#: d0cb33481a0b43e8bf774323eae4136b of
 #: pydantic.main.BaseModel.model_validate_strings:2
 msgid "Validate the given object with string data against the Pydantic model."
 msgstr ""
 
-#: da8bfbc59a064cf7be09ffd449ab6635 of
+#: 1ab22dc505e7403c8348700af68bdbb6 of
 #: pydantic.main.BaseModel.model_validate_strings:4
 msgid "Args:"
 msgstr ""
 
-#: 799be63a11f24c2cb55dfb78f3b43abe of
+#: 7d170a3f1856433681e6de510753b19c of
 #: pydantic.main.BaseModel.model_validate_strings:5
 msgid ""
 "obj: The object containing string data to validate. strict: Whether to "
-"enforce types strictly. context: Extra variables to pass to the "
-"validator. by_alias: Whether to use the field's alias when validating "
-"against the provided input data. by_name: Whether to use the field's name"
-" when validating against the provided input data."
+"enforce types strictly. extra: Whether to ignore, allow, or forbid extra "
+"data during model validation."
 msgstr ""
 
-#: 901e0abc02094406ade242d99a5066ab of
-#: pydantic.main.BaseModel.model_validate_strings:11
+#: e04ce9d650cc42f6a7e3593b775659e0 of
+#: pydantic.main.BaseModel.model_validate_strings:8
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: 34d639e4903b48f9a75fe3304e129325 of
+#: pydantic.main.BaseModel.model_validate_strings:9
+msgid ""
+"context: Extra variables to pass to the validator. by_alias: Whether to "
+"use the field's alias when validating against the provided input data. "
+"by_name: Whether to use the field's name when validating against the "
+"provided input data."
+msgstr ""
+
+#: dc3f43b1fe244cf5bdf6f5fecf2335eb of
+#: pydantic.main.BaseModel.model_validate_strings:13
 msgid "Returns:"
 msgstr ""
 
-#: 32e90d27981a472c92f04515f2a4e48d of
-#: pydantic.main.BaseModel.model_validate_strings:12
+#: 25055861a5e44eb5838bf46eb8d722af of
+#: pydantic.main.BaseModel.model_validate_strings:14
 msgid "The validated Pydantic model."
 msgstr ""
+
+#~ msgid ""
+#~ "obj: The object containing string data"
+#~ " to validate. strict: Whether to "
+#~ "enforce types strictly. context: Extra "
+#~ "variables to pass to the validator. "
+#~ "by_alias: Whether to use the field's "
+#~ "alias when validating against the "
+#~ "provided input data. by_name: Whether to"
+#~ " use the field's name when validating"
+#~ " against the provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.linear_trend.LinearTrend.model_copy.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.linear_trend.LinearTrend.model_copy.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,27 +21,27 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.linear_trend.LinearTrend.model_copy.rst:2
-#: 726d09f0a1934ef3b9a425818c0fe9c8
+#: a8facd2a4075402290dadaef396c4d64
 msgid "LinearTrend.model\\_copy"
 msgstr ""
 
-#: 0c421a4e081b4a0b845a58dc0fcd83c6 of pydantic.main.BaseModel.model_copy:2
+#: 12e3f5f7e5c146daa5d0e09f2401e1cc of pydantic.main.BaseModel.model_copy:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: beb3a97c2e4042a394f14bd4dd7b7770 of pydantic.main.BaseModel.model_copy:3
-msgid "[`model_copy`](../concepts/serialization.md#model_copy)"
+#: e257a8591e0f414783a00dabe86057cf of pydantic.main.BaseModel.model_copy:3
+msgid "[`model_copy`](../concepts/models.md#model-copy)"
 msgstr ""
 
-#: e5f4f58bba034ff29442aea7a94fb825 of pydantic.main.BaseModel.model_copy:5
+#: bda5df382f9449cf85c6c605b8d1eb78 of pydantic.main.BaseModel.model_copy:5
 msgid "Returns a copy of the model."
 msgstr ""
 
-#: 00bee6fdb2054a63b11875f983120b66 of pydantic.main.BaseModel.model_copy:7
+#: a4f02546067742b0a7bef456c90acd7d of pydantic.main.BaseModel.model_copy:7
 msgid "!!! note"
 msgstr ""
 
-#: 81e1ddda77514e6cb6df97860f5cb443 of pydantic.main.BaseModel.model_copy:8
+#: 67ff84d6ee4343dca12ae2f218209a82 of pydantic.main.BaseModel.model_copy:8
 msgid ""
 "The underlying instance's [`__dict__`][object.__dict__] attribute is "
 "copied. This might have unexpected side effects if you store anything in "
@@ -49,28 +49,31 @@ msgid ""
 "properties][functools.cached_property])."
 msgstr ""
 
-#: 8e13ede9e7324050a269324518ffb427 of pydantic.main.BaseModel.model_copy:12
+#: 79d5e7f087a142e1a2435c0cbbf87a39 of pydantic.main.BaseModel.model_copy:12
 msgid "Args:"
 msgstr ""
 
-#: 65afd1fb908b4cd78e2a90c9d095e6cc of pydantic.main.BaseModel.model_copy:13
+#: 8d2224d17a0646e588b76b6335b65405 of pydantic.main.BaseModel.model_copy:13
 msgid ""
 "update: Values to change/add in the new model. Note: the data is not "
 "validated"
 msgstr ""
 
-#: 0196d63debaf402e82ceaed84d64bced of pydantic.main.BaseModel.model_copy:14
+#: a9143be77297430fa5f5f1ec72366ec6 of pydantic.main.BaseModel.model_copy:14
 msgid "before creating the new model. You should trust this data."
 msgstr ""
 
-#: 5c5b47201eca461fa60f6e4686ddd98f of pydantic.main.BaseModel.model_copy:15
+#: 427a4dd6b4ae4748b09dbab031d22106 of pydantic.main.BaseModel.model_copy:15
 msgid "deep: Set to `True` to make a deep copy of the model."
 msgstr ""
 
-#: 030589fb400c4969aa931e70dc7cace8 of pydantic.main.BaseModel.model_copy:17
+#: caaad831b8ef4885bdbdb0901e8a8753 of pydantic.main.BaseModel.model_copy:17
 msgid "Returns:"
 msgstr ""
 
-#: 3272c994238446c7935688335885673a of pydantic.main.BaseModel.model_copy:18
+#: 6da7841f1bde44b78570976498555a11 of pydantic.main.BaseModel.model_copy:18
 msgid "New model instance."
 msgstr ""
+
+#~ msgid "[`model_copy`](../concepts/serialization.md#model_copy)"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.linear_trend.LinearTrend.model_dump.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.linear_trend.LinearTrend.model_dump.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,40 +21,40 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.linear_trend.LinearTrend.model_dump.rst:2
-#: 0c5f827511104043bc4e559c064f013c
+#: a06903a6aa7a4faab553117e5ae2d09f
 msgid "LinearTrend.model\\_dump"
 msgstr ""
 
-#: c4e3ff7d11934ee9ab0b47dc7f48fe9a of pydantic.main.BaseModel.model_dump:2
+#: b1f8c81284894903b5d09813db6ca35e of pydantic.main.BaseModel.model_dump:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: d0e34df0eb90496b9951f17c256772d8 of pydantic.main.BaseModel.model_dump:3
-msgid "[`model_dump`](../concepts/serialization.md#modelmodel_dump)"
+#: ae96e5f8125243b28404fbc659c4c159 of pydantic.main.BaseModel.model_dump:3
+msgid "[`model_dump`](../concepts/serialization.md#python-mode)"
 msgstr ""
 
-#: c6f8f7c954af416d82fe33fe4525c1fb of pydantic.main.BaseModel.model_dump:5
+#: 95fef189d6dc47a2bbf49e4e1a1de679 of pydantic.main.BaseModel.model_dump:5
 msgid ""
 "Generate a dictionary representation of the model, optionally specifying "
 "which fields to include or exclude."
 msgstr ""
 
-#: a0dd7fa5f192480d94bb725caee1f951 of pydantic.main.BaseModel.model_dump:7
+#: e18cc08f2b014a4682ab3902d9963f2a of pydantic.main.BaseModel.model_dump:7
 msgid "Args:"
 msgstr ""
 
-#: 37f290ff909a4aa782b3e9874f3f237e of pydantic.main.BaseModel.model_dump:8
+#: 09b7a7f7ef864f2f8c359846a681ea92 of pydantic.main.BaseModel.model_dump:8
 msgid "mode: The mode in which `to_python` should run."
 msgstr ""
 
-#: 38739c71990f46aaa9ab07f5df06c5d5 of pydantic.main.BaseModel.model_dump:9
+#: fc51120d179044849613c399f145910d of pydantic.main.BaseModel.model_dump:9
 msgid ""
 "If mode is 'json', the output will only contain JSON serializable types. "
 "If mode is 'python', the output may contain non-JSON-serializable Python "
 "objects."
 msgstr ""
 
-#: 2dc828cf56374dadad73fd777d92887d of pydantic.main.BaseModel.model_dump:11
+#: 9038d844b1d44b6cae6b8c52f84202fb of pydantic.main.BaseModel.model_dump:11
 msgid ""
 "include: A set of fields to include in the output. exclude: A set of "
 "fields to exclude from the output. context: Additional context to pass to"
@@ -62,41 +62,77 @@ msgid ""
 "dictionary key if defined. exclude_unset: Whether to exclude fields that "
 "have not been explicitly set. exclude_defaults: Whether to exclude fields"
 " that are set to their default value. exclude_none: Whether to exclude "
-"fields that have a value of `None`. round_trip: If True, dumped values "
-"should be valid as input for non-idempotent types such as Json[T]. "
-"warnings: How to handle serialization errors. False/\"none\" ignores "
-"them, True/\"warn\" logs errors,"
+"fields that have a value of `None`. exclude_computed_fields: Whether to "
+"exclude computed fields."
 msgstr ""
 
-#: b790a29e88e6446596ebe902f7d06773 of pydantic.main.BaseModel.model_dump:20
+#: 9b69fbbd73d840689241b4365882f163 of pydantic.main.BaseModel.model_dump:19
+msgid ""
+"While this can be useful for round-tripping, it is usually recommended tu"
+" use the dedicated `round_trip` parameter instead."
+msgstr ""
+
+#: 23fdac66f07040c295318e5befbdfd70 of pydantic.main.BaseModel.model_dump:21
+msgid ""
+"round_trip: If True, dumped values should be valid as input for non-"
+"idempotent types such as Json[T]. warnings: How to handle serialization "
+"errors. False/\"none\" ignores them, True/\"warn\" logs errors,"
+msgstr ""
+
+#: 5cb1271bb7cd446081928037971d7ef6 of pydantic.main.BaseModel.model_dump:23
 msgid ""
 "\"error\" raises a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError]."
 msgstr ""
 
-#: f6aed6a7d34e40f390eb8127528142d8 of pydantic.main.BaseModel.model_dump:21
+#: f9c2c25e06ad4cfbbf8a63bc20565dd3 of pydantic.main.BaseModel.model_dump:24
 msgid ""
 "fallback: A function to call when an unknown value is encountered. If not"
 " provided,"
 msgstr ""
 
-#: d86cf4fbe47949b9aad218f035d28a06 of pydantic.main.BaseModel.model_dump:22
+#: 9d5c03626a874af789babf17037336f3 of pydantic.main.BaseModel.model_dump:25
 msgid ""
 "a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError] "
 "error is raised."
 msgstr ""
 
-#: 31542c137e1547f19754d1fc74c58b3c of pydantic.main.BaseModel.model_dump:23
+#: 89c7de820d064a8ea3ab6dad9d78642a of pydantic.main.BaseModel.model_dump:26
 msgid ""
 "serialize_as_any: Whether to serialize fields with duck-typing "
 "serialization behavior."
 msgstr ""
 
-#: 8d49db0b7ae94474abf19331d74bf3ea of pydantic.main.BaseModel.model_dump:25
+#: faacee9e7ad4470f84f3effd47db7cea of pydantic.main.BaseModel.model_dump:28
 msgid "Returns:"
 msgstr ""
 
-#: 349b25d2771a4297b71ded738a6fc9fb of pydantic.main.BaseModel.model_dump:26
+#: 3bd3024b18c54c57938dbc3e3c73574a of pydantic.main.BaseModel.model_dump:29
 msgid "A dictionary representation of the model."
 msgstr ""
+
+#~ msgid "[`model_dump`](../concepts/serialization.md#modelmodel_dump)"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "include: A set of fields to "
+#~ "include in the output. exclude: A "
+#~ "set of fields to exclude from the"
+#~ " output. context: Additional context to "
+#~ "pass to the serializer. by_alias: "
+#~ "Whether to use the field's alias "
+#~ "in the dictionary key if defined. "
+#~ "exclude_unset: Whether to exclude fields "
+#~ "that have not been explicitly set. "
+#~ "exclude_defaults: Whether to exclude fields"
+#~ " that are set to their default "
+#~ "value. exclude_none: Whether to exclude "
+#~ "fields that have a value of "
+#~ "`None`. round_trip: If True, dumped "
+#~ "values should be valid as input "
+#~ "for non-idempotent types such as "
+#~ "Json[T]. warnings: How to handle "
+#~ "serialization errors. False/\"none\" ignores "
+#~ "them, True/\"warn\" logs errors,"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.linear_trend.LinearTrend.model_dump_json.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.linear_trend.LinearTrend.model_dump_json.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,83 +21,133 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.linear_trend.LinearTrend.model_dump_json.rst:2
-#: 5910422aa9744f64ae335f9f0dff393d
+#: 57b80222d23b48498f60711d27fe9920
 msgid "LinearTrend.model\\_dump\\_json"
 msgstr ""
 
-#: a42070ba052a49649ac0d92e9a44b169 of
+#: 8f6563b4472f4b0fa4012f0698a14114 of
 #: pydantic.main.BaseModel.model_dump_json:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 08a63c2551444d6e92b9351ffbcb8442 of
+#: 66cdd170ae4b44f49f4f7ca562718040 of
 #: pydantic.main.BaseModel.model_dump_json:3
-msgid "[`model_dump_json`](../concepts/serialization.md#modelmodel_dump_json)"
+msgid "[`model_dump_json`](../concepts/serialization.md#json-mode)"
 msgstr ""
 
-#: 62b8792774434037b6527fe872edf229 of
+#: b4a42318546c462e9f194a1a5bf5911d of
 #: pydantic.main.BaseModel.model_dump_json:5
 msgid ""
 "Generates a JSON representation of the model using Pydantic's `to_json` "
 "method."
 msgstr ""
 
-#: 091d82ea1d6a427c9b765ae1fb961ab1 of
+#: 01a31ead175c4f93af3fa73e5e41a35b of
 #: pydantic.main.BaseModel.model_dump_json:7
 msgid "Args:"
 msgstr ""
 
-#: 95793bb7ffdd4d71a9180dd5c8781a02 of
+#: 67fb16f6109f42baaa8dd9ecda108c99 of
 #: pydantic.main.BaseModel.model_dump_json:8
 msgid ""
 "indent: Indentation to use in the JSON output. If None is passed, the "
-"output will be compact. include: Field(s) to include in the JSON output. "
-"exclude: Field(s) to exclude from the JSON output. context: Additional "
-"context to pass to the serializer. by_alias: Whether to serialize using "
-"field aliases. exclude_unset: Whether to exclude fields that have not "
-"been explicitly set. exclude_defaults: Whether to exclude fields that are"
-" set to their default value. exclude_none: Whether to exclude fields that"
-" have a value of `None`. round_trip: If True, dumped values should be "
-"valid as input for non-idempotent types such as Json[T]. warnings: How to"
-" handle serialization errors. False/\"none\" ignores them, True/\"warn\" "
-"logs errors,"
+"output will be compact. ensure_ascii: If `True`, the output is guaranteed"
+" to have all incoming non-ASCII characters escaped."
 msgstr ""
 
-#: accab1d11d7b49e7bad20e2ea407f63f of
-#: pydantic.main.BaseModel.model_dump_json:18
+#: 08d7eacdcdb648b4a18eb3a4c36f3df1 of
+#: pydantic.main.BaseModel.model_dump_json:10
+msgid "If `False` (the default), these characters will be output as-is."
+msgstr ""
+
+#: dd3e16fe132d4465bc5195db247dfeea of
+#: pydantic.main.BaseModel.model_dump_json:11
+msgid ""
+"include: Field(s) to include in the JSON output. exclude: Field(s) to "
+"exclude from the JSON output. context: Additional context to pass to the "
+"serializer. by_alias: Whether to serialize using field aliases. "
+"exclude_unset: Whether to exclude fields that have not been explicitly "
+"set. exclude_defaults: Whether to exclude fields that are set to their "
+"default value. exclude_none: Whether to exclude fields that have a value "
+"of `None`. exclude_computed_fields: Whether to exclude computed fields."
+msgstr ""
+
+#: b965ef1b9a454e258402bcf184bec4ba of
+#: pydantic.main.BaseModel.model_dump_json:19
+msgid ""
+"While this can be useful for round-tripping, it is usually recommended to"
+" use the dedicated `round_trip` parameter instead."
+msgstr ""
+
+#: 80330178f2444cab8330ebf7d0313dbf of
+#: pydantic.main.BaseModel.model_dump_json:21
+msgid ""
+"round_trip: If True, dumped values should be valid as input for non-"
+"idempotent types such as Json[T]. warnings: How to handle serialization "
+"errors. False/\"none\" ignores them, True/\"warn\" logs errors,"
+msgstr ""
+
+#: 6231c825ce034025b289888349e64015 of
+#: pydantic.main.BaseModel.model_dump_json:23
 msgid ""
 "\"error\" raises a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError]."
 msgstr ""
 
-#: 3d9a59c69bbf4bd893724df0613163ea of
-#: pydantic.main.BaseModel.model_dump_json:19
+#: 98bdb82d6f1b4faf9debea39f8074066 of
+#: pydantic.main.BaseModel.model_dump_json:24
 msgid ""
 "fallback: A function to call when an unknown value is encountered. If not"
 " provided,"
 msgstr ""
 
-#: 64090d0b354e48c088288f811f61c157 of
-#: pydantic.main.BaseModel.model_dump_json:20
+#: 21d0692f28ed43448a963f2997005a07 of
+#: pydantic.main.BaseModel.model_dump_json:25
 msgid ""
 "a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError] "
 "error is raised."
 msgstr ""
 
-#: 9a42183663a444a0b0ef8e8aee45e168 of
-#: pydantic.main.BaseModel.model_dump_json:21
+#: 3073a73e93c5431d9f9aea7c1169ce02 of
+#: pydantic.main.BaseModel.model_dump_json:26
 msgid ""
 "serialize_as_any: Whether to serialize fields with duck-typing "
 "serialization behavior."
 msgstr ""
 
-#: 8a834fca13b4433abece85d98f75d111 of
-#: pydantic.main.BaseModel.model_dump_json:23
+#: 2252a0e140054bb68e6de8bf081c9f26 of
+#: pydantic.main.BaseModel.model_dump_json:28
 msgid "Returns:"
 msgstr ""
 
-#: e8bd52af03c74f11aab67233d98c33be of
-#: pydantic.main.BaseModel.model_dump_json:24
+#: 2e46698a68124392be0abdf551d7c937 of
+#: pydantic.main.BaseModel.model_dump_json:29
 msgid "A JSON string representation of the model."
 msgstr ""
+
+#~ msgid "[`model_dump_json`](../concepts/serialization.md#modelmodel_dump_json)"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "indent: Indentation to use in the "
+#~ "JSON output. If None is passed, "
+#~ "the output will be compact. include: "
+#~ "Field(s) to include in the JSON "
+#~ "output. exclude: Field(s) to exclude "
+#~ "from the JSON output. context: "
+#~ "Additional context to pass to the "
+#~ "serializer. by_alias: Whether to serialize "
+#~ "using field aliases. exclude_unset: Whether"
+#~ " to exclude fields that have not "
+#~ "been explicitly set. exclude_defaults: Whether"
+#~ " to exclude fields that are set "
+#~ "to their default value. exclude_none: "
+#~ "Whether to exclude fields that have "
+#~ "a value of `None`. round_trip: If "
+#~ "True, dumped values should be valid "
+#~ "as input for non-idempotent types "
+#~ "such as Json[T]. warnings: How to "
+#~ "handle serialization errors. False/\"none\" "
+#~ "ignores them, True/\"warn\" logs errors,"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.linear_trend.LinearTrend.model_json_schema.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.linear_trend.LinearTrend.model_json_schema.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,44 +21,77 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.linear_trend.LinearTrend.model_json_schema.rst:2
-#: 712fcf9d9bd641beb634769e14050aa7
+#: fe2be89685aa49d5b187af1739cf1bae
 msgid "LinearTrend.model\\_json\\_schema"
 msgstr ""
 
-#: 7e7cfb9f123a4eb7850ad281e446faba of
+#: dbe1bf27b1c34a4292a4fcbf13ecbdad of
 #: pydantic.main.BaseModel.model_json_schema:2
 msgid "Generates a JSON schema for a model class."
 msgstr ""
 
-#: 36ff4be564f346a4acd1c52b4b5a52e3 of
+#: 16fcabf00d7b4c398a4333c5d6096cf9 of
 #: pydantic.main.BaseModel.model_json_schema:4
 msgid "Args:"
 msgstr ""
 
-#: a25e0f4ac85e4264b2ed43c9e7bb6221 of
+#: 1148d91117ab48afa97d0515469caff6 of
 #: pydantic.main.BaseModel.model_json_schema:5
 msgid ""
 "by_alias: Whether to use attribute aliases or not. ref_template: The "
-"reference template. schema_generator: To override the logic used to "
-"generate the JSON schema, as a subclass of"
+"reference template. union_format: The format to use when combining "
+"schemas from unions together. Can be one of:"
 msgstr ""
 
-#: 0020cba36337480a875d8ce14af09a87 of
-#: pydantic.main.BaseModel.model_json_schema:8
+#: 7ef29eab1be64fee8f207a83a3c4e891 of
+#: pydantic.main.BaseModel.model_json_schema:9
+msgid ""
+"`'any_of'`: Use the [`anyOf`](https://json-schema.org/understanding-json-"
+"schema/reference/combining#anyOf)"
+msgstr ""
+
+#: 0825ccf0bf6b47a781e163187000810f of
+#: pydantic.main.BaseModel.model_json_schema:10
+msgid ""
+"keyword to combine schemas (the default). - `'primitive_type_array'`: Use"
+" the [`type`](https://json-schema.org/understanding-json-"
+"schema/reference/type) keyword as an array of strings, containing each "
+"type of the combination. If any of the schemas is not a primitive type "
+"(`string`, `boolean`, `null`, `integer` or `number`) or contains "
+"constraints/metadata, falls back to `any_of`."
+msgstr ""
+
+#: ee29e93749c8470c892ba27f34d3e646 of
+#: pydantic.main.BaseModel.model_json_schema:15
+msgid ""
+"schema_generator: To override the logic used to generate the JSON schema,"
+" as a subclass of"
+msgstr ""
+
+#: 529f5433fc534e9ca244cbdab2133358 of
+#: pydantic.main.BaseModel.model_json_schema:16
 msgid "`GenerateJsonSchema` with your desired modifications"
 msgstr ""
 
-#: bef8f29a2033407cb67b0f8be2b04c3e of
-#: pydantic.main.BaseModel.model_json_schema:9
+#: 6bd901b7edb44fb0be57256ae7b241b1 of
+#: pydantic.main.BaseModel.model_json_schema:17
 msgid "mode: The mode in which to generate the schema."
 msgstr ""
 
-#: db5892313b2a4b29ad8fab9e03871301 of
-#: pydantic.main.BaseModel.model_json_schema:11
+#: 5289881e40cf4730bbb7ec73411a9c4c of
+#: pydantic.main.BaseModel.model_json_schema:19
 msgid "Returns:"
 msgstr ""
 
-#: 3254fe8f376547939db01f19d71f7d97 of
-#: pydantic.main.BaseModel.model_json_schema:12
+#: e628694bc51844f8b556729a8bcb166f of
+#: pydantic.main.BaseModel.model_json_schema:20
 msgid "The JSON schema for the given model class."
 msgstr ""
+
+#~ msgid ""
+#~ "by_alias: Whether to use attribute "
+#~ "aliases or not. ref_template: The "
+#~ "reference template. schema_generator: To "
+#~ "override the logic used to generate "
+#~ "the JSON schema, as a subclass of"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.linear_trend.LinearTrend.model_validate.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.linear_trend.LinearTrend.model_validate.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,21 +21,33 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.linear_trend.LinearTrend.model_validate.rst:2
-#: 83dde8384461433892e845bf2e630499
+#: aeec0e0984894d399aebd5a5840ec650
 msgid "LinearTrend.model\\_validate"
 msgstr ""
 
-#: 6cf710c9d0e54fe1b95cffdc951cb3cb of pydantic.main.BaseModel.model_validate:2
+#: cc8887b30f054a89bc8fbdd6a1bf46bb of pydantic.main.BaseModel.model_validate:2
 msgid "Validate a pydantic model instance."
 msgstr ""
 
-#: d6f957a1676c4ebb9d38f55bf08fdd6c of pydantic.main.BaseModel.model_validate:4
+#: 87a614d943a5453aa4f2abd7954b2377 of pydantic.main.BaseModel.model_validate:4
 msgid "Args:"
 msgstr ""
 
-#: 22b12d124253412abffb06d5bec12795 of pydantic.main.BaseModel.model_validate:5
+#: 730a1629774d48419b42594d356e454e of pydantic.main.BaseModel.model_validate:5
 msgid ""
 "obj: The object to validate. strict: Whether to enforce types strictly. "
+"extra: Whether to ignore, allow, or forbid extra data during model "
+"validation."
+msgstr ""
+
+#: 92c65921cd2b41fb91332dc72edbaa7b of pydantic.main.BaseModel.model_validate:8
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: 5c7466ed0d0741f8b4df33b9cb65f29a of pydantic.main.BaseModel.model_validate:9
+msgid ""
 "from_attributes: Whether to extract data from object attributes. context:"
 " Additional context to pass to the validator. by_alias: Whether to use "
 "the field's alias when validating against the provided input data. "
@@ -43,22 +55,35 @@ msgid ""
 "provided input data."
 msgstr ""
 
-#: 69893166c7ec40d69b985004766f5a6e of
-#: pydantic.main.BaseModel.model_validate:12
+#: 4cb17e0ed65d44cf8d8ad7abd01486a5 of
+#: pydantic.main.BaseModel.model_validate:14
 msgid "Raises:"
 msgstr ""
 
-#: b12322930b494b34bc0a043691890f8a of
-#: pydantic.main.BaseModel.model_validate:13
+#: f91776606b6e4788aa0490178fed3255 of
+#: pydantic.main.BaseModel.model_validate:15
 msgid "ValidationError: If the object could not be validated."
 msgstr ""
 
-#: bb6f19cc40a74b3487170e951cba24e1 of
-#: pydantic.main.BaseModel.model_validate:15
+#: 63e719ca9ca0457b92f8f70b46be108d of
+#: pydantic.main.BaseModel.model_validate:17
 msgid "Returns:"
 msgstr ""
 
-#: 0d7ae65475e74953a00b2419c46431ef of
-#: pydantic.main.BaseModel.model_validate:16
+#: 190968242e454c9d8778352deabc95ec of
+#: pydantic.main.BaseModel.model_validate:18
 msgid "The validated model instance."
 msgstr ""
+
+#~ msgid ""
+#~ "obj: The object to validate. strict: "
+#~ "Whether to enforce types strictly. "
+#~ "from_attributes: Whether to extract data "
+#~ "from object attributes. context: Additional"
+#~ " context to pass to the validator."
+#~ " by_alias: Whether to use the field's"
+#~ " alias when validating against the "
+#~ "provided input data. by_name: Whether to"
+#~ " use the field's name when validating"
+#~ " against the provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.linear_trend.LinearTrend.model_validate_json.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.linear_trend.LinearTrend.model_validate_json.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,58 +21,84 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.linear_trend.LinearTrend.model_validate_json.rst:2
-#: 086f9584749946af8b9553306d3094f7
+#: bebc38227ec1408c8c958505f15a8372
 msgid "LinearTrend.model\\_validate\\_json"
 msgstr ""
 
-#: ca1f9fde7aa946109c0f5460c6cc2138 of
+#: e44060417a0647faa536654a2ec7f73f of
 #: pydantic.main.BaseModel.model_validate_json:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 249432c361374bf3af26d9db6f62e84d of
+#: 02082e5d5013439dba5f4cdeb48c33bf of
 #: pydantic.main.BaseModel.model_validate_json:3
 msgid "[JSON Parsing](../concepts/json.md#json-parsing)"
 msgstr ""
 
-#: 35126e702a03429b862d32b1131889a9 of
+#: 6bf8d15bc0df4e7992d176214811f4a9 of
 #: pydantic.main.BaseModel.model_validate_json:5
 msgid "Validate the given JSON data against the Pydantic model."
 msgstr ""
 
-#: 154080a7370b419397de35e7efdb1f78 of
+#: fda6857aabc343ea9e2d7789b737256f of
 #: pydantic.main.BaseModel.model_validate_json:7
 msgid "Args:"
 msgstr ""
 
-#: f250eec695214646937802ce1dfe2853 of
+#: 27fb92793dfb49758102de74d69da599 of
 #: pydantic.main.BaseModel.model_validate_json:8
 msgid ""
 "json_data: The JSON data to validate. strict: Whether to enforce types "
-"strictly. context: Extra variables to pass to the validator. by_alias: "
-"Whether to use the field's alias when validating against the provided "
-"input data. by_name: Whether to use the field's name when validating "
-"against the provided input data."
+"strictly. extra: Whether to ignore, allow, or forbid extra data during "
+"model validation."
 msgstr ""
 
-#: ee19448af39a4e3783884071e726b0f5 of
-#: pydantic.main.BaseModel.model_validate_json:14
+#: 0815cec41ef146e59c455fb5f1ebe701 of
+#: pydantic.main.BaseModel.model_validate_json:11
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: 34c2dffed48142b9bab95021bcdaa2d0 of
+#: pydantic.main.BaseModel.model_validate_json:12
+msgid ""
+"context: Extra variables to pass to the validator. by_alias: Whether to "
+"use the field's alias when validating against the provided input data. "
+"by_name: Whether to use the field's name when validating against the "
+"provided input data."
+msgstr ""
+
+#: b6380912fb08412ba798f969fcacd5ad of
+#: pydantic.main.BaseModel.model_validate_json:16
 msgid "Returns:"
 msgstr ""
 
-#: 46d872478e2c4122a9650c5dea35b72b of
-#: pydantic.main.BaseModel.model_validate_json:15
+#: 25f6ef1196904bbfb09aba5b29c5aa8b of
+#: pydantic.main.BaseModel.model_validate_json:17
 msgid "The validated Pydantic model."
 msgstr ""
 
-#: d306d77f6b04444ca92d79188dad8684 of
-#: pydantic.main.BaseModel.model_validate_json:17
+#: 7967d532af3c46d1b3b2be36aff851c0 of
+#: pydantic.main.BaseModel.model_validate_json:19
 msgid "Raises:"
 msgstr ""
 
-#: 0d939dfbc5124b2298cbfe700b4bb826 of
-#: pydantic.main.BaseModel.model_validate_json:18
+#: 030dbdf91f1a4f6e878e18a67cff87aa of
+#: pydantic.main.BaseModel.model_validate_json:20
 msgid ""
 "ValidationError: If `json_data` is not a JSON string or the object could "
 "not be validated."
 msgstr ""
+
+#~ msgid ""
+#~ "json_data: The JSON data to validate."
+#~ " strict: Whether to enforce types "
+#~ "strictly. context: Extra variables to "
+#~ "pass to the validator. by_alias: Whether"
+#~ " to use the field's alias when "
+#~ "validating against the provided input "
+#~ "data. by_name: Whether to use the "
+#~ "field's name when validating against the"
+#~ " provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.linear_trend.LinearTrend.model_validate_strings.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.linear_trend.LinearTrend.model_validate_strings.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,36 +21,62 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.linear_trend.LinearTrend.model_validate_strings.rst:2
-#: 9fc1a9f577654c6eb8322027fad80a00
+#: 6bccd4cec5464b05a0717e07a7ba16ff
 msgid "LinearTrend.model\\_validate\\_strings"
 msgstr ""
 
-#: c869f949d93644fc873fd8d9813a4d25 of
+#: 2fb2e8d1e3784a7da98bc4de58a96cec of
 #: pydantic.main.BaseModel.model_validate_strings:2
 msgid "Validate the given object with string data against the Pydantic model."
 msgstr ""
 
-#: 6431880ea87c4b11af9d602bc72edc7a of
+#: 724508b6be2d4f799288fff779f2be25 of
 #: pydantic.main.BaseModel.model_validate_strings:4
 msgid "Args:"
 msgstr ""
 
-#: 5ef8b92df05145a683fc48fbd5954d29 of
+#: c059047210344f59a5c47673063f5b8a of
 #: pydantic.main.BaseModel.model_validate_strings:5
 msgid ""
 "obj: The object containing string data to validate. strict: Whether to "
-"enforce types strictly. context: Extra variables to pass to the "
-"validator. by_alias: Whether to use the field's alias when validating "
-"against the provided input data. by_name: Whether to use the field's name"
-" when validating against the provided input data."
+"enforce types strictly. extra: Whether to ignore, allow, or forbid extra "
+"data during model validation."
 msgstr ""
 
-#: 7c9790aa99e149a08172f3c37e292f26 of
-#: pydantic.main.BaseModel.model_validate_strings:11
+#: 9ad792e9d2c24f0e8a7b13168c5d0a87 of
+#: pydantic.main.BaseModel.model_validate_strings:8
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: 3b9783e749e3487db292d54312640d02 of
+#: pydantic.main.BaseModel.model_validate_strings:9
+msgid ""
+"context: Extra variables to pass to the validator. by_alias: Whether to "
+"use the field's alias when validating against the provided input data. "
+"by_name: Whether to use the field's name when validating against the "
+"provided input data."
+msgstr ""
+
+#: e83cc4a9c48e4ad387d492993e7217a7 of
+#: pydantic.main.BaseModel.model_validate_strings:13
 msgid "Returns:"
 msgstr ""
 
-#: 186aa41231a4404681fc786f8587a318 of
-#: pydantic.main.BaseModel.model_validate_strings:12
+#: a3d32b5cc06542cc8780686754492618 of
+#: pydantic.main.BaseModel.model_validate_strings:14
 msgid "The validated Pydantic model."
 msgstr ""
+
+#~ msgid ""
+#~ "obj: The object containing string data"
+#~ " to validate. strict: Whether to "
+#~ "enforce types strictly. context: Extra "
+#~ "variables to pass to the validator. "
+#~ "by_alias: Whether to use the field's "
+#~ "alias when validating against the "
+#~ "provided input data. by_name: Whether to"
+#~ " use the field's name when validating"
+#~ " against the provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.scaling.Scaling.model_copy.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.scaling.Scaling.model_copy.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,27 +21,27 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.scaling.Scaling.model_copy.rst:2
-#: 1ce9b21041fe415c845af46f3eeabe24
+#: 086d7e6f434e4723bcb2f24124b5aae1
 msgid "Scaling.model\\_copy"
 msgstr ""
 
-#: 462b99ed95c1404dbf9fc55ab8a27760 of pydantic.main.BaseModel.model_copy:2
+#: 40fa8938982543ee86aacaa8f095b6e0 of pydantic.main.BaseModel.model_copy:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: cd10b203694943d9a4d593e94a5caf69 of pydantic.main.BaseModel.model_copy:3
-msgid "[`model_copy`](../concepts/serialization.md#model_copy)"
+#: 9394fe8952c94de1bcfd764b494e4120 of pydantic.main.BaseModel.model_copy:3
+msgid "[`model_copy`](../concepts/models.md#model-copy)"
 msgstr ""
 
-#: 736f25a269984aae9ed0d7524fabf43c of pydantic.main.BaseModel.model_copy:5
+#: c535a30265ab49b5b309430fee43cfa5 of pydantic.main.BaseModel.model_copy:5
 msgid "Returns a copy of the model."
 msgstr ""
 
-#: c418f4619515430baf2106db13131006 of pydantic.main.BaseModel.model_copy:7
+#: 0d1e101ec6e14926b76b19fcdbd8fd2d of pydantic.main.BaseModel.model_copy:7
 msgid "!!! note"
 msgstr ""
 
-#: e8e0c067b2954f58bdc0e66ea72b29eb of pydantic.main.BaseModel.model_copy:8
+#: b5ce9fcbf9a44517bb9855f8c2d0b2c3 of pydantic.main.BaseModel.model_copy:8
 msgid ""
 "The underlying instance's [`__dict__`][object.__dict__] attribute is "
 "copied. This might have unexpected side effects if you store anything in "
@@ -49,28 +49,31 @@ msgid ""
 "properties][functools.cached_property])."
 msgstr ""
 
-#: 3afa6c1b760f4b158461c3f83d522280 of pydantic.main.BaseModel.model_copy:12
+#: 4e5583fd14f5435ea765d9f17c135ea0 of pydantic.main.BaseModel.model_copy:12
 msgid "Args:"
 msgstr ""
 
-#: 76be6d1c14c54396ae1b20fe35fad487 of pydantic.main.BaseModel.model_copy:13
+#: e3fb8d00c6cd4968b48ce9fa78ce294b of pydantic.main.BaseModel.model_copy:13
 msgid ""
 "update: Values to change/add in the new model. Note: the data is not "
 "validated"
 msgstr ""
 
-#: e7640acc735546c3afb795cacaddf194 of pydantic.main.BaseModel.model_copy:14
+#: 6c7b69fbbe664b829ee44c59015abd71 of pydantic.main.BaseModel.model_copy:14
 msgid "before creating the new model. You should trust this data."
 msgstr ""
 
-#: 955b48fb62d04d4e93cd47db77ea8c7d of pydantic.main.BaseModel.model_copy:15
+#: 6db0f1b55027439298f3db9173d93b68 of pydantic.main.BaseModel.model_copy:15
 msgid "deep: Set to `True` to make a deep copy of the model."
 msgstr ""
 
-#: e7a8e73025714cf4a92b9f5eb657a4a5 of pydantic.main.BaseModel.model_copy:17
+#: ae87314edffe440a93c8d2ecb8943226 of pydantic.main.BaseModel.model_copy:17
 msgid "Returns:"
 msgstr ""
 
-#: 3fd126cf265d4c4d8891e8edc69000ac of pydantic.main.BaseModel.model_copy:18
+#: 9b5d38450bea4195b64dac433f6a3c5d of pydantic.main.BaseModel.model_copy:18
 msgid "New model instance."
 msgstr ""
+
+#~ msgid "[`model_copy`](../concepts/serialization.md#model_copy)"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.scaling.Scaling.model_dump.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.scaling.Scaling.model_dump.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,40 +21,40 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.scaling.Scaling.model_dump.rst:2
-#: 2ecf12a8791e44e69b06e2accec7a1ee
+#: 70371b9185464745aa66a641b35bc7cb
 msgid "Scaling.model\\_dump"
 msgstr ""
 
-#: e433bdc07b2a48b3bd338b02047ac580 of pydantic.main.BaseModel.model_dump:2
+#: 2fb8c3cfefb54a738408f9735a101c30 of pydantic.main.BaseModel.model_dump:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: b2301445f290447da37d6ca69532450b of pydantic.main.BaseModel.model_dump:3
-msgid "[`model_dump`](../concepts/serialization.md#modelmodel_dump)"
+#: d13af8de537c4ffbaabfd6ccf1119b6c of pydantic.main.BaseModel.model_dump:3
+msgid "[`model_dump`](../concepts/serialization.md#python-mode)"
 msgstr ""
 
-#: 3f08bff21a7c4bb5b2b06a3ea24e0732 of pydantic.main.BaseModel.model_dump:5
+#: b3eab38171c5481db2815d21e88ef21f of pydantic.main.BaseModel.model_dump:5
 msgid ""
 "Generate a dictionary representation of the model, optionally specifying "
 "which fields to include or exclude."
 msgstr ""
 
-#: e9c9a17d5baf4ef5becbcb16e9df17ca of pydantic.main.BaseModel.model_dump:7
+#: bce0547f3c0643ca90df893cbd4aefd1 of pydantic.main.BaseModel.model_dump:7
 msgid "Args:"
 msgstr ""
 
-#: 8ed0cc11fae1427f8032dbd384343c78 of pydantic.main.BaseModel.model_dump:8
+#: fff333b1a2d4480b85cabee620698c22 of pydantic.main.BaseModel.model_dump:8
 msgid "mode: The mode in which `to_python` should run."
 msgstr ""
 
-#: 1b42dd550a8d4e16a95ebb3e53dd1656 of pydantic.main.BaseModel.model_dump:9
+#: 4ebc81a143ef47cfa7dbb6328c5cd2fb of pydantic.main.BaseModel.model_dump:9
 msgid ""
 "If mode is 'json', the output will only contain JSON serializable types. "
 "If mode is 'python', the output may contain non-JSON-serializable Python "
 "objects."
 msgstr ""
 
-#: 6c7dbb81937a4207ad40b3db07461fa5 of pydantic.main.BaseModel.model_dump:11
+#: 3247c34f88064eb0b107ae8ee40e0df3 of pydantic.main.BaseModel.model_dump:11
 msgid ""
 "include: A set of fields to include in the output. exclude: A set of "
 "fields to exclude from the output. context: Additional context to pass to"
@@ -62,41 +62,77 @@ msgid ""
 "dictionary key if defined. exclude_unset: Whether to exclude fields that "
 "have not been explicitly set. exclude_defaults: Whether to exclude fields"
 " that are set to their default value. exclude_none: Whether to exclude "
-"fields that have a value of `None`. round_trip: If True, dumped values "
-"should be valid as input for non-idempotent types such as Json[T]. "
-"warnings: How to handle serialization errors. False/\"none\" ignores "
-"them, True/\"warn\" logs errors,"
+"fields that have a value of `None`. exclude_computed_fields: Whether to "
+"exclude computed fields."
 msgstr ""
 
-#: db7706ece2364b4c958d328dd7ba1876 of pydantic.main.BaseModel.model_dump:20
+#: 8c635924bb1a454580397dc79028f831 of pydantic.main.BaseModel.model_dump:19
+msgid ""
+"While this can be useful for round-tripping, it is usually recommended tu"
+" use the dedicated `round_trip` parameter instead."
+msgstr ""
+
+#: 86db06e2414c4b8bb2f9a49585fa211b of pydantic.main.BaseModel.model_dump:21
+msgid ""
+"round_trip: If True, dumped values should be valid as input for non-"
+"idempotent types such as Json[T]. warnings: How to handle serialization "
+"errors. False/\"none\" ignores them, True/\"warn\" logs errors,"
+msgstr ""
+
+#: aae5b91944fb4087b874ddb66b6b23f2 of pydantic.main.BaseModel.model_dump:23
 msgid ""
 "\"error\" raises a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError]."
 msgstr ""
 
-#: e413c26c56be43cdaeeab848b5430749 of pydantic.main.BaseModel.model_dump:21
+#: 566055192b82463d911861502294ac7e of pydantic.main.BaseModel.model_dump:24
 msgid ""
 "fallback: A function to call when an unknown value is encountered. If not"
 " provided,"
 msgstr ""
 
-#: 4e9513625dec48b9a79f78a3d08f3115 of pydantic.main.BaseModel.model_dump:22
+#: 45d51746bcee4df991cba66d44ce1ec6 of pydantic.main.BaseModel.model_dump:25
 msgid ""
 "a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError] "
 "error is raised."
 msgstr ""
 
-#: 705a04b24313499fa8e5e9b2261b6e51 of pydantic.main.BaseModel.model_dump:23
+#: 5a5c4ca5111740c3b1b6c4e5ea4b9ca5 of pydantic.main.BaseModel.model_dump:26
 msgid ""
 "serialize_as_any: Whether to serialize fields with duck-typing "
 "serialization behavior."
 msgstr ""
 
-#: eed260bad88c4acd96c02c0569607704 of pydantic.main.BaseModel.model_dump:25
+#: 1c1cf05f5d0942329c93ff6730e41753 of pydantic.main.BaseModel.model_dump:28
 msgid "Returns:"
 msgstr ""
 
-#: c25c4771393e45c69c160a531571a9b8 of pydantic.main.BaseModel.model_dump:26
+#: 047cf26182664d36aeb33ef444d1025c of pydantic.main.BaseModel.model_dump:29
 msgid "A dictionary representation of the model."
 msgstr ""
+
+#~ msgid "[`model_dump`](../concepts/serialization.md#modelmodel_dump)"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "include: A set of fields to "
+#~ "include in the output. exclude: A "
+#~ "set of fields to exclude from the"
+#~ " output. context: Additional context to "
+#~ "pass to the serializer. by_alias: "
+#~ "Whether to use the field's alias "
+#~ "in the dictionary key if defined. "
+#~ "exclude_unset: Whether to exclude fields "
+#~ "that have not been explicitly set. "
+#~ "exclude_defaults: Whether to exclude fields"
+#~ " that are set to their default "
+#~ "value. exclude_none: Whether to exclude "
+#~ "fields that have a value of "
+#~ "`None`. round_trip: If True, dumped "
+#~ "values should be valid as input "
+#~ "for non-idempotent types such as "
+#~ "Json[T]. warnings: How to handle "
+#~ "serialization errors. False/\"none\" ignores "
+#~ "them, True/\"warn\" logs errors,"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.scaling.Scaling.model_dump_json.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.scaling.Scaling.model_dump_json.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,83 +21,133 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.scaling.Scaling.model_dump_json.rst:2
-#: 90c66a84bee24221931c5df5e6ff0bf6
+#: c7e9ef20aabe424c97c96a1808365d2a
 msgid "Scaling.model\\_dump\\_json"
 msgstr ""
 
-#: 9f9af0e8d6cf4a25a5f1797b2f702604 of
+#: 68d14ecbf6504d4382f00a00ecb4a3a9 of
 #: pydantic.main.BaseModel.model_dump_json:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 83062385d2e24e849e1a1c8bd63aaa32 of
+#: 9f9971a0b7184fedb62e8e8cc5fb903f of
 #: pydantic.main.BaseModel.model_dump_json:3
-msgid "[`model_dump_json`](../concepts/serialization.md#modelmodel_dump_json)"
+msgid "[`model_dump_json`](../concepts/serialization.md#json-mode)"
 msgstr ""
 
-#: 7ebcac6027064b049f92c75bd0cb5179 of
+#: c52580a1b64e428f8397b90bd055a223 of
 #: pydantic.main.BaseModel.model_dump_json:5
 msgid ""
 "Generates a JSON representation of the model using Pydantic's `to_json` "
 "method."
 msgstr ""
 
-#: d8f480b8ac3541a3af880f41f1a67dd1 of
+#: ddd3513b2d404434bceeff54d4e9dc57 of
 #: pydantic.main.BaseModel.model_dump_json:7
 msgid "Args:"
 msgstr ""
 
-#: b43e1f133b5049eda56e5abeedcc01ea of
+#: 60d93225d0ef4cd89806646d29a56762 of
 #: pydantic.main.BaseModel.model_dump_json:8
 msgid ""
 "indent: Indentation to use in the JSON output. If None is passed, the "
-"output will be compact. include: Field(s) to include in the JSON output. "
-"exclude: Field(s) to exclude from the JSON output. context: Additional "
-"context to pass to the serializer. by_alias: Whether to serialize using "
-"field aliases. exclude_unset: Whether to exclude fields that have not "
-"been explicitly set. exclude_defaults: Whether to exclude fields that are"
-" set to their default value. exclude_none: Whether to exclude fields that"
-" have a value of `None`. round_trip: If True, dumped values should be "
-"valid as input for non-idempotent types such as Json[T]. warnings: How to"
-" handle serialization errors. False/\"none\" ignores them, True/\"warn\" "
-"logs errors,"
+"output will be compact. ensure_ascii: If `True`, the output is guaranteed"
+" to have all incoming non-ASCII characters escaped."
 msgstr ""
 
-#: 3f4b020a164b41019fee402521992c20 of
-#: pydantic.main.BaseModel.model_dump_json:18
+#: 7310395f2f0c47a9ae112d51e7acc446 of
+#: pydantic.main.BaseModel.model_dump_json:10
+msgid "If `False` (the default), these characters will be output as-is."
+msgstr ""
+
+#: dab28cc29422484b920c51681a71451c of
+#: pydantic.main.BaseModel.model_dump_json:11
+msgid ""
+"include: Field(s) to include in the JSON output. exclude: Field(s) to "
+"exclude from the JSON output. context: Additional context to pass to the "
+"serializer. by_alias: Whether to serialize using field aliases. "
+"exclude_unset: Whether to exclude fields that have not been explicitly "
+"set. exclude_defaults: Whether to exclude fields that are set to their "
+"default value. exclude_none: Whether to exclude fields that have a value "
+"of `None`. exclude_computed_fields: Whether to exclude computed fields."
+msgstr ""
+
+#: b24b5a76ac1149db83c7c019812e7ee3 of
+#: pydantic.main.BaseModel.model_dump_json:19
+msgid ""
+"While this can be useful for round-tripping, it is usually recommended to"
+" use the dedicated `round_trip` parameter instead."
+msgstr ""
+
+#: e64c86c700354f549940a3df4ebeee48 of
+#: pydantic.main.BaseModel.model_dump_json:21
+msgid ""
+"round_trip: If True, dumped values should be valid as input for non-"
+"idempotent types such as Json[T]. warnings: How to handle serialization "
+"errors. False/\"none\" ignores them, True/\"warn\" logs errors,"
+msgstr ""
+
+#: 6727c89a93ae418198de8b89fdb3e1d0 of
+#: pydantic.main.BaseModel.model_dump_json:23
 msgid ""
 "\"error\" raises a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError]."
 msgstr ""
 
-#: a975e01148c842c8867d27f0652f3560 of
-#: pydantic.main.BaseModel.model_dump_json:19
+#: 7138a0dd45904aa28dc3c33cdba92862 of
+#: pydantic.main.BaseModel.model_dump_json:24
 msgid ""
 "fallback: A function to call when an unknown value is encountered. If not"
 " provided,"
 msgstr ""
 
-#: c0f8a5746a534e7cb83d2887dec02f47 of
-#: pydantic.main.BaseModel.model_dump_json:20
+#: 074fd77917eb4eca9f77523ee12b5827 of
+#: pydantic.main.BaseModel.model_dump_json:25
 msgid ""
 "a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError] "
 "error is raised."
 msgstr ""
 
-#: 15794225b79a49ae8678aba07f460c31 of
-#: pydantic.main.BaseModel.model_dump_json:21
+#: 95cde7bddb394cdab31e86240318b41c of
+#: pydantic.main.BaseModel.model_dump_json:26
 msgid ""
 "serialize_as_any: Whether to serialize fields with duck-typing "
 "serialization behavior."
 msgstr ""
 
-#: 1b33803bcc1b4ca3bdc585d95f8bd436 of
-#: pydantic.main.BaseModel.model_dump_json:23
+#: 1a69a53a1bd04ab0894ddaf181bacbc7 of
+#: pydantic.main.BaseModel.model_dump_json:28
 msgid "Returns:"
 msgstr ""
 
-#: 5519285ea7a346afa88be5550f93eaf6 of
-#: pydantic.main.BaseModel.model_dump_json:24
+#: 8a4ef20f62bc438bbdaad2ae974c3aee of
+#: pydantic.main.BaseModel.model_dump_json:29
 msgid "A JSON string representation of the model."
 msgstr ""
+
+#~ msgid "[`model_dump_json`](../concepts/serialization.md#modelmodel_dump_json)"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "indent: Indentation to use in the "
+#~ "JSON output. If None is passed, "
+#~ "the output will be compact. include: "
+#~ "Field(s) to include in the JSON "
+#~ "output. exclude: Field(s) to exclude "
+#~ "from the JSON output. context: "
+#~ "Additional context to pass to the "
+#~ "serializer. by_alias: Whether to serialize "
+#~ "using field aliases. exclude_unset: Whether"
+#~ " to exclude fields that have not "
+#~ "been explicitly set. exclude_defaults: Whether"
+#~ " to exclude fields that are set "
+#~ "to their default value. exclude_none: "
+#~ "Whether to exclude fields that have "
+#~ "a value of `None`. round_trip: If "
+#~ "True, dumped values should be valid "
+#~ "as input for non-idempotent types "
+#~ "such as Json[T]. warnings: How to "
+#~ "handle serialization errors. False/\"none\" "
+#~ "ignores them, True/\"warn\" logs errors,"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.scaling.Scaling.model_json_schema.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.scaling.Scaling.model_json_schema.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,44 +21,77 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.scaling.Scaling.model_json_schema.rst:2
-#: 7445df16acbf484c8926b29f47ccbed2
+#: 9e09c32485eb40e0bcdada226922bc04
 msgid "Scaling.model\\_json\\_schema"
 msgstr ""
 
-#: 261da7f94ef345afb767e3bcf098d866 of
+#: af1d2fb22a15404289e59e71a91f26ed of
 #: pydantic.main.BaseModel.model_json_schema:2
 msgid "Generates a JSON schema for a model class."
 msgstr ""
 
-#: 05da15fca6a74856b475ca509ba93a96 of
+#: 36c15f44d6364141a01806a8b404137a of
 #: pydantic.main.BaseModel.model_json_schema:4
 msgid "Args:"
 msgstr ""
 
-#: 4a99b2737ef9449caa5caf649501a1f2 of
+#: c8784750251144799649fe46004b9c2d of
 #: pydantic.main.BaseModel.model_json_schema:5
 msgid ""
 "by_alias: Whether to use attribute aliases or not. ref_template: The "
-"reference template. schema_generator: To override the logic used to "
-"generate the JSON schema, as a subclass of"
+"reference template. union_format: The format to use when combining "
+"schemas from unions together. Can be one of:"
 msgstr ""
 
-#: 8a573c72e1fb47e79dfd6d00f2b1725a of
-#: pydantic.main.BaseModel.model_json_schema:8
+#: 2e70d5e06555498bacd3b8145c00983d of
+#: pydantic.main.BaseModel.model_json_schema:9
+msgid ""
+"`'any_of'`: Use the [`anyOf`](https://json-schema.org/understanding-json-"
+"schema/reference/combining#anyOf)"
+msgstr ""
+
+#: 9bdc9b82e9894c76886799e0fb45c239 of
+#: pydantic.main.BaseModel.model_json_schema:10
+msgid ""
+"keyword to combine schemas (the default). - `'primitive_type_array'`: Use"
+" the [`type`](https://json-schema.org/understanding-json-"
+"schema/reference/type) keyword as an array of strings, containing each "
+"type of the combination. If any of the schemas is not a primitive type "
+"(`string`, `boolean`, `null`, `integer` or `number`) or contains "
+"constraints/metadata, falls back to `any_of`."
+msgstr ""
+
+#: 2b8e32262f4249c3afaa78d31309805a of
+#: pydantic.main.BaseModel.model_json_schema:15
+msgid ""
+"schema_generator: To override the logic used to generate the JSON schema,"
+" as a subclass of"
+msgstr ""
+
+#: fcd1b6abcc17484cad0da8c06292ed19 of
+#: pydantic.main.BaseModel.model_json_schema:16
 msgid "`GenerateJsonSchema` with your desired modifications"
 msgstr ""
 
-#: 900de15143a94762950c7e5490ed9938 of
-#: pydantic.main.BaseModel.model_json_schema:9
+#: 59805c6caa4f4d02a2637da9d1804fdd of
+#: pydantic.main.BaseModel.model_json_schema:17
 msgid "mode: The mode in which to generate the schema."
 msgstr ""
 
-#: c4d8895b4b7944a1a4edd50f4fb6561e of
-#: pydantic.main.BaseModel.model_json_schema:11
+#: fe788bc502b441d4adfd04784c3f25d5 of
+#: pydantic.main.BaseModel.model_json_schema:19
 msgid "Returns:"
 msgstr ""
 
-#: d1b6708cdf34499693443bec5290afde of
-#: pydantic.main.BaseModel.model_json_schema:12
+#: 398b459dbe69420b82ec248c4e44e511 of
+#: pydantic.main.BaseModel.model_json_schema:20
 msgid "The JSON schema for the given model class."
 msgstr ""
+
+#~ msgid ""
+#~ "by_alias: Whether to use attribute "
+#~ "aliases or not. ref_template: The "
+#~ "reference template. schema_generator: To "
+#~ "override the logic used to generate "
+#~ "the JSON schema, as a subclass of"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.scaling.Scaling.model_validate.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.scaling.Scaling.model_validate.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,21 +21,33 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.scaling.Scaling.model_validate.rst:2
-#: 371fdd39a60d4ee5a47f203a36c9c06b
+#: 38b766c48e774f07a833fa3201a1c8ad
 msgid "Scaling.model\\_validate"
 msgstr ""
 
-#: 2a2d1766cd5c4cee86a9be0fbf488d20 of pydantic.main.BaseModel.model_validate:2
+#: d2af7a47931e4ad3aa647868d5af6ee5 of pydantic.main.BaseModel.model_validate:2
 msgid "Validate a pydantic model instance."
 msgstr ""
 
-#: 364b2090568047b0b434825c257829b0 of pydantic.main.BaseModel.model_validate:4
+#: 5e420c358aa6447a977e18e921cedadf of pydantic.main.BaseModel.model_validate:4
 msgid "Args:"
 msgstr ""
 
-#: 97ba5f7a5be34ef5b020c106c7e39315 of pydantic.main.BaseModel.model_validate:5
+#: 6bfd748c7e454ab0ad3b97ef49985cb4 of pydantic.main.BaseModel.model_validate:5
 msgid ""
 "obj: The object to validate. strict: Whether to enforce types strictly. "
+"extra: Whether to ignore, allow, or forbid extra data during model "
+"validation."
+msgstr ""
+
+#: bd303b5145b14ee2991945ca18e43520 of pydantic.main.BaseModel.model_validate:8
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: 0ee7647e50574bcfb15df0cd44e213e3 of pydantic.main.BaseModel.model_validate:9
+msgid ""
 "from_attributes: Whether to extract data from object attributes. context:"
 " Additional context to pass to the validator. by_alias: Whether to use "
 "the field's alias when validating against the provided input data. "
@@ -43,22 +55,35 @@ msgid ""
 "provided input data."
 msgstr ""
 
-#: e7c0954838214d15bcc6e78ba8c88107 of
-#: pydantic.main.BaseModel.model_validate:12
+#: 559299429a4749d18d1e732ed39d0971 of
+#: pydantic.main.BaseModel.model_validate:14
 msgid "Raises:"
 msgstr ""
 
-#: 3acbe3fbaf144e9480133bd4e7a914dc of
-#: pydantic.main.BaseModel.model_validate:13
+#: 492fb9f5ce4d45959bdb36f91e8f3ac1 of
+#: pydantic.main.BaseModel.model_validate:15
 msgid "ValidationError: If the object could not be validated."
 msgstr ""
 
-#: 14adcd3a031b48c2962d4319a3b48272 of
-#: pydantic.main.BaseModel.model_validate:15
+#: cfcd58b9d90d4f63bbc0409b3bfff7c1 of
+#: pydantic.main.BaseModel.model_validate:17
 msgid "Returns:"
 msgstr ""
 
-#: ae683082640f410c8ed9f3379d940968 of
-#: pydantic.main.BaseModel.model_validate:16
+#: 6d3b6fd3e30d4f9a9bad9604bfe8faaf of
+#: pydantic.main.BaseModel.model_validate:18
 msgid "The validated model instance."
 msgstr ""
+
+#~ msgid ""
+#~ "obj: The object to validate. strict: "
+#~ "Whether to enforce types strictly. "
+#~ "from_attributes: Whether to extract data "
+#~ "from object attributes. context: Additional"
+#~ " context to pass to the validator."
+#~ " by_alias: Whether to use the field's"
+#~ " alias when validating against the "
+#~ "provided input data. by_name: Whether to"
+#~ " use the field's name when validating"
+#~ " against the provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.scaling.Scaling.model_validate_json.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.scaling.Scaling.model_validate_json.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,58 +21,84 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.scaling.Scaling.model_validate_json.rst:2
-#: 0ad6599a861c4486bbdc68a67598fabc
+#: bd728b633f884be0be88500cf54f300b
 msgid "Scaling.model\\_validate\\_json"
 msgstr ""
 
-#: 95ba26cca717499ca985d7c08f25585a of
+#: 10256f74e5f64185928804f67b46ad31 of
 #: pydantic.main.BaseModel.model_validate_json:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: b86fb7b7c6344f139e818c19b9262c81 of
+#: 673d646c466d458e8d2eb03eeef59ca6 of
 #: pydantic.main.BaseModel.model_validate_json:3
 msgid "[JSON Parsing](../concepts/json.md#json-parsing)"
 msgstr ""
 
-#: de575c5d47e84e1598cd26d76979862c of
+#: efa50bd4d479406398417f25a34dc400 of
 #: pydantic.main.BaseModel.model_validate_json:5
 msgid "Validate the given JSON data against the Pydantic model."
 msgstr ""
 
-#: ffe77488ec3b46d9b5dd3ca83646046e of
+#: a12877ea06584b14bebaeddf7ee70a30 of
 #: pydantic.main.BaseModel.model_validate_json:7
 msgid "Args:"
 msgstr ""
 
-#: ebdce595fd424da4a8f4dabe34680be6 of
+#: 4ca1f076f0de4f778c8d9709edb691c1 of
 #: pydantic.main.BaseModel.model_validate_json:8
 msgid ""
 "json_data: The JSON data to validate. strict: Whether to enforce types "
-"strictly. context: Extra variables to pass to the validator. by_alias: "
-"Whether to use the field's alias when validating against the provided "
-"input data. by_name: Whether to use the field's name when validating "
-"against the provided input data."
+"strictly. extra: Whether to ignore, allow, or forbid extra data during "
+"model validation."
 msgstr ""
 
-#: 4f128bbe763141ff8a0eb186a3f6f880 of
-#: pydantic.main.BaseModel.model_validate_json:14
+#: 408ba1fc74c845dd935add0b4814ed71 of
+#: pydantic.main.BaseModel.model_validate_json:11
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: 40de01fbb3d74e34a47baa7a7ff69f80 of
+#: pydantic.main.BaseModel.model_validate_json:12
+msgid ""
+"context: Extra variables to pass to the validator. by_alias: Whether to "
+"use the field's alias when validating against the provided input data. "
+"by_name: Whether to use the field's name when validating against the "
+"provided input data."
+msgstr ""
+
+#: 489c253802584c5ab110430b6ac9f895 of
+#: pydantic.main.BaseModel.model_validate_json:16
 msgid "Returns:"
 msgstr ""
 
-#: 3ad575560d1b41798b0df3dcb6ad1965 of
-#: pydantic.main.BaseModel.model_validate_json:15
+#: a0c7cd5223e045d59f05829ec8880700 of
+#: pydantic.main.BaseModel.model_validate_json:17
 msgid "The validated Pydantic model."
 msgstr ""
 
-#: f5e21989c668414b951d7a253c29ea0c of
-#: pydantic.main.BaseModel.model_validate_json:17
+#: 0d3dbe6d096341ec9700c2cbd4523154 of
+#: pydantic.main.BaseModel.model_validate_json:19
 msgid "Raises:"
 msgstr ""
 
-#: 8abb108a4d524604b66c719bd1478042 of
-#: pydantic.main.BaseModel.model_validate_json:18
+#: 3ed16c0d9a584d9d8a32cca1ed89f9c1 of
+#: pydantic.main.BaseModel.model_validate_json:20
 msgid ""
 "ValidationError: If `json_data` is not a JSON string or the object could "
 "not be validated."
 msgstr ""
+
+#~ msgid ""
+#~ "json_data: The JSON data to validate."
+#~ " strict: Whether to enforce types "
+#~ "strictly. context: Extra variables to "
+#~ "pass to the validator. by_alias: Whether"
+#~ " to use the field's alias when "
+#~ "validating against the provided input "
+#~ "data. by_name: Whether to use the "
+#~ "field's name when validating against the"
+#~ " provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.scaling.Scaling.model_validate_strings.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.scaling.Scaling.model_validate_strings.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,36 +21,62 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.scaling.Scaling.model_validate_strings.rst:2
-#: e6325ee91d2f45089f0e5cb0461b7cbf
+#: 1c183ca3916748eb899b2c58cdd0dc90
 msgid "Scaling.model\\_validate\\_strings"
 msgstr ""
 
-#: cdc42050407a4acc8eb996ed7c373825 of
+#: 594ddf14e07441de99b54b7e54f514df of
 #: pydantic.main.BaseModel.model_validate_strings:2
 msgid "Validate the given object with string data against the Pydantic model."
 msgstr ""
 
-#: ddb415a25e8b463480eb32f167342d7e of
+#: 2b0f71303f424370a005bcd62880818e of
 #: pydantic.main.BaseModel.model_validate_strings:4
 msgid "Args:"
 msgstr ""
 
-#: 8b5f3351d4f4428ea05cf0085342cee9 of
+#: adb38aab5f934db6bc6429e6e1b182d8 of
 #: pydantic.main.BaseModel.model_validate_strings:5
 msgid ""
 "obj: The object containing string data to validate. strict: Whether to "
-"enforce types strictly. context: Extra variables to pass to the "
-"validator. by_alias: Whether to use the field's alias when validating "
-"against the provided input data. by_name: Whether to use the field's name"
-" when validating against the provided input data."
+"enforce types strictly. extra: Whether to ignore, allow, or forbid extra "
+"data during model validation."
 msgstr ""
 
-#: 627703161e5547c0862958715897265f of
-#: pydantic.main.BaseModel.model_validate_strings:11
+#: dc6f28533b6e44a2ba75df6185c70ade of
+#: pydantic.main.BaseModel.model_validate_strings:8
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: 1a807d56f0ec477ab0e538ec365a0712 of
+#: pydantic.main.BaseModel.model_validate_strings:9
+msgid ""
+"context: Extra variables to pass to the validator. by_alias: Whether to "
+"use the field's alias when validating against the provided input data. "
+"by_name: Whether to use the field's name when validating against the "
+"provided input data."
+msgstr ""
+
+#: eaa08c265c6846149a03cc12589b29ce of
+#: pydantic.main.BaseModel.model_validate_strings:13
 msgid "Returns:"
 msgstr ""
 
-#: a6587e91a4764488a4cae85b208c073d of
-#: pydantic.main.BaseModel.model_validate_strings:12
+#: 94c7bb47266046e09ef94d0064ff3ee2 of
+#: pydantic.main.BaseModel.model_validate_strings:14
 msgid "The validated Pydantic model."
 msgstr ""
+
+#~ msgid ""
+#~ "obj: The object containing string data"
+#~ " to validate. strict: Whether to "
+#~ "enforce types strictly. context: Extra "
+#~ "variables to pass to the validator. "
+#~ "by_alias: Whether to use the field's "
+#~ "alias when validating against the "
+#~ "provided input data. by_name: Whether to"
+#~ " use the field's name when validating"
+#~ " against the provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.scaling.VariableScaling.model_copy.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.scaling.VariableScaling.model_copy.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,27 +21,27 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.scaling.VariableScaling.model_copy.rst:2
-#: c0f0fead8282450d80e29ebff82a585b
+#: bd3a38b1ec5a4f90a81df2b758aaed59
 msgid "VariableScaling.model\\_copy"
 msgstr ""
 
-#: e210fba2a5c14ec68483333c8e693297 of pydantic.main.BaseModel.model_copy:2
+#: ee32d4209a244559a8a3016786299190 of pydantic.main.BaseModel.model_copy:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 23674b93b11245899f2aee57f8782f2c of pydantic.main.BaseModel.model_copy:3
-msgid "[`model_copy`](../concepts/serialization.md#model_copy)"
+#: fd542cce20104c8aa5d6eefac4497fbf of pydantic.main.BaseModel.model_copy:3
+msgid "[`model_copy`](../concepts/models.md#model-copy)"
 msgstr ""
 
-#: afed2a7771ca4f3786b86c392cf51445 of pydantic.main.BaseModel.model_copy:5
+#: dcd418adf3d84da2a546233a31b1d880 of pydantic.main.BaseModel.model_copy:5
 msgid "Returns a copy of the model."
 msgstr ""
 
-#: b6d9ba81a1aa47b1a44ddc758eee6295 of pydantic.main.BaseModel.model_copy:7
+#: ee103150ff9e4d94b75121ed4ad024c1 of pydantic.main.BaseModel.model_copy:7
 msgid "!!! note"
 msgstr ""
 
-#: 5b6a2739b70f46b4bcc5bc130f14710d of pydantic.main.BaseModel.model_copy:8
+#: 4af76ea15cbe42d397517e66c032ea58 of pydantic.main.BaseModel.model_copy:8
 msgid ""
 "The underlying instance's [`__dict__`][object.__dict__] attribute is "
 "copied. This might have unexpected side effects if you store anything in "
@@ -49,28 +49,31 @@ msgid ""
 "properties][functools.cached_property])."
 msgstr ""
 
-#: 2264ab9454e24e4781c8e879120949ce of pydantic.main.BaseModel.model_copy:12
+#: ccc7c7e5e75d41fc9c019a24b2b3e8f3 of pydantic.main.BaseModel.model_copy:12
 msgid "Args:"
 msgstr ""
 
-#: 5821f2aec6704327b99bedc501cffe24 of pydantic.main.BaseModel.model_copy:13
+#: 42c7a0f72f6a40deb0581e8f211f9f18 of pydantic.main.BaseModel.model_copy:13
 msgid ""
 "update: Values to change/add in the new model. Note: the data is not "
 "validated"
 msgstr ""
 
-#: 07c7389a020a4baf8bb31c1f8b5b4f46 of pydantic.main.BaseModel.model_copy:14
+#: a9dc6d88977d4349859be45c1f82195e of pydantic.main.BaseModel.model_copy:14
 msgid "before creating the new model. You should trust this data."
 msgstr ""
 
-#: f7c5455ba74d4d59ad2c3076816709e2 of pydantic.main.BaseModel.model_copy:15
+#: 8b9ec4ae705345e1bcc1e2ba01e30ea2 of pydantic.main.BaseModel.model_copy:15
 msgid "deep: Set to `True` to make a deep copy of the model."
 msgstr ""
 
-#: f744517b0aa94eb49765f86d75635fc5 of pydantic.main.BaseModel.model_copy:17
+#: 55922545db78436498e249219b25e7f9 of pydantic.main.BaseModel.model_copy:17
 msgid "Returns:"
 msgstr ""
 
-#: e71eb95a4e8c44f59cfcbe813ecf708c of pydantic.main.BaseModel.model_copy:18
+#: 02ec7e6456b84939856ff45e94574d05 of pydantic.main.BaseModel.model_copy:18
 msgid "New model instance."
 msgstr ""
+
+#~ msgid "[`model_copy`](../concepts/serialization.md#model_copy)"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.scaling.VariableScaling.model_dump.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.scaling.VariableScaling.model_dump.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,40 +21,40 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.scaling.VariableScaling.model_dump.rst:2
-#: b06fbf1e22764ae9aefaaa97b05a79e7
+#: 8a3850d316544543ac0e68d47fb222d2
 msgid "VariableScaling.model\\_dump"
 msgstr ""
 
-#: fdb376c1afe2495493ef772aa4896eca of pydantic.main.BaseModel.model_dump:2
+#: 9b8584e8df3a42e2b821a75a41e3be7e of pydantic.main.BaseModel.model_dump:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 2f99259163684960b88602a140e2039b of pydantic.main.BaseModel.model_dump:3
-msgid "[`model_dump`](../concepts/serialization.md#modelmodel_dump)"
+#: 873972806132490a8686ada17e385195 of pydantic.main.BaseModel.model_dump:3
+msgid "[`model_dump`](../concepts/serialization.md#python-mode)"
 msgstr ""
 
-#: 1deb9660d708439fa2c8ca82e4500c9e of pydantic.main.BaseModel.model_dump:5
+#: a63fff2e3abf45de9f82bbfc37bf271a of pydantic.main.BaseModel.model_dump:5
 msgid ""
 "Generate a dictionary representation of the model, optionally specifying "
 "which fields to include or exclude."
 msgstr ""
 
-#: 3738b37e590445e28786138c771544d6 of pydantic.main.BaseModel.model_dump:7
+#: b932135a101149219018f9095b4d360b of pydantic.main.BaseModel.model_dump:7
 msgid "Args:"
 msgstr ""
 
-#: d30d83e86c184750a48645eaf6e7ca28 of pydantic.main.BaseModel.model_dump:8
+#: dc5dd05a67324dc89237e85ec4ce4c6f of pydantic.main.BaseModel.model_dump:8
 msgid "mode: The mode in which `to_python` should run."
 msgstr ""
 
-#: 4c11c0a3dbf9424db28969384a5ba410 of pydantic.main.BaseModel.model_dump:9
+#: 2e8dd8c7f9094adbac3b8da5221e44f4 of pydantic.main.BaseModel.model_dump:9
 msgid ""
 "If mode is 'json', the output will only contain JSON serializable types. "
 "If mode is 'python', the output may contain non-JSON-serializable Python "
 "objects."
 msgstr ""
 
-#: 81abf94c28754bbbb48d0d78209cc595 of pydantic.main.BaseModel.model_dump:11
+#: e46425034ed84efea6891370602faa5a of pydantic.main.BaseModel.model_dump:11
 msgid ""
 "include: A set of fields to include in the output. exclude: A set of "
 "fields to exclude from the output. context: Additional context to pass to"
@@ -62,41 +62,77 @@ msgid ""
 "dictionary key if defined. exclude_unset: Whether to exclude fields that "
 "have not been explicitly set. exclude_defaults: Whether to exclude fields"
 " that are set to their default value. exclude_none: Whether to exclude "
-"fields that have a value of `None`. round_trip: If True, dumped values "
-"should be valid as input for non-idempotent types such as Json[T]. "
-"warnings: How to handle serialization errors. False/\"none\" ignores "
-"them, True/\"warn\" logs errors,"
+"fields that have a value of `None`. exclude_computed_fields: Whether to "
+"exclude computed fields."
 msgstr ""
 
-#: 58dea778493b46c0a7443294af9d2bc7 of pydantic.main.BaseModel.model_dump:20
+#: 51a134d50a4044d5a2740f6e2bb388a4 of pydantic.main.BaseModel.model_dump:19
+msgid ""
+"While this can be useful for round-tripping, it is usually recommended tu"
+" use the dedicated `round_trip` parameter instead."
+msgstr ""
+
+#: 4db3209b08bb4f6abad1eb1e852f6c39 of pydantic.main.BaseModel.model_dump:21
+msgid ""
+"round_trip: If True, dumped values should be valid as input for non-"
+"idempotent types such as Json[T]. warnings: How to handle serialization "
+"errors. False/\"none\" ignores them, True/\"warn\" logs errors,"
+msgstr ""
+
+#: 912cfa8bfc4745549e1308e83be31181 of pydantic.main.BaseModel.model_dump:23
 msgid ""
 "\"error\" raises a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError]."
 msgstr ""
 
-#: c1ab66a8de6a48a69f2e737d763a07c1 of pydantic.main.BaseModel.model_dump:21
+#: 858dd70409574b4cb10dd48b808197fe of pydantic.main.BaseModel.model_dump:24
 msgid ""
 "fallback: A function to call when an unknown value is encountered. If not"
 " provided,"
 msgstr ""
 
-#: 56ffc5f06c7e4d4098671c317dd70584 of pydantic.main.BaseModel.model_dump:22
+#: faf01dc6d04a43959b83b02440c25621 of pydantic.main.BaseModel.model_dump:25
 msgid ""
 "a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError] "
 "error is raised."
 msgstr ""
 
-#: 1196e1338dbb488b8702577fffc6038d of pydantic.main.BaseModel.model_dump:23
+#: 6f80e62426b84986bdbea59686ccc846 of pydantic.main.BaseModel.model_dump:26
 msgid ""
 "serialize_as_any: Whether to serialize fields with duck-typing "
 "serialization behavior."
 msgstr ""
 
-#: 413f389e2ae2465cb1cedd88833b03c4 of pydantic.main.BaseModel.model_dump:25
+#: 7a0b3f2e1fe44b2ab1d42570486baf4e of pydantic.main.BaseModel.model_dump:28
 msgid "Returns:"
 msgstr ""
 
-#: 5f32f21c26474be6985576511f3075a6 of pydantic.main.BaseModel.model_dump:26
+#: c1e41123930d4ac2bfd60d12fa5cc870 of pydantic.main.BaseModel.model_dump:29
 msgid "A dictionary representation of the model."
 msgstr ""
+
+#~ msgid "[`model_dump`](../concepts/serialization.md#modelmodel_dump)"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "include: A set of fields to "
+#~ "include in the output. exclude: A "
+#~ "set of fields to exclude from the"
+#~ " output. context: Additional context to "
+#~ "pass to the serializer. by_alias: "
+#~ "Whether to use the field's alias "
+#~ "in the dictionary key if defined. "
+#~ "exclude_unset: Whether to exclude fields "
+#~ "that have not been explicitly set. "
+#~ "exclude_defaults: Whether to exclude fields"
+#~ " that are set to their default "
+#~ "value. exclude_none: Whether to exclude "
+#~ "fields that have a value of "
+#~ "`None`. round_trip: If True, dumped "
+#~ "values should be valid as input "
+#~ "for non-idempotent types such as "
+#~ "Json[T]. warnings: How to handle "
+#~ "serialization errors. False/\"none\" ignores "
+#~ "them, True/\"warn\" logs errors,"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.scaling.VariableScaling.model_dump_json.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.scaling.VariableScaling.model_dump_json.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,83 +21,133 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.scaling.VariableScaling.model_dump_json.rst:2
-#: 12659c33c9e340afadafca38f8f05201
+#: 245c5c3f0944454b897d8b7e7bc42cba
 msgid "VariableScaling.model\\_dump\\_json"
 msgstr ""
 
-#: f06dc3e5f3564c4d99c7808a467c7fa5 of
+#: 45ade9cb0a794c37873f36aae80c91a8 of
 #: pydantic.main.BaseModel.model_dump_json:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: 51b163f0315647a38350c8c529aa47bf of
+#: b8d91ebae21b481eae7f5a16ed176e37 of
 #: pydantic.main.BaseModel.model_dump_json:3
-msgid "[`model_dump_json`](../concepts/serialization.md#modelmodel_dump_json)"
+msgid "[`model_dump_json`](../concepts/serialization.md#json-mode)"
 msgstr ""
 
-#: 90614cb64d784b03b70065652de51e6f of
+#: 6e6db95736da4789b4f55baff62a7908 of
 #: pydantic.main.BaseModel.model_dump_json:5
 msgid ""
 "Generates a JSON representation of the model using Pydantic's `to_json` "
 "method."
 msgstr ""
 
-#: be77f3299e12416d864d86392883635a of
+#: 933d38da4f8a4db2815cbbc60b3adecb of
 #: pydantic.main.BaseModel.model_dump_json:7
 msgid "Args:"
 msgstr ""
 
-#: 10f784f8bfc24e99a963c5f5179726c0 of
+#: 1237d946d7334189a3a9d9a2a864d739 of
 #: pydantic.main.BaseModel.model_dump_json:8
 msgid ""
 "indent: Indentation to use in the JSON output. If None is passed, the "
-"output will be compact. include: Field(s) to include in the JSON output. "
-"exclude: Field(s) to exclude from the JSON output. context: Additional "
-"context to pass to the serializer. by_alias: Whether to serialize using "
-"field aliases. exclude_unset: Whether to exclude fields that have not "
-"been explicitly set. exclude_defaults: Whether to exclude fields that are"
-" set to their default value. exclude_none: Whether to exclude fields that"
-" have a value of `None`. round_trip: If True, dumped values should be "
-"valid as input for non-idempotent types such as Json[T]. warnings: How to"
-" handle serialization errors. False/\"none\" ignores them, True/\"warn\" "
-"logs errors,"
+"output will be compact. ensure_ascii: If `True`, the output is guaranteed"
+" to have all incoming non-ASCII characters escaped."
 msgstr ""
 
-#: 8520f720c6c045b593471c7d4087e4d0 of
-#: pydantic.main.BaseModel.model_dump_json:18
+#: fa0d2cf8c65742cd832e04723dfb3c1d of
+#: pydantic.main.BaseModel.model_dump_json:10
+msgid "If `False` (the default), these characters will be output as-is."
+msgstr ""
+
+#: ab02f9111c7b4dd2a7819c6be304d559 of
+#: pydantic.main.BaseModel.model_dump_json:11
+msgid ""
+"include: Field(s) to include in the JSON output. exclude: Field(s) to "
+"exclude from the JSON output. context: Additional context to pass to the "
+"serializer. by_alias: Whether to serialize using field aliases. "
+"exclude_unset: Whether to exclude fields that have not been explicitly "
+"set. exclude_defaults: Whether to exclude fields that are set to their "
+"default value. exclude_none: Whether to exclude fields that have a value "
+"of `None`. exclude_computed_fields: Whether to exclude computed fields."
+msgstr ""
+
+#: 62bf8aac37384c80bae91f71f6c9b419 of
+#: pydantic.main.BaseModel.model_dump_json:19
+msgid ""
+"While this can be useful for round-tripping, it is usually recommended to"
+" use the dedicated `round_trip` parameter instead."
+msgstr ""
+
+#: f0bafef19f7040349a08385660098a16 of
+#: pydantic.main.BaseModel.model_dump_json:21
+msgid ""
+"round_trip: If True, dumped values should be valid as input for non-"
+"idempotent types such as Json[T]. warnings: How to handle serialization "
+"errors. False/\"none\" ignores them, True/\"warn\" logs errors,"
+msgstr ""
+
+#: c3a0a882d0d5489fbdbbef803c4d46e0 of
+#: pydantic.main.BaseModel.model_dump_json:23
 msgid ""
 "\"error\" raises a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError]."
 msgstr ""
 
-#: c530e1d11aea4279bd6e1ca73b20078f of
-#: pydantic.main.BaseModel.model_dump_json:19
+#: ad625de8f932412196d7de8f54be6134 of
+#: pydantic.main.BaseModel.model_dump_json:24
 msgid ""
 "fallback: A function to call when an unknown value is encountered. If not"
 " provided,"
 msgstr ""
 
-#: bfaa6fa00a5848f4b4e6f63d636b83dd of
-#: pydantic.main.BaseModel.model_dump_json:20
+#: 4a49b1f2ddca44b3b99293ddcff462ae of
+#: pydantic.main.BaseModel.model_dump_json:25
 msgid ""
 "a "
 "[`PydanticSerializationError`][pydantic_core.PydanticSerializationError] "
 "error is raised."
 msgstr ""
 
-#: 2b5cc751f5174fca8d2db6da2e396206 of
-#: pydantic.main.BaseModel.model_dump_json:21
+#: e9796732e12d4c51ae4d95ade7ca80f7 of
+#: pydantic.main.BaseModel.model_dump_json:26
 msgid ""
 "serialize_as_any: Whether to serialize fields with duck-typing "
 "serialization behavior."
 msgstr ""
 
-#: fa09565b01c644009b928cf543aa2ef5 of
-#: pydantic.main.BaseModel.model_dump_json:23
+#: 4f2bf848d6c043dfbaf3e40abb444d1a of
+#: pydantic.main.BaseModel.model_dump_json:28
 msgid "Returns:"
 msgstr ""
 
-#: 1a6e72d985bb4b4d822b8a43ad599576 of
-#: pydantic.main.BaseModel.model_dump_json:24
+#: 72bd22d74577464cadb203edb88e4d8a of
+#: pydantic.main.BaseModel.model_dump_json:29
 msgid "A JSON string representation of the model."
 msgstr ""
+
+#~ msgid "[`model_dump_json`](../concepts/serialization.md#modelmodel_dump_json)"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "indent: Indentation to use in the "
+#~ "JSON output. If None is passed, "
+#~ "the output will be compact. include: "
+#~ "Field(s) to include in the JSON "
+#~ "output. exclude: Field(s) to exclude "
+#~ "from the JSON output. context: "
+#~ "Additional context to pass to the "
+#~ "serializer. by_alias: Whether to serialize "
+#~ "using field aliases. exclude_unset: Whether"
+#~ " to exclude fields that have not "
+#~ "been explicitly set. exclude_defaults: Whether"
+#~ " to exclude fields that are set "
+#~ "to their default value. exclude_none: "
+#~ "Whether to exclude fields that have "
+#~ "a value of `None`. round_trip: If "
+#~ "True, dumped values should be valid "
+#~ "as input for non-idempotent types "
+#~ "such as Json[T]. warnings: How to "
+#~ "handle serialization errors. False/\"none\" "
+#~ "ignores them, True/\"warn\" logs errors,"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.scaling.VariableScaling.model_json_schema.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.scaling.VariableScaling.model_json_schema.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,44 +21,77 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.scaling.VariableScaling.model_json_schema.rst:2
-#: e3047504be374fa2b82dc2787b555877
+#: d017af2277244beb9049964bef41dee3
 msgid "VariableScaling.model\\_json\\_schema"
 msgstr ""
 
-#: c4614f4e9e9d4cadb3f9b324c66568c9 of
+#: 03db5916653b4ca3bbd9c487c441fb95 of
 #: pydantic.main.BaseModel.model_json_schema:2
 msgid "Generates a JSON schema for a model class."
 msgstr ""
 
-#: 3c6d95cc293241e3aaa4fbb0f0263191 of
+#: 78e3d6275b9b452d8696d084e48692fa of
 #: pydantic.main.BaseModel.model_json_schema:4
 msgid "Args:"
 msgstr ""
 
-#: 6339eced232e4f1bba2b47b547147f50 of
+#: 4205714f6abb4eb6bec15dfacdd13538 of
 #: pydantic.main.BaseModel.model_json_schema:5
 msgid ""
 "by_alias: Whether to use attribute aliases or not. ref_template: The "
-"reference template. schema_generator: To override the logic used to "
-"generate the JSON schema, as a subclass of"
+"reference template. union_format: The format to use when combining "
+"schemas from unions together. Can be one of:"
 msgstr ""
 
-#: e0a4fbd1831f4d9bb661dd1afc9206b7 of
-#: pydantic.main.BaseModel.model_json_schema:8
+#: ebdb5e26c31f4ed495283900bce87b79 of
+#: pydantic.main.BaseModel.model_json_schema:9
+msgid ""
+"`'any_of'`: Use the [`anyOf`](https://json-schema.org/understanding-json-"
+"schema/reference/combining#anyOf)"
+msgstr ""
+
+#: a52aacf8aa32449ebeb4277b2bc68f83 of
+#: pydantic.main.BaseModel.model_json_schema:10
+msgid ""
+"keyword to combine schemas (the default). - `'primitive_type_array'`: Use"
+" the [`type`](https://json-schema.org/understanding-json-"
+"schema/reference/type) keyword as an array of strings, containing each "
+"type of the combination. If any of the schemas is not a primitive type "
+"(`string`, `boolean`, `null`, `integer` or `number`) or contains "
+"constraints/metadata, falls back to `any_of`."
+msgstr ""
+
+#: ff321ad05f6847c48e1f3542a9c9c8eb of
+#: pydantic.main.BaseModel.model_json_schema:15
+msgid ""
+"schema_generator: To override the logic used to generate the JSON schema,"
+" as a subclass of"
+msgstr ""
+
+#: fe25eb0513104cf59bd3b0442ffb739e of
+#: pydantic.main.BaseModel.model_json_schema:16
 msgid "`GenerateJsonSchema` with your desired modifications"
 msgstr ""
 
-#: 892d208dbcf04259a70f3b8bd35c4372 of
-#: pydantic.main.BaseModel.model_json_schema:9
+#: 522fe7baa0bc40f196e9844bb628131e of
+#: pydantic.main.BaseModel.model_json_schema:17
 msgid "mode: The mode in which to generate the schema."
 msgstr ""
 
-#: 07beb82d81824ef88060449d99d9c742 of
-#: pydantic.main.BaseModel.model_json_schema:11
+#: e2a8aff4f74e4f14960d15bb3e88a275 of
+#: pydantic.main.BaseModel.model_json_schema:19
 msgid "Returns:"
 msgstr ""
 
-#: 9cb1b8fe64c2481a921610975d0ed6f6 of
-#: pydantic.main.BaseModel.model_json_schema:12
+#: 63a6d30cce8f451dabd921065161b78a of
+#: pydantic.main.BaseModel.model_json_schema:20
 msgid "The JSON schema for the given model class."
 msgstr ""
+
+#~ msgid ""
+#~ "by_alias: Whether to use attribute "
+#~ "aliases or not. ref_template: The "
+#~ "reference template. schema_generator: To "
+#~ "override the logic used to generate "
+#~ "the JSON schema, as a subclass of"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.scaling.VariableScaling.model_validate.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.scaling.VariableScaling.model_validate.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,21 +21,33 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.scaling.VariableScaling.model_validate.rst:2
-#: 2725473814dc479796b187f635138f4e
+#: 97e7637eec6f482f93f879b36f6f39bc
 msgid "VariableScaling.model\\_validate"
 msgstr ""
 
-#: 7d0ae18d73de463692f7802682403d5f of pydantic.main.BaseModel.model_validate:2
+#: 3ae6520547934cf4883a6281964a7a71 of pydantic.main.BaseModel.model_validate:2
 msgid "Validate a pydantic model instance."
 msgstr ""
 
-#: ef4664df890f44efa6f4ceedffd6f0d3 of pydantic.main.BaseModel.model_validate:4
+#: 4984fb81ebe4440a9fd16a5205939c8f of pydantic.main.BaseModel.model_validate:4
 msgid "Args:"
 msgstr ""
 
-#: 5fa45f79a2ab41668164c79bb0ac31d5 of pydantic.main.BaseModel.model_validate:5
+#: cf4543e99d9f4cf7a3bd50654036a56f of pydantic.main.BaseModel.model_validate:5
 msgid ""
 "obj: The object to validate. strict: Whether to enforce types strictly. "
+"extra: Whether to ignore, allow, or forbid extra data during model "
+"validation."
+msgstr ""
+
+#: 277731052897477e8648ec480a5fa6c0 of pydantic.main.BaseModel.model_validate:8
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: 2c8a694b019c4404b92e05b28730398e of pydantic.main.BaseModel.model_validate:9
+msgid ""
 "from_attributes: Whether to extract data from object attributes. context:"
 " Additional context to pass to the validator. by_alias: Whether to use "
 "the field's alias when validating against the provided input data. "
@@ -43,22 +55,35 @@ msgid ""
 "provided input data."
 msgstr ""
 
-#: dfbb329749c6444e8e9d277d21c5b3e7 of
-#: pydantic.main.BaseModel.model_validate:12
+#: 47110bce7d28483eae0198ce62fd4017 of
+#: pydantic.main.BaseModel.model_validate:14
 msgid "Raises:"
 msgstr ""
 
-#: 4e0e909dab7a42bdbf35793d975bccd3 of
-#: pydantic.main.BaseModel.model_validate:13
+#: 4c3f9d03063e47c8af82ae5650417eab of
+#: pydantic.main.BaseModel.model_validate:15
 msgid "ValidationError: If the object could not be validated."
 msgstr ""
 
-#: 78eca8e6eef44243b1738ffb90afe2ae of
-#: pydantic.main.BaseModel.model_validate:15
+#: 3d48ce95f0cc4859a705e3714350c462 of
+#: pydantic.main.BaseModel.model_validate:17
 msgid "Returns:"
 msgstr ""
 
-#: 781703b463374ae2a0b2b2cfb560cac6 of
-#: pydantic.main.BaseModel.model_validate:16
+#: b8d3ae8e8c524c9cb05148aa7e0db7cc of
+#: pydantic.main.BaseModel.model_validate:18
 msgid "The validated model instance."
 msgstr ""
+
+#~ msgid ""
+#~ "obj: The object to validate. strict: "
+#~ "Whether to enforce types strictly. "
+#~ "from_attributes: Whether to extract data "
+#~ "from object attributes. context: Additional"
+#~ " context to pass to the validator."
+#~ " by_alias: Whether to use the field's"
+#~ " alias when validating against the "
+#~ "provided input data. by_name: Whether to"
+#~ " use the field's name when validating"
+#~ " against the provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.scaling.VariableScaling.model_validate_json.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.scaling.VariableScaling.model_validate_json.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,58 +21,84 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.scaling.VariableScaling.model_validate_json.rst:2
-#: f05d0fa4d22541a2a1a31da339462bb9
+#: 45ee51c25c7e4faea9177d18de1d5c20
 msgid "VariableScaling.model\\_validate\\_json"
 msgstr ""
 
-#: a06653cb6cb44fc1b39156cf6929b99f of
+#: f4ac0b3229314a488edb7678e65f336e of
 #: pydantic.main.BaseModel.model_validate_json:2
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
-#: f663746f4c29408e8b1dd840219dd582 of
+#: b0653f7c312542919f61dcc7238ca5f2 of
 #: pydantic.main.BaseModel.model_validate_json:3
 msgid "[JSON Parsing](../concepts/json.md#json-parsing)"
 msgstr ""
 
-#: f2297c24a6b94802933674308345b8c0 of
+#: 4b6bfb0040da4286b88ec3b1bb5a9519 of
 #: pydantic.main.BaseModel.model_validate_json:5
 msgid "Validate the given JSON data against the Pydantic model."
 msgstr ""
 
-#: 489b22df3d524580a864ae5f614bd7ba of
+#: 4c26f4e13d94421ebd4473d8a907fa6c of
 #: pydantic.main.BaseModel.model_validate_json:7
 msgid "Args:"
 msgstr ""
 
-#: 881b0a0480bd4caaab35e2a687b2d936 of
+#: 574f5730bdbe44c6b14187eeb8f53dec of
 #: pydantic.main.BaseModel.model_validate_json:8
 msgid ""
 "json_data: The JSON data to validate. strict: Whether to enforce types "
-"strictly. context: Extra variables to pass to the validator. by_alias: "
-"Whether to use the field's alias when validating against the provided "
-"input data. by_name: Whether to use the field's name when validating "
-"against the provided input data."
+"strictly. extra: Whether to ignore, allow, or forbid extra data during "
+"model validation."
 msgstr ""
 
-#: 0ad64389eba340bcaf46b8fdd5c187d1 of
-#: pydantic.main.BaseModel.model_validate_json:14
+#: a0574b269ee146798a346fdc1888573d of
+#: pydantic.main.BaseModel.model_validate_json:11
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: 9c09feba4e364ebd91aad4c80b91ab73 of
+#: pydantic.main.BaseModel.model_validate_json:12
+msgid ""
+"context: Extra variables to pass to the validator. by_alias: Whether to "
+"use the field's alias when validating against the provided input data. "
+"by_name: Whether to use the field's name when validating against the "
+"provided input data."
+msgstr ""
+
+#: 23eab1ff6a7346318bea54feefa3c38b of
+#: pydantic.main.BaseModel.model_validate_json:16
 msgid "Returns:"
 msgstr ""
 
-#: 73a34e7b42584b0abb8c95abf359d8a4 of
-#: pydantic.main.BaseModel.model_validate_json:15
+#: c26058c8eb664fa1bb3fad5fd463110d of
+#: pydantic.main.BaseModel.model_validate_json:17
 msgid "The validated Pydantic model."
 msgstr ""
 
-#: e586d2a8267e4a7f920762ed0aef9029 of
-#: pydantic.main.BaseModel.model_validate_json:17
+#: 8bc0fa69e1e24592b440a764aa48cf0c of
+#: pydantic.main.BaseModel.model_validate_json:19
 msgid "Raises:"
 msgstr ""
 
-#: e4d4cfc65c1b40059604d7b5af55540c of
-#: pydantic.main.BaseModel.model_validate_json:18
+#: b598d9ba5a4041a6adcfbdb271e2810f of
+#: pydantic.main.BaseModel.model_validate_json:20
 msgid ""
 "ValidationError: If `json_data` is not a JSON string or the object could "
 "not be validated."
 msgstr ""
+
+#~ msgid ""
+#~ "json_data: The JSON data to validate."
+#~ " strict: Whether to enforce types "
+#~ "strictly. context: Extra variables to "
+#~ "pass to the validator. by_alias: Whether"
+#~ " to use the field's alias when "
+#~ "validating against the provided input "
+#~ "data. by_name: Whether to use the "
+#~ "field's name when validating against the"
+#~ " provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.scaling.VariableScaling.model_validate_strings.po
+++ b/locales/es/LC_MESSAGES/api/generated/classmethods/pymc_marketing.mmm.scaling.VariableScaling.model_validate_strings.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,36 +21,62 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/classmethods/pymc_marketing.mmm.scaling.VariableScaling.model_validate_strings.rst:2
-#: ceb4a756b475431da63d2e4b54f0e629
+#: 811a4f0fa80e478c8080db115dd865c3
 msgid "VariableScaling.model\\_validate\\_strings"
 msgstr ""
 
-#: 83bba1e1a0eb4fb385fec0c0a48eb359 of
+#: 50b9912fe21042de87030b58ca6627bc of
 #: pydantic.main.BaseModel.model_validate_strings:2
 msgid "Validate the given object with string data against the Pydantic model."
 msgstr ""
 
-#: 75f9c72048114a7496f27f5adc68195f of
+#: ae223f9748964d68b0842280139a7f3b of
 #: pydantic.main.BaseModel.model_validate_strings:4
 msgid "Args:"
 msgstr ""
 
-#: a153e770e8c74df182730b295f569537 of
+#: 0b44a41fb0f44065841432dd5ddb3875 of
 #: pydantic.main.BaseModel.model_validate_strings:5
 msgid ""
 "obj: The object containing string data to validate. strict: Whether to "
-"enforce types strictly. context: Extra variables to pass to the "
-"validator. by_alias: Whether to use the field's alias when validating "
-"against the provided input data. by_name: Whether to use the field's name"
-" when validating against the provided input data."
+"enforce types strictly. extra: Whether to ignore, allow, or forbid extra "
+"data during model validation."
 msgstr ""
 
-#: 4cf1fe58ad2045ee8b5fb861f5bddfca of
-#: pydantic.main.BaseModel.model_validate_strings:11
+#: 1985f37630ec4b75a37da1e5a8bc23d1 of
+#: pydantic.main.BaseModel.model_validate_strings:8
+msgid ""
+"See the [`extra` configuration value][pydantic.ConfigDict.extra] for "
+"details."
+msgstr ""
+
+#: 752cf689ddee40ef86c418a4bc5ac927 of
+#: pydantic.main.BaseModel.model_validate_strings:9
+msgid ""
+"context: Extra variables to pass to the validator. by_alias: Whether to "
+"use the field's alias when validating against the provided input data. "
+"by_name: Whether to use the field's name when validating against the "
+"provided input data."
+msgstr ""
+
+#: 5dcdb30f605f455c83d3589e7d6a1086 of
+#: pydantic.main.BaseModel.model_validate_strings:13
 msgid "Returns:"
 msgstr ""
 
-#: 9f5eb13cc0434684930da457295c4e9b of
-#: pydantic.main.BaseModel.model_validate_strings:12
+#: 921f75e8483f4b388c7d6ad47dda3170 of
+#: pydantic.main.BaseModel.model_validate_strings:14
 msgid "The validated Pydantic model."
 msgstr ""
+
+#~ msgid ""
+#~ "obj: The object containing string data"
+#~ " to validate. strict: Whether to "
+#~ "enforce types strictly. context: Extra "
+#~ "variables to pass to the validator. "
+#~ "by_alias: Whether to use the field's "
+#~ "alias when validating against the "
+#~ "provided input data. by_name: Whether to"
+#~ " use the field's name when validating"
+#~ " against the provided input data."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/pymc_marketing.mmm.hsgp.HSGP.po
+++ b/locales/es/LC_MESSAGES/api/generated/pymc_marketing.mmm.hsgp.HSGP.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,24 +21,24 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:2
-#: 72474cd9cfd540e08c1af0bc1541d0f3
+#: 18423ace17f24f67b9a5b2bad9328947
 msgid "HSGP"
 msgstr ""
 
-#: 6eaf06cd67fc45a7bb29e8d5cd3979a8 of pymc_marketing.mmm.hsgp.HSGP:2
+#: 9e25f1635a65434abe4410afbdbfed15 of pymc_marketing.mmm.hsgp.HSGP:2
 msgid "HSGP component."
 msgstr ""
 
-#: 5b525fc379ed4390853fd20a207bebdb of pymc_marketing.mmm.hsgp.HSGP:19
+#: 73d70404ccf643fc8dc02bdfbc45a9ab of pymc_marketing.mmm.hsgp.HSGP:19
 msgid "Examples"
 msgstr ""
 
-#: 8bf5b0e06f4243ea80f56bdd8da0b02c of pymc_marketing.mmm.hsgp.HSGP:20
+#: 0d04891cffd94065af5d3504f89994b4 of pymc_marketing.mmm.hsgp.HSGP:20
 msgid "Literature recommended HSGP configuration:"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:34
-#: 4d8ab2cd27934ffab959f10ae80e3ace
+#: f96b5d8ad71f44ef8ed97fde237491a6
 msgid ""
 "(:download:`Source code <../../../gettext/plot_directive/api/generated"
 "/pymc_marketing-mmm-hsgp-HSGP-1.py>`, :download:`png "
@@ -50,12 +50,12 @@ msgid ""
 "HSGP-1.pdf>`)"
 msgstr ""
 
-#: 4e69790f724c4cbbb4887eec38bc2547 of pymc_marketing.mmm.hsgp.HSGP:53
+#: 044eeb56a21f47709a57fce5dfeedde2 of pymc_marketing.mmm.hsgp.HSGP:53
 msgid "Using a demeaned basis to remove \"intercept\" effect of first basis:"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:41
-#: a1b91a4fa48e41c69acc80ecac0cd054
+#: c22b77fb11264c63bca87839e915546b
 msgid ""
 "(:download:`Source code <../../../gettext/plot_directive/api/generated"
 "/pymc_marketing-mmm-hsgp-HSGP-2.py>`, :download:`png "
@@ -67,12 +67,12 @@ msgid ""
 "HSGP-2.pdf>`)"
 msgstr ""
 
-#: da044ed2174448398447535b9e7e674a of pymc_marketing.mmm.hsgp.HSGP:93
+#: 16dbc3fd09ad43c09603939c1b0c55f9 of pymc_marketing.mmm.hsgp.HSGP:93
 msgid "HSGP with different covariance function"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:35
-#: 19dbb725ff5d4610b64ff0f72fb667c0
+#: 2176dfad59e3435ea3b3cff251d84ea7
 msgid ""
 "(:download:`Source code <../../../gettext/plot_directive/api/generated"
 "/pymc_marketing-mmm-hsgp-HSGP-3.py>`, :download:`png "
@@ -84,11 +84,11 @@ msgid ""
 "HSGP-3.pdf>`)"
 msgstr ""
 
-#: 32ddafdd2ddf4154a0ba498579fa1712 of pymc_marketing.mmm.hsgp.HSGP:127
+#: 2bfe9cba485141b58cca6a706a12d4ab of pymc_marketing.mmm.hsgp.HSGP:127
 msgid "HSGP with different link function via `transform` argument"
 msgstr ""
 
-#: cb8623c239b641f4b31019415beb9ddc of pymc_marketing.mmm.hsgp.HSGP:131
+#: a104e518428745c5ac841b6d24299e91 of pymc_marketing.mmm.hsgp.HSGP:131
 msgid ""
 "The `transform` parameter must be registered or from either "
 "`pytensor.tensor` or `pymc.math` namespaces. See the "
@@ -96,7 +96,7 @@ msgid ""
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:35
-#: dc0553534aa0448ba6bea4847b8515d4
+#: dc5d78c483b84cbd9d190b6160f3fb26
 msgid ""
 "(:download:`Source code <../../../gettext/plot_directive/api/generated"
 "/pymc_marketing-mmm-hsgp-HSGP-4.py>`, :download:`png "
@@ -108,12 +108,12 @@ msgid ""
 "HSGP-4.pdf>`)"
 msgstr ""
 
-#: 7c32e1e50e7f4e628c1aa53ba777d581 of pymc_marketing.mmm.hsgp.HSGP:166
+#: 97689f51014f4ab895f27c8618d036b0 of pymc_marketing.mmm.hsgp.HSGP:166
 msgid "New data predictions with HSGP"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:72
-#: 3d2edd02ad7e4017b52809c29d666926
+#: 7fe9af9d4ce64c34ae4916de07a039c9
 msgid ""
 "(:download:`Source code <../../../gettext/plot_directive/api/generated"
 "/pymc_marketing-mmm-hsgp-HSGP-5.py>`, :download:`png "
@@ -125,12 +125,12 @@ msgid ""
 "HSGP-5.pdf>`)"
 msgstr ""
 
-#: f1d6720f9e9a44018daf600d6ddbb963 of pymc_marketing.mmm.hsgp.HSGP:237
+#: 663de1f5152547c2b690c098ba4b50d6 of pymc_marketing.mmm.hsgp.HSGP:237
 msgid "Higher dimensional HSGP"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:40
-#: 57438827587d49a38c4c5b60b59bbce0
+#: b838a218f4934216bca9b786c370aff4
 msgid ""
 "(:download:`Source code <../../../gettext/plot_directive/api/generated"
 "/pymc_marketing-mmm-hsgp-HSGP-6.py>`, :download:`png "
@@ -143,104 +143,104 @@ msgid ""
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:12
-#: 70f218492f9c4c659edce2213f7dd150
+#: 0ccce758e4024c40a97f3a21e3a1d08e
 msgid "Methods"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 3cfa404f3c784fb3b38fc255dc3b8582
+#: 165fd7cc69d94954886baa018950da28
 msgid ""
 ":py:obj:`HSGP.__init__ <pymc_marketing.mmm.hsgp.HSGP.__init__>`\\ "
 "\\(\\*\\*data\\)"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: d8478c3b75314bf89154a57606dfa2eb
+#: e273352374be4e53b7cfb050a9fd9501
 msgid ""
 "Create a new model by parsing and validating input data from keyword "
 "arguments."
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: ad78c984257e48a7a1d288758e76f756
+#: d60ed58083294e07a16acde57e03586a
 msgid ""
 ":py:obj:`HSGP.construct <pymc_marketing.mmm.hsgp.HSGP.construct>`\\ "
 "\\(\\[\\_fields\\_set\\]\\)"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 7e9e0e8684a64a8f83be6288aa553bab
+#: 089f6e38ee62499db7dcea947a59c72f
 msgid ""
 ":py:obj:`HSGP.copy <pymc_marketing.mmm.hsgp.HSGP.copy>`\\ \\(\\*\\[\\, "
 "include\\, exclude\\, update\\, deep\\]\\)"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 6d6a84cd703a4700b18980182e270c14
+#: b54c822ac0a74765a9ea47cb83904539
 msgid "Returns a copy of the model."
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 2aa739bfecef4c10ab96149d3866b071
+#: 0066d0dcdbd84444be6d18f2a7344fb6
 msgid ""
 ":py:obj:`HSGP.create_variable "
 "<pymc_marketing.mmm.hsgp.HSGP.create_variable>`\\ \\(name\\)"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: d1fa63c1c84c403594a615e0221e3784
+#: e179641864f041e9b6a4072bf9d95f17
 msgid "Create a variable from HSGP configuration."
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: bf5539fe1dd7415cb170b09c2fd80a41
+#: 80dee11208384daea46c3cbef6bdeddc
 msgid ""
 ":py:obj:`HSGP.deterministics_to_replace "
 "<pymc_marketing.mmm.hsgp.HSGP.deterministics_to_replace>`\\ \\(name\\)"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 5a4c82c27b2a4f4c94d2c236236500d1
+#: 81db8750a3a44788bbbfb74349e206da
 msgid ""
 "Name of the Deterministic variables that are replaced with pm.Flat for "
 "out-of-sample."
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: cc11fb2e94a44c6fb1e31456c73fcad1
+#: befdfea0e7e443a080bc1d6c1564fb3e
 msgid ""
 ":py:obj:`HSGP.dict <pymc_marketing.mmm.hsgp.HSGP.dict>`\\ \\(\\*\\[\\, "
 "include\\, exclude\\, by\\_alias\\, ...\\]\\)"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: ff9897aa8ea6427788a668746d35a4b0
+#: 2a59b09339d14c588d9bd56aead88d81
 msgid ""
 ":py:obj:`HSGP.from_dict <pymc_marketing.mmm.hsgp.HSGP.from_dict>`\\ "
 "\\(data\\)"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: c084adb3d299437fad4b6ca8a4b9eb5b
+#: be03b41801d14d32ad49959ed8ffc12d
 msgid "Create an object from a dictionary."
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 62ffc3e52a604ba7baebf2d08008aa90
+#: 823cbfec74054be9a0582bb2beaaa2ad
 msgid ""
 ":py:obj:`HSGP.from_orm <pymc_marketing.mmm.hsgp.HSGP.from_orm>`\\ "
 "\\(obj\\)"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 156a6a1f754b4eda835f3b529e5d80a3
+#: 568e3ef453a54d79aad03249c2660819
 msgid ""
 ":py:obj:`HSGP.json <pymc_marketing.mmm.hsgp.HSGP.json>`\\ \\(\\*\\[\\, "
 "include\\, exclude\\, by\\_alias\\, ...\\]\\)"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: ed8312736406433588c8111ed1854d1b
+#: 1be34e470b504d56adb748908d7b464f
 msgid ""
 ":py:obj:`HSGP.model_construct "
 "<pymc_marketing.mmm.hsgp.HSGP.model_construct>`\\ "
@@ -248,40 +248,40 @@ msgid ""
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: e74ff07de26149f98772a28abdccf6da
+#: 4125214dbe344098a8f822ba8dc73194
 msgid "Creates a new instance of the `Model` class with validated data."
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 3a7e62c2676a48d7a3dc74881b23a3d0
+#: 985cca1f21b244f89fcb9c8bb011e457
 msgid ""
 ":py:obj:`HSGP.model_copy <pymc_marketing.mmm.hsgp.HSGP.model_copy>`\\ "
 "\\(\\*\\[\\, update\\, deep\\]\\)"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 4894a58813464503b8b782b1dbcb7390 5fd6772b315c418186e74b5b7120f948
-#: 87df8e65ce3e4c5780f4920d8884b236 b1735db227624d4f9badeb77e936d809
+#: 13c5fef3103c4cab8d2b9d5af0461d97 2720e2fed10846d4896e6f152e867487
+#: 2e15fd9b42814d48ba6524a3ad5eddb1 2e6b993ae71043258f581c49473819c9
 msgid "!!! abstract \"Usage Documentation\""
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 6ff39459fb4643b685b16421c712a2f8
+#: c5fa2e67b87e4262848a0ba609a4672f
 msgid ""
 ":py:obj:`HSGP.model_dump <pymc_marketing.mmm.hsgp.HSGP.model_dump>`\\ "
 "\\(\\*\\[\\, mode\\, include\\, exclude\\, ...\\]\\)"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 82a3f52090bb4eb5afaef691fe569545
+#: 68b57c9998e342d896c852a4233322f4
 msgid ""
 ":py:obj:`HSGP.model_dump_json "
 "<pymc_marketing.mmm.hsgp.HSGP.model_dump_json>`\\ \\(\\*\\[\\, indent\\, "
-"include\\, ...\\]\\)"
+"...\\]\\)"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: c510759f1ddf4989848b8758f4c67da5
+#: ea5d995c6d554ab4af91ed26a9c5360b
 msgid ""
 ":py:obj:`HSGP.model_json_schema "
 "<pymc_marketing.mmm.hsgp.HSGP.model_json_schema>`\\ \\(\\[by\\_alias\\, "
@@ -289,38 +289,38 @@ msgid ""
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 44abc3fe14d84158a821eac279e9fc2d
+#: 24ecb266ff41451fb554a48a0a93bdf0
 msgid "Generates a JSON schema for a model class."
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 6d5b17e62f5e4bd68f92dbf5bcc86f8b
+#: 91a5613b0ca34c53bd68bf4b9ca1211c
 msgid ""
 ":py:obj:`HSGP.model_parametrized_name "
 "<pymc_marketing.mmm.hsgp.HSGP.model_parametrized_name>`\\ \\(params\\)"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 9277185af3b2496b85af6da422d0f055
+#: 3ec678c450514426ba454cbe6d64a2ea
 msgid "Compute the class name for parametrizations of generic classes."
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 14ac877e8b4a401dadb0bcc27efeec1a
+#: 87ccc375e22645849bfd91a277b9549f
 msgid ""
 ":py:obj:`HSGP.model_post_init "
 "<pymc_marketing.mmm.hsgp.HSGP.model_post_init>`\\ \\(context\\, \\/\\)"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 4f9e5f0b52934a629210ebb9b5994996
+#: 15a5736489c644a6b37e8ce7af7b91d3
 msgid ""
 "Override this method to perform additional initialization after "
 "`__init__` and `model_construct`."
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 9b992f827bd34e9dac282fa420cb09f8
+#: 6f60adef1adf4179964b82d9fab915b2
 msgid ""
 ":py:obj:`HSGP.model_rebuild "
 "<pymc_marketing.mmm.hsgp.HSGP.model_rebuild>`\\ \\(\\*\\[\\, force\\, "
@@ -328,25 +328,25 @@ msgid ""
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 725bcdcf4c544bf39400d302a00487d8
+#: 9a4de7b2700d4305a87dc9d19cb48e09
 msgid "Try to rebuild the pydantic-core schema for the model."
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 979b25c909bb49afa02d20540aaeef69
+#: 57df9161bdae42d284a12aa74e605161
 msgid ""
 ":py:obj:`HSGP.model_validate "
 "<pymc_marketing.mmm.hsgp.HSGP.model_validate>`\\ \\(obj\\, \\*\\[\\, "
-"strict\\, ...\\]\\)"
+"strict\\, extra\\, ...\\]\\)"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: d0135861771345b3bfe46d7b5fbe5e34
+#: 65d8ad826ee54ed9a5dc628db0f6dff6
 msgid "Validate a pydantic model instance."
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 0eaecfcee44a4f0eaa16635bf2cd3938
+#: 659ac3685a394b5797740527cffbe5c0
 msgid ""
 ":py:obj:`HSGP.model_validate_json "
 "<pymc_marketing.mmm.hsgp.HSGP.model_validate_json>`\\ \\(json\\_data\\, "
@@ -354,7 +354,7 @@ msgid ""
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 0a2c4bbc4a7f4b3a92cc8861cb3267fa
+#: d6f7b04a715645d28f568afb667b4bb5
 msgid ""
 ":py:obj:`HSGP.model_validate_strings "
 "<pymc_marketing.mmm.hsgp.HSGP.model_validate_strings>`\\ \\(obj\\, "
@@ -362,12 +362,12 @@ msgid ""
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: abd5ac3265f84a42b28a51ac2cd6de80
+#: a1a27eacd1584403a76461c24079484d
 msgid "Validate the given object with string data against the Pydantic model."
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: b5253e70dd4b4796bbb3c5de948821f2
+#: 7da10c22d63b438aaaf43707ce794978
 msgid ""
 ":py:obj:`HSGP.parameterize_from_data "
 "<pymc_marketing.mmm.hsgp.HSGP.parameterize_from_data>`\\ \\(X\\, "
@@ -375,214 +375,226 @@ msgid ""
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 11eb796852124138ac09084c48347599
+#: 2025fdb61e4d40218a0693ab34172f6a
 msgid "Create a HSGP informed by the data with literature-based recommendations."
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 20ba66e03609402fb0850ae2e037fb71
+#: d81c54e8ed6d42d795931483e88c2a65
 msgid ""
 ":py:obj:`HSGP.parse_file <pymc_marketing.mmm.hsgp.HSGP.parse_file>`\\ "
 "\\(path\\, \\*\\[\\, content\\_type\\, ...\\]\\)"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: ac504a229c534d5a8da1d5b09491ebee
+#: 95ba66e437344d9395ab55fe32da4905
 msgid ""
 ":py:obj:`HSGP.parse_obj <pymc_marketing.mmm.hsgp.HSGP.parse_obj>`\\ "
 "\\(obj\\)"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 98f26b1a68a24e97abcd8d6e719b6650
+#: 4cd182df10f14351a4e8610d64973f9d
 msgid ""
 ":py:obj:`HSGP.parse_raw <pymc_marketing.mmm.hsgp.HSGP.parse_raw>`\\ "
 "\\(b\\, \\*\\[\\, content\\_type\\, ...\\]\\)"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 99f6974c785e402fac1c5484311cc074
+#: 670b63e098aa41f5a01a7839495a5c0b
 msgid ""
 ":py:obj:`HSGP.plot_curve <pymc_marketing.mmm.hsgp.HSGP.plot_curve>`\\ "
 "\\(curve\\[\\, n\\_samples\\, ...\\]\\)"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 19a2395312094087b6fed8f0082f961a
+#: bf38ac4c17d941d8a615dbe4e89f3768
 msgid "Plot the curve."
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 220fd11d4b7c4b46b23eed63b018bd6d
+#: f5fb72a98c2947ffbcfe83bce03d846c
 msgid ""
 ":py:obj:`HSGP.register_data "
 "<pymc_marketing.mmm.hsgp.HSGP.register_data>`\\ \\(X\\)"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 8cda743a8b604c09a4614f3092646a49
+#: 092a355698c0494e91d0ac61c43b3324
 msgid "Register the data to be used in the model."
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 3462278825d540ddac851202bc473d12
+#: c2ebc09d86e74e538452f2b0ba0c2272
 msgid ""
 ":py:obj:`HSGP.sample_prior <pymc_marketing.mmm.hsgp.HSGP.sample_prior>`\\"
 " \\(\\[coords\\]\\)"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: ac815a24d0ea402cb1684d74a16fc2b6
+#: a064f4abdd1e4b3b9a11c9dc9eb17057
 msgid "Sample from the prior distribution."
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: afb9c782d57b42b0a4423f348947e626
+#: 22fc041e007e479ea1cf0f1198714a91
 msgid ""
 ":py:obj:`HSGP.schema <pymc_marketing.mmm.hsgp.HSGP.schema>`\\ "
 "\\(\\[by\\_alias\\, ref\\_template\\]\\)"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 2826bf7063ec4a4d975dd16225fbff5b
+#: 6cf38d7ee7e9414abb76111e073893fa
 msgid ""
 ":py:obj:`HSGP.schema_json <pymc_marketing.mmm.hsgp.HSGP.schema_json>`\\ "
 "\\(\\*\\[\\, by\\_alias\\, ref\\_template\\]\\)"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 35c4cacd40894bccad1d98b36e6e9137
+#: be8771ed0ed048fdb76d4c768bfbdf08
 msgid ":py:obj:`HSGP.to_dict <pymc_marketing.mmm.hsgp.HSGP.to_dict>`\\ \\(\\)"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 917dff1878a1411f82bd8367026407cd
+#: c989a8b8886540b4954457b710959388
 msgid "Convert the object to a dictionary."
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 7f7f60c31b5c4c2796de91735bb103e2
+#: ab18749a52bb490daa784bfc7cb99792
 msgid ""
 ":py:obj:`HSGP.update_forward_refs "
 "<pymc_marketing.mmm.hsgp.HSGP.update_forward_refs>`\\ \\(\\*\\*localns\\)"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:53:<autosummary>:1
-#: 24bf44c0f8a846768c6de436e72a4e34
+#: 5ecd86860af34943b19b6d01a22dc1d8
 msgid ""
 ":py:obj:`HSGP.validate <pymc_marketing.mmm.hsgp.HSGP.validate>`\\ "
 "\\(value\\)"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:55
-#: 2cab4b2d4c7549a6b92fbcc2e0270dbe
+#: 3d2f8735b7f042b0adcdab041ecd2c08
 msgid "Attributes"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:74:<autosummary>:1
-#: 1d564f162f7c4623b7081f326bdd4c7a
+#: b825a4a325c24da395db1af6dc0f8843
 msgid ""
 ":py:obj:`model_computed_fields "
 "<pymc_marketing.mmm.hsgp.HSGP.model_computed_fields>`\\"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:74:<autosummary>:1
-#: b6b24a5af9db4b1497ab2745532ba157
+#: 25a1b9b488da4291a83d74bba28e9e12
 msgid ":py:obj:`model_config <pymc_marketing.mmm.hsgp.HSGP.model_config>`\\"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:74:<autosummary>:1
-#: 64878853f22c4c399540ccaf34ec8430
+#: 85892ebbbf2640a98fb8ce0b77793211
 msgid ""
 "Configuration for the model, should be a dictionary conforming to "
 "[`ConfigDict`][pydantic.config.ConfigDict]."
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:74:<autosummary>:1
-#: bfec367d86d64187b5a7cfd644b3da09
+#: 4da15420883c44af9f53c313c35bd71a
 msgid ":py:obj:`model_extra <pymc_marketing.mmm.hsgp.HSGP.model_extra>`\\"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:74:<autosummary>:1
-#: ca935c56300b4909a4c18f8afcdefca8
+#: ec931e9d8ff643a4955bac55b41eb69e
 msgid "Get extra fields set during validation."
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:74:<autosummary>:1
-#: 8f5965cf90064547a11b94d149d48547
+#: 8947fc362b0d4a6884f0dab66ba2603d
 msgid ":py:obj:`model_fields <pymc_marketing.mmm.hsgp.HSGP.model_fields>`\\"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:74:<autosummary>:1
-#: 559a0bfbb1284e63afd4e8b60e58e924
+#: d191f909364b4bc781aa8153a10f4a39
 msgid ""
 ":py:obj:`model_fields_set "
 "<pymc_marketing.mmm.hsgp.HSGP.model_fields_set>`\\"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:74:<autosummary>:1
-#: 65f433efae7b47028e993756f09607c3
+#: 320473ed67f84e05a1e2a52cb21b8658
 msgid ""
 "Returns the set of fields that have been explicitly set on this model "
 "instance."
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:74:<autosummary>:1
-#: 9caece0da7a349f5b5a5485d8b0fa4c9
+#: 1ba95c4f3b6f430896e27992f225cc94
 msgid ":py:obj:`ls <pymc_marketing.mmm.hsgp.HSGP.ls>`\\"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:74:<autosummary>:1
-#: f7b9285659bf490684b2ad959a7311a6
+#: 5f7316768a5040089244756b188167ec
 msgid ":py:obj:`eta <pymc_marketing.mmm.hsgp.HSGP.eta>`\\"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:74:<autosummary>:1
-#: 098902b8f6ca4d20837b44df1d961420
+#: b3dd162551c84c7ca9a0680ba543f82b
 msgid ":py:obj:`L <pymc_marketing.mmm.hsgp.HSGP.L>`\\"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:74:<autosummary>:1
-#: 363d5e87611c49b2bba7963085ad7d75
+#: b0e62b1d87614222b58143145d1d29e4
 msgid ":py:obj:`centered <pymc_marketing.mmm.hsgp.HSGP.centered>`\\"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:74:<autosummary>:1
-#: 6dd10d8c3185416f9d5c62713fb62be6
+#: db19949187c54d9d83bd7b626478c6bd
 msgid ":py:obj:`drop_first <pymc_marketing.mmm.hsgp.HSGP.drop_first>`\\"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:74:<autosummary>:1
-#: fa25f66741c94d3a8cfae63847c869bc
+#: 429f34c2c7294f468d989350c3b3a3ae
 msgid ":py:obj:`cov_func <pymc_marketing.mmm.hsgp.HSGP.cov_func>`\\"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:74:<autosummary>:1
-#: 99d52c7f6105453caa76615a21fe7b83
+#: db508e95503e4d7fb1d57d2017ea6da6
 msgid ":py:obj:`m <pymc_marketing.mmm.hsgp.HSGP.m>`\\"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:74:<autosummary>:1
-#: 7cbcf13271b24ae88ee689f6c0219c07
+#: 311412306eed4cf9b259f1604cfc3f15
 msgid ":py:obj:`X <pymc_marketing.mmm.hsgp.HSGP.X>`\\"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:74:<autosummary>:1
-#: 2e410057d2544e0f808217e460c5061f
+#: aa623c6e61404b70b2049899573e10f2
 msgid ":py:obj:`X_mid <pymc_marketing.mmm.hsgp.HSGP.X_mid>`\\"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:74:<autosummary>:1
-#: 21dce79641b8474883d9faa5211de846
+#: 13676ee189d34bbc8ca4e406023b092f
 msgid ":py:obj:`dims <pymc_marketing.mmm.hsgp.HSGP.dims>`\\"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:74:<autosummary>:1
-#: 8d6b1733ada347a0978232916f6c7fe9
+#: 0c0f2cd5a87946789b0c87ef12dd79ac
 msgid ":py:obj:`transform <pymc_marketing.mmm.hsgp.HSGP.transform>`\\"
 msgstr ""
 
 #: ../source/api/generated/pymc_marketing.mmm.hsgp.HSGP.rst:74:<autosummary>:1
-#: dd609a7bdcc64d248a1e568554acc4c7
+#: 0a2a90bf74c04ee98479127cf36c948a
 msgid ":py:obj:`demeaned_basis <pymc_marketing.mmm.hsgp.HSGP.demeaned_basis>`\\"
 msgstr ""
+
+#~ msgid ""
+#~ ":py:obj:`HSGP.model_dump_json "
+#~ "<pymc_marketing.mmm.hsgp.HSGP.model_dump_json>`\\ \\(\\*\\[\\,"
+#~ " indent\\, include\\, ...\\]\\)"
+#~ msgstr ""
+
+#~ msgid ""
+#~ ":py:obj:`HSGP.model_validate "
+#~ "<pymc_marketing.mmm.hsgp.HSGP.model_validate>`\\ \\(obj\\, "
+#~ "\\*\\[\\, strict\\, ...\\]\\)"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/api/generated/pymc_marketing.mmm.lift_test.add_cost_per_target_potentials.po
+++ b/locales/es/LC_MESSAGES/api/generated/pymc_marketing.mmm.lift_test.add_cost_per_target_potentials.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -21,16 +21,16 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../source/api/generated/pymc_marketing.mmm.lift_test.add_cost_per_target_potentials.rst:2
-#: 854bb944396e4ad3ad32d01bdc483b93
+#: cc161bbc08174f068acab75ba8c95ee1
 msgid "add\\_cost\\_per\\_target\\_potentials"
 msgstr ""
 
-#: 5c1e32a248e444d1b4b96a9dd2c2c985 of
+#: e683fdd4097943e5bce99bc2286da793 of
 #: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:2
 msgid "Add ``pm.Potential`` penalties to calibrate cost-per-target."
 msgstr ""
 
-#: 7c30271ad2a14002bd5f0d86799c559c of
+#: 54450cc29ab84de7bee707121b17e54f of
 #: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:4
 msgid ""
 "For each row, we compute the mean of ``cpt_variable_name`` across the "
@@ -38,97 +38,136 @@ msgid ""
 "quadratic penalty:"
 msgstr ""
 
-#: f276e7482ed34d93a29c13c10b415fbb of
+#: 53525fda959e4e4692e34b13d5d631f2 of
 #: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:8
 msgid "``penalty = - |cpt_mean - target|^2 / (2 * sigma^2)``."
 msgstr ""
 
-#: 0878128afea141bb8f6e12cfc250a768 of
+#: efa8147164694337b61ef7d767bfcda6 of
 #: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials
 msgid "Parameters"
 msgstr ""
 
-#: d255dcd0b1be4735969017f2e4dcc529 of
+#: f8377e5188b34786b430a41ccaddd2fb of
 #: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:12
 msgid "**calibration_df** : :obj:`pd.DataFrame`"
 msgstr ""
 
-#: 7ee0eb022edf4aa4a0faa49b53d1d12d of
+#: b6bc5f9e7ad34c82ba34206725d303a3 of
 #: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:11
 msgid "pd.DataFrame"
 msgstr ""
 
-#: 2a5c6f310bf44eacbe8c1fd458ff4c5f of
+#: 1caad0146813459ca7be13664d3a5796 of
 #: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:13
 msgid ""
 "Must include columns ``channel``, ``sigma``, and a target column. By "
-"default the target column is assumed to be ``cost_per_target``; if a "
-"column matching ``cpt_variable_name`` is present it will be used instead."
-" The DataFrame must also include one column per model dimension found in "
-"the CPT variable (excluding ``date``)."
+"default the target column is assumed to be ``cost_per_target``. The "
+"DataFrame must also include one column per model dimension found in the "
+"CPT variable (excluding ``date``)."
 msgstr ""
 
-#: 06860942a1634f089cd543ef5a4bf8b6 of
-#: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:19
+#: d7710f5de4c14e42a7c3ec544176b6e6 of
+#: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:18
 msgid "**model** : :obj:`pm.Model`, optional"
 msgstr ""
 
-#: 9455611bb6ae4670822aead56a8a1e82 of
-#: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:18
+#: 0fb4a0a2908c404d9537e0059cd3e172 of
+#: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:17
 msgid "pm.Model, optional"
 msgstr ""
 
-#: a9df3c98aa4e4683a7f9f86e6cb29087 of
-#: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:20
+#: 5673d6eb28a64da1b2e5b9a6b78f2911 of
+#: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:19
 msgid ""
-"Model containing the ``cpt_variable_name`` Deterministic with dims "
-"(\"date\", *dims, \"channel\"). If None, uses the current model context."
+"Model containing the cost-per-target tensor. If None, uses the current "
+"model context."
 msgstr ""
 
-#: 348937b1f4ec43409d63b284b9273772 of
-#: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:23
-msgid "**cpt_variable_name** : :class:`python:str`"
+#: ec6ce354f4d74376b4c0b216293b4ce3 of
+#: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:21
+msgid "**cpt_value** : :class:`~pytensor.tensor.TensorVariable`"
 msgstr ""
 
-#: 51628732927a42e5aab5f6b4a4c38285 7372db5eee184d1ebb08aa9f78ef160d of
+#: 25be161ed61c493cac6a577e7bbe056a of
+#: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:20
+msgid "TensorVariable"
+msgstr ""
+
+#: fdfc715fa848494187cf774e0b58a24e of
 #: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:22
-#: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:25
+msgid "Tensor representing cost-per-target values over the model coordinates."
+msgstr ""
+
+#: cab52c90f00e43b9a851449febba1af4 of
+#: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:24
+msgid "**target_column** : :class:`python:str`"
+msgstr ""
+
+#: 28d1c9e3c1be4db1ae7ae7fc7bf6d113 4149da51d37e43fa9f3c0ae63615fe76 of
+#: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:23
+#: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:26
 msgid "python:str"
 msgstr ""
 
-#: fdcab45ee5c14ea1ac0d73dbede82fc7 of
-#: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:24
-msgid "Name of the cost-per-target Deterministic variable."
+#: f85070a6242f4a248221aac06ee84e68 of
+#: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:25
+msgid "Column in ``calibration_df`` containing the calibration targets."
 msgstr ""
 
-#: 1cf841777b6c456d8fcc25aa93d5910c of
-#: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:26
+#: 829905762032485d8d953557ad1ab9a2 of
+#: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:27
 msgid "**name_prefix** : :class:`python:str`"
 msgstr ""
 
-#: 7bd189476028498f8cc080babf0c06e4 of
-#: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:27
+#: 1f2c721ff9e34b04bffe0dff699e7546 of
+#: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:28
 msgid "Prefix for created potential names."
 msgstr ""
 
-#: 535d710a649a48aa96e05ba0b425a5de of
-#: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:29
+#: 8fd9d3016c734c398c8ee4fb159544b3 of
+#: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:30
 msgid ""
 "**get_indices** : :obj:`Callable`\\[[:obj:`pd.DataFrame`, "
 ":obj:`pm.Model`], :obj:`Indices`]"
 msgstr ""
 
-#: 4f74f876d45c4259bc0c5a7c3ad8cc7e of
-#: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:28
+#: b3abbcde12fe4baea4072c98590bfc53 of
+#: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:29
 msgid "Callable[[pd.DataFrame, pm.Model], Indices]"
 msgstr ""
 
-#: 806df57c27cd425b953b2fceed57fc7e of
-#: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:30
+#: 03a670396c0941b9859c6e585c444166 of
+#: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:31
 msgid "Alignment function mapping rows to model coordinate indices."
 msgstr ""
 
-#: 9016df489f3a42bd8bea0281d59c556d of
-#: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:45
+#: 5c25fd2d6fdc494e93eace8f4e6bdff8 of
+#: pymc_marketing.mmm.lift_test.add_cost_per_target_potentials:46
 msgid "Examples"
 msgstr ""
+
+#~ msgid ""
+#~ "Must include columns ``channel``, ``sigma``,"
+#~ " and a target column. By default "
+#~ "the target column is assumed to be"
+#~ " ``cost_per_target``; if a column matching"
+#~ " ``cpt_variable_name`` is present it will"
+#~ " be used instead. The DataFrame must"
+#~ " also include one column per model"
+#~ " dimension found in the CPT variable"
+#~ " (excluding ``date``)."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Model containing the ``cpt_variable_name`` "
+#~ "Deterministic with dims (\"date\", *dims, "
+#~ "\"channel\"). If None, uses the current"
+#~ " model context."
+#~ msgstr ""
+
+#~ msgid "**cpt_variable_name** : :class:`python:str`"
+#~ msgstr ""
+
+#~ msgid "Name of the cost-per-target Deterministic variable."
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/gallery/gallery.po
+++ b/locales/es/LC_MESSAGES/gallery/gallery.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -20,15 +20,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
-#: ../source/gallery/gallery.md:2 0e5eec1844f448058b7816ec5b5577cb
+#: ../source/gallery/gallery.md:2 7c631ee182334c0c92e176ca44101ae4
 msgid "Example Gallery"
 msgstr ""
 
-#: ../source/gallery/gallery.md:8 81cd63c4f7cb46ee9e4bdf2246ec0747
+#: ../source/gallery/gallery.md:8 962f01064e3d48a981f135bdbaf0a63d
 msgid "Introduction"
 msgstr ""
 
-#: ../source/gallery/gallery.md:10 a15809bb8c0a4792ae1811fb1b620624
+#: ../source/gallery/gallery.md:10 79a20623ec7f4f538376c590b8e675f2
 msgid ""
 "Welcome to the PyMC-Marketing example gallery! This gallery provides "
 "visual navigation to all of our example notebooks to help you quickly "
@@ -36,178 +36,182 @@ msgid ""
 "needs."
 msgstr ""
 
-#: ../source/gallery/gallery.md:12 01d9cb0a7c4449f78f05d1978e4cef34
+#: ../source/gallery/gallery.md:12 21e2a485ff67439ba21667efd6240b70
 msgid "Marketing Mix Models (MMM)"
 msgstr ""
 
-#: ../source/gallery/gallery.md:14 df769305adc3407c87e4922388f5862e
+#: ../source/gallery/gallery.md:14 593509aa87df441a8a11247a6425b531
 msgid "Fundamentals"
 msgstr ""
 
-#: ../source/gallery/gallery.md:19 d3573f89e5e84bca8ad798adf8d498dc
+#: ../source/gallery/gallery.md:19 887ba244be694867ab373283b82bb2ca
 msgid "MMM Quickstart Guide"
 msgstr ""
 
-#: ../source/gallery/gallery.md:24 bd9acbc597ee45b3a483351ab425f9aa
+#: ../source/gallery/gallery.md:24 9f2d716667034e1fb1de4e2809d1f3b3
 msgid "MMM Example: Extensive Introduction Notebook"
 msgstr ""
 
-#: ../source/gallery/gallery.md:29 9ecdd320d90045a5823290b0a3aaa3f3
+#: ../source/gallery/gallery.md:29 108a02743be24b10b158349feed78a24
 msgid "Custom Models with MMM components"
 msgstr ""
 
-#: ../source/gallery/gallery.md:34 2e38f80e6e1a4aa383d441d816dc5a76
+#: ../source/gallery/gallery.md:34 948368d6aab542c1815ce39ad0052b5f
 msgid "MMM Multidimensional Example Notebook (e.g. Geo-MMM)"
 msgstr ""
 
-#: ../source/gallery/gallery.md:39 ee6d57d329314f95ad8f3890a5a9556a
+#: ../source/gallery/gallery.md:39 b623083dc3d94790b70238aa972caa2e
+msgid "Build MMM from YAML Configuration"
+msgstr ""
+
+#: ../source/gallery/gallery.md:44 7ed78c76daa24facb21e0d339afba42e
 msgid "Sensitivity Analysis and Marginal Effects"
 msgstr ""
 
-#: ../source/gallery/gallery.md:45 93f737643fee43618ecc1fd9ba573635
+#: ../source/gallery/gallery.md:50 0e325b4876674d608fdecbb77fac875a
 msgid "Data Connectors"
 msgstr ""
 
-#: ../source/gallery/gallery.md:50 6334eede30464553acb94cd89540624e
+#: ../source/gallery/gallery.md:55 ff16ac1d85b74afba55b2e9627003fb1
 msgid "MMM Fivetran Connectors"
 msgstr ""
 
-#: ../source/gallery/gallery.md:56 beda2eed09b14f86881054a1712dd668
+#: ../source/gallery/gallery.md:61 d8879976061947cabcbabc7dfe69f8ed
 msgid "Budget Allocation"
 msgstr ""
 
-#: ../source/gallery/gallery.md:61 0cf2c9fbe77d429292ddf6191721a453
+#: ../source/gallery/gallery.md:66 0e1a8f3f1b5a4f3087e1b8ee8da11524
 msgid "Budget Allocation Example"
 msgstr ""
 
-#: ../source/gallery/gallery.md:66 206eec7c84754044aa1b397070523e0e
+#: ../source/gallery/gallery.md:71 b41ee72b31744d739da222cb5218e001
 msgid "Budget Allocation and Risk Assessment"
 msgstr ""
 
-#: ../source/gallery/gallery.md:72 0e0cac358c1c4186844dadc4889a241a
+#: ../source/gallery/gallery.md:77 2c5ee96b2d6f48a9945781de4d4e5ebd
 msgid "Lift Test Calibration"
 msgstr ""
 
-#: ../source/gallery/gallery.md:77 791e87e1014f4309a35948792f141281
+#: ../source/gallery/gallery.md:82 3dc7db5124794a17ace8fb2029b2395f
 msgid "Introduction to Lift Test Calibration"
 msgstr ""
 
-#: ../source/gallery/gallery.md:82 569780c3c96845778207ebf6ac845bc9
+#: ../source/gallery/gallery.md:87 8f292d61e1ad4a48bc7b76857f760995
 msgid "Case Study: Unobserved Confounders, ROAS and Lift Tests"
 msgstr ""
 
-#: ../source/gallery/gallery.md:88 8319ce27be4844148c79d552fe85c679
+#: ../source/gallery/gallery.md:93 fbee470b6fb6411dbbcf1589a9bf2a3a
 msgid "Time-Varying Parameters"
 msgstr ""
 
-#: ../source/gallery/gallery.md:93 dea3ae4dd07e444f987d21321e27c24e
+#: ../source/gallery/gallery.md:98 b63e5d3db0eb4e72b2a08f49120b9300
 msgid "MMM with time-varying media baseline"
 msgstr ""
 
-#: ../source/gallery/gallery.md:98 6dc7b8f6687d40d1a61aba41ca712ee2
+#: ../source/gallery/gallery.md:103 5534c7302e124280b9fd8ca3aef56e0e
 msgid "MMM with time-varying parameters"
 msgstr ""
 
-#: ../source/gallery/gallery.md:104 9b80a9c12a614cf9b676c48367450313
+#: ../source/gallery/gallery.md:109 3de958634b714c8ba850af1d44509288
 msgid "Model Evaluation"
 msgstr ""
 
-#: ../source/gallery/gallery.md:109 2f7d9166383b49ed8d7a4f510bc0ee5c
+#: ../source/gallery/gallery.md:114 e5c0b7fe619b44998a8858d996782603
 msgid "Cross-Validation"
 msgstr ""
 
-#: ../source/gallery/gallery.md:114 28d9d779512d4f0db20417251a643e0a
+#: ../source/gallery/gallery.md:119 d39fcb1ae88542a5ad0c8ddd8f10ffd4
 msgid "Metrics and Model Evaluation"
 msgstr ""
 
-#: ../source/gallery/gallery.md:120 6f92b53eab3e4bee96c1bc665d6b8fb2
+#: ../source/gallery/gallery.md:125 f95e1ebafff240ce9643ab5d0c6f2ae5
 msgid "Causal Inference"
 msgstr ""
 
-#: ../source/gallery/gallery.md:126 226ca23b6242442e824c0b01761bab24
+#: ../source/gallery/gallery.md:131 fc22ec2ad28443b5a90c7e5a2123d387
 msgid "Causal Identification"
 msgstr ""
 
-#: ../source/gallery/gallery.md:131 70df6bd2d81d453d8ed20bfff0702251
+#: ../source/gallery/gallery.md:136 d77165fa710c4f42802d37369d56e1e3
 msgid "MMMs and Pearl's ladder of causal inference"
 msgstr ""
 
-#: ../source/gallery/gallery.md:137 ae8bc62a576a43e0948a5d45d16954ad
+#: ../source/gallery/gallery.md:142 fef62973b5eb47f891a1c05de5793477
 msgid "Case Studies"
 msgstr ""
 
-#: ../source/gallery/gallery.md:142 0d0617332fae4bfdbbd025e5c1115a4d
+#: ../source/gallery/gallery.md:147 7c5b73e8ee8340d1b38ebf28399eac6c
 msgid "MMM End-to-End Case Study"
 msgstr ""
 
-#: ../source/gallery/gallery.md:148 dc3afff8cd864a28a87a7335c4386736
+#: ../source/gallery/gallery.md:153 8292077d497b43eba7feafd6cb06c2fb
 msgid "Customer Lifetime Value (CLV) Models"
 msgstr ""
 
-#: ../source/gallery/gallery.md:153 5e4562bb941749f0870ef8bfd7766bfe
+#: ../source/gallery/gallery.md:158 efc8468983734b35bc83435e5b1587d8
 msgid "CLV Quickstart"
 msgstr ""
 
-#: ../source/gallery/gallery.md:158 a39810106408437eabd118cbd0143c68
+#: ../source/gallery/gallery.md:163 b83c0e39c7a54b68a95464453d422e05
 msgid "BG/NBD Model"
 msgstr ""
 
-#: ../source/gallery/gallery.md:163 a831c23b621340fcae61b3224c8f2103
+#: ../source/gallery/gallery.md:168 14d06c8570fb4fe9bbe8b17106a9e269
 msgid "MBG/NBD Model"
 msgstr ""
 
-#: ../source/gallery/gallery.md:168 823a4193582648b6bc79168f7a7a8542
+#: ../source/gallery/gallery.md:173 e531361a86a84a98982cddfdd11f17ce
 msgid "Pareto/NBD Model"
 msgstr ""
 
-#: ../source/gallery/gallery.md:173 9f3e97d26c844010b5678e2a65c7d634
+#: ../source/gallery/gallery.md:178 ac07a5af28c44633b8567cf7989a8769
 msgid "Gamma-Gamma Model"
 msgstr ""
 
-#: ../source/gallery/gallery.md:178 ecc975f8b9a346068a9b0dce035c5166
+#: ../source/gallery/gallery.md:183 ebd1263e214f49829ebee1d9a7d0fb0f
 msgid "sBG Model"
 msgstr ""
 
-#: ../source/gallery/gallery.md:184 11bf50a4c26a4712b3950ff45dcca254
+#: ../source/gallery/gallery.md:189 05897427bba6442aa8df53a415654157
 msgid "Customer Choice Models"
 msgstr ""
 
-#: ../source/gallery/gallery.md:189 bd70f86a33b540be8e63a82b133fdf80
+#: ../source/gallery/gallery.md:194 7482954ec11f40b5a11ad452bd310ae9
 msgid "MV-ITS Saturated"
 msgstr ""
 
-#: ../source/gallery/gallery.md:194 c5f3967f08d14fada8a3639fb12e459f
+#: ../source/gallery/gallery.md:199 5cac2d1b3e7c439ba7cd176fe4bc4f2b
 msgid "MV-ITS Unsaturated"
 msgstr ""
 
-#: ../source/gallery/gallery.md:199 946ae3e97fd843718c536b1ebe25f394
+#: ../source/gallery/gallery.md:204 e6b5177530fa47abb3992b7f73ea2446
 msgid "Multinomial Logit Discrete Choice"
 msgstr ""
 
-#: ../source/gallery/gallery.md:204 a5a702b0de1149c5ba4a7bf1d867e6eb
+#: ../source/gallery/gallery.md:209 24b5c370a236403abb5edef69778444b
 msgid "Nested Logit Discrete Choice"
 msgstr ""
 
-#: ../source/gallery/gallery.md:210 e77f933a3ce04bbcb70a5b530c5b8719
+#: ../source/gallery/gallery.md:215 1283f8d3d4424ebda85fac2d72a224b7
 msgid "Bass Diffusion Model"
 msgstr ""
 
-#: ../source/gallery/gallery.md:215 14a6924c19844111b009aad86d8c1a1d
+#: ../source/gallery/gallery.md:220 e0f41d93b2454531ae4f8384856ba147
 msgid "Bass Diffusion Model Example"
 msgstr ""
 
-#: ../source/gallery/gallery.md:221 935b2c0f7a8c4444946da726120fdd17
+#: ../source/gallery/gallery.md:226 637a6402134e4a2b9c19a07e202f1272
 msgid "General Tutorials"
 msgstr ""
 
-#: ../source/gallery/gallery.md:226 67bbaedf9fc8441c82267b35259fa708
+#: ../source/gallery/gallery.md:231 720002d201ac493490334ea8b2d3fd85
 msgid "Model Configuration"
 msgstr ""
 
-#: ../source/gallery/gallery.md:231 366a4aad3675461395ab89187384cc8c
+#: ../source/gallery/gallery.md:236 e58485e3ef314393a03d1c08793e6073
 msgid "Prior Predictive Checks"
 msgstr ""
 
-#: ../source/gallery/gallery.md:236 aa82ddc3b5f54dd2bc125cfd312db054
+#: ../source/gallery/gallery.md:241 0e544396188b4f1b954aa1bb633a56d6
 msgid "NUTS Samplers"
 msgstr ""

--- a/locales/es/LC_MESSAGES/notebooks/mmm/mmm_build_from_yml_example.po
+++ b/locales/es/LC_MESSAGES/notebooks/mmm/mmm_build_from_yml_example.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pymc-marketing local\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-07 18:10+0300\n"
+"POT-Creation-Date: 2025-10-13 11:28+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -20,116 +20,125 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
-#: ../source/notebooks/mmm/mmm_build_from_yml_example.ipynb:10002
-#: 68c3f6ca0747454d9c79a8981b8c21ac
-msgid "Introduction"
-msgstr ""
-
 #: ../source/notebooks/mmm/mmm_build_from_yml_example.ipynb:10003
-#: 49465ad2f16c46d784660da89509df9a
+#: 360cb647f989438ca083cb676f7a29d5
 msgid "Learning how to create models with yml files"
 msgstr ""
 
-#: ../source/notebooks/mmm/mmm_build_from_yml_example.ipynb:10006
-#: a429cfaa201547c280c7b25a838376a6
+#: ../source/notebooks/mmm/mmm_build_from_yml_example.ipynb:10005
+#: 16a4671fae684d018cdfc3d7e7263397
+msgid ""
+"The following notebook will teach you to create pymc-marketing models "
+"from yml files, allowing you to easily recreate your models in production"
+" environments without several lines of code."
+msgstr ""
+
+#: ../source/notebooks/mmm/mmm_build_from_yml_example.ipynb:10007
+#: 078015c96e9645ecbce766cf8750c5a4
 msgid "Setup"
 msgstr ""
 
 #: ../source/notebooks/mmm/mmm_build_from_yml_example.ipynb:60002
-#: d6954523f86a43029bb2e6a1d3eeb142
+#: f55f94b5f42642cdbf760432369002fa
 msgid "Multidimensional model"
 msgstr ""
 
 #: ../source/notebooks/mmm/mmm_build_from_yml_example.ipynb:120002
-#: 26993d6246924544a49661e98e4b3fea
+#: 5c598d55f69f448081c380a4d044f7ec
 msgid "How the config works?"
 msgstr ""
 
 #: ../source/notebooks/mmm/mmm_build_from_yml_example.ipynb:140002
-#: d781bdabb2d2471481d191c36f1b41c9
+#: a2a23ace111d4b4c84386ee99f166400
 msgid ""
 "The configuration file uses a structured YAML format with several key "
 "sections:"
 msgstr ""
 
 #: ../source/notebooks/mmm/mmm_build_from_yml_example.ipynb:140003
-#: 5fd5a2f2e3734de4b53791aab2c9825f
+#: 7679a602706746fcb21b1f081c1f7e35
 msgid "schema_version: Version identifier for the configuration schema"
 msgstr ""
 
 #: ../source/notebooks/mmm/mmm_build_from_yml_example.ipynb:140004
-#: b5d90296dd8c4cef83b08b97a46ce68a
+#: 6a1e1d2b45664d63925a762b57e7b64e
 msgid "model: The main model configuration"
 msgstr ""
 
 #: ../source/notebooks/mmm/mmm_build_from_yml_example.ipynb:140005
-#: 9e4230f1fdd440f0835476e057b4c12e
+#: 8aeb1fbfd8924dbea9fbcf09a39d8e1f
 msgid "class: The Python class to instantiate (fully qualified name)"
 msgstr ""
 
 #: ../source/notebooks/mmm/mmm_build_from_yml_example.ipynb:140006
-#: b88942432dc7465ea43584a84ace4963
+#: 80251ad3274643d1abac9bac06435704
 msgid "kwargs: Arguments passed to the model constructor"
 msgstr ""
 
 #: ../source/notebooks/mmm/mmm_build_from_yml_example.ipynb:140007
-#: 45b9623f39544a649dde7fde31054a23
+#: cf83817b1714470f8a680920b3f43ad6
 msgid "Including data columns, transformations (adstock, saturation)"
 msgstr ""
 
 #: ../source/notebooks/mmm/mmm_build_from_yml_example.ipynb:140008
-#: e32b47819d4d42aab78b38b6994a55c7
+#: 3a9331d43a634ed4be6dce05fbccfdc4
 msgid "sample_kwargs: Optional parameters for the sampling process"
 msgstr ""
 
 #: ../source/notebooks/mmm/mmm_build_from_yml_example.ipynb:140009
-#: 2b92d759e8724d5e8178055b6b18118f
+#: 9f9ce15a442b4c8090396f3b6d473f6e
 msgid "data: Optional paths to data files"
 msgstr ""
 
 #: ../source/notebooks/mmm/mmm_build_from_yml_example.ipynb:140011
-#: d6ccff4951a64dd7bdc960b37b3525e5
+#: 935c167e47cc4cdbb16f365158d06b83
 msgid "The build_mmm_from_yaml function:"
 msgstr ""
 
 #: ../source/notebooks/mmm/mmm_build_from_yml_example.ipynb:140012
-#: ec548553826540718e4c2f4db2551444
+#: 41b66a2db5a34ee28144a534620af5af
 msgid "Parses this YAML configuration"
 msgstr ""
 
 #: ../source/notebooks/mmm/mmm_build_from_yml_example.ipynb:140013
-#: 0148b983121b401f9a4a322fd515bae2
+#: f62034ff60d045e9836403a466fd0779
 msgid "Uses the 'build' function to instantiate objects recursively"
 msgstr ""
 
 #: ../source/notebooks/mmm/mmm_build_from_yml_example.ipynb:140014
-#: 5efd8345bfe94d3081331fb3abd48ff3
+#: a206702999bd4dbda5d0a16161baa813
 msgid "Handles special cases like priors and distributions"
 msgstr ""
 
 #: ../source/notebooks/mmm/mmm_build_from_yml_example.ipynb:140015
-#: d3360e42aa0442beb3c7945864391887
+#: b88e19278a5f4783ab6ba5c59f1e3e10
 msgid "Returns a fully configured MMM model ready for sampling"
 msgstr ""
 
 #: ../source/notebooks/mmm/mmm_build_from_yml_example.ipynb:140016
-#: ab34fcffa6e44310be4470f70da29a9b
+#: 45c798f7a7634d32b608f90acfa760c0
 msgid ""
 "If idata_path is provided then the idata from a previous class is used in"
 " the model in the idata property."
 msgstr ""
 
 #: ../source/notebooks/mmm/mmm_build_from_yml_example.ipynb:150002
-#: b5dd86107363415898d0fba978cca63b
+#: e9bd3673a887426b8ed4f7b687845891
 msgid "Basic model"
 msgstr ""
 
 #: ../source/notebooks/mmm/mmm_build_from_yml_example.ipynb:190002
-#: 8b38da5854b848fcaaa103bf491a5e01
+#: c16189d6055944cc8c657740329ed338
 msgid "Multidimensional Hierarchical Model"
 msgstr ""
 
 #: ../source/notebooks/mmm/mmm_build_from_yml_example.ipynb:230002
-#: 0ad82653ba92402287b2649cd3bef72e
-msgid "Multidimensional Hierarchical with arbitrary effects"
+#: 01ab48d89c4040adbcf874ced07de638
+msgid "Multidimensional Hierarchical with arbitrary effects and calibration"
 msgstr ""
+
+#~ msgid "Introduction"
+#~ msgstr ""
+
+#~ msgid "Multidimensional Hierarchical with arbitrary effects"
+#~ msgstr ""

--- a/locales/es/LC_MESSAGES/notebooks/mmm/mmm_case_study.po
+++ b/locales/es/LC_MESSAGES/notebooks/mmm/mmm_case_study.po
@@ -23,7 +23,7 @@ msgstr ""
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:10003
 #: 67dad46917554efbae0b28a738d7f28d
 msgid "MMM End-to-End Case Study"
-msgstr ""
+msgstr "Caso de Estudio Completo de MMM"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:10005
 #: 427f8af3682e44d3926c1fac206fc1dd
@@ -33,7 +33,7 @@ msgid ""
 "driving business growth. This notebook demonstrates how to leverage PyMC-"
 "Marketing's Media Mix Modeling (MMM) to gain actionable insights into "
 "marketing effectiveness and optimize budget allocation."
-msgstr ""
+msgstr "En el competitivo entorno empresarial actual, optimizar el gasto de marketing en todos los canales es crucial para maximizar el retorno de inversión y fomentar el crecimiento empresarial. Este cuaderno muestra cómo aprovechar el Modelado de Mezcla de Medios (MMM) de PyMC-Marketing para obtener ideas útiles sobre la efectividad del marketing y optimizar la asignación del presupuesto."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:10007
 #: 424388f255ea4bd2bcb183372a8cf7c0
@@ -43,86 +43,86 @@ msgid ""
 " - Media Mix Modeling:How to Measure the Effectiveness of "
 "Advertising](https://www.youtube.com/watch?v=u4U_PUTasPQ)). Our goal is "
 "to show how MMM can help marketing teams:"
-msgstr ""
+msgstr "Recorreremos un caso de estudio del mundo real utilizando datos de una presentación de [PyData Global 2022](https://pydata.org/global2022/) ([Hajime Takeda - Media Mix Modeling: How to Measure the Effectiveness of Advertising](https://www.youtube.com/watch?v=u4U_PUTasPQ)). Nuestro objetivo es mostrar cómo el MMM puede ayudar a los equipos de marketing:"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:10009
 #: 5dc5da2d73da429ebf32c553c3eb7da9
 msgid "Quantify the impact of different marketing channels on sales"
-msgstr ""
+msgstr "Cuantificar el impacto de diferentes canales de marketing en las ventas"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:10010
 #: 8ed9aa05d6394e6f8d3b11b873cfb789
 msgid "Understand saturation effects and diminishing returns"
-msgstr ""
+msgstr "Entender los efectos de saturación y la ley de los rendimientos decrecientes"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:10011
 #: 77ec3c03e2c846238d56be9cf604de08
 msgid "Identify opportunities to reallocate budget for improved performance"
-msgstr ""
+msgstr "Identificar oportunidades para reubicar el presupuesto y mejorar el rendimiento"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:10012
 #: 55d886d65a144498b8e7724702e80c1b
 msgid "Make data-driven decisions about future marketing investments"
-msgstr ""
+msgstr "Tomar decisiones basadas en datos sobre inversiones futuras en marketing"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:10014
 #: a1ef58fe70174811ac35b92c554951a6
 msgid "**Outline**"
-msgstr ""
+msgstr "**Esquema**"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:10016
 #: a340c0f4c66e415ab06900998049e5d9
 msgid "Data Preparation and Exploratory Analysis"
-msgstr ""
+msgstr "Preparación de Datos y Análisis Exploratorio"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:10017
 #: 76e5ad118e0b4a218dfb4fe1206330bb
 msgid "Model Specification and Fitting"
-msgstr ""
+msgstr "Especificación y Ajuste del Modelo"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:10018
 #: 68cca5e256b3400e92b9a0ab7006d058
 msgid "Model Diagnostics and Validation"
-msgstr ""
+msgstr "Diagnósticos y Validación del Modelo"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:10019
 #: 826335984cec49b6bc5257b4b7e41e2f
 msgid "Marketing Channel Deep Dive"
-msgstr ""
+msgstr "Análisis Detallado de Canales de Marketing"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:10020
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:500006
 #: 5d754109d39c4ab8a6fe24d70a492741 db3b9fd766f3417884c60189c89d5d5b
 msgid "Channel Contributions"
-msgstr ""
+msgstr "Contribuciones del Canal"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:10021
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:550002
 #: 4f4f331696dd4d96a4da375ea04194d2 5c83ae636dd14e1484606e3bd7afb0e8
 msgid "Saturation Curves"
-msgstr ""
+msgstr "Curvas de Saturación"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:10022
 #: 543c79dee6654937a65af87a7530ddc8
 msgid "Return on Ad Spend (ROAS)"
-msgstr ""
+msgstr "Retorno sobre Gasto Publicitario (ROAS)"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:10023
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:690002
 #: 108112c5a1374d03be47614fafd861ab c633690154ba456eaf88cf41dd81cca4
 msgid "Out-of-Sample Predictions"
-msgstr ""
+msgstr "Predicciones Fuera de Muestra"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:10024
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:820002
 #: 0fb231c3b9a64f1fa0a94ee65dc6d884 f29ccb905995481b92fee20a1588cc63
 msgid "Budget Optimization"
-msgstr ""
+msgstr "Optimización del Presupuesto"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:10025
 #: 6c0a94118f4d4e198a3dfff341efc69b
 msgid "Key Takeaways and Next Steps"
-msgstr ""
+msgstr "Conclusiones Clave y Próximos Pasos"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:10028
 #: 9d1a5e8937b74bb1a2a77ca4294a5369
@@ -133,22 +133,22 @@ msgid ""
 "business context). We focus on the application of the model for a "
 "concrete business case. If you want to know more about the model "
 "specification please refer to the {ref}`mmm_example` notebook."
-msgstr ""
+msgstr "En este cuaderno te guiamos a través de cómo se ve una primera iteración típica de MMM (ten en cuenta que lo que significa una primera iteración depende del contexto empresarial). Nos centramos en la aplicación del modelo para un caso de negocio concreto. Si deseas saber más sobre la especificación del modelo, por favor consulta el cuaderno {ref}`mmm_example`."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:20002
 #: 104b3568ae2648ba96d90219588ec0a5
 msgid "Prepare Notebook"
-msgstr ""
+msgstr "Preparar Cuaderno"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:20004
 #: abe9d9402542445f8eeed4ed3be3861e
 msgid "We load the necessary libraries and set the notebook's configuration."
-msgstr ""
+msgstr "Cargamos las bibliotecas necesarias y configuramos el cuaderno."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:50002
 #: 4059fcad98dc481ca438c1ac0574ded0
 msgid "Load Data"
-msgstr ""
+msgstr "Cargar Datos"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:50004
 #: 152eadddf2a940e2bd1d5bcdfbd9ee0d
@@ -156,59 +156,59 @@ msgid ""
 "We load the data from a CSV file as a pandas DataFrame. We also do some "
 "light data cleaning following the filtering of the original case study. "
 "In essence, we are filtering and renaming certain marketing channels."
-msgstr ""
+msgstr "Cargamos los datos de un archivo CSV como un DataFrame de pandas. También realizamos una limpieza ligera de datos siguiendo el filtrado del caso de estudio original. En esencia, estamos filtrando y renombrando ciertos canales de marketing."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:70002
 #: a077a6058d7b49ffab34e59ec1ca9141
 msgid "Exploratory Data Analysis"
-msgstr ""
+msgstr "Análisis Exploratorio de Datos"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:70004
 #: 299309e1b93241bfb3a59900256fc870
 msgid ""
 "We should always start looking at the data! We can start by plotting the "
 "target variable, i.e. the sales."
-msgstr ""
+msgstr "¡Siempre deberíamos comenzar observando los datos! Podemos comenzar graficando la variable objetivo, es decir, las ventas."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:90002
 #: 04974886ab614bc8a5d984a3af64465f
 msgid ""
 "This time series, which comes in weekly granularity, has a clear yearly "
 "seasonality pattern and apparently a mild downward trend."
-msgstr ""
+msgstr "Esta serie temporal, que viene en granularidad semanal, tiene un claro patrón de estacionalidad anual y aparentemente una ligera tendencia descendente."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:100002
 #: 88f0e177c13e4ce4b83811a57f826ce0
 msgid ""
 "Next, let's look into the marketing channels spend data. We first look "
 "into the share to get a feeling on the relative spend across channels."
-msgstr ""
+msgstr "A continuación, analicemos los datos de gasto de los canales de marketing. Primero miramos la participación para tener una idea del gasto relativo entre canales."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:120002
 #: 55e815385e7f45479d156af738f82f6b
 msgid ""
 "In this specific example we see that `Direct Mail` is the channel with "
 "the highest spend, followed by `Newspaper` and `Online Display`."
-msgstr ""
+msgstr "En este ejemplo específico vemos que `Direct Mail` es el canal con el gasto más alto, seguido de `Newspaper` y `Online Display`."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:130002
 #: b933ef3120dc415fb8a952e418d7b2ee
 msgid "Next, we look into the time series of each of the marketing channels."
-msgstr ""
+msgstr "A continuación, examinamos las series temporales de cada uno de los canales de marketing."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:150002
 #: 982fd80df08e4ada82b3e0d198f86409
 msgid ""
 "We see an overall decerease spend over time. This might explain the "
 "downward trend in the sales time series."
-msgstr ""
+msgstr "Observamos una disminución general del gasto a lo largo del tiempo. Esto podría explicar la tendencia descendente en la serie temporal de ventas."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:160002
 #: 25bf690dbb4d4f589a26d20930a4304d
 msgid ""
 "Next, we can compute the correlation between the marketing channels and "
 "the sales."
-msgstr ""
+msgstr "Luego, podemos calcular la correlación entre los canales de marketing y las ventas."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:160005
 #: 79055b0a16e543bc99531e4644e40454
@@ -217,7 +217,7 @@ msgid ""
 "good idea to look into the correlation between the marketing channels and"
 " the target variable. This can hel us spot issues in the data (very "
 "commom in real cases) and inspire some feature engineering."
-msgstr ""
+msgstr "Todos sabemos que la correlación no implica causalidad. Sin embargo, es una buena idea observar la correlación entre los canales de marketing y la variable objetivo. Esto puede ayudarnos a detectar problemas en los datos (muy comunes en casos reales) e inspirar algo de ingeniería de características."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:180002
 #: 123994fff87b474b8ab3a6eccab38ba5
@@ -225,19 +225,19 @@ msgid ""
 "The channels with the highest correlation with the sales are `TV`, "
 "`Insert`, and `Online Display`. Observe that the biggest channel in "
 "spend, `Direct Mail`, has the lowest correlation."
-msgstr ""
+msgstr "Los canales con la correlación más alta con las ventas son `TV`, `Insert`, y `Online Display`. Observa que el canal más grande en gasto, `Direct Mail`, tiene la correlación más baja."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:190002
 #: 78db19e0d23c4ca4b38699240b9711d1
 msgid "Train Test Split"
-msgstr ""
+msgstr "División Entrenamiento-Prueba"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:190004
 #: 76a3e41043744dd4bbd673cbac755884
 msgid ""
 "We are now ready to fit the model. We start by splitting the data into "
 "training and testing."
-msgstr ""
+msgstr "Ahora estamos listos para ajustar el modelo. Comenzamos dividiendo los datos en entrenamiento y prueba."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:190007
 #: d07cac76627c489c9350d69fe551ece7
@@ -246,12 +246,12 @@ msgid ""
 "In a real case scenario you should use more data for training than for "
 "testing (see {ref}`mmm_time_slice_cross_validation`). In this case we are"
 " using a small dataset for demonstrative purposes."
-msgstr ""
+msgstr "En un escenario de caso real, deberías usar más datos para entrenamiento que para prueba (vea {ref}`mmm_time_slice_cross_validation`). En este caso estamos usando un conjunto de datos pequeño para fines demostrativos."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:220002
 #: 45c6bd03bf8848ba8819c01caf58c45d
 msgid "Model Specification"
-msgstr ""
+msgstr "Especificación del Modelo"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:220004
 #: 0519a403875b46689ddf328665a53c98
@@ -259,7 +259,7 @@ msgid ""
 "Assuming we are working on the first iteration, we typically would not "
 "have lift tests data to calibrate the model. This is fine, we can start "
 "with a spends priors to get started."
-msgstr ""
+msgstr "Suponiendo que estamos trabajando en la primera iteración, generalmente no tendríamos datos de pruebas de elevación para calibrar el modelo. Esto está bien, podemos comenzar con prior de gastos para empezar."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:220008
 #: a471a4c2e7f147cd84ab1ce177dbd31e
@@ -268,7 +268,7 @@ msgid ""
 "Ideally, in the next iteration we should have some of these lift tests to"
 " calibrate the model. For more details see {ref}`mmm_lift_test` and the "
 "{ref}`mmm_roas` case study notebook."
-msgstr ""
+msgstr "Idealmente, en la próxima iteración deberíamos tener algunas de estas pruebas de elevación para calibrar el modelo. Para más detalles, consulte el cuaderno de caso de estudio {ref}`mmm_lift_test` y {ref}`mmm_roas`."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:220011
 #: 8f34190b0fa14316aa483b602bdd2a3a
@@ -279,14 +279,14 @@ msgid ""
 "higher spend channels more flexibility to fit the data with a wider "
 "prior. Let's see how this looks like. First, we compute the spend shares "
 "(on the training data!)."
-msgstr ""
+msgstr "La idea detrás de los priors de gasto es que usamos las proporciones de gasto como un proxy para el efecto de los canales de medios en las ventas. Esto no es perfecto, pero puede ser un buen punto de partida. En esencia, estamos dando a los canales de mayor gasto más flexibilidad para ajustar los datos con un prior más amplio. Veamos cómo se ve esto. Primero, calculamos las proporciones de gasto (¡en los datos de entrenamiento!)."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:240002
 #: 0f96de7a84944cb1b4de90306a5ac031
 msgid ""
 "Next, we use these spend shares to set the prior of the model using the "
 "model configuration."
-msgstr ""
+msgstr "A continuación, utilizamos estas proporciones de gasto para establecer el prior del modelo utilizando la configuración del modelo."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:260002
 #: 72037c76304149a5b8e704b807d51c67
@@ -295,19 +295,19 @@ msgid ""
 "We are now ready to specify the model (see {ref}`mmm_example` for more "
 "details). As the yearly seasonal component is not that strong, we use few"
 " Fourier terms."
-msgstr ""
+msgstr "Ahora estamos listos para especificar el modelo (consulte {ref}`mmm_example` para obtener más detalles). Dado que el componente estacional anual no es tan fuerte, usamos pocos términos de Fourier."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:280002
 #: acff33a2168044e2ad829172d46bceb0
 msgid "Prior Predictive Checks"
-msgstr ""
+msgstr "Verificaciones Predictivas Previas"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:280004
 #: 08337874e6cc49eda377a5c7b8ec6588
 msgid ""
 "We can now generate prior predictive samples to see how the model behaves"
 " under the prior specification."
-msgstr ""
+msgstr "Ahora podemos generar muestras predictivas previas para ver cómo se comporta el modelo bajo la especificación previa."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:300002
 #: 0b6d3bb1be434d26a81443a0230bccc2
@@ -316,41 +316,41 @@ msgid ""
 "approximately one order of magnitude of the observed data. Note that the "
 "choice of likelihood as a truncated normal is to avoid negative values "
 "for the target variable."
-msgstr ""
+msgstr "En general, los priors no son muy informativos y los rangos están aproximadamente a un orden de magnitud de los datos observados. Tenga en cuenta que la elección de la verosimilitud como una normal truncada es para evitar valores negativos para la variable objetivo."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:310002
 #: 943a0a9439d643a1b38d058bb68d4c6e
 msgid ""
 "Let's look into the channel contribution share **before** fitting the "
 "model."
-msgstr ""
+msgstr "Veamos la proporción de contribución del canal **antes** de ajustar el modelo."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:330002
 #: a8cab6c726604a508afb9f6f4693e0d7
 msgid ""
 "We confirm these represent the spend shares as expected from the prior "
 "specification."
-msgstr ""
+msgstr "Confirmamos que estos representan las proporciones de gasto como se esperaba de la especificación previa."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:340002
 #: b0b3ce017c334e448f9ed321c061a773
 msgid "Model Fitting"
-msgstr ""
+msgstr "Ajuste del Modelo"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:340004
 #: 009a20a1963646b5ab285b1fd2e2b1bf
 msgid "We now fit the model to the training data."
-msgstr ""
+msgstr "Ahora ajustamos el modelo a los datos de entrenamiento."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:360002
 #: 01a87faafa80452bb2f0deeb01da6cbc
 msgid "Model Diagnostics"
-msgstr ""
+msgstr "Diagnósticos del Modelo"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:360004
 #: dcf224cb384c4a2a9cc9303d76a4048d
 msgid "Before looking into the results let's check some diagnostics."
-msgstr ""
+msgstr "Antes de examinar los resultados, vamos a verificar algunos diagnósticos."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:370002
 #: 8a69cc92bcda4495bae3b67461055054
@@ -360,38 +360,38 @@ msgstr ""
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:380002
 #: 6a66c51b1f78460e805cf4df1b480746
 msgid "We do not have divergent transitions, which is good!"
-msgstr ""
+msgstr "No tenemos transiciones divergentes, lo cual es bueno!"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:400002
 #: 352dc8db2e724dc88457cdd401c50d83
 msgid ""
 "On the other hand, the R-hat statistics are all close to 1, which is also"
 " good!"
-msgstr ""
+msgstr "Por otro lado, todas las estadísticas R-hat están cerca de 1, ¡lo cual también es bueno!"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:410002
 #: 234160dbb856456fbac87f434200a2ce
 msgid "Next let's look into the model trace."
-msgstr ""
+msgstr "Ahora vamos a examinar el rastro del modelo."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:430002
 #: a2fc7aac33cc444fbfd34a570cc1fdac
 msgid ""
 "We see a good mixing in the trace, which is consistent with the good "
 "R-hat statistics."
-msgstr ""
+msgstr "Observamos una buena mezcla en el rastro, lo cual es consistente con los buenos estadísticos R-hat."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:440002
 #: 2b5e9df4e09546f0a69aa9031f4df6d6
 msgid "Posterior Predictive Checks"
-msgstr ""
+msgstr "Verificaciones Predictivas Posteriores"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:440004
 #: 263ccb11e231475ea55b31cb4bf2cb8f
 msgid ""
 "As our model and posterior samples are looking good, we can now look into"
 " the posterior predictive checks."
-msgstr ""
+msgstr "Como nuestro modelo y muestras posteriores parecen buenas, ahora podemos examinar las verificaciones predictivas posteriores."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:460002
 #: 06023218b0284a17be0cfcb19924d8b9
@@ -399,56 +399,56 @@ msgid ""
 "The posterior predictive sales look quite reasonable. We are explaining a"
 " good amount of the variance in the data and the trends are well "
 "captured."
-msgstr ""
+msgstr "Las ventas predictivas posteriores parecen bastante razonables. Estamos explicando una buena cantidad de la varianza en los datos y las tendencias están bien capturadas."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:470002
 #: 86b67520262c479bb3697468bedf7b14
 msgid "We can look into the errors of the model:"
-msgstr ""
+msgstr "Podemos examinar los errores del modelo:"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:490002
 #: 1e5fd9b06e394052a04fd723df1d4524
 msgid "We do not detect any obvious patterns in the errors."
-msgstr ""
+msgstr "No detectamos patrones obvios en los errores."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:500002
 #: 7a6c5e120cbd4aa0bc87c00d44758341
 msgid "Media Deep Dive"
-msgstr ""
+msgstr "Análisis a Fondo de Medios"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:500004
 #: 99be27be8c654298b6b34556780804a4
 msgid "In this section we perform a deep dive into the media channels insights."
-msgstr ""
+msgstr "En esta sección realizamos un análisis a fondo de las ideas sobre los canales de medios."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:500009
 #: cf9290d531bd44bea001b0e5cc3f7c01
 msgid ""
 "Now that we are happy with the global model fit, we can look into the "
 "media and individual channels contributions."
-msgstr ""
+msgstr "Ahora que estamos satisfechos con el ajuste global del modelo, podemos examinar las contribuciones de los medios y de los canales individuales."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:500011
 #: cc838c95db524563834eee7c92f5aa8f
 msgid "We start by looking into the aggregated contributions."
-msgstr ""
+msgstr "Empezamos examinando las contribuciones agregadas."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:520002
 #: 1518544323c04343a132bc302cf9914c
 msgid "Next, we look into deeper into the components:"
-msgstr ""
+msgstr "A continuación, analizamos más a fondo los componentes:"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:540002
 #: b391a993de5f4111a65c5481d7047c4e
 msgid "Here are some interesting observations about the model:"
-msgstr ""
+msgstr "Aquí hay algunas observaciones interesantes sobre el modelo:"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:540004
 #: f83170164a844057b4623c002fb442de
 msgid ""
 "The `intercept` accounts for approximately $60\\%$ of the contribution. "
 "This is what people usually call the \"baseline\"."
-msgstr ""
+msgstr "El `intercepto` representa aproximadamente el $60\%$ de la contribución. Esto es lo que la gente suele llamar \"línea base\"."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:540005
 #: c3efbfd84cb54ed3ad86c5a44f31f7e5
@@ -456,14 +456,14 @@ msgid ""
 "The top media contribution channels are `Online Display`, `Direct Mail` "
 "and `TV`. In some sense we see how the model is averaging the spend share"
 " (prior) and the predictive power of the media channels (posterior) ."
-msgstr ""
+msgstr "Los principales canales de contribución de medios son `Online Display`, `Direct Mail` y `TV`. En cierto sentido, vemos cómo el modelo está promediando la proporción de gasto (prior) y el poder predictivo de los canales de medios (posterior)."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:550004
 #: 27159bb87d97409382ea0617ff3c67ec
 msgid ""
 "We continue our analysis by looking into the direct response curves. "
 "These will be the main input for the budget optimization step below."
-msgstr ""
+msgstr "Continuamos nuestro análisis examinando las curvas de respuesta directa. Estas serán la entrada principal para la optimización del presupuesto a continuación."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:570003
 #: c24b9fb0cb124c5da17491a49a86cbe7
@@ -474,7 +474,7 @@ msgid ""
 " This process can be a good starting point with engage with the team. "
 "That being said, we can do better with custom optimization rutines as "
 "described in the following sections."
-msgstr ""
+msgstr "Estas curvas por sí solas pueden ser una excelente entrada para la planificación de marketing. Uno podría usarlas para establecer el presupuesto para los próximos períodos y optimizar manualmente el gasto para estos canales en función de los puntos de saturación. Este proceso puede ser un buen punto de partida para involucrar al equipo. Sin embargo, podemos hacerlo mejor con rutinas de optimización personalizadas descritas en las siguientes secciones."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:570006
 #: 095d476f55dc470b8e7448f5076283d7
@@ -484,19 +484,19 @@ msgid ""
 "the time series spend by a value $\\delta > 0$ and seeing the expected "
 "contribution. PyMC-Marketing also shows the $94\\%$ Highest Density "
 "Interval (HDI) of the simulations results."
-msgstr ""
+msgstr "Además de las curvas de respuesta directa, podemos examinar gráficos de simulaciones de contribuciones agregadas. La idea es variar el gasto multiplicando globalmente la serie temporal de gasto por un valor $\\delta > 0$ y viendo la contribución esperada. PyMC-Marketing también muestra el $94\\%$ Intervalo de Densidad de Probabilidad Más Alto (HDI) de los resultados de las simulaciones."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:590002
 #: 5f4d7bb04187414dbdfefef18f2dcffb
 msgid "We can clearly see the saturation effects for the different channels."
-msgstr ""
+msgstr "Podemos ver claramente los efectos de saturación para los diferentes canales."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:590004
 #: e0f29418d5114363bf0229f9835ded9a
 msgid ""
 "A complementary plot is to plot these same simulations against the actual"
 " spend:"
-msgstr ""
+msgstr "Un gráfico complementario es graficar estas mismas simulaciones contra el gasto real:"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:610002
 #: c18fbca9c95c433ea3c9b670b1fd1840
@@ -508,24 +508,24 @@ msgid ""
 "be good candidates to increase the spend. These are the concrete "
 "actionable insights you can extract from these typo of models to optimize"
 " your media spend mix 🚀!"
-msgstr ""
+msgstr "Las líneas verticales muestran el gasto de los datos observados (es decir, = 1 arriba). Este gráfico muestra claramente que, por ejemplo, `Direct Mail` no tendrá mucha contribución incremental si seguimos aumentando el gasto. Por otro lado, canales como `Online Display` e `Insert` parecen ser buenos candidatos para incrementar el gasto. Estas son las ideas accionables concretas que puedes extraer de este tipo de modelos para optimizar tu mezcla de gasto en medios 🚀!"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:620002
 #: 2aaede3a031f418a957a6c8cd4e9051e
 msgid "Return on Ads Spend (ROAS)"
-msgstr ""
+msgstr "Retorno sobre Gasto Publicitario (ROAS)"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:620004
 #: a1b659e7c31341adb1e172e7215292b7
 msgid ""
 "To have a more quantitative metric of efficiency we compute the Return on"
 " Ads Spend (ROAS) over the whole training period."
-msgstr ""
+msgstr "Para tener una métrica más cuantitativa de eficiencia, calculamos el Retorno sobre Gasto de Anuncios (ROAS) durante todo el período de entrenamiento."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:620006
 #: afe5c3927a0240dd9006dbc8e588a9ed
 msgid "To begin lets plot the contribution share for each channel."
-msgstr ""
+msgstr "Para comenzar, vamos a graficar la contribución por canal."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:640002
 #: 1ee1565ab96c4c02ab5cbc3ff9f663e5
@@ -534,7 +534,7 @@ msgid ""
 "want to get a better picture of the efficiency of each channel we need to"
 " look into the Return on Ads Spend (ROAS). This is done by computing the "
 "ratio of the mean contribution and the spend for each channel."
-msgstr ""
+msgstr "Estas contribuciones están, por supuesto, influidas por los niveles de gasto. Si queremos obtener una mejor imagen de la eficiencia de cada canal, debemos observar el Retorno sobre Gasto de Anuncios (ROAS). Esto se hace calculando la proporción de la contribución media y el gasto para cada canal."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:660002
 #: 2b0b9909f4b14ed88928006c7ed91f28
@@ -543,7 +543,7 @@ msgid ""
 "`Online Display` and `Insert` whereas `Direct Mail` has the lowest ROAS. "
 "This is consistent with the previous findings analyzing the direct and "
 "global response curves."
-msgstr ""
+msgstr "Aquí vemos que los canales con el ROAS más alto **en promedio** son `Online Display` e `Insert`, mientras que `Direct Mail` tiene el ROAS más bajo. Esto es consistente con los hallazgos previos al analizar las curvas de respuesta directa y global."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:660005
 #: 5de3bb2bce434c71b1626f1cd36c46f3
@@ -553,7 +553,7 @@ msgid ""
 "relatively small. Event though we use the spend share as priors, the "
 "overall spend levels are also reflected in the estimate (see for example "
 "how small the HDI is for `Direct Mail`)."
-msgstr ""
+msgstr "Los amplios intervalos del HDI para el ROAS de los canales principales provienen del hecho de que la proporción de gasto de ellos durante el período de entrenamiento es relativamente pequeña. Aunque usamos las proporciones de gasto como priors, los niveles generales de gasto también se reflejan en la estimación (ver, por ejemplo, cuán pequeño es el HDI para `Direct Mail`)."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:660007
 #: 116ab32e410c45b193b1fe37bb2a7a78
@@ -564,12 +564,12 @@ msgid ""
 "below) we can improve our marketing mix and at the same time create more "
 "variance in the training data so that we get refined ROAS estimates for "
 "future iterations 😎."
-msgstr ""
+msgstr "¡Podemos ver esto como una oportunidad! Basándonos en este análisis, vemos que `Online Display` e `Insert` son los mejores canales en los que invertir. Por lo tanto, si optimizamos nuestro presupuesto en consecuencia (más sobre la optimización del presupuesto a continuación), podemos mejorar nuestra mezcla de marketing y al mismo tiempo crear más variación en los datos de entrenamiento para obtener estimaciones de ROAS más refinadas para futuras iteraciones 😎."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:670002
 #: 14b459e7ea5c45b89bbb560c7845da3f
 msgid "It is also useful to compare the ROAS and the contribution share."
-msgstr ""
+msgstr "También es útil comparar el ROAS y la contribución por canal."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:690004
 #: c2e29710e8254ed586ca4bb21935236d
@@ -579,36 +579,36 @@ msgid ""
 "that the model is not only good in explaining the past but also good at "
 "making predictions. This is a key component to getting the buy in from "
 "the business stakeholders."
-msgstr ""
+msgstr "Hasta ahora hemos analizado el ajuste del modelo desde la perspectiva dentro de la muestra. Si queremos seguir las recomendaciones del modelo, necesitamos tener evidencia de que el modelo no solo es bueno explicando el pasado, sino también en hacer predicciones. Este es un componente clave para obtener el apoyo de los interesados comerciales."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:690006
 #: e53a177896854f7b9d9521a3cc2d252a
 msgid ""
 "The PyMC-Marketing MMM API allows to easily generate out-of-sample "
 "predictions from a fitted model as follows:"
-msgstr ""
+msgstr "La API de PyMC-Marketing MMM permite generar fácilmente predicciones fuera de muestra a partir de un modelo ajustado de la siguiente manera:"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:710002
 #: 36fd293432694b349c7b3165c268065b
 msgid "We can visualize and compare the in sample and out of sample predictions."
-msgstr ""
+msgstr "Podemos visualizar y comparar las predicciones de muestra y fuera de muestra."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:730002
 #: fec00a81c1124a12a1adf05aaec9d468
 msgid ""
 "Overall, both the in-sample and out-of-sample predictions look very "
 "reasonable."
-msgstr ""
+msgstr "En general, tanto las predicciones de muestra como las predicciones fuera de muestra parecen bastante razonables."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:730004
 #: f6faf4beeba14d50b5ae0f5657a5be2d
 msgid "Let's zoom in the out-of-sample predictions:"
-msgstr ""
+msgstr "Vamos a acercarnos a las predicciones fuera de muestra:"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:750002
 #: a61eb9f928f547a5aa2a17623e0f2c33
 msgid "These look actually very good!"
-msgstr ""
+msgstr "Estas predicciones parecen realmente muy buenas!"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:760004
 #: f428828e995b4e5ab9a1f88dd2c11341
@@ -620,33 +620,33 @@ msgid ""
 "generalization of the mean absolute error to the case of probabilistic "
 "predictions. For more detail see the "
 "{ref}`mmm_time_slice_cross_validation` notebook."
-msgstr ""
+msgstr "Para tener una métrica de puntuación concreta, podemos usar el Puntaje de Probabilidad Clasificada Continua ([CRPS](https://towardsdatascience.com/crps-a-scoring-function-for-bayesian-machine-learning-models-dd55a7a337a8)). Esta es una generalización del error absoluto medio al caso de predicciones probabilísticas. Para más detalles, consulte el cuaderno {ref}`mmm_time_slice_cross_validation`."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:780002
 #: 932f724d5eb14aba97ef5934c8360560
 msgid ""
 "Interestingly enough, the model performance is better in the test set. "
 "There could me many reasons for it:"
-msgstr ""
+msgstr "Curiosamente, el rendimiento del modelo es mejor en el conjunto de prueba. Podría haber muchas razones para ello:"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:780004
 #: d919d3924b9443868c89ca782aa5b7d7
 msgid ""
 "The model is not capturing the end of the seasonality very well in the "
 "training set."
-msgstr ""
+msgstr "El modelo no está capturando bien el final de la estacionalidad en el conjunto de entrenamiento."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:780005
 #: 654bb37646cf470f9a7685c3ff1c4561
 msgid "There is less variability or complexity in the test set data."
-msgstr ""
+msgstr "Hay menos variabilidad o complejidad en los datos del conjunto de prueba."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:780006
 #: 01c8ebfc6913423a91e98ef75411da54
 msgid ""
 "The test set has fewer points, which could affect the CRPS calculation "
 "comparison."
-msgstr ""
+msgstr "El conjunto de prueba tiene menos puntos, lo que podría afectar la comparación del cálculo de CRPS."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:780008
 #: f0726924f2d0465d8e8130fef847034c
@@ -655,12 +655,12 @@ msgid ""
 "In order to have a better comparison we should look into the time slice "
 "cross validation results as in the {ref}`mmm_time_slice_cross_validation`"
 " notebook."
-msgstr ""
+msgstr "Para tener una mejor comparación, deberíamos consultar los resultados de validación cruzada por intervalo de tiempo como en el cuaderno {ref}`mmm_time_slice_cross_validation`."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:790002
 #: bebdadb5f27349db93f9e84800a75b0f
 msgid "Next, we look into the out-of-sample channel contributions."
-msgstr ""
+msgstr "A continuación, examinamos las contribuciones de canales fuera de muestra."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:810002
 #: 2d9ed96f2d1c49d29c7518357df6bbf6
@@ -670,7 +670,7 @@ msgid ""
 " we can still do the time slice cross validation at the channel level to "
 "analyze the stability of the out-of-sample predictions and media "
 "parameters (adstock and saturation)."
-msgstr ""
+msgstr "No tenemos para comparar las contribuciones de los valores *verdaderos* porque esto es lo que estamos tratando de estimar en primer lugar. Sin embargo, todavía podemos hacer la validación cruzada por intervalo de tiempo a nivel de canal para analizar la estabilidad de las predicciones fuera de muestra y los parámetros de medios (adstock y saturación)."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:820004
 #: 621213d9f2c947fbb7410893be0d979d
@@ -680,7 +680,7 @@ msgid ""
 "optimization of the media budget allocation. The main idea is to use the "
 "response curves to optimize the spend. For more details see "
 "{ref}`mmm_budget_allocation_example` notebook."
-msgstr ""
+msgstr "En esta última sección explicamos cómo usar PyMC-Marketing para realizar la optimización de la asignación del presupuesto de medios. La idea principal es usar las curvas de respuesta para optimizar el gasto. Para más detalles, consulte el cuaderno {ref}`mmm_budget_allocation_example`."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:830002
 #: defb26e4852c4344935bf60537929425
@@ -691,12 +691,12 @@ msgid ""
 "Hence, when we specify the `budget` variable we are actually specifying "
 "the weekly budget (in this case). Therefore, it is important to "
 "understand the past average weekly spend per channel:"
-msgstr ""
+msgstr "Para este ejemplo, supongamos que queremos reasignar el presupuesto del conjunto de pruebas. El optimizador MMM de PyMC-Marketing asumiría que asignaremos equitativamente el presupuesto a todos los canales durante los próximos `num_periods` períodos. Por lo tanto, cuando especificamos la variable `budget`, en realidad estamos especificando el presupuesto semanal (en este caso). Por lo tanto, es importante entender el gasto semanal promedio pasado por canal:"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:860002
 #: f713ca39e76e493c91b211aa47206f14
 msgid "Let's plot the average weekly spend per channel for the *actual* test set."
-msgstr ""
+msgstr "Vamos a graficar el gasto promedio semanal por canal para el conjunto de prueba *real*."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:880002
 #: 305d954475904bbba2b93f41376c111b
@@ -707,7 +707,7 @@ msgid ""
 "opportunities. For example that in the test set we have on average more "
 "spend on `Online Display` while less spend on `Insert`, both with high "
 "ROAS from the training data."
-msgstr ""
+msgstr "Observe que la distribución del gasto en el conjunto de prueba es considerablemente diferente del conjunto de entrenamiento. Al planificar gastos futuros, este suele ser el caso, ya que el equipo podría estar explorando nuevas oportunidades de inversión. Por ejemplo, en el conjunto de prueba tenemos en promedio más gasto en `Online Display` y menos gasto en `Insert`, ambos con alto ROAS de los datos de entrenamiento."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:900002
 #: ba01659a04f141c6bc63a58d340dea8f
@@ -718,31 +718,31 @@ msgid ""
 "strategy, which generally plays well with the stakeholders, is to allow a"
 " custom degree of flexibility and some upper and lower bounds for each "
 "channel budget."
-msgstr ""
+msgstr "A continuación, hablemos sobre la variabilidad de la asignación. Incluso si el modelo encuentra que `Insert` es el canal más eficiente, estratégicamente es muy difícil simplemente poner $100\%$ del presupuesto en este canal. Una mejor estrategia, que generalmente juega bien con las partes interesadas, es permitir un grado de flexibilidad personalizado y algunos límites superiores e inferiores para cada presupuesto de canal."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:900004
 #: 9de2bffe2f184065bc59a9ce65fe19a1
 msgid ""
 "For example, we will allow a $50\\%$ difference on the past average "
 "weekly spend for each channel."
-msgstr ""
+msgstr "Por ejemplo, permitiremos una diferencia del $50\%$ sobre el gasto semanal promedio pasado para cada canal."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:920002
 #: 34ece1e7c5ba45219796e64edc92521d
 msgid "Now we are ready to pass all this business requirements to the optimizer."
-msgstr ""
+msgstr "Ahora estamos listos para pasar todos estos requisitos de negocio al optimizador."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:940002
 #: 78b90992bfcd484eab9c2d94f507b9c4
 msgid "Let's visualize the results."
-msgstr ""
+msgstr "Vamos a visualizar los resultados."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:960002
 #: 237338120e5244b58e548c60ceef0869
 msgid ""
 "We verify that the sum of the budget allocation is the same as the "
 "initial budget."
-msgstr ""
+msgstr "Verificamos que la suma de la asignación del presupuesto sea la misma que el presupuesto inicial."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:980002
 #: ee316b9256044f6a94af83f05592d3e5
@@ -754,14 +754,14 @@ msgid ""
 "Display` is slightly reduced. This might be explained by the fact that "
 "this channel already had an average spend increase from the training to "
 "the test set."
-msgstr ""
+msgstr "Lo primero que notamos es cómo se ha reducido el gasto en `Direct Mail`. Esto es consistente con los hallazgos previos de que este canal no es muy eficiente. El gasto se ha distribuido más uniformemente entre los otros canales. Curiosamente, vemos cómo se reduce ligeramente el gasto en `Online Display`. Esto podría explicarse por el hecho de que este canal ya había tenido un aumento promedio de gasto desde el entrenamiento hasta el conjunto de prueba."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:990002
 #: dee0c57df86d411d8f4c4a182ebd3e87
 msgid ""
 "Next, we can look into the expected channel contributions with this new "
 "budget allocation over time."
-msgstr ""
+msgstr "A continuación, podemos analizar las contribuciones esperadas del canal con esta nueva asignación de presupuesto a lo largo del tiempo."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:1010003
 #: e2ab7f932a574f458a8e6f217ca5286b
@@ -771,28 +771,28 @@ msgid ""
 " to $250$K and we are now recommending around $350$K. The fact that this "
 "spend level has not been reached before is refelected in the increased "
 "uncertainty (yellow band)."
-msgstr ""
+msgstr "Observe que la incertidumbre aumenta dado el nuevo nivel de gasto. Por ejemplo, el gasto histórico en `Online Display` fue entre $200$K y $250$K y ahora estamos recomendando alrededor de $350$K. El hecho de que este nivel de gasto no se haya alcanzado antes se refleja en la mayor incertidumbre (banda amarilla)."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:1020002
 #: 5d94554d80e6472eacce5683c3d12e06
 msgid ""
 "We can also obtain the average expected contributions per channel with "
 "the new budget allocation."
-msgstr ""
+msgstr "También podemos obtener las contribuciones esperadas promedio por canal con la nueva asignación de presupuesto."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:1040002
 #: 8dd2fcaa9fed495ea390b07aeaaff38b
 msgid ""
 "Lastly, we want to compare the optimized budget allocation with the "
 "initial (naive) allocation. We compare this at two levels:"
-msgstr ""
+msgstr "Por último, queremos comparar la asignación del presupuesto optimizada con la asignación inicial (ingenua). Comparamos esto en dos niveles:"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:1040004
 #: 7460d2a6c91f4802b0e6ee618934a1e3
 msgid ""
 "Channel contributions: We compute the difference between the optimized "
 "and naive channel contributions from the posterior predictive samples."
-msgstr ""
+msgstr "Contribuciones del canal: Calculamos la diferencia entre las contribuciones del canal optimizadas e ingenuas a partir de las muestras predictivas posteriores."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:1040005
 #: 4b539a5d63cf4e8b9f996ae46c28e0ae
@@ -801,12 +801,12 @@ msgid ""
 "total sales from the posterior predictive samples. In this case we "
 "include the intercept and seasonality, but we se the control variables to"
 " zero as in many cases we do not have them for the future."
-msgstr ""
+msgstr "Ventas Totales: Calculamos la diferencia entre las ventas totales optimizadas e ingenuas a partir de las muestras predictivas posteriores. En este caso, incluimos el intercepto y la estacionalidad, pero dejamos las variables de control en cero, ya que en muchos casos no las tenemos para el futuro."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:1050002
 #: 8644a45fb1f841b6bf8526a9e83580b7
 msgid "Channel Contribution Comparison"
-msgstr ""
+msgstr "Comparación de Contribuciones de Canal"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:1050004
 #: 0452d480fbec4f40a9fc30d2739215a2
@@ -816,12 +816,12 @@ msgid ""
 "values as uniform across the test period and then using the model "
 "(trained on the training period) to compute the expected channel "
 "contributions."
-msgstr ""
+msgstr "Lo primero que necesitamos hacer es calcular las contribuciones de canal ingenuas para el periodo de prueba. Hacemos esto simplemente estableciendo estos valores como uniformes a lo largo del periodo de prueba y luego usando el modelo (entrenado en el periodo de entrenamiento) para calcular las contribuciones de canal esperadas."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:1070002
 #: 6f6d70620f6749e390eb538313b16c84
 msgid "Let's visualize the optimized and naive channel contributions."
-msgstr ""
+msgstr "Vamos a visualizar las contribuciones de canal optimizadas y no optimizadas."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:1090002
 #: 168facae74ec432286d9f16f69af7cbd
@@ -829,14 +829,14 @@ msgid ""
 "We see indeed that the optimized allocation strategy is more efficient "
 "regarding the aggregated channel contributions. This is exactly what we "
 "were looking for!"
-msgstr ""
+msgstr "Vemos que, de hecho, la estrategia de asignación optimizada es más eficiente en cuanto a las contribuciones agregadas de los canales. ¡Esto es exactamente lo que estábamos buscando!"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:1090004
 #: 34789209fae64f878d327a9912a19cc5
 msgid ""
 "We can quantify the percentage improvement of the optimized allocation by"
 " comparing the two posterior distributions aggregated over time."
-msgstr ""
+msgstr "Podemos cuantificar el porcentaje de mejora de la asignación optimizada comparando las dos distribuciones posteriores agregadas a lo largo del tiempo."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:1110002
 #: d857e068c6d64a4e8c8be53e51457f25
@@ -844,7 +844,7 @@ msgid ""
 "Concretely, we see an approximately $10\\%$ increase in the aggregated "
 "channel contributions. This could result in a significant increase in "
 "monetary value!"
-msgstr ""
+msgstr "Concretamente, vemos un aumento de aproximadamente $10\%$ en las contribuciones agregadas de los canales. ¡Esto podría resultar en un aumento significativo en valor monetario!"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:1110005
 #: 002a2feb3c0547be9802bef5fbea8ca7
@@ -853,12 +853,12 @@ msgid ""
 "to the reference value of zero. Hence, we have a probability of more than"
 " $80\\%$ that the optimized allocation will perform better than the "
 "initial allocation."
-msgstr ""
+msgstr "La línea naranja y el rango correspondiente comparan estas muestras posteriores con el valor de referencia de cero. Por lo tanto, tenemos una probabilidad de más del $80\%$ de que la asignación optimizada funcione mejor que la asignación inicial."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:1120002
 #: 9f0c8c185f494c3bb671fa2110fe004e
 msgid "Sales Comparison"
-msgstr ""
+msgstr "Comparación de Ventas"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:1120004
 #: 7fb7dfa4f395418286652256e40c537c
@@ -871,7 +871,7 @@ msgid ""
 "comparison. This is what is done in the "
 "{meth}`~pymc_marketing.mmm.mmm.MMM.allocate_budget_to_maximize_response` "
 "method."
-msgstr ""
+msgstr "A continuación, queremos comparar las ventas totales optimizadas e ingenuas. La estrategia es la misma que en el caso anterior. La única diferencia es que añadimos variables adicionales como estacionalidad y línea base (intercepto). Como se mencionó anteriormente, establecemos las variables de control en cero para efectos de comparación. Esto es lo que se hace en el método {meth}`~pymc_marketing.mmm.mmm.MMM.allocate_budget_to_maximize_response`."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:1140002
 #: 85dc1e1bd7ee46b38d445da0a6c0e187
@@ -880,7 +880,7 @@ msgid ""
 " the baseline and seasonality (which are the same in both cases) explain "
 "most of the variance as the average weekly media spend in this last "
 "period is much smaller as in the training set."
-msgstr ""
+msgstr "A nivel de ventas totales, en este caso la diferencia es insignificante ya que la línea base y la estacionalidad (que son iguales en ambos casos) explican la mayor parte de la varianza, ya que el gasto medio semanal en medios en este último período es mucho menor que en el conjunto de entrenamiento."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:1160002
 #: 85e1a148d4ac4a51af10680c753e983c
@@ -895,12 +895,12 @@ msgid ""
 " teams), to change the budget up to $60\\%$ we improved the channel "
 "contributions significantly but not at the same order of magnitude of the"
 " other model components."
-msgstr ""
+msgstr "En este caso vemos que cuando comparamos las muestras posteriores del crecimiento con el valor de referencia de cero no encontramos ninguna diferencia. Esto no debería ser desalentador ya que vimos un aumento del $10\%$ en las contribuciones de canal agregadas (a lo largo del tiempo). ¡Esto puede traducirse en mucho dinero! No hay discrepancia en los resultados. Lo que estamos viendo es que el problema de optimización restringida en el que solo se nos permite, debido a requisitos comerciales (que es muy común para muchos equipos de marketing), cambiar el presupuesto hasta un $60\%$ mejoramos las contribuciones del canal significativamente, pero no en el mismo orden de magnitud que los otros componentes del modelo."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:1170002
 #: c268acbf16fc456b926b2ec4ac7caec4
 msgid "Conclusion"
-msgstr ""
+msgstr "Conclusión"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:1170004
 #: 917fd04522c14309bed4f00a2a3865fe
@@ -914,12 +914,12 @@ msgid ""
 " their saturation effects, and return on ad spend. We were able to use "
 "these insights to propose an optimized budget allocation that aims to "
 "maximize sales while respecting business constraints."
-msgstr ""
+msgstr "Este caso de estudio demostró cómo aprovechar las capacidades de Modelado de Mezcla de Medios de PyMC-Marketing para obtener ideas accionables sobre la efectividad del marketing y optimizar la asignación de presupuesto. Recorrimos todo el proceso desde la preparación de datos y el análisis exploratorio hasta el ajuste del modelo, diagnósticos y optimización del presupuesto. El modelo proporcionó valiosas ideas sobre la efectividad de diferentes canales de marketing, sus efectos de saturación y el retorno sobre el gasto publicitario. Pudimos usar estas ideas para proponer una asignación de presupuesto optimizada que busca maximizar las ventas respetando las restricciones comerciales."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:1170007
 #: 4978dd272a5f4180928157fa5083f674
 msgid "Next Steps"
-msgstr ""
+msgstr "Próximos Pasos"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:1170009
 #: 91089875af5e4e12b42513d4597140a1
@@ -927,14 +927,14 @@ msgid ""
 "Stakeholder engagement: Present findings to key stakeholders, focusing on"
 " actionable insights and potential business impact. Understand their "
 "feedback and iterate."
-msgstr ""
+msgstr "Compromiso con las partes interesadas: presenta hallazgos a las partes interesadas clave, enfocándote en ideas accionables y el impacto potencial en el negocio. Entiende sus comentarios y repite."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:1170011
 #: 3c093d7f96674bbf81ae31a7412817b5
 msgid ""
 "Scenario planning: Use the model to simulate various budget scenarios and"
 " market conditions to support strategic decision-making."
-msgstr ""
+msgstr "Planificación de escenarios: usa el modelo para simular varios escenarios presupuestarios y condiciones de mercado para apoyar la toma de decisiones estratégicas."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:1170013
 #: a4df3f52a4bd46d282e26c60e8a3df0e
@@ -942,7 +942,7 @@ msgid ""
 "Integration with other tools: Explore ways to integrate the MMM insights "
 "with other marketing analytics tools and processes for a more holistic "
 "view of marketing performance."
-msgstr ""
+msgstr "Integración con otras herramientas: explora formas de integrar las ideas de MMM con otras herramientas y procesos analíticos de marketing para una vista más holística del rendimiento del marketing."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:1170015
 #: 47448b420ec44924b59b5efa7d461ac3
@@ -951,44 +951,44 @@ msgid ""
 "Time-slice cross-validation: Implement a more robust validation strategy "
 "to ensure model stability and performance over time (see "
 "{ref}`mmm_time_slice_cross_validation`)."
-msgstr ""
+msgstr "Validación cruzada por intervalos de tiempo: implementa una estrategia de validación más robusta para asegurar la estabilidad y el rendimiento del modelo con el tiempo (ver {ref}`mmm_time_slice_cross_validation`)."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:1170017
 #: 67705b07deae42e9be393ca23323da09
 msgid ""
 "Iterate and refine: This analysis represents a first iteration. Future "
 "iterations could incorporate:"
-msgstr ""
+msgstr "Iterar y refinar: Este análisis representa una primera iteración. Las iteraciones futuras podrían incorporar:"
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:1170019
 #: 8c24a56becec4fa780fdc5afdcdddb85
 #, python-brace-format
 msgid "Lift test data to better calibrate the model (see {ref}`mmm_lift_test`)"
-msgstr ""
+msgstr "Datos de prueba de elevación para calibrar mejor el modelo (ver {ref}`mmm_lift_test`)."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:1170020
 #: 524df5425119439ca1c3f40efdd4e9bc
 msgid "More granular data (e.g., daily instead of weekly)"
-msgstr ""
+msgstr "Datos más granulares (por ejemplo, diarios en lugar de semanales)."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:1170021
 #: 961a10a1737d4e7389d878496c7905be
 msgid "Additional variables like competitor actions or macroeconomic factors"
-msgstr ""
+msgstr "Variables adicionales como acciones de la competencia o factores macroeconómicos."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:1170023
 #: b20ccb74913743cf963f8b720674642f
 msgid ""
 "A/B (or Geo) testing: Design experiments to test the model's "
 "recommendations and validate its predictions in the real world."
-msgstr ""
+msgstr "Pruebas A/B (o Geo): diseña experimentos para probar las recomendaciones del modelo y validar sus predicciones en el mundo real."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:1170025
 #: 25a738b4724b418980a8681b8082d32e
 msgid ""
 "Regular updates: Establish a process for regularly updating the model "
 "with new data to keep insights current."
-msgstr ""
+msgstr "Actualizaciones regulares: establece un proceso para actualizar regularmente el modelo con nuevos datos para mantener las ideas actualizadas."
 
 #: ../source/notebooks/mmm/mmm_case_study.ipynb:1170027
 #: 5045b5d148e24b29868614bb3698ab20
@@ -999,4 +999,4 @@ msgid ""
 "{ref}`mmm_tv_intercept` {ref}`(mmm_time_varying_media_example`) and "
 "custom models like hierarchical levels or more complex seasonality "
 "patterns, to further refine the model (see {ref}`mmm_components`)."
-msgstr ""
+msgstr "Explora características avanzadas: investiga otras capacidades de PyMC-Marketing, como la incorporación de parámetros variables en el tiempo (ver y {ref}`mmm_tv_intercept` {ref}`(mmm_time_varying_media_example`) y modelos personalizados como niveles jerárquicos o patrones de estacionalidad más complejos, para refinar aún más el modelo (ver {ref}`mmm_components`)."

--- a/locales/es/LC_MESSAGES/notebooks/mmm/mmm_multidimensional_example.po
+++ b/locales/es/LC_MESSAGES/notebooks/mmm/mmm_multidimensional_example.po
@@ -23,7 +23,7 @@ msgstr ""
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:10003
 #: 0bf75e9e36cd4cb09a89b91263e7798c
 msgid "MMM Multidimensional Example Notebook"
-msgstr ""
+msgstr "Cuaderno de ejemplo multidimensional de MMM"
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:10005
 #: 3a57faa926e442449706de6105c121f5
@@ -34,6 +34,10 @@ msgid ""
 " its capabilities, we extend the {ref}`mmm_example` simulation to create "
 "a multidimensional hierarchical model."
 msgstr ""
+"En este cuaderno presentamos una nueva clase experimental de modelo de mezcla "
+"de medios para crear modelos de marketing mix multidimensionales y "
+"personalizados. Para mostrar sus capacidades, extendemos la simulación "
+"{ref}`mmm_example` para crear un modelo jerárquico multidimensional."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:10008
 #: 9f3c01cb85f142a08f104877310aaf55
@@ -45,22 +49,26 @@ msgid ""
 "marketing mix models. This model is under active development and will be "
 "further improved in the future (feedback welcome!)."
 msgstr ""
+"Aunque la nueva clase {class}`MMM <pymc_marketing.mmm.multidimensional.MMM>` "
+"es experimental, es totalmente funcional y puede utilizarse para crear modelos "
+"de marketing mix multidimensionales. Este modelo está en desarrollo activo y "
+"se seguirá mejorando en el futuro (¡se agradecen comentarios!)."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:20002
 #: 6b8c50f71c8f4c1d8bd26be6a3dcc302
 msgid "Prepare Notebook"
-msgstr ""
+msgstr "Preparar cuaderno"
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:50002
 #: 3783715d66d247cc908c7219c040201f
 msgid "Read Data"
-msgstr ""
+msgstr "Leer datos"
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:50004
 #: 453f41253c874e4186b21d5da4166880
 #, python-brace-format
 msgid "We read the simulated data from the {ref}`mmm_multidimensional_example`."
-msgstr ""
+msgstr "Leemos los datos simulados de {ref}`mmm_multidimensional_example`."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:70002
 #: 24b531740f6f44c19ef3230d9f60e2b0
@@ -73,6 +81,13 @@ msgid ""
 "sales, but the relationship is noisy. Our mission is to see if the MMM "
 "can parse the signal in the noise."
 msgstr ""
+"Para nuestro planteamiento, imagine que vendemos un producto en dos países "
+"distintos (`geo_a` y `geo_b`). Nuestro equipo de marketing gestiona dos "
+"canales: uno suele estar siempre activo y el otro es más táctico y se activa "
+"durante las campañas de marketing. La inspección visual de los datos sugiere "
+"que existe al menos algún efecto del marketing sobre las ventas, pero la "
+"relación es ruidosa. Nuestra misión es ver si el MMM puede separar la señal "
+"del ruido."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:70004
 #: fccde99728ee4daeb5a288e396a4bc0e
@@ -86,11 +101,18 @@ msgid ""
 "to fit an MMM to multiple markets at the same time and make decisions "
 "about how to pool information across the two contexts."
 msgstr ""
+"Una estrategia para tratar con datos ruidosos y de baja señal es aprovechar "
+"información de contextos similares. Si el canal 2 parece ser bastante "
+"efectivo en `geo_b`, eso nos da razones para sospechar que también lo será en "
+"`geo_a`. Esto puede implementarse con **full pooling** o **partial pooling** "
+"(los modelos de partial pooling a menudo se llaman 'jerárquicos' o 'multinivel'). "
+"Este cuaderno mostrará cómo ajustar un MMM a múltiples mercados al mismo tiempo "
+"y tomar decisiones sobre cómo agrupar información entre los dos contextos."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:90002
 #: e88259d625c348ffa5c1e524e71840da
 msgid "Prior Specification"
-msgstr ""
+msgstr "Especificación de priors"
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:90004
 #: 8601fca85a304466a14eb6b117cfb98d
@@ -103,6 +125,12 @@ msgid ""
 "product. To capture this, we'll allow the saturation point to vary across"
 " geography."
 msgstr ""
+"El parámetro Beta representa el número máximo de ventas semanales que podrías "
+"impulsar a través de un canal. Beta será el único parámetro jerárquico en este "
+"modelo. Hay buenas razones para pensar que distintos mercados se saturan en "
+"niveles diferentes. Un producto puede ser popular en un lugar y la audiencia "
+"potencial muy grande. En otro mercado, es un producto de nicho. Para capturar "
+"esto, permitiremos que el punto de saturación varíe según la geografía."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:90006
 #: a8fecacc72104a0691b9ba4367a0f580
@@ -120,6 +148,16 @@ msgid ""
 "Modeling\"](https://www.pymc.io/projects/examples/en/latest/generalized_linear_models/multilevel_modeling.html)"
 " in the PyMC documentation."
 msgstr ""
+"Un modelo jerárquico hace algo ingenioso: en lugar de suponer que cada "
+"geografía es diferente, suponemos que al menos están parcialmente relacionadas "
+"entre sí. Si tuvieras 10 geos y 9 de ellas tuvieran un alto punto de saturación, "
+"razonablemente esperarías que la décima también lo tuviera. Un modelo jerárquico "
+"agrupará adaptativamente información entre contextos. Cuando cada geo es muy "
+"diferente, transferirá menos información entre ellas. Cuando cada geo es muy "
+"similar, transferirá más información. A esto también se le llama **partial pooling**. "
+"Si necesitas una introducción a los modelos jerárquicos bayesianos, consulta el "
+"ejemplo completo [\"A Primer on Bayesian Methods for Multilevel Modeling\"](https://www.pymc.io/projects/examples/en/latest/generalized_linear_models/multilevel_modeling.html) "
+"en la documentación de PyMC."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:90008
 #: 5b587cd8eeb44fe4bafe4dc82a6d2e52
@@ -134,6 +172,14 @@ msgid ""
 "interior parameters, `mu` and `sigma`, they will act as constraints on "
 "the behaviour of the individual beta parameters."
 msgstr ""
+"Podemos construir parámetros jerárquicos con la API de priors. Observa que tenemos "
+"un objeto Prior con dimensiones `(channel, geos)` y luego tenemos más Priors para "
+"cada parámetro. El prior sobre `mu` captura lo que esperamos que hagan los canales, "
+"sin considerar su variación por geografía. El prior sobre `sigma` representa cuánto "
+"varía el efecto entre geografías. La inferencia bayesiana propaga información a lo "
+"largo de toda la red de parámetros: a medida que aprendemos los valores de los "
+"parámetros internos, `mu` y `sigma`, actuarán como restricciones sobre el "
+"comportamiento de los parámetros Beta individuales."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:90010
 #: c543e1d234354eb5b0cae53804b32564
@@ -147,6 +193,13 @@ msgid ""
 "ones that are independent. Channel 1 in `geo_a` influences channel 1 in "
 "`geo_b`, but channel 1 never influences channel 2."
 msgstr ""
+"Hay muchas opciones sobre cómo codificar cada tipo de efecto. Puede ser difícil "
+"llevar la cuenta de qué parámetros comparten información, cuáles están completamente "
+"separados y cuáles están compartidos. Pero hay un truco para recordarlo: fíjate que "
+"los Priors internos tienen menos dimensiones que el Prior principal. La dimensión extra "
+"representa la dimensión a lo largo de la cual se transfiere la información. Las "
+"dimensiones compartidas representan las que son independientes. El canal 1 en `geo_a` "
+"influye en el canal 1 en `geo_b`, pero el canal 1 nunca influye en el canal 2."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:110002
 #: ae4af118dd27432d898ac7c5caa4121f
@@ -160,6 +213,13 @@ msgid ""
 "do not specify \"geo\" dims. The package will automatically broadcast the"
 " channel effect for each geography."
 msgstr ""
+"Este cuaderno es solo ilustrativo, así que te mostraremos cómo codificar cada tipo "
+"de suposición que podrías hacer (¡no estamos recomendando una solución universal!). "
+"Lambda representa la eficiencia de un canal. Cuanto mayor sea lambda, más sensibles "
+"serán las ventas al gasto en ese canal. Haremos que el parámetro lambda esté **fully "
+"pooled** en todas las geografías. Suponemos que el canal 1 tiene la misma eficiencia "
+"en ambas geos, por lo que no especificamos dims de \"geo\". El paquete difundirá "
+"automáticamente el efecto del canal para cada geografía."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:130002
 #: b09cb73200d94a87ad3dc920e5c67c1b
@@ -170,6 +230,10 @@ msgid ""
 "each other. Notice that we put a dim for both geos and channels to "
 "indicate that we want 4 unique effects."
 msgstr ""
+"Adstock alpha representa cuánto tiempo recuerdan los clientes el marketing. Para "
+"adstock, ilustraremos la estrategia **unpooled**. Aquí, cada canal en cada geografía "
+"tiene su propio efecto y esos efectos no se influyen entre sí. Observa que ponemos "
+"una dim para geos y canales para indicar que queremos 4 efectos únicos."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:150002
 #: 1077108e23a94afc9f290e4d452d0e64
@@ -183,6 +247,13 @@ msgid ""
 " but it can make the model slower to estimate, more complicated to debug,"
 " and more difficult to reason about."
 msgstr ""
+"Puedes combinar las estrategias unpooled, fully pooled y partially pooled para "
+"cualquiera de tus efectos. Puedes extender esta estrategia a controles o parámetros "
+"de ruido también. Dada la variedad de opciones, puede ser difícil saber qué estrategia "
+"de agrupamiento elegir para un efecto dado. En nuestra opinión, la elección está "
+"impulsada principalmente por consideraciones computacionales. El partial pooling suele "
+"ser una suposición más razonable, pero puede hacer que el modelo sea más lento de "
+"estimar, más complicado de depurar y más difícil de razonar."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:150004
 #: e9817d2e159f4a03b8a4a4d7f015ce5f
@@ -197,6 +268,13 @@ msgid ""
 "complexity slowly, verifying your model performance and accuracy at each "
 "stage."
 msgstr ""
+"Por ejemplo, puedes notar que configuramos nuestro prior con `centered=False`. Esto "
+"se conoce como una reparametrización, una [estrategia para resolver dificultades "
+"computacionales](https://www.pymc.io/projects/examples/en/latest/diagnostics_and_criticism/Diagnosing_biased_Inference_with_Divergences.html) "
+"con las que los algoritmos MCMC pueden encontrarse al ajustar modelos jerárquicos. "
+"Recomendamos empezar con un modelo que use solo efectos fully pooled o unpooled. Una vez "
+"tengas un buen modelo funcionando, puedes añadir complejidad lentamente, verificando el "
+"rendimiento y la precisión del modelo en cada etapa."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:150006
 #: 406c43ecb33648d08f0c34867a2f675d
@@ -205,11 +283,12 @@ msgid ""
 "We complete the model specification with similar priors as in the "
 "{ref}`mmm_example`."
 msgstr ""
+"Completamos la especificación del modelo con priors similares a los de {ref}`mmm_example`."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:170002
 #: acf7029aeffe4c7bbd7c7aa67324a597
 msgid "Model Definition"
-msgstr ""
+msgstr "Definición del modelo"
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:170004
 #: fc3035cc9c9f4b3f9765e5a086caefec
@@ -218,16 +297,18 @@ msgid ""
 "We are now ready to define the model class. The API is very similar to "
 "the one in the {ref}`mmm_example`."
 msgstr ""
+"Ya estamos listos para definir la clase del modelo. La API es muy similar a la de "
+"{ref}`mmm_example`."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:190003
 #: 21bcbe12fc6e41c186c2b455796faa21
 msgid "Observe we have the following two new arguments:"
-msgstr ""
+msgstr "Observa que tenemos los dos argumentos nuevos siguientes:"
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:190004
 #: 357245987587423e9dbc0fc0b2b86d00
 msgid "`dims`: a tuple of strings that specify the dimensions of the model."
-msgstr ""
+msgstr "`dims`: una tupla de cadenas de texto que especifica las dimensiones del modelo."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:190005
 #: 2452575f81af4124be11eb03531ba39d
@@ -237,11 +318,15 @@ msgid ""
 " empty as we want to scale the target variable for each geo (see details "
 "below)."
 msgstr ""
+"`scaling`: un diccionario que especifica el método de escalado y las dimensiones "
+"para la variable objetivo y las variables de medios. En este caso dejamos las "
+"dimensiones vacías porque queremos escalar la variable objetivo por cada geo (ver "
+"detalles abajo)."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:200002
 #: 1a9af6633d5a444c8a70610d33d89dee
 msgid "We can now prepare the training data."
-msgstr ""
+msgstr "Ahora podemos preparar los datos de entrenamiento."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:220002
 #: 91b9de3f22f24d17b20a2ab98f6b34e3
@@ -249,6 +334,8 @@ msgid ""
 "To build the model, we need to specify the training data and the target "
 "variables."
 msgstr ""
+"Para construir el modelo, necesitamos especificar los datos de entrenamiento y las "
+"variables objetivo."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:220005
 #: c0f938c8c08e47c78d42111bf5cd1957
@@ -256,11 +343,13 @@ msgid ""
 "We do not need to build the model, we can simply fit the model. This is "
 "just to inspect the model structure."
 msgstr ""
+"No necesitamos construir el modelo; simplemente podemos ajustarlo. Esto es solo para "
+"inspeccionar la estructura del modelo."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:240002
 #: 944224604062418397685650009b3f06
 msgid "Let's look into the model graph:"
-msgstr ""
+msgstr "Veamos el grafo del modelo:"
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:260002
 #: 11907aa42f074c44a2cab4521802cb99
@@ -268,6 +357,8 @@ msgid ""
 "It is great to see that the model automatically vectorizes and creates "
 "the expected hierarchies and dimensions 🚀!"
 msgstr ""
+"¡Es genial ver que el modelo se vectoriza automáticamente y crea las jerarquías y "
+"dimensiones esperadas 🚀!"
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:270002
 #: ced9efe0f7cd489faaaf2def733e7adc
@@ -275,11 +366,13 @@ msgid ""
 "As we are scaling our data internally, we can add deterministic terms to "
 "recover the component contributions in the original scale."
 msgstr ""
+"Como estamos escalando nuestros datos internamente, podemos añadir términos deterministas "
+"para recuperar las contribuciones de los componentes en la escala original."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:290002
 #: 165f6576e8934710a239de364518a495
 msgid "Coming back to the scalers, we can get them as an xarray dataset."
-msgstr ""
+msgstr "Volviendo a los escaladores, podemos obtenerlos como un dataset de xarray."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:310002
 #: acd915f8c8614a0f8ed43d506e3eb6d3
@@ -287,11 +380,13 @@ msgid ""
 "As expected, from the model definition, we have scalers for the target "
 "and media variables across geos."
 msgstr ""
+"Como era de esperar por la definición del modelo, tenemos escaladores para la variable "
+"objetivo y las variables de medios en todas las geos."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:320002
 #: 8ee6d2c07bca442d8201f2cba421eeac
 msgid "Prior Predictive Checks"
-msgstr ""
+msgstr "Comprobaciones predictivas previas"
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:320004
 #: 57948d9c1c0c41e3983773de941c7118
@@ -299,16 +394,17 @@ msgid ""
 "Before fitting the model, we can inspect the prior predictive "
 "distribution."
 msgstr ""
+"Antes de ajustar el modelo, podemos inspeccionar la distribución predictiva previa."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:350002
 #: eaf052f0937e4a9eb9c1512a477456ef
 msgid "The prior predictive distribution looks good and not too restrictive."
-msgstr ""
+msgstr "La distribución predictiva previa se ve bien y no es demasiado restrictiva."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:360002
 #: 0180b396d53a45359ceabefb2d8e5444
 msgid "Model Fitting"
-msgstr ""
+msgstr "Ajuste del modelo"
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:360004
 #: 64925c06f1ff4238a51e0248573a90ee
@@ -316,6 +412,7 @@ msgid ""
 "We can now fit the model and generate the posterior predictive "
 "distribution."
 msgstr ""
+"Ahora podemos ajustar el modelo y generar la distribución predictiva posterior."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:380002
 #: c1b698f78a83470188885f95f10c2e3d
@@ -323,11 +420,12 @@ msgid ""
 "The sampling looks good. No divergences and the r-hat values are close to"
 " $1$."
 msgstr ""
+"El muestreo se ve bien. No hay divergencias y los valores de r-hat están cercanos a $1$."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:420002
 #: 072a00020a1e44b686c7a04da4ad0716
 msgid "Posterior Predictive Checks"
-msgstr ""
+msgstr "Comprobaciones predictivas posteriores"
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:420004
 #: 073ca47fe0624268a3310905c1a59d82
@@ -336,6 +434,9 @@ msgid ""
 "need to scale the posterior predictive to the original scale to make it "
 "comparable to the data."
 msgstr ""
+"Ahora podemos inspeccionar la distribución predictiva posterior. Como antes, "
+"necesitamos escalar la predictiva posterior a la escala original para hacerla "
+"comparable con los datos."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:440002
 #: 67569099ee824016a1fd180e46e4d03b
@@ -344,11 +445,14 @@ msgid ""
 " cannot predict. However, the main movements in the sales are either "
 "captured by our seasonality model or the MMM components."
 msgstr ""
+"¡El ajuste se ve bien! Hay mucho ruido blanco en el proceso de ventas que no podemos "
+"predecir. Sin embargo, los movimientos principales en las ventas están capturados ya "
+"sea por nuestro modelo de estacionalidad o por los componentes del MMM."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:450002
 #: ef3e83e9340d4103ac7cc3d448dc6e7a
 msgid "Model Components"
-msgstr ""
+msgstr "Componentes del modelo"
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:450004
 #: 99c8a5961179400da1b3615e34b2bcaf
@@ -356,11 +460,13 @@ msgid ""
 "We can extract the contributions of each component of the model in the "
 "original scale thanks to the deterministic variables added to the model."
 msgstr ""
+"Podemos extraer las contribuciones de cada componente del modelo en la escala original "
+"gracias a las variables deterministas añadidas al modelo."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:470002
 #: 234ec3b62ce94a56897782f06b84cc60
 msgid "Media Deep Dive"
-msgstr ""
+msgstr "Análisis profundo de medios"
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:470004
 #: a8cfe7693830463297f9c0ab67ce78cf
@@ -369,6 +475,9 @@ msgid ""
 "This new class has a new `plot` name space that contains many plotting "
 "methods."
 msgstr ""
+"A continuación, podemos analizar las contribuciones individuales por canal en las "
+"distintas geos. Esta nueva clase tiene un nuevo espacio de nombres `plot` que contiene "
+"muchos métodos de visualización."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:490002
 #: bed1a2a8593e4a33912361186c5c258a
@@ -376,6 +485,8 @@ msgid ""
 "We can plot the saturation curves for each channel and geo, using a few "
 "different functions:"
 msgstr ""
+"Podemos graficar las curvas de saturación para cada canal y geo usando varias funciones "
+"diferentes:"
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:490003
 #: 681ff9cf9e0f481891033e65891bbbfa
@@ -383,6 +494,8 @@ msgid ""
 "Using `saturation_scatterplot`, we can get only the scatterplot between "
 "investment and estimated returns."
 msgstr ""
+"Usando `saturation_scatterplot`, podemos obtener únicamente el diagrama de dispersión "
+"entre inversión y retornos estimados."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:490004
 #: acde4a2c881d42b5ac4be86abb97c4de
@@ -390,11 +503,13 @@ msgid ""
 "Using `saturation_curves`, we can get the posterior of the curves and "
 "their posterior fit regarding the given mean contribution."
 msgstr ""
+"Usando `saturation_curves`, podemos obtener la posterior de las curvas y su ajuste "
+"posterior respecto a la contribución media dada."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:520002
 #: 02f9d8df11314be29ef0e51ec53324a8
 msgid "Parameter recovery"
-msgstr ""
+msgstr "Recuperación de parámetros"
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:520004
 #: 0f07a9e7d79c4f7185ad68cc4a818b2b
@@ -411,6 +526,16 @@ msgid ""
 "parameter recovery in simulations that might be helpful if you need even "
 "more rigorous evidence the model is working correctly."
 msgstr ""
+"Una buena señal de que el modelo funciona como se pretende es que puede recuperar los "
+"valores verdaderos de los parámetros subyacentes al mecanismo de marketing. En nuestro "
+"caso, conocemos los valores verdaderos de los parámetros porque simulamos los datos. "
+"De forma informal, si la mayor parte de la distribución posterior cubre el valor del "
+"parámetro, es una buena señal. No esperamos que la media de la posterior siempre "
+"coincida con el valor verdadero: para datos pequeños o ruidosos, deberíamos esperar "
+"que la posterior cubra un intervalo amplio independientemente de si construimos un buen "
+"modelo o no. También existen [marcos formales](https://arxiv.org/abs/2502.03279) para "
+"pensar sobre la recuperación de parámetros en simulaciones que pueden ser útiles si "
+"necesitas evidencia aún más rigurosa de que el modelo funciona correctamente."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:520006
 #: 7affdfce5ca741f392817e9021591709
@@ -419,11 +544,13 @@ msgid ""
 "main MMM parameters (`saturation lambda`, `saturation beta` and `adstock "
 "alpha`)."
 msgstr ""
+"A continuación comparamos la distribución posterior con los valores verdaderos de los "
+"principales parámetros del MMM (`saturation lambda`, `saturation beta` y `adstock alpha`)."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:570002
 #: 640c37b481c04dab93820865f4501089
 msgid "Out of Sample Predictions"
-msgstr ""
+msgstr "Predicciones fuera de muestra"
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:570004
 #: 44b7e4456f36463886cf2dcad4b9d8b3
@@ -436,6 +563,12 @@ msgid ""
 "sample. This way we can create a new dataset with the future dates and "
 "channel spends and use the model to make predictions."
 msgstr ""
+"Es muy importante poder hacer predicciones fuera de la muestra. Esto es clave para la "
+"validación del modelo, la planificación de escenarios prospectivos y la toma de decisiones "
+"empresariales. De forma similar a {ref}`mmm_example`, asumimos que las inversiones futuras "
+"son las mismas que el último día de la muestra de entrenamiento. De este modo podemos crear "
+"un nuevo dataset con las fechas futuras y los gastos por canal y usar el modelo para hacer "
+"predicciones."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:590002
 #: ffd1a6763f234840a0112dffcdf58cae
@@ -443,11 +576,12 @@ msgid ""
 "Using the same `sample_posterior_predictive` method, we can now generate "
 "the forecast."
 msgstr ""
+"Usando el mismo método `sample_posterior_predictive`, ahora podemos generar el pronóstico."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:620002
 #: 8935b1632f084d918d0d0d3b890e5f2b
 msgid "Optimization"
-msgstr ""
+msgstr "Optimización"
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:620004
 #: 1b14e43c6ea54c65a39e326c3ba42a68
@@ -455,6 +589,7 @@ msgid ""
 "If you want to run optimizations, then you need to use the "
 "`MultiDimensionalBudgetOptimizerWrapper`."
 msgstr ""
+"Si quieres ejecutar optimizaciones, entonces necesitas usar `MultiDimensionalBudgetOptimizerWrapper`."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:640002
 #: df4cbb26cc5942979bfac9525aefe41e
@@ -462,11 +597,12 @@ msgid ""
 "This object is an xarray dataset with the allocation and posterior "
 "predictive responses!"
 msgstr ""
+"¡Este objeto es un dataset de xarray con la asignación y las respuestas predictivas posteriores!"
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:660002
 #: 71194ccb038046f5b17421f988db015a
 msgid "Once you get the allocation, you can plot a the results 🚀"
-msgstr ""
+msgstr "Una vez obtengas la asignación, puedes graficar los resultados 🚀"
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:680002
 #: 8ec02ddc0c4447a096578a41e82de477
@@ -476,6 +612,9 @@ msgid ""
 "identify automatically the number of dimensions and tries to create a "
 "plot based on them."
 msgstr ""
+"El gráfico muestra el presupuesto óptimo para cada canal en cada geo, junto a su "
+"contribución media respectiva dado el presupuesto óptimo. El método identifica "
+"automáticamente el número de dimensiones e intenta crear una gráfica en función de ellas."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:680004
 #: 61909db083a14281965d370d90fc8716
@@ -483,6 +622,8 @@ msgid ""
 "If you want to see the full uncertainty over time, you can use the plot "
 "suite and the method `allocated_contribution_by_channel_over_time`."
 msgstr ""
+"Si quieres ver la incertidumbre completa a lo largo del tiempo, puedes usar la suite de "
+"gráficos y el método `allocated_contribution_by_channel_over_time`."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:700002
 #: b8b939c7a4de4c149b99562e9f34ec0f
@@ -492,11 +633,14 @@ msgid ""
 "don't need to modify anything. Otherwise, for the plots, you may want to "
 "use `scale_factor=N`. E.g:"
 msgstr ""
+"Si tienes un modelo personalizado, puedes envolverlo en el protocolo del modelo y usar el "
+"optimizador después. Si tu modelo gestiona las escalas internamente, no necesitas modificar "
+"nada. De lo contrario, para las gráficas, quizá quieras usar `scale_factor=N`. Por ejemplo:"
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:710002
 #: 46b45f6105484e9282eba1f1c5845281
 msgid "Save Model"
-msgstr ""
+msgstr "Guardar modelo"
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:710004
 #: 506aa4f8c37c43b08583b8923941dbe0
@@ -506,6 +650,10 @@ msgid ""
 "dimensions. So it can sometimes be helpful to compress the idata before "
 "saving. Below are a couple of tricks."
 msgstr ""
+"Opcionalmente puedes guardar el resultado de tu trabajo. Los objetos de resultados del "
+"modelo (idata) pueden volverse muy grandes cuando empezamos a trabajar en múltiples "
+"dimensiones. Por ello, a veces puede ser útil comprimir el idata antes de guardarlo. A "
+"continuación hay un par de trucos."
 
 #: ../source/notebooks/mmm/mmm_multidimensional_example.ipynb:730003
 #: b8b6e6ac1e12482593b17e8d28a91e0a
@@ -513,3 +661,5 @@ msgid ""
 "We are very excited about this new feature and the possibilities it opens"
 " up. We are looking forward to hearing your feedback!"
 msgstr ""
+"Estamos muy entusiasmados con esta nueva funcionalidad y las posibilidades que abre. "
+"¡Esperamos tus comentarios!"

--- a/locales/es/LC_MESSAGES/notebooks/mmm/mmm_quickstart.po
+++ b/locales/es/LC_MESSAGES/notebooks/mmm/mmm_quickstart.po
@@ -23,7 +23,7 @@ msgstr ""
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:10004
 #: cd3f43ae5bc4424fbeaaeda2c33c3e2b
 msgid "MMM Quickstart Guide"
-msgstr ""
+msgstr "Guía de inicio rápido de MMM"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:10006
 #: fb6b33757bd44bda8c44a834d4eb6a2e
@@ -34,11 +34,16 @@ msgid ""
 "enables Bayesian inferenc. In this quickstart, we'll walk through fitting"
 " a basic Media Mix Model (MMM) in PyMC-Marketing."
 msgstr ""
+"Bienvenido a **PyMC-Marketing**. Esta biblioteca ofrece poderosas herramientas "
+"de modelado bayesiano para analítica de marketing. PyMC-Marketing está construido "
+"sobre [PyMC](https://www.pymc.io/), una biblioteca de programación probabilística que "
+"habilita la inferencia bayesiana. En esta guía rápida, recorreremos cómo ajustar "
+"un modelo básico de Mezcla de Medios (MMM) en PyMC-Marketing."
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:10009
 #: 942b9fb1e7044a52b996803df3136546
 msgid "What is Media Mix Modeling?"
-msgstr ""
+msgstr "¿Qué es el Modelado de Mezcla de Medios?"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:10011
 #: da37cb8b4f66436eb5baa39e2a4af050
@@ -46,53 +51,53 @@ msgid ""
 "Media Mix Modeling (MMM) helps marketers understand how different "
 "advertising channels contribute to business outcomes (like sales or "
 "conversions). MMM answers key questions:"
-msgstr ""
+msgstr "El Modelado de Mezcla de Medios (MMM) ayuda a los especialistas en marketing a comprender cómo distintos canales de publicidad contribuyen a los resultados del negocio (como ventas o conversiones). MMM responde preguntas clave:"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:10013
 #: 4ff066c91d9b43fb8a818977ae540727
 msgid "**Which channels drive the most sales?**"
-msgstr ""
+msgstr "**¿Qué canales impulsan más las ventas?**"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:10014
 #: dc57ea2addc14b8196ba050f3e96bcba
 msgid "**What is the Return on Ad Spend (ROAS) for each channel?**"
-msgstr ""
+msgstr "**¿Cuál es el Retorno de la Inversión Publicitaria (ROAS) de cada canal?**"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:10015
 #: ef0bd28ae31441f69270aa0a5807c47c
 msgid "**How should I allocate my marketing budget?**"
-msgstr ""
+msgstr "**¿Cómo debería asignar mi presupuesto de marketing?**"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:10017
 #: 49d45302305f46e591bd1aa4a4e6552f
 msgid "Key Concepts"
-msgstr ""
+msgstr "Conceptos clave"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:10019
 #: e065ae784858450e8b0cb41aaaa1b5ae
 msgid "MMM accounts for two important phenomena in advertising:"
-msgstr ""
+msgstr "MMM tiene en cuenta dos fenómenos importantes en la publicidad:"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:10021
 #: b300ee34658244b4b59c1842c1e69aec
 msgid ""
 "**Adstock (Carry-over effect)**: The impact of advertising doesn't happen"
 " instantaneously—it builds up over time and gradually decays."
-msgstr ""
+msgstr "**Adstock (efecto de arrastre)**: El impacto de la publicidad no ocurre de forma instantánea; se acumula con el tiempo y se atenúa gradualmente."
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:10022
 #: f634de6fe9dc4d27804c01a5fbbc628d
 msgid ""
 "**Saturation**: Returns diminish as you increase spend—the first dollar "
 "spent is more effective than the millionth dollar."
-msgstr ""
+msgstr "**Saturación**: Los rendimientos disminuyen a medida que aumentas el gasto; el primer dólar gastado es más efectivo que el millonésimo."
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:10024
 #: 85d40576b5724d9aadd999ff648d14e7
 msgid ""
 "Let's see how we can fit a basic MMM model to understand these effects "
 "and measure channel contributions."
-msgstr ""
+msgstr "Veamos cómo ajustar un modelo MMM básico para entender estos efectos y medir las contribuciones de los canales."
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:10027
 #: a6f95f6ce81f4092ba83c811c01e4ded
@@ -105,6 +110,12 @@ msgid ""
 "you will find extensive resources to help you and guide you through the "
 "MMM modeling iterative process."
 msgstr ""
+"El objetivo de PyMC-Marketing es brindar herramientas para aplicaciones reales. "
+"Normalmente, necesitamos pensar en la estructura causal, la calibración de pruebas de lift "
+"y la optimización avanzada del presupuesto. Este ejemplo debe considerarse como un primer paso "
+"hacia un conjunto de herramientas más complejo y completo para impulsar decisiones de marketing "
+"por valor de millones de dólares. En nuestra galería de ejemplos encontrarás recursos extensos "
+"para ayudarte y guiarte a través del proceso iterativo de modelado MMM."
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:10031
 #: 4dec8bc160554a23ab29276f4d8fb14a
@@ -114,6 +125,9 @@ msgid ""
 "delve deeper into the data generating process and model diagnostics. We "
 "also include ROAS estimation and out of sample predictions."
 msgstr ""
+"Para una versión extendida de este ejemplo, consulta {ref}`mmm_example`. Aquí profundizamos "
+"en el proceso de generación de datos y en el diagnóstico del modelo. También incluimos la "
+"estimación del ROAS y las predicciones fuera de muestra."
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:10032
 #: 875754d2a0624103be32d69668a157df
@@ -124,21 +138,24 @@ msgid ""
 "through the entire process of model specification, fitting, optimization "
 "and scenario planning."
 msgstr ""
+"Si deseas ver un análisis completo de principio a fin, consulta {ref}`mmm_case_study`. Aquí "
+"tomamos un conjunto de datos \"real\" y recorremos todo el proceso de especificación del modelo, "
+"ajuste, optimización y planificación de escenarios."
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:20002
 #: 3a6e544cadcc420db66c818f1412c4ff
 msgid "Prepare Notebook"
-msgstr ""
+msgstr "Preparar el cuaderno"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:20004
 #: e1f9fb60fb65461b9d8cc07aaf668282
 msgid "Let's import the necessary libraries:"
-msgstr ""
+msgstr "Importemos las librerías necesarias:"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:50002
 #: 95d2b83eae034c7293b34b872ddb9f5d
 msgid "Load Data"
-msgstr ""
+msgstr "Cargar datos"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:50004
 #: 9913dd4d65f143b7859cab75ba605aea
@@ -146,76 +163,76 @@ msgid ""
 "We'll use a synthetic dataset that simulates weekly sales data along with"
 " spend on two marketing channels (`x1` and `x2`), plus some control "
 "variables for special events."
-msgstr ""
+msgstr "Usaremos un conjunto de datos sintético que simula datos semanales de ventas junto con el gasto en dos canales de marketing (`x1` y `x2`), además de algunas variables de control para eventos especiales."
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:70002
 #: fdfa36e323b6446aae6bdb3d3c35ad0a
 msgid "Let's visualize our target variable (sales) and the media spend over time:"
-msgstr ""
+msgstr "Visualicemos nuestra variable objetivo (ventas) y el gasto en medios a lo largo del tiempo:"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:90002
 #: f50600facb764e569f7d203fddbbbcc4
 msgid "Feature Engineering"
-msgstr ""
+msgstr "Ingeniería de características"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:90004
 #: 14d2cf71c0884497a8ff459ddcad3537
 msgid "For our MMM model, we'll include:"
-msgstr ""
+msgstr "Para nuestro modelo MMM, incluiremos:"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:90006
 #: 5c490227d21f4e53a74cb725fde5b4e6
 msgid "**Trend**: A linear trend to capture long-term growth"
-msgstr ""
+msgstr "**Tendencia**: Una tendencia lineal para capturar el crecimiento a largo plazo"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:90007
 #: 37903b5a6c4d4b00bbdf560dc053fee0
 msgid "**Seasonality**: Yearly seasonality (handled automatically by the model)"
-msgstr ""
+msgstr "**Estacionalidad**: Estacionalidad anual (manejada automáticamente por el modelo)"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:90008
 #: cdd4d55d224a425487ec3b3c603af86f
 msgid "**Events**: Binary indicators for special events"
-msgstr ""
+msgstr "**Eventos**: Indicadores binarios para eventos especiales"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:90009
 #: baa810d0bf7f43d2bbe48f7d4e1ae770
 msgid "**Media channels**: Our two advertising channels"
-msgstr ""
+msgstr "**Canales de medios**: Nuestros dos canales de publicidad"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:110002
 #: dfed261cfcc045a6b593a605900635f5
 msgid "Model Specification"
-msgstr ""
+msgstr "Especificación del modelo"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:110004
 #: 22f2de72d05341e9b55697f7b1a28161
 msgid "Now we'll configure our MMM model. The key components are:"
-msgstr ""
+msgstr "Ahora configuraremos nuestro modelo MMM. Los componentes clave son:"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:110006
 #: 43ef9c3e7646420fa2575178d7c9a0d7
 msgid ""
 "**Adstock transformation**: We use `GeometricAdstock` with a maximum lag "
 "of 8 weeks"
-msgstr ""
+msgstr "**Transformación Adstock**: Usamos `GeometricAdstock` con un retraso máximo de 8 semanas"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:110007
 #: 63f31b14197242d98cf54df6aebac4d3
 msgid ""
 "**Saturation transformation**: We use `LogisticSaturation` to capture "
 "diminishing returns"
-msgstr ""
+msgstr "**Transformación de saturación**: Usamos `LogisticSaturation` para capturar los rendimientos decrecientes"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:110008
 #: 3ab2f1f5de684e59913fcd2d460f56dc
 msgid "**Priors**: We can customize priors based on domain knowledge"
-msgstr ""
+msgstr "**Distribuciones a priori**: Podemos personalizar las distribuciones a priori según el conocimiento del dominio"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:110010
 #: 8d3f1fe74a314c91bae9af972cee4db1
 msgid "Setting Priors"
-msgstr ""
+msgstr "Configuración de distribuciones a priori"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:110012
 #: f05b97ec21b7434a8cb5bacba313a1ef
@@ -224,16 +241,18 @@ msgid ""
 "prior knowledge. Here's a simple heuristic for channel priors based on "
 "spend share:"
 msgstr ""
+"Una característica poderosa del modelado bayesiano es la capacidad de incorporar conocimiento previo. "
+"Aquí hay una heurística sencilla para las distribuciones a priori de los canales basada en la participación de gasto:"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:130002
 #: 7486d5aa714747448de541b1321e5890
 msgid "Now let's define our model configuration:"
-msgstr ""
+msgstr "Ahora definamos la configuración de nuestro modelo:"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:150002
 #: 40e826d20f3744b7b751f190b1bbf986
 msgid "Prior Predictive Check"
-msgstr ""
+msgstr "Verificación predictiva a priori"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:150005
 #: 2836714cdb344156ab41fc33b8d98513
@@ -243,22 +262,22 @@ msgid ""
 "reasonable. Hence, is strongly recommended to perform this check before "
 "fitting the model. If you are new to Bayesian modeling, take a look into "
 "our {ref}`prior_predictive` guide notebook."
-msgstr ""
+msgstr "La verificación predictiva a priori es una excelente manera de comprobar que nuestras distribuciones a priori son razonables. Por ello, se recomienda encarecidamente realizar esta verificación antes de ajustar el modelo. Si eres nuevo en el modelado bayesiano, consulta nuestro notebook de guía {ref}`prior_predictive`."
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:150008
 #: e734cbacb7d245f4b98a807edbc9f1c1
 msgid "Before fitting, let's check that our priors are reasonable:"
-msgstr ""
+msgstr "Antes de ajustar, verifiquemos que nuestras distribuciones a priori sean razonables:"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:170002
 #: f46be77808de439eb227cad376e9d4b0
 msgid "Overall, the prior predictive check looks good."
-msgstr ""
+msgstr "En general, la verificación predictiva a priori se ve bien."
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:180002
 #: 3684b6a2931d401eaedb08b806a79078
 msgid "Model Fitting"
-msgstr ""
+msgstr "Ajuste del modelo"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:180004
 #: e97fedb22e5d4a0da20f42800d500257
@@ -268,85 +287,83 @@ msgid ""
 "can use different samplers by passing the `nuts_sampler` argument. For "
 "instance, we can use `numpyro` `nutpie` or `blackjax` samplers (see "
 "{ref}`other_nuts_samplers` for more details)."
-msgstr ""
+msgstr "Ahora ajustemos el modelo a nuestros datos usando muestreo MCMC. Ten en cuenta que podemos usar diferentes muestreadores pasando el argumento `nuts_sampler`. Por ejemplo, podemos usar los muestreadores `numpyro`, `nutpie` o `blackjax` (consulta {ref}`other_nuts_samplers` para más detalles)."
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:200002
 #: 1e59f8fd1b0c4be39e72bf340665bac9
 msgid "Model Diagnostics"
-msgstr ""
+msgstr "Diagnóstico del modelo"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:200004
 #: 8ddc1983ed5a490795bae17395a7785a
 msgid ""
 "After fitting, we should check the model quality. Let's start with "
 "divergences:"
-msgstr ""
+msgstr "Después del ajuste, debemos verificar la calidad del modelo. Comencemos con las divergencias:"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:220002
 #: b71eac99be834970a6f377fb91b4b3f5
 msgid "Parameter Summary"
-msgstr ""
+msgstr "Resumen de parámetros"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:220004
 #: ae0679412cd74fce96046c66711aa7c3
 msgid "Let's examine the estimated parameters:"
-msgstr ""
+msgstr "Examinemos los parámetros estimados:"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:240002
 #: a2decdf92aaa4b8c9dba9dc118909562
 msgid "Good trace plots should show:"
-msgstr ""
+msgstr "Los gráficos de traza adecuados deben mostrar:"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:240003
 #: 444f66b79ac844fea5dae20852ecc38a
 msgid "**Left side**: Smooth, bell-shaped distributions"
-msgstr ""
+msgstr "**Lado izquierdo**: Distribuciones suaves con forma de campana"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:240004
 #: 633203436abb4e9dbbe45664b56cf16b
-msgid ""
-"**Right side**: \"Fuzzy caterpillar\" patterns (good mixing) with no "
-"trends"
-msgstr ""
+msgid "**Right side**: \"Fuzzy caterpillar\" patterns (good mixing) with no trends"
+msgstr "**Lado derecho**: patrones de "oruga difusa" (buen mezclado) sin tendencias"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:250002
 #: 2c49ae6a3c18463584aea238b92a3371
 msgid "Posterior Predictive Check"
-msgstr ""
+msgstr "Verificación predictiva posterior"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:250004
 #: 4255302aea6b4019922f5ecebc9bc554
 msgid "How well does our model fit the observed data?"
-msgstr ""
+msgstr "¿Qué tan bien se ajusta nuestro modelo a los datos observados?"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:270002
 #: b71ca0f963fd47878254fb7bab2df85a
 msgid ""
 "The model captures the observed data well if the black dots (actual "
 "sales) fall within the shaded uncertainty bands."
-msgstr ""
+msgstr "El modelo captura bien los datos observados si los puntos negros (ventas reales) caen dentro de las bandas de incertidumbre sombreadas."
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:280002
 #: f5fa2463f17b4fafbb24f8250d2b3743
 msgid "Contribution Analysis"
-msgstr ""
+msgstr "Análisis de contribución"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:280004
 #: c1bb536c57c94e84b97b6ad5cbab18dc
 msgid ""
 "Now for the fun part—understanding how much each component contributes to"
 " sales!"
-msgstr ""
+msgstr "Ahora viene la parte divertida: ¡entender cuánto contribuye cada componente a las ventas!"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:280006
 #: c79282f509b34d27bb306cea1b3137ed
 msgid "Component Contributions Over Time"
-msgstr ""
+msgstr "Contribuciones de componentes a lo largo del tiempo"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:280008
 #: e97f7b20c1b54a3e9c056cf82eb7db4d
 msgid "Let's visualize the contribution of each component of the model over time:"
-msgstr ""
+msgstr "Visualicemos la contribución de cada componente del modelo a lo largo del tiempo:"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:300002
 #: 774a06e020bd4a6494735003c054fba8
@@ -354,60 +371,60 @@ msgid ""
 "We see that we have captured the linear trend, events contributions and "
 "the seasonalities in the data. The remaining variation is due to the "
 "media channels, which is exactly what we want to understand."
-msgstr ""
+msgstr "Observamos que hemos capturado la tendencia lineal, las contribuciones de los eventos y las estacionalidades en los datos. La variación restante se debe a los canales de medios, que es exactamente lo que queremos entender."
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:310002
 #: 49a6f7e9b6b84a468538f76829bac80f
 msgid "Waterfall Chart: Total Contribution by Component"
-msgstr ""
+msgstr "Gráfico de cascada: Contribución total por componente"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:310004
 #: 1bfd7d4016ae455ebc5452aaac0c2c72
 msgid ""
 "A waterfall chart shows the total contribution of each component across "
 "the entire time period:"
-msgstr ""
+msgstr "Un gráfico de cascada muestra la contribución total de cada componente en todo el período de tiempo:"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:330002
 #: 6b1962f885b846d587597fb16ca83331
 msgid ""
 "This chart answers the question: **\"How much did each component "
 "contribute to total sales?\"**"
-msgstr ""
+msgstr "Este gráfico responde a la pregunta: **\"¿Cuánto contribuyó cada componente a las ventas totales?\"**"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:340002
 #: 884f0490b8524c6896a5d9e26e21d8e7
 msgid "Channel Contribution Share"
-msgstr ""
+msgstr "Participación de contribución por canal"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:340004
 #: 18af143e70b04e1a9b92b521c85d8508
 msgid "What percentage of media-driven sales comes from each channel?"
-msgstr ""
+msgstr "¿Qué porcentaje de ventas impulsadas por medios proviene de cada canal?"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:360002
 #: 68b848d2e914471fb77ed74b33cb8afb
 msgid "Direct Contribution Curves"
-msgstr ""
+msgstr "Curvas de contribución directa"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:360004
 #: b2e292fd19b44f5cab186158b4a1b9d8
 msgid ""
 "These curves show the relationship between spend and contribution, "
 "accounting for saturation:"
-msgstr ""
+msgstr "Estas curvas muestran la relación entre gasto y contribución, teniendo en cuenta la saturación:"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:380002
 #: 702a6629e711455c996c9d7815c774f0
 msgid ""
 "Notice how the curves flatten at higher spend levels—this is the "
 "saturation effect in action!"
-msgstr ""
+msgstr "Observa cómo las curvas se aplanan a niveles de gasto más altos: ¡este es el efecto de saturación en acción!"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:390002
 #: c8d7d36ec7854178bfc8a66d7ae56bff
 msgid "Channel Contribution Grid"
-msgstr ""
+msgstr "Cuadrícula de contribución por canal"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:400002
 #: b50ea076fd5a409c9643b1d71176836a
@@ -419,7 +436,7 @@ msgid ""
 " data and for $\\delta = 1.5$ we have a $50\\%$ increase in the spend, "
 "then we can compute the channel contribution at a grid of "
 "$\\delta$-values and plot the results:"
-msgstr ""
+msgstr "Una vista complementaria del rendimiento de los medios consiste en evaluar la contribución por canal en **diferentes niveles de participación de gasto durante todo el período de entrenamiento**. Concretamente, si denotamos por $\\delta$ el nivel porcentual del gasto de entrada del canal, de modo que para $\\delta = 1$ tenemos los datos de gasto de entrada del modelo y para $\\delta = 1.5$ tenemos un aumento del 50\\% en el gasto, entonces podemos calcular la contribución por canal en una cuadrícula de valores de $\\delta$ y graficar los resultados:"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:420002
 #: bd0c1baf0b3b48c1a54aed93cc967ce5
@@ -427,24 +444,24 @@ msgid ""
 "Here we can also see the saturation effect and the relative contribution "
 "of each channel as a function of the share spend level on the aggregate "
 "time period."
-msgstr ""
+msgstr "Aquí también podemos ver el efecto de saturación y la contribución relativa de cada canal en función del nivel de participación de gasto en el período de tiempo agregado."
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:430002
 #: 5277191696da49089ca7628ca57885a6
 msgid "Next Steps"
-msgstr ""
+msgstr "Próximos pasos"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:430004
 #: 552b9bac08b14abcafd76b1957b11d78
 msgid ""
 "Congratulations! You've successfully fitted your first MMM model with "
 "PyMC-Marketing. 🎉"
-msgstr ""
+msgstr "¡Felicidades! Has ajustado con éxito tu primer modelo MMM con PyMC-Marketing. 🎉"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:430006
 #: 667d55f56dab4a03a3948d3e96691c3e
 msgid "To continue your journey, check out:"
-msgstr ""
+msgstr "Para continuar tu recorrido, revisa:"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:430008
 #: 447ca0fbdc304c188ced489268c3d7f9
@@ -453,14 +470,15 @@ msgid ""
 "{ref}`mmm_example`: A comprehensive walkthrough including data "
 "generation, ROAS calculation, and more advanced diagnostics"
 msgstr ""
+"{ref}`mmm_example`: Un recorrido completo que incluye generación de datos, cálculo de ROAS y diagnósticos avanzados"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:430009
 #: 88d9159224b94be298da5f420f4ca28c
 #, python-brace-format
 msgid ""
-"{ref}`mmm_budget_allocation_example`: Learn how to optimize your "
-"marketing budget allocation"
+"{ref}`mmm_budget_allocation_example`: Aprende cómo optimizar la asignación de tu presupuesto de marketing"
 msgstr ""
+"{ref}`mmm_budget_allocation_example`: Aprende cómo optimizar la asignación de tu presupuesto de marketing"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:430010
 #: 8c34b78a8679437eb1f3404513ef4d15
@@ -469,25 +487,26 @@ msgid ""
 "{ref}`mmm_lift_test`: Incorporate experimental results to improve model "
 "accuracy"
 msgstr ""
+"{ref}`mmm_lift_test`: Incorpora resultados experimentales para mejorar la precisión del modelo"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:430011
 #: 913f2fc04fa9457c80691a73af5c0521
 #, python-brace-format
-msgid "{ref}`mmm_tv_intercept`: Model changing baseline effects over time"
-msgstr ""
+msgid "{ref}`mmm_tv_intercept`: Modela los cambios en los efectos de línea base a lo largo del tiempo"
+msgstr "{ref}`mmm_tv_intercept`: Modela los cambios en los efectos de línea base a lo largo del tiempo"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:430012
 #: fbf776a4863c43efa670160fbe31d29d
 #, python-brace-format
 msgid ""
-"{ref}`mmm_time_varying_media_example`: Model changing media efficiency "
-"over time"
+"{ref}`mmm_time_varying_media_example`: Modela la eficiencia de los medios variable a lo largo del tiempo"
 msgstr ""
+"{ref}`mmm_time_varying_media_example`: Modela la eficiencia de los medios variable a lo largo del tiempo"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:440002
 #: 79ae0f4438d6471caf317a30923aed05
 msgid "PyMC-Marketing MMM Features"
-msgstr ""
+msgstr "Características MMM de PyMC-Marketing"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:440004
 #: 64812acbe26d45abb16c6168bc5e3acc
@@ -495,165 +514,165 @@ msgid ""
 "PyMC-Marketing provides a comprehensive suite of tools for Marketing Mix "
 "Modeling:"
 msgstr ""
+"PyMC-Marketing ofrece un conjunto completo de herramientas para el Modelado de "
+"Mezcla de Medios:"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:150004
 #: 617d085d825f47c490c8a7f17f28004c
 msgid "Feature"
-msgstr ""
+msgstr "Característica"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:150004
 #: f1ae68a4c84f4b9ea63038bf1fb2bf11
 msgid "Description"
-msgstr ""
+msgstr "Descripción"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:150004
 #: babbc7e29c08489f85f190ab1e8e04c6
 msgid "**Custom Priors and Likelihoods**"
-msgstr ""
+msgstr "**Distribuciones a priori y verosimilitudes personalizadas**"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:150004
 #: 7dc9a37b17444e969d9335a7957a8373
-msgid ""
-"Tailor your model to your specific business needs by including domain "
-"knowledge via prior distributions"
-msgstr ""
+msgid "Tailor your model to your specific business needs by including domain knowledge via prior distributions"
+msgstr "Adapta tu modelo a tus necesidades específicas de negocio incluyendo conocimiento del dominio mediante distribuciones a priori"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:150004
 #: c2aafd011c284ecbb73b9b1895e895b7
 msgid "**Adstock Transformation**"
-msgstr ""
+msgstr "**Transformación Adstock**"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:150004
 #: f869c8ee7bf94c12998f6109204cc7d0
 msgid "Optimize the carry-over effects in your marketing channels"
-msgstr ""
+msgstr "Optimiza los efectos de arrastre en tus canales de marketing"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:150004
 #: 8bcf46e8922c4b368c18f19ab5f977bd
 msgid "**Saturation Effects**"
-msgstr ""
+msgstr "**Efectos de saturación**"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:150004
 #: 9fc6fb28a80046129ab7ff8fc4494427
 msgid "Understand the diminishing returns in media investments"
-msgstr ""
+msgstr "Comprende los rendimientos decrecientes en las inversiones en medios"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:150004
 #: 533e1bd5a5c14f6ca0301e679deb3905
 msgid "**Customize adstock and saturation functions**"
-msgstr ""
+msgstr "**Personaliza las funciones de adstock y saturación**"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:150004
 #: 02188d3015ff467090b2ad7b3bbd2acf
 msgid ""
 "Select from a variety of adstock and saturation functions, or implement "
 "your own custom functions"
-msgstr ""
+msgstr "Elige entre una variedad de funciones de adstock y saturación, o implementa tus propias funciones personalizadas"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:150004
 #: 0721093c8dea4717b2ea249c873489ef
 msgid "**Time-varying Intercept**"
-msgstr ""
+msgstr "**Intercepto variable en el tiempo**"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:150004
 #: 2c5b5b35261944e3b4456878cbd31d63
 msgid ""
 "Capture time-varying baseline contributions using modern and efficient "
 "Gaussian processes approximation methods"
-msgstr ""
+msgstr "Captura las contribuciones de línea base variables en el tiempo utilizando métodos modernos y eficientes de aproximación con procesos Gaussianos"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:150004
 #: d94bf94bcc79433494e7576b004ce3ad
 msgid "**Time-varying Media Contribution**"
-msgstr ""
+msgstr "**Contribución de medios variable en el tiempo**"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:150004
 #: 0a2c5ee096f343e0befcb452ae992d15
 msgid "Capture time-varying media efficiency in your model"
-msgstr ""
+msgstr "Captura la eficiencia de los medios variable en el tiempo en tu modelo"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:150004
 #: 1c32bb626b7c4fc7b89a1f99be2987c6
 msgid "**Visualization and Model Diagnostics**"
-msgstr ""
+msgstr "**Visualización y diagnóstico del modelo**"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:150004
 #: f75f5e6374794151a1fdd03709df2128
 msgid "Get a comprehensive view of your model's performance and insights"
-msgstr ""
+msgstr "Obtén una visión completa del rendimiento y los insights de tu modelo"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:150004
 #: adcd47e656cf446f90c24c85a91692d4
 msgid "**Causal Identification**"
-msgstr ""
+msgstr "**Identificación causal**"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:150004
 #: beda56b278cb43a091c350271b3f0b3e
 msgid ""
 "Input a business-driven directed acyclic graph to identify meaningful "
 "variables for causal conclusions"
-msgstr ""
+msgstr "Introduce un grafo acíclico dirigido basado en objetivos de negocio para identificar variables significativas para conclusiones causales"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:150004
 #: 31461a17dfdd45ee92715ff4286f3515
 msgid "**Multiple inference algorithms**"
-msgstr ""
+msgstr "**Múltiples algoritmos de inferencia**"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:150004
 #: bd6c6710012e45e4aabd87386deb7212
 msgid "Choose between various NUTS samplers (e.g., BlackJax, NumPyro, and Nutpie)"
-msgstr ""
+msgstr "Elige entre varios muestreadores NUTS (p. ej., BlackJax, NumPyro y Nutpie)"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:150004
 #: 33900928899a4937a739bda304c4610e
 msgid "**GPU Support**"
-msgstr ""
+msgstr "**Compatibilidad con GPU**"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:150004
 #: 339cbf12799a45c99e2ae9499f35ae2d
 msgid "PyMC's multiple backends allow for GPU acceleration"
-msgstr ""
+msgstr "Los múltiples backends de PyMC permiten aceleración por GPU"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:150004
 #: c10cd6d05e8f4c2fac2012ecf1ee4bae
 msgid "**Out-of-sample Predictions**"
-msgstr ""
+msgstr "**Predicciones fuera de muestra**"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:150004
 #: 26baf77ac62c436daf53b0454bf45917
 msgid ""
 "Forecast future marketing performance with credible intervals for "
 "simulations and scenario planning"
-msgstr ""
+msgstr "Pronostica el rendimiento futuro de marketing con intervalos creíbles para simulaciones y planificación de escenarios"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:150004
 #: 51a2a9c06db0491290e7cac8970d2728
 msgid "**Budget Optimization**"
-msgstr ""
+msgstr "**Optimización de presupuesto**"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:150004
 #: 1754bd11ab3f4eb6945b960a698546f9
 msgid ""
 "Allocate your marketing spend efficiently across various channels for "
 "maximum ROI"
-msgstr ""
+msgstr "Asigna tu gasto de marketing de manera eficiente entre varios canales para maximizar el ROI"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:150004
 #: 3e1d7d4cb4a746efa3b323f96564ec23
 msgid "**Experiment Calibration**"
-msgstr ""
+msgstr "**Calibración de experimentos**"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:150004
 #: 9ae865a2138b47c9b6f3913e33dda095
 msgid ""
 "Fine-tune your model based on empirical experiments (lift tests) for a "
 "more unified view of marketing"
-msgstr ""
+msgstr "Ajusta tu modelo basándote en experimentos empíricos (pruebas de lift) para una visión de marketing más unificada"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:450002
 #: a40f3816412a4531bc647aaf0e90760b
 msgid "References"
-msgstr ""
+msgstr "Referencias"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:450004
 #: fbc190ce152a4ae5a79cfca309ce2bbd
@@ -661,16 +680,16 @@ msgid ""
 "Jin, Y., Wang, Y., Sun, Y., Chan, D., & Koehler, J. (2017). [Bayesian "
 "Methods for Media Mix Modeling with Carryover and Shape "
 "Effects.](https://research.google/pubs/pub46001/)"
-msgstr ""
+msgstr "Jin, Y., Wang, Y., Sun, Y., Chan, D. y Koehler, J. (2017). [Métodos bayesianos para el Modelado de Mezcla de Medios con efectos de arrastre y de forma.](https://research.google/pubs/pub46001/)"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:450005
 #: 3a06777c2e6141d8a7529b2287743b5a
 msgid "[PyMC-Marketing Documentation](https://www.pymc-marketing.io/)"
-msgstr ""
+msgstr "[Documentación de PyMC-Marketing](https://www.pymc-marketing.io/)"
 
 #: ../source/notebooks/mmm/mmm_quickstart.ipynb:450006
 #: 1465cb0314414acf954647b0939792e5
 msgid ""
 "Juan Orduz, [Media Effect Estimation with PyMC: Adstock, Saturation & "
 "Diminishing Returns](https://juanitorduz.github.io/pymc_mmm/)"
-msgstr ""
+msgstr "Juan Orduz, [Estimación de efectos de medios con PyMC: Adstock, Saturación y Rendimientos decrecientes](https://juanitorduz.github.io/pymc_mmm/)"


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->
Translating notebooks:
1. Quick start
2. case study
3. multidimensional example.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--1995.org.readthedocs.build/en/1995/

<!-- readthedocs-preview pymc-marketing end -->