### PR TITLE
Add Cursor command and rules documentation

### DIFF
--- a/.cursor/commands/code_best_practice.md
+++ b/.cursor/commands/code_best_practice.md
@@ -1,0 +1,165 @@
+# PyMC-Marketing Best Practices Guide
+
+This document outlines the coding conventions, preferred implementations, and style guidelines for contributing to `pymc-marketing`.
+
+## 1. Coding Style & Standards
+
+We follow strict linting and formatting rules enforced by **Ruff** and **MyPy**.
+
+### Python Conventions
+- **Type Hints**: All function arguments and return types must be typed.
+  ```python
+  # Good
+  def calculate_metric(data: pd.DataFrame, col: str) -> xarray.DataArray: ...
+
+  # Bad
+  def calculate_metric(data, col): ...
+  ```
+- **Line Length**: Maximum 120 characters.
+- **Imports**: Sorted automatically by Ruff.
+- **Validation**: Use `pydantic` for runtime validation of user inputs in `__init__` methods.
+
+### Docstrings (NumPy Style)
+All public classes and functions must have docstrings following the **NumPy style**.
+- **Sections**: Summary, Parameters, Returns, References (if applicable), Examples.
+- **Math**: Include citations to relevant papers for statistical models.
+- **Examples**: Use `.. code-block:: python` directive for code examples.
+
+```python
+def expected_purchases(self, future_t: int) -> xarray.DataArray:
+    """
+    Compute expected number of future purchases.
+
+    Parameters
+    ----------
+    future_t : int
+        Number of time periods to predict.
+
+    Returns
+    -------
+    xarray.DataArray
+        The expected number of purchases.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        model = MyModel(data)
+        model.fit()
+        model.expected_purchases(future_t=12)
+
+    References
+    ----------
+    .. [1] Fader, P. S., et al. (2005). "Counting Your Customers..."
+    """
+```
+
+## 2. Preferred Implementations for Speed & Scalability
+
+### Vectorization over Loops
+Avoid Python loops for mathematical operations. Use `numpy`, `xarray`, or `pytensor` (via `pymc`) broadcasting.
+
+- **Why**: Python loops are slow; vectorized operations in C/Fortran backends are orders of magnitude faster.
+
+```python
+# Bad: Iterating over customers
+results = []
+for customer in customers:
+    results.append(calculate_val(customer))
+
+# Good: Vectorized operation
+results = alpha * np.exp(-beta * data)
+```
+
+### Efficient PyMC Modeling
+1. **Use `pm.Data` for Mutable Inputs**:
+   Allows you to change data (e.g., for out-of-sample predictions) without rebuilding the model graph.
+   ```python
+   # In build_model
+   self.model_coords = {"customer_id": unique_ids}
+   with pm.Model(coords=self.model_coords) as self.model:
+       # Mutable data container
+       x_data = pm.Data("x_data", data[cols], dims="customer_id")
+       ...
+   ```
+
+2. **Batch Dimensions (Coords)**:
+   Use named dimensions (`dims`) instead of raw shapes. This integrates with `xarray` for post-processing.
+   ```python
+   # Good
+   alpha = pm.Normal("alpha", mu=0, sigma=1, dims="channel")
+   ```
+
+3. **HSGP for Gaussian Processes**:
+   For time-varying parameters (like in MMM), prefer **Hilbert Space Gaussian Processes (HSGP)** over standard GPs. HSGP approximates the GP using basis functions, reducing complexity from $O(n^3)$ to $O(n \cdot m)$.
+
+### PyTensor for Optimization & Analysis
+When implementing functionality like sensitivity analysis, optimization routines, or complex transformations, **prefer `pytensor` operations** over pure Python/NumPy.
+
+- **Backend Capabilities**: PyTensor graphs can be compiled to C, JAX, or MLX (Apple Silicon), enabling hardware acceleration and automatic differentiation.
+- **Automatic Differentiation**: Essential for gradient-based optimization and sensitivity analysis.
+
+```python
+import pytensor.tensor as pt
+
+# Good: PyTensor implementation
+def saturation(x, alpha):
+    return 1 - pt.exp(-alpha * x)
+
+# This graph can now be differentiated with respect to alpha
+```
+
+## 3. Class Structure & Design Patterns
+
+### Model Class Architecture
+Models should inherit from base classes (`BaseMMM`, `CLVModel`) and implement specific lifecycle methods:
+
+1.  **`__init__`**:
+    -   Validate inputs using `validate_call` or `pydantic`.
+    -   Store configuration (priors) in a `model_config` dictionary.
+    -   **Do not** build the PyMC model here.
+
+2.  **`build_model`**:
+    -   Constructs the PyMC model context.
+    -   Defines `pm.Data` containers and random variables.
+
+3.  **`_extract_predictive_variables`**:
+    -   Helper to prepare input data for predictions, converting `pandas` to `xarray`.
+
+### Configuration Management & Priors
+Use a `default_model_config` property to define default priors. This allows users to easily override specific priors without rewriting the whole model.
+
+**Always use `pymc_extras.prior.Prior` for defining distributions.** This provides a dictionary-based specification that is serializable and easy for users to modify.
+
+```python
+from pymc_extras.prior import Prior
+
+@property
+def default_model_config(self) -> dict:
+    return {
+        "alpha": Prior("Weibull", alpha=2, beta=10),
+        "beta": Prior("Normal", mu=0, sigma=1),
+    }
+```
+
+## 4. Testing Best Practices
+
+- **Framework**: `pytest`.
+- **Coverage**: High test coverage is required.
+- **Parametrization**: Use `@pytest.mark.parametrize` to test multiple scenarios efficiently.
+- **Synthetic Data**: Use helper functions to generate synthetic data for testing model recovery.
+
+```python
+@pytest.mark.parametrize("future_t", [1, 10])
+def test_expected_purchases(model, future_t):
+    pred = model.expected_purchases(future_t=future_t)
+    assert pred.shape == (4000, 100)  # (chains*draws, customers)
+```
+
+## 5. Workflow Checklist
+
+Before submitting a PR:
+1.  **Lint**: `make lint` (runs Ruff).
+2.  **Type Check**: `pre-commit run mypy --all-files`.
+3.  **Test**: `make test`.
+4.  **Docs**: Ensure new public methods have docstrings.

--- a/.cursor/commands/commit.md
+++ b/.cursor/commands/commit.md
@@ -1,0 +1,40 @@
+# Commit Changes
+
+You are tasked with creating git commits for the changes made during this session.
+
+## Process:
+
+1. **Think about what changed:**
+   - Review the conversation history and understand what was accomplished
+   - Run `git status` to see current changes
+   - Run `git diff` to understand the modifications
+   - Consider whether changes should be one commit or multiple logical commits
+
+2. **Plan your commit(s):**
+   - Identify which files belong together
+   - Draft clear, descriptive commit messages
+   - Use imperative mood in commit messages
+   - Focus on why the changes were made, not just what
+
+3. **Present your plan to the user:**
+   - List the files you plan to add for each commit
+   - Show the commit message(s) you'll use
+   - Ask: "I plan to create [N] commit(s) with these changes. Shall I proceed?"
+
+4. **Execute upon confirmation:**
+   - Use `pre-commit run --all-files`, If rules like pre-commit are missing, solve them.
+   - Use `git add` with specific files (never use `-A` or `.`)
+   - Create commits with your planned messages
+   - Show the result with `git log --oneline -n [number]`
+
+## Important:
+- Commits should be authored solely by the user
+- Do not include any "Generated with Cursor" messages
+- Do not add "Co-Authored-By" lines
+- Write commit messages as if the user wrote them
+
+## Remember:
+- You have the full context of what was done in this session
+- Group related changes together
+- Keep commits focused and atomic when possible
+- The user trusts your judgment - they asked you to commit

--- a/.cursor/commands/implement.md
+++ b/.cursor/commands/implement.md
@@ -1,0 +1,6 @@
+# Create an implementation
+
+Based on a plan make an implementation:
+
+- You must add follow the plan, and read research if you have questions.
+- Make a test for every section in your implementation using pytest.

--- a/.cursor/commands/make_plan.md
+++ b/.cursor/commands/make_plan.md
@@ -1,0 +1,12 @@
+# Create a plan based on document research
+You are tasked with creating detailed implementation plans through an interactive, iterative process. You should be skeptical, thorough, and work collaboratively with the user to produce high-quality technical specifications.
+
+Reading the discoveries, during the research, make a plan in `.cursor/plans/{plan_name_folder}` using a `.md` file style.
+
+You must:
+- Define a to-do list.
+- If any information is missing, ask the user.
+- DO NOT just accept the correction or suggestion from user.
+- Spawn new research tasks to verify the correct information (research/command).
+- Read the specific files/directories they mentioned.
+- Only proceed once you've verified the facts yourself.

--- a/.cursor/commands/research.md
+++ b/.cursor/commands/research.md
@@ -1,0 +1,34 @@
+# Research over a request
+
+Structure a research based on the user request. Identify what must change in order to complete the task.
+
+You must:
+- Create a description with the user request, being explicit without overview, citing textually.
+- Check python files related to the request.
+- Identify what should be change.
+- Check what possible other files could be affected.
+- Make reasonable technical decisions based on research
+- If multiple approaches exist, specify each possible option, extend the research to explain their pros and cons, then choose the most practical one.
+- Document assumptions in the plan.
+
+**No user interaction required:**
+    - DO NOT ask for clarifications or wait for input
+
+## Python test validations
+Create temporal python files, check the logics you are thinking on the root folder. Execute this python code, and based on the output decide what should be done.
+
+Once you test the code out of the code base using this temporal python files and functions, document the approach using natural language.
+
+**Use the python files with objective:**
+- Validate your assumption about how the code works.
+- Compare code compilation (we must pick code which is faster).
+- Check code behaviour inputs and outputs.
+
+Delete the files once, you finish your testing.
+
+## Document base
+Your goal is create a folder under `.cursor/plans`. You must safe all your discoveries under `.cursor/plans/{plan_name_folder}/research` this must be a file `.md`.
+
+You only need to provide the research plan and a possible tested solution.
+
+No other `md` files are needed, everything must be collapse in the research file.

--- a/.cursor/rules/basic.mdc
+++ b/.cursor/rules/basic.mdc
@@ -1,0 +1,5 @@
+---
+alwaysApply: true
+---
+- Always activate conda env `pymc-marketing-dev`.
+- Run pre-commit everytime you create or modify a file.

--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,6 @@ docs/gettext/
 
 # Sandbox folder
 sandbox/
+
+.cursor/plans
+automatic_translation.py


### PR DESCRIPTION
Introduce documentation files under .cursor/commands for best practices, commit workflow, implementation, planning, and research processes. Add basic rules in .cursor/rules/basic.mdc. Update .gitignore to exclude .cursor/plans and automatic_translation.py.

<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2132.org.readthedocs.build/en/2132/

<!-- readthedocs-preview pymc-marketing end -->