### PR TITLE
Solving issue in #2006 doing the optimization more obvious not close to the limit.

### DIFF
--- a/docs/source/notebooks/mmm/mmm_multi_objective_optimization.ipynb
+++ b/docs/source/notebooks/mmm/mmm_multi_objective_optimization.ipynb
@@ -1455,7 +1455,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "min_total_response = 10\n",
+    "min_total_response = 8\n",
     "\n",
     "\n",
     "def mean_response_eq_constraint_fun(budgets_sym, total_budget_sym, optimizer):\n",


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->
Changing the limit to be lower and be less closer to the upper limit avoiding sometimes the optimization runs out of iterations.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #2006
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2007.org.readthedocs.build/en/2007/

<!-- readthedocs-preview pymc-marketing end -->