### PR TITLE
Fix plot_curve documentation examples not rendering

### DIFF
--- a/pymc_marketing/plot.py
+++ b/pymc_marketing/plot.py
@@ -684,7 +684,7 @@ def plot_curve(
 
     .. plot::
         :include-source: True
-        :context: reset
+        :context: close-figs
 
         fig, axes = plot_curve(
             curve,


### PR DESCRIPTION
Fixed the `plot_curve` documentation examples that were not rendering on the API documentation page.

## Changes
- Changed the second example's Sphinx plot directive from `:context: reset` to `:context: close-figs` in `pymc_marketing/plot.py:687`

## Root Cause
The second example was using `:context: reset` which clears all previous variables from the Sphinx plot directive context. This caused the example to fail because it tried to reference `curve` and `rng` variables that were defined in the first example but were cleared by the reset directive.

## Solution
By using `:context: close-figs` instead, the example now:
- Closes previous figures to avoid display issues
- Preserves all variables and imports from the first example
- Allows the second and third examples to properly reference `curve` and `rng`

## Testing
The fix ensures that all three plot examples in the `plot_curve` docstring will now render correctly in the documentation build.

Fixes #2127

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2130.org.readthedocs.build/en/2130/

<!-- readthedocs-preview pymc-marketing end -->