### PR TITLE
Fix: Use **kwargs instead of kwargs parameter in MNLogit methods

### DIFF
--- a/pymc_marketing/customer_choice/mnl_logit.py
+++ b/pymc_marketing/customer_choice/mnl_logit.py
@@ -373,7 +373,7 @@ class MNLogit(RegressionModelBuilder):
 
         return attrs
 
-    def sample_prior_predictive(self, extend_idata, kwargs):
+    def sample_prior_predictive(self, extend_idata, **kwargs):
         """Sample Prior Predictive Distribution."""
         with self.model:  # sample with new input data
             prior_pred: az.InferenceData = pm.sample_prior_predictive(500, **kwargs)
@@ -385,7 +385,7 @@ class MNLogit(RegressionModelBuilder):
             else:
                 self.idata = prior_pred
 
-    def fit(self, extend_idata, kwargs):
+    def fit(self, extend_idata, **kwargs):
         """Fit Nested Logit Model."""
         if extend_idata:
             with self.model:
@@ -394,7 +394,7 @@ class MNLogit(RegressionModelBuilder):
             with self.model:
                 self.idata = pm.sample(**kwargs)
 
-    def sample_posterior_predictive(self, extend_idata, kwargs):
+    def sample_posterior_predictive(self, extend_idata, **kwargs):
         """Sample Posterior Predictive Distribution."""
         if extend_idata:
             with self.model:
@@ -448,11 +448,11 @@ class MNLogit(RegressionModelBuilder):
             self.model = model
 
         self.sample_prior_predictive(
-            extend_idata=True, kwargs=sample_prior_predictive_kwargs
+            extend_idata=True, **sample_prior_predictive_kwargs
         )
-        self.fit(extend_idata=True, kwargs=fit_kwargs)
+        self.fit(extend_idata=True, **fit_kwargs)
         self.sample_posterior_predictive(
-            extend_idata=True, kwargs=sample_posterior_predictive_kwargs
+            extend_idata=True, **sample_posterior_predictive_kwargs
         )
         return self
 


### PR DESCRIPTION
## Description
This PR fixes the method signatures for `sample_prior_predictive`, `fit`, and `sample_posterior_predictive` in the `MNLogit` class to properly use `**kwargs` instead of accepting `kwargs` as a regular parameter.

##Changes made:
- Updated method signatures to use `**kwargs` directly in the function definition
- Modified the `sample()` method to unpack kwargs dictionaries when calling these methods (changed from `kwargs=dict_name` to `**dict_name`)

This allows keyword arguments to be properly passed through to the underlying PyMC sampling functions (`pm.sample_prior_predictive`, `pm.sample`, and `pm.sample_posterior_predictive`).

## Related Issue
- [x] Closes #2111

## Checklist
- [x] Checked that the pre-commit linting/style checks pass
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using numpydoc format
- [x] If you are a pro: each commit corresponds to a relevant logical change



<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2131.org.readthedocs.build/en/2131/

<!-- readthedocs-preview pymc-marketing end -->