### PR TITLE
Pin some docs and tests dependencies because of lifetimes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ docs = [
 ]
 lint = ["mypy", "pandas-stubs", "pre-commit>=2.19.0", "ruff>=0.1.4"]
 test = [
+    "Setuptools<81",
     "blackjax",
     "nutpie",
     "numpyro",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
 [project.optional-dependencies]
 dag = ["dowhy", "networkx", "osqp<1.0.0,>=0.6.2", "pygraphviz"]
 docs = [
+    "Setuptools<81",
     "blackjax",
     "fastprogress",
     "graphviz",


### PR DESCRIPTION
Tests notebooks are failing because

```python
----> 3 from lifetimes.datasets import load_cdnow_summary
      5 from pymc_marketing import clv
      7 az.style.use("arviz-darkgrid")

File ~/work/pymc-marketing/pymc-marketing/.venv/lib/python3.12/site-packages/lifetimes/datasets/__init__.py:6
      4 import pandas as pd
      5 from .. import utils
----> 6 from pkg_resources import resource_filename
      8 __all__ = [
      9     "load_cdnow_summary",
     10     "load_transaction_data",
     11     "load_cdnow_summary_data_with_monetary_value",
     12     "load_donations",
     13 ]
     16 def load_dataset(filename, **kwargs):

ModuleNotFoundError: No module named 'pkg_resources'
```

We do have a warning

```python
UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
```

As pointed out by Ricardo 

> Eventually we have to move away from lifetimes. Just hard code the results we were getting from them in the tests and have some notes on how to reproduce them (will need older versions of python at some point)

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2269.org.readthedocs.build/en/2269/

<!-- readthedocs-preview pymc-marketing end -->