### PR TITLE
Solving issue with wrapper detection in optimizer

### DIFF
--- a/pymc_marketing/mmm/budget_optimizer.py
+++ b/pymc_marketing/mmm/budget_optimizer.py
@@ -681,7 +681,7 @@ class BudgetOptimizer(BaseModel):
         # Only perform non-zero channel detection for MMM instances.
         # For OptimizerCompatibleModelWrapper, default to optimizing all channels unless a mask is provided.
         is_wrapper = (
-            False if "channel_contribution" in self.mmm_model.idata.posterior else True
+            "channel_contribution" not in self.mmm_model.idata.posterior.data_vars
         )
 
         if self.budgets_to_optimize is None:


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2021.org.readthedocs.build/en/2021/

<!-- readthedocs-preview pymc-marketing end -->