### PR TITLE
Correct spelling of 'FiveTran' to 'Fivetran'

### DIFF
--- a/docs/source/notebooks/mmm/mmm_fivetran_connectors.ipynb
+++ b/docs/source/notebooks/mmm/mmm_fivetran_connectors.ipynb
@@ -5,7 +5,7 @@
    "id": "9c7c1b1e",
    "metadata": {},
    "source": [
-    "# FiveTran Data Loaders\n",
+    "# Fivetran Data Loaders\n",
     "\n",
     "This notebook demonstrates how to use PyMC-Marketing's Fivetran data loaders to quickly prepare data for MMM modeling.\n",
     "\n",
@@ -399,7 +399,7 @@
    "source": [
     "All `ad_reporting` tables can provide information about your drivers (media channels) which affect your target metric. But how can you get information from your target?\n",
     "\n",
-    "Currently, FiveTran allows you to get information from Shopify, using [dbt_shopify](https://github.com/fivetran/dbt_shopify?tab=readme-ov-file#step-3-define-database-and-schema-variables). You can use the data loaders to access the `shopify__orders` schema and then transform the dataset to get the output ready for your media mix model."
+    "Currently, Fivetran allows you to get information from Shopify, using [dbt_shopify](https://github.com/fivetran/dbt_shopify?tab=readme-ov-file#step-3-define-database-and-schema-variables). You can use the data loaders to access the `shopify__orders` schema and then transform the dataset to get the output ready for your media mix model."
    ]
   },
   {


### PR DESCRIPTION
Correct spelling of 'FiveTran' to 'Fivetran'


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2084.org.readthedocs.build/en/2084/

<!-- readthedocs-preview pymc-marketing end -->