### PR TITLE
Enforce original scale variable before CPT calibration

### DIFF
--- a/data/config_files/multi_dimensional_hierarchical_with_arbitrary_effects_model.yml
+++ b/data/config_files/multi_dimensional_hierarchical_with_arbitrary_effects_model.yml
@@ -107,6 +107,10 @@ effects:
             b: 0.1
             dims: ["weekly_fourier", "market"]
 
+original_scale_vars:
+  - channel_contribution
+  - intercept_contribution
+
 # ----------------------------------------------------------------------
 # Calibration examples (lift tests + CPT constraints)
 calibration:

--- a/pymc_marketing/mmm/builders/yaml.py
+++ b/pymc_marketing/mmm/builders/yaml.py
@@ -181,15 +181,15 @@ def build_mmm_from_yaml(
     # 4 ───────────────────────────────────────────── build PyMC graph
     model.build_model(X, y)  # this **must** precede any idata loading
 
-    # 4b ──────────────────────────────────────────── apply calibration steps (if any)
-    _apply_and_validate_calibration_steps(model, cfg, config_path.parent)
-
     # 5 ───────────────────────── add original scale contribution variables
     original_scale_vars = cfg.get("original_scale_vars", [])
     if original_scale_vars:
         model.add_original_scale_contribution_variable(var=original_scale_vars)
 
-    # 6 ──────────────────────────────────────────── attach inference data
+    # 6 ──────────────────────────────────────────── apply calibration steps (if any)
+    _apply_and_validate_calibration_steps(model, cfg, config_path.parent)
+
+    # 7 ──────────────────────────────────────────── attach inference data
     if (idata_fp := cfg.get("idata_path")) is not None:
         idata_path = Path(idata_fp)
         if os.path.exists(idata_path):

--- a/pymc_marketing/mmm/multidimensional.py
+++ b/pymc_marketing/mmm/multidimensional.py
@@ -2062,10 +2062,10 @@ class MMM(RegressionModelBuilder):
         with self.model:
             # Ensure original-scale contribution exists
             if "channel_contribution_original_scale" not in self.model.named_vars:
-                self.add_original_scale_contribution_variable(
-                    [
-                        "channel_contribution",
-                    ]
+                raise ValueError(
+                    "`channel_contribution_original_scale` is not in the model."
+                    "Please, add the original scale contribution variable using the method "
+                    "`add_original_scale_contribution_variable` before adding the cost-per-target calibration."
                 )
 
             denom = pt.clip(

--- a/tests/mmm/test_lift_test.py
+++ b/tests/mmm/test_lift_test.py
@@ -643,3 +643,127 @@ def test_add_cost_per_target_potentials_missing_columns(dummy_mmm_model):
             cpt_value=const_cpt,
             name_prefix="cpt_calibration",
         )
+
+
+def test_add_cost_per_target_potentials_with_posterior_predictive_out_of_sample(
+    mock_pymc_sample,
+):
+    """Test that add_cost_per_target_potentials works with sample_posterior_predictive on out-of-sample data.
+
+    This test validates that:
+    1. Adding cost_per_target potentials doesn't break posterior predictive sampling
+    2. Out-of-sample data (different dates than training) works correctly
+    3. The returned data structure is valid
+    """
+    # Create sample data for model
+    np.random.seed(42)
+    n_train = 40
+    n_test = 10
+
+    df_train = pd.DataFrame(
+        {
+            "date": pd.to_datetime(pd.date_range("2024-01-01", periods=n_train)),
+            "organic": np.random.rand(n_train) * 520,
+            "paid": np.random.rand(n_train) * 200,
+            "social": np.random.rand(n_train) * 50,
+            "y": np.random.rand(n_train) * 500,
+        }
+    )
+
+    X_train = df_train[["date", "organic", "paid", "social"]]
+    y_train = df_train["y"]
+
+    # Initialize and build model
+    mmm = MMM(
+        date_column="date",
+        adstock=GeometricAdstock(l_max=4),
+        saturation=LogisticSaturation(),
+        channel_columns=["organic", "paid", "social"],
+    )
+    mmm.build_model(X_train, y_train)
+
+    # Create a cost_per_target tensor over (date, channel)
+    dates = mmm.model.coords["date"]
+    channels = mmm.model.coords["channel"]
+    const_cpt = pt.as_tensor_variable(
+        np.full((len(dates), len(channels)), 25.0, dtype=float)
+    )
+
+    # Calibration DataFrame with targets
+    calibration_df = pd.DataFrame(
+        {
+            "channel": [channels[0], channels[1]],
+            "cost_per_target": [25.0, 35.0],
+            "sigma": [3.0, 4.0],
+        }
+    )
+
+    # Add cost_per_target potentials to the model
+    add_cost_per_target_potentials(
+        calibration_df=calibration_df,
+        model=mmm.model,
+        cpt_value=const_cpt,
+        name_prefix="cpt_calibration",
+    )
+
+    # Verify potential was added
+    pot_names = [getattr(p, "name", None) for p in mmm.model.potentials]
+    assert "cpt_calibration" in pot_names
+
+    # Fit the model
+    mmm.fit(X_train, y_train, draws=25, tune=25, chains=1, random_seed=42)
+
+    # Verify model was fitted
+    assert hasattr(mmm, "idata")
+    assert mmm.idata is not None
+
+    # Create out-of-sample data with different dates
+    df_test = pd.DataFrame(
+        {
+            "date": pd.to_datetime(
+                pd.date_range(
+                    start=df_train["date"].max() + pd.Timedelta(days=1), periods=n_test
+                )
+            ),
+            "organic": np.random.rand(n_test) * 520,
+            "paid": np.random.rand(n_test) * 200,
+            "social": np.random.rand(n_test) * 50,
+        }
+    )
+
+    X_test = df_test[["date", "organic", "paid", "social"]]
+
+    # Sample posterior predictive with out-of-sample data
+    # This is the critical test - it should work without errors
+    posterior_pred = mmm.sample_posterior_predictive(
+        X_test, extend_idata=False, random_seed=42
+    )
+
+    # Validate the output structure
+    assert posterior_pred is not None
+    assert "y" in posterior_pred, "Posterior predictive should contain 'y' variable"
+
+    # Validate dimensions - should match test data
+    assert "date" in posterior_pred.dims, "Should have 'date' dimension"
+    assert len(posterior_pred.coords["date"]) == n_test, (
+        f"Date dimension should have {n_test} entries for test data"
+    )
+
+    # Verify that the dates match the test data
+    np.testing.assert_array_equal(
+        posterior_pred.coords["date"].values,
+        X_test["date"].values,
+        err_msg="Posterior predictive dates should match test data dates",
+    )
+
+    # Verify shape of predictions
+    # When extend_idata=False and combined=True (default), dimensions are stacked
+    expected_dims = ("sample", "date")
+    assert set(posterior_pred["y"].dims) == set(expected_dims), (
+        f"Predictions should have dimensions {expected_dims}, got {posterior_pred['y'].dims}"
+    )
+
+    # Verify no NaN values in predictions
+    assert not np.isnan(posterior_pred["y"].values).any(), (
+        "Predictions should not contain NaN values"
+    )

--- a/tests/mmm/test_multidimensional.py
+++ b/tests/mmm/test_multidimensional.py
@@ -1316,6 +1316,9 @@ def test_add_calibration_test_measurements(multi_dim_data):
     # Build the model
     mmm.build_model(X, y)
 
+    # Add original scale contribution variable first (required before calibration)
+    mmm.add_original_scale_contribution_variable(var=["channel_contribution"])
+
     # Spend data: same structure as X (use X directly for simplicity)
     spend_df = X.copy()
 
@@ -1371,6 +1374,46 @@ def test_add_cost_per_target_calibration_requires_model(multi_dim_data) -> None:
 
     with pytest.raises(
         RuntimeError, match=r"Model must be built before adding calibration."
+    ):
+        mmm.add_cost_per_target_calibration(
+            data=spend_df,
+            calibration_data=calibration_df,
+            name_prefix="cpt_calibration",
+        )
+
+
+def test_add_cost_per_target_calibration_requires_original_scale(
+    multi_dim_data,
+) -> None:
+    """Test that add_cost_per_target_calibration raises error when original scale variable doesn't exist."""
+    X, y = multi_dim_data
+
+    mmm = MMM(
+        date_column="date",
+        target_column="target",
+        channel_columns=["channel_1", "channel_2", "channel_3"],
+        dims=("country",),
+        adstock=GeometricAdstock(l_max=2),
+        saturation=LogisticSaturation(),
+    )
+
+    mmm.build_model(X, y)
+
+    # Don't add original scale variable - should cause error
+    spend_df = X.copy()
+    countries = mmm.model.coords["country"]
+    calibration_df = pd.DataFrame(
+        {
+            "country": [countries[0]],
+            "channel": ["channel_1"],
+            "cost_per_target": [30.0],
+            "sigma": [2.0],
+        }
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"`channel_contribution_original_scale` is not in the model.",
     ):
         mmm.add_cost_per_target_calibration(
             data=spend_df,
@@ -2922,6 +2965,9 @@ def test_calibration_spend_reindexing_in_posterior_predictive(
         }
     )
 
+    # Add original scale contribution variable first (required before calibration)
+    mmm.add_original_scale_contribution_variable(var=["channel_contribution"])
+
     # Add calibration
     mmm.add_cost_per_target_calibration(
         data=spend_df,
@@ -3014,6 +3060,9 @@ def test_calibration_spend_with_different_dtypes(multi_dim_data, mock_pymc_sampl
         }
     )
 
+    # Add original scale contribution variable first (required before calibration)
+    mmm.add_original_scale_contribution_variable(var=["channel_contribution"])
+
     # Add calibration
     mmm.add_cost_per_target_calibration(
         data=spend_df,
@@ -3075,6 +3124,9 @@ def test_calibration_duplicate_name_error(multi_dim_data, mock_pymc_sample):
         }
     )
 
+    # Add original scale contribution variable first (required before calibration)
+    mmm.add_original_scale_contribution_variable(var=["channel_contribution"])
+
     # Add calibration first time
     mmm.add_cost_per_target_calibration(
         data=spend_df,
@@ -3109,6 +3161,9 @@ def test_calibration_shape_mismatch_error(multi_dim_data, mock_pymc_sample):
 
     # Build the model
     mmm.build_model(X, y)
+
+    # Add original scale contribution variable first (required before calibration)
+    mmm.add_original_scale_contribution_variable(var=["channel_contribution"])
 
     # Create spend data with different shape (remove some countries)
     spend_df = X.copy()
@@ -3161,6 +3216,9 @@ def test_calibration_coordinate_label_mismatch_error(multi_dim_data, mock_pymc_s
 
     # Build the model
     mmm.build_model(X, y)
+
+    # Add original scale contribution variable first (required before calibration)
+    mmm.add_original_scale_contribution_variable(var=["channel_contribution"])
 
     # Create spend data with the same shape but mismatched coordinate labels
     spend_df = X.copy()


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->
Now calibration require the original scale contribution variable to be added before applying cost-per-target (CPT) calibration in multidimensional MMM models. 

Updated the YAML builder to add original scale variables before calibration, improved error handling, and added/updated tests to validate this requirement and ensure correct behavior with out-of-sample posterior predictive sampling.


## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2036.org.readthedocs.build/en/2036/

<!-- readthedocs-preview pymc-marketing end -->