### PR TITLE
feat: VariableFactory support in HSGP components

### DIFF
--- a/pymc_marketing/mmm/hsgp.py
+++ b/pymc_marketing/mmm/hsgp.py
@@ -29,7 +29,7 @@ from matplotlib.figure import Figure
 from pydantic import BaseModel, Field, InstanceOf, model_validator, validate_call
 from pymc.distributions.shape_utils import Dims
 from pymc_extras.deserialize import register_deserialization
-from pymc_extras.prior import Prior, _get_transform, create_dim_handler
+from pymc_extras.prior import Prior, VariableFactory, _get_transform, create_dim_handler
 from pytensor.tensor import TensorLike
 from pytensor.tensor.variable import TensorVariable
 
@@ -719,8 +719,12 @@ class HSGP(HSGPBase):
 
     """
 
-    ls: InstanceOf[Prior] | float = Field(..., description="Prior for the lengthscales")
-    eta: InstanceOf[Prior] | float = Field(..., description="Prior for the variance")
+    ls: InstanceOf[VariableFactory] | float = Field(
+        ..., description="Prior for the lengthscales"
+    )
+    eta: InstanceOf[VariableFactory] | float = Field(
+        ..., description="Prior for the variance"
+    )
     L: float = Field(..., gt=0, description="Extent of basis functions")
     centered: bool = Field(False, description="Whether the model is centered or not")
     drop_first: bool = Field(
@@ -730,7 +734,7 @@ class HSGP(HSGPBase):
 
     @model_validator(mode="after")
     def _ls_is_scalar_prior(self) -> Self:
-        if not isinstance(self.ls, Prior):
+        if not isinstance(self.ls, VariableFactory):
             return self
 
         if self.ls.dims != ():
@@ -740,7 +744,7 @@ class HSGP(HSGPBase):
 
     @model_validator(mode="after")
     def _eta_is_scalar_prior(self) -> Self:
-        if not isinstance(self.eta, Prior):
+        if not isinstance(self.eta, VariableFactory):
             return self
 
         if self.eta.dims != ():
@@ -1144,8 +1148,12 @@ class HSGPPeriodic(HSGPBase):
 
     """
 
-    ls: InstanceOf[Prior] | float = Field(..., description="Prior for the lengthscale")
-    scale: InstanceOf[Prior] | float = Field(..., description="Prior for the scale")
+    ls: InstanceOf[VariableFactory] | float = Field(
+        ..., description="Prior for the lengthscale"
+    )
+    scale: InstanceOf[VariableFactory] | float = Field(
+        ..., description="Prior for the scale"
+    )
     cov_func: PeriodicCovFunc = Field(
         PeriodicCovFunc.Periodic,
         description="The covariance function",
@@ -1154,7 +1162,7 @@ class HSGPPeriodic(HSGPBase):
 
     @model_validator(mode="after")
     def _ls_is_scalar_prior(self) -> Self:
-        if not isinstance(self.ls, Prior):
+        if not isinstance(self.ls, VariableFactory):
             return self
 
         if self.ls.dims != ():
@@ -1164,7 +1172,7 @@ class HSGPPeriodic(HSGPBase):
 
     @model_validator(mode="after")
     def _scale_is_scalar_prior(self) -> Self:
-        if not isinstance(self.scale, Prior):
+        if not isinstance(self.scale, VariableFactory):
             return self
 
         if self.scale.dims != ():

--- a/tests/mmm/test_hsgp.py
+++ b/tests/mmm/test_hsgp.py
@@ -548,3 +548,214 @@ def test_softplus_hsgp_intercept_is_non_negative() -> None:
 
     # Verify intercept contribution never negative
     assert (idata.prior["intercept"] >= 0).all()
+
+
+# VariableFactory Test Classes
+class ScalarVariableFactory:
+    """A VariableFactory with scalar dimensions."""
+
+    dims = ()  # Scalar: no dimensions
+
+    def create_variable(self, name: str):
+        """Create a scalar variable."""
+        return pm.HalfNormal(name, sigma=1.0)
+
+
+class NonScalarVariableFactory:
+    """A VariableFactory with non-scalar dimensions."""
+
+    dims = ("time",)  # Non-scalar: has dimensions
+
+    def create_variable(self, name: str):
+        """Create a non-scalar variable."""
+        return pm.HalfNormal(name, sigma=1.0, shape=(10,))
+
+
+class SerializableVariableFactory:
+    """A VariableFactory with serialization support."""
+
+    dims = ()
+
+    def create_variable(self, name: str):
+        """Create a variable."""
+        return pm.HalfNormal(name, sigma=1.0)
+
+    def to_dict(self):
+        """Serialization method."""
+        return {"type": "SerializableVariableFactory"}
+
+
+class TestVariableFactoryHSGP:
+    """Test HSGP class with VariableFactory support."""
+
+    def test_hsgp_accepts_scalar_variable_factory(self):
+        """Test that HSGP accepts scalar VariableFactory instances."""
+        data = np.arange(10)
+        scalar_factory = ScalarVariableFactory()
+
+        # Should not raise
+        hsgp = HSGP(
+            X=data,
+            dims="time",
+            m=200,
+            L=5,
+            eta=scalar_factory,
+            ls=scalar_factory,
+        )
+
+        assert hsgp.ls is scalar_factory
+        assert hsgp.eta is scalar_factory
+
+    def test_hsgp_rejects_non_scalar_ls_variable_factory(self):
+        """Test that HSGP rejects non-scalar VariableFactory for ls."""
+        data = np.arange(10)
+        non_scalar_factory = NonScalarVariableFactory()
+        scalar_factory = ScalarVariableFactory()
+
+        with pytest.raises(ValueError, match="lengthscale prior must be scalar"):
+            HSGP(
+                X=data,
+                dims="time",
+                m=200,
+                L=5,
+                eta=scalar_factory,
+                ls=non_scalar_factory,  # Non-scalar should fail
+            )
+
+    def test_hsgp_rejects_non_scalar_eta_variable_factory(self):
+        """Test that HSGP rejects non-scalar VariableFactory for eta."""
+        data = np.arange(10)
+        non_scalar_factory = NonScalarVariableFactory()
+        scalar_factory = ScalarVariableFactory()
+
+        with pytest.raises(ValueError, match="eta prior must be scalar"):
+            HSGP(
+                X=data,
+                dims="time",
+                m=200,
+                L=5,
+                eta=non_scalar_factory,  # Non-scalar should fail
+                ls=scalar_factory,
+            )
+
+    def test_hsgp_backwards_compatibility_with_prior(self):
+        """Test that HSGP still works with Prior objects (backwards compatibility)."""
+        data = np.arange(10)
+        ls_prior = Prior("HalfNormal", sigma=1.0)
+        eta_prior = Prior("HalfNormal", sigma=1.0)
+
+        # Should not raise - Prior objects implement VariableFactory
+        hsgp = HSGP(
+            X=data,
+            dims="time",
+            m=200,
+            L=5,
+            eta=eta_prior,
+            ls=ls_prior,
+        )
+
+        assert hsgp.ls is ls_prior
+        assert hsgp.eta is eta_prior
+
+
+class TestVariableFactoryHSGPPeriodic:
+    """Test HSGPPeriodic class with VariableFactory support."""
+
+    def test_hsgp_periodic_accepts_scalar_variable_factory(self):
+        """Test that HSGPPeriodic accepts scalar VariableFactory instances."""
+        scalar_factory = ScalarVariableFactory()
+
+        # Should not raise
+        hsgp = HSGPPeriodic(
+            scale=scalar_factory,
+            ls=scalar_factory,
+            m=20,
+            period=60,
+            dims="time",
+        )
+
+        assert hsgp.ls is scalar_factory
+        assert hsgp.scale is scalar_factory
+
+    def test_hsgp_periodic_rejects_non_scalar_ls_variable_factory(self):
+        """Test that HSGPPeriodic rejects non-scalar VariableFactory for ls."""
+        non_scalar_factory = NonScalarVariableFactory()
+        scalar_factory = ScalarVariableFactory()
+
+        with pytest.raises(ValueError, match="lengthscale prior must be scalar"):
+            HSGPPeriodic(
+                scale=scalar_factory,
+                ls=non_scalar_factory,  # Non-scalar should fail
+                m=20,
+                period=60,
+                dims="time",
+            )
+
+    def test_hsgp_periodic_rejects_non_scalar_scale_variable_factory(self):
+        """Test that HSGPPeriodic rejects non-scalar VariableFactory for scale."""
+        non_scalar_factory = NonScalarVariableFactory()
+        scalar_factory = ScalarVariableFactory()
+
+        with pytest.raises(ValueError, match="scale prior must be scalar"):
+            HSGPPeriodic(
+                scale=non_scalar_factory,  # Non-scalar should fail
+                ls=scalar_factory,
+                m=20,
+                period=60,
+                dims="time",
+            )
+
+    def test_hsgp_periodic_backwards_compatibility_with_prior(self):
+        """Test that HSGPPeriodic still works with Prior objects (backwards compatibility)."""
+        ls_prior = Prior("HalfNormal", sigma=1.0)
+        scale_prior = Prior("HalfNormal", sigma=1.0)
+
+        # Should not raise - Prior objects implement VariableFactory
+        hsgp = HSGPPeriodic(
+            scale=scale_prior,
+            ls=ls_prior,
+            m=20,
+            period=60,
+            dims="time",
+        )
+
+        assert hsgp.ls is ls_prior
+        assert hsgp.scale is scale_prior
+
+
+class TestVariableFactorySerialization:
+    """Test serialization behavior with VariableFactory objects."""
+
+    def test_serializable_variable_factory(self):
+        """Test VariableFactory with to_dict method is serializable."""
+        serializable_factory = SerializableVariableFactory()
+
+        hsgp = HSGP(
+            X=np.arange(10),
+            dims="time",
+            m=200,
+            L=5,
+            eta=serializable_factory,
+            ls=serializable_factory,
+        )
+
+        # Should not raise during to_dict - object has to_dict method
+        result = hsgp.to_dict()
+        assert isinstance(result, dict)
+
+    def test_non_serializable_variable_factory_fallback(self):
+        """Test VariableFactory without to_dict method falls back gracefully."""
+        non_serializable_factory = ScalarVariableFactory()  # No to_dict method
+
+        hsgp = HSGP(
+            X=np.arange(10),
+            dims="time",
+            m=200,
+            L=5,
+            eta=non_serializable_factory,
+            ls=non_serializable_factory,
+        )
+
+        # Should not raise - serialization should handle missing to_dict gracefully
+        result = hsgp.to_dict()
+        assert isinstance(result, dict)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #1340
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2164.org.readthedocs.build/en/2164/

<!-- readthedocs-preview pymc-marketing end -->