### PR TITLE
Docs: clean up Streamlit MMM explainer README

### DIFF
--- a/streamlit/mmm-explainer/README.md
+++ b/streamlit/mmm-explainer/README.md
@@ -14,8 +14,14 @@ To run the app, you need a Python environment with **Python 3.11 or newer**.
    ```bash
    conda create -c conda-forge -n marketing_stream python=3.11 pymc-marketing
    conda activate marketing_stream
-2. **Install App Dependencies:** 
-    The Streamlit app requires extra libraries (like streamlit and plotly) that are not in the main package.
+2. **Install App Dependencies:**
+
+The Streamlit app has additional dependencies listed in `streamlit/mmm-explainer/requirements.txt`.
+Install them using:
+
+```bash
+pip install -r streamlit/mmm-explainer/requirements.txt
+```
 3. **Launch the App:**
     streamlit run Visualise_Priors.py
 


### PR DESCRIPTION
## Description
This PR cleans up the README for the Streamlit MMM explainer by:
- Removing accidental instructional text that was not meant for end users
- Fixing formatting and section structure
- Clarifying local setup and run instructions

No functional code changes are included.

## Related Issue
- [ ] Closes #
- [x] Related to # (maintainer review feedback)

## Checklist
- [x] Checked that pre-commit linting/style checks pass (docs-only change)
- [ ] Included tests that prove the fix is effective (not applicable — documentation-only)
- [ ] Added necessary documentation using numpydoc format (not applicable — README-only change)
- [x] Each commit corresponds to a relevant logical change


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2170.org.readthedocs.build/en/2170/

<!-- readthedocs-preview pymc-marketing end -->