### PR TITLE
update closing-labels action

### DIFF
--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v5
     - name: Sync labels with closing issues
-      uses: williambdean/closing-labels@v0.0.4
+      uses: williambdean/closing-labels@v0.0.6
       with:
         exclude: "question,request discussion,help wanted"
         respect_unlabeled: true


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

My action broke due to a github CLI update. This PR fixes it.

The action does run here using the previous configuration due to the trigger of `pull_request_target` instead of `pull_request`:

https://github.com/pymc-labs/pymc-marketing/blob/9e08684f576c2bb5514055b11c086711f80f7048/.github/workflows/pr-auto-label.yml?plain=1#L2-L3

However, I've testing this fix with separate repos.

Current logs: https://github.com/pymc-labs/pymc-marketing/actions/runs/18813004819

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2038.org.readthedocs.build/en/2038/

<!-- readthedocs-preview pymc-marketing end -->