### PR TITLE
Move cursor commands into skills with metadata

### DIFF
--- a/.cursor/skills/code-best-practice/SKILL.md
+++ b/.cursor/skills/code-best-practice/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: code-best-practice
+description: PyMC-Marketing coding conventions, preferred implementations, and style guidelines.
+disable-model-invocation: true
+---
+
 # PyMC-Marketing Best Practices Guide
 
 This document outlines the coding conventions, preferred implementations, and style guidelines for contributing to `pymc-marketing`.

--- a/.cursor/skills/commit/SKILL.md
+++ b/.cursor/skills/commit/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: commit
+description: Create git commits for changes made during the session.
+disable-model-invocation: true
+---
+
 # Commit Changes
 
 You are tasked with creating git commits for the changes made during this session.

--- a/.cursor/skills/implement/SKILL.md
+++ b/.cursor/skills/implement/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: implement
+description: Create an implementation based on a plan.
+disable-model-invocation: true
+---
+
 # Create an implementation
 
 Based on a plan make an implementation:

--- a/.cursor/skills/make-plan/SKILL.md
+++ b/.cursor/skills/make-plan/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: make-plan
+description: Create a plan based on document research through an interactive, iterative process.
+disable-model-invocation: true
+---
+
 # Create a plan based on document research
 You are tasked with creating detailed implementation plans through an interactive, iterative process. You should be skeptical, thorough, and work collaboratively with the user to produce high-quality technical specifications.
 

--- a/.cursor/skills/research/SKILL.md
+++ b/.cursor/skills/research/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: research
+description: Structure a research based on the user request. Identify what must change in order to complete the task.
+disable-model-invocation: true
+---
+
 # Research over a request
 
 Structure a research based on the user request. Identify what must change in order to complete the task.


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->
Rename files from .cursor/commands/* to .cursor/skills/* (each moved into a per-skill directory and renamed to SKILL.md) and add YAML frontmatter to register each as a skill. The frontmatter includes name, description, and disable-model-invocation: true. Affected items: code_best_practice -> code-best-practice/SKILL.md, commit -> commit/SKILL.md, implement -> implement/SKILL.md, make_plan -> make-plan/SKILL.md, research -> research/SKILL.md.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2274.org.readthedocs.build/en/2274/

<!-- readthedocs-preview pymc-marketing end -->