### PR TITLE
Add Causal Reasoning and Discovery example to gallery

### DIFF
--- a/docs/source/gallery/gallery.md
+++ b/docs/source/gallery/gallery.md
@@ -152,10 +152,10 @@ Welcome to the PyMC-Marketing example gallery! This gallery provides visual navi
 :link: ../notebooks/mmm/mmm_counterfactuals.html
 :::
 
-::::{grid-item-card} Upper-funnel causal approach
+:::{grid-item-card} Upper-funnel causal approach
 :img-top: ../gallery/images/mmm_causal_identification.png
 :link: ../notebooks/mmm/mmm_upper_funnel_causal_approach.html
-::::
+:::
 
 :::{grid-item-card} Causal Reasoning and Discovery
 :img-top: ../gallery/images/mmm_causal_reasoning_and_discovery.png


### PR DESCRIPTION
Added a new grid item card for 'Causal Reasoning and Discovery' in the gallery markdown.

<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2033.org.readthedocs.build/en/2033/

<!-- readthedocs-preview pymc-marketing end -->