### PR TITLE
import bass function from module instead of submodule

### DIFF
--- a/pymc_marketing/bass/__init__.py
+++ b/pymc_marketing/bass/__init__.py
@@ -12,3 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 """Bass model."""
+
+from pymc_marketing.bass.model import BassPriors, create_bass_model
+
+__all__ = ["BassPriors", "create_bass_model"]

--- a/pymc_marketing/bass/model.py
+++ b/pymc_marketing/bass/model.py
@@ -89,7 +89,7 @@ Create a basic Bass model for multiple products:
     import pandas as pd
     import pymc as pm
 
-    from pymc_marketing.bass.model import create_bass_model
+    from pymc_marketing.bass import create_bass_model, BassPriors
     from pymc_marketing.plot import plot_curve
     from pymc_extras.prior import Prior
 
@@ -102,7 +102,7 @@ Create a basic Bass model for multiple products:
     coords = {"T": t, "product": ["A", "B", "C"]}
 
     # Define priors
-    priors = {
+    priors: BassPriors = {
         "m": Prior("DiracDelta", c=10_000),  # Market potential
         "p": Prior("Beta", alpha=13.85, beta=692.43, dims="product"),  # Innovation coefficient
         "q": Prior("Beta", alpha=36.2, beta=54.4),  # Imitation coefficient
@@ -125,7 +125,7 @@ Create a basic Bass model for multiple products:
 
 """
 
-from typing import Any
+from typing import Any, TypedDict
 
 import pymc as pm
 import pytensor.tensor as pt
@@ -216,10 +216,19 @@ def f(
     )
 
 
+class BassPriors(TypedDict):
+    """Priors for the Bass diffusion model."""
+
+    m: Prior | Censored | VariableFactory
+    p: Prior | Censored | VariableFactory
+    q: Prior | Censored | VariableFactory
+    likelihood: Prior | Censored
+
+
 def create_bass_model(
     t: pt.TensorLike,
     observed: pt.TensorLike | None,
-    priors: dict[str, Prior | Censored | VariableFactory],
+    priors: BassPriors,
     coords: dict[str, Any],
 ) -> Model:
     r"""Define a Bass diffusion model for product adoption forecasting.
@@ -246,7 +255,7 @@ def create_bass_model(
     observed : pt.TensorLike | None
         Observed adoption data at each time point. If None, only
         prior predictive sampling is possible.
-    priors : dict[str, Prior | Censored | VariableFactory]
+    priors : BassPriors
         Dictionary containing priors for:
         - 'm': Market potential prior
         - 'p': Innovation coefficient prior


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

```python
from pymc_marketing.bass.model import create_bass_model
```

is now


```python
from pymc_marketing.bass import create_bass_model
```

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->