### PR TITLE
Support MLflow 2.18.0+ API updates

### DIFF
--- a/pymc_marketing/mlflow.py
+++ b/pymc_marketing/mlflow.py
@@ -167,12 +167,18 @@ except ImportError:  # pragma: no cover
     raise ImportError(msg)
 
 from mlflow.utils.autologging_utils import autologging_integration
+from packaging import version
 
 from pymc_marketing.clv.models.basic import CLVModel
 from pymc_marketing.mmm import MMM
 from pymc_marketing.mmm.evaluation import compute_summary_metrics
 from pymc_marketing.mmm.multidimensional import MMM as MultiDimensionalMMM
 from pymc_marketing.version import __version__
+
+# MLflow 2.18.0+ deprecated artifact_path in favor of name
+_MLFLOW_SUPPORTS_NAME_PARAM = version.parse(mlflow.__version__) >= version.parse(
+    "2.18.0"
+)
 
 FLAVOR_NAME = "pymc"
 
@@ -887,10 +893,14 @@ def log_mmm(
         original_scale=original_scale,
     )
 
-    mlflow.pyfunc.log_model(
-        name=artifact_path,
-        python_model=mlflow_mmm,
-    )
+    # MLflow 2.18.0+ uses 'name' parameter, older versions use 'artifact_path'
+    log_model_kwargs: dict[str, Any] = {"python_model": mlflow_mmm}
+    if _MLFLOW_SUPPORTS_NAME_PARAM:
+        log_model_kwargs["name"] = artifact_path
+    else:
+        log_model_kwargs["artifact_path"] = artifact_path
+
+    mlflow.pyfunc.log_model(**log_model_kwargs)
     run_id = mlflow.active_run().info.run_id
     model_uri = f"runs:/{run_id}/{artifact_path}"
 

--- a/pymc_marketing/mlflow.py
+++ b/pymc_marketing/mlflow.py
@@ -888,7 +888,7 @@ def log_mmm(
     )
 
     mlflow.pyfunc.log_model(
-        artifact_path=artifact_path,
+        name=artifact_path,
         python_model=mlflow_mmm,
     )
     run_id = mlflow.active_run().info.run_id


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
Fixed MLflow deprecation warning in the `log_mmm` function by replacing the deprecated `artifact_path` parameter with the new `name` parameter in `mlflow.pyfunc.log_model()`. This change aligns with MLflow 2.18.0+ API updates while maintaining backward compatibility with the project's minimum MLflow requirement (>= 2.0.0).

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #1913
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2237.org.readthedocs.build/en/2237/

<!-- readthedocs-preview pymc-marketing end -->
**The code in this pull request was generated by GitHub Copilot with the Claude Sonnet 4.5 model.**