### PR TITLE
chore: remove mlflow module experimental warning

### DIFF
--- a/pymc_marketing/mlflow.py
+++ b/pymc_marketing/mlflow.py
@@ -183,15 +183,6 @@ _MLFLOW_SUPPORTS_NAME_PARAM = version.parse(mlflow.__version__) >= version.parse
 FLAVOR_NAME = "pymc"
 
 
-PYMC_MARKETING_ISSUE = "https://github.com/pymc-labs/pymc-marketing/issues/new"
-warning_msg = (
-    "This functionality is experimental and subject to change. "
-    "If you encounter any issues or have suggestions, please raise them at: "
-    f"{PYMC_MARKETING_ISSUE}"
-)
-warnings.warn(warning_msg, FutureWarning, stacklevel=1)
-
-
 def _exclude_tuning(func):
     def callback(trace, draw):
         if draw.tuning:

--- a/tests/test_mlflow.py
+++ b/tests/test_mlflow.py
@@ -13,7 +13,6 @@
 #   limitations under the License.
 import json
 import logging
-import warnings
 from collections import namedtuple
 from pathlib import Path
 
@@ -29,18 +28,15 @@ from mlflow.client import MlflowClient
 from pymc.exceptions import SamplingError
 
 from pymc_marketing.clv import BetaGeoModel
-
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore", FutureWarning)
-    from pymc_marketing.mlflow import (
-        autolog,
-        create_log_callback,
-        log_error,
-        log_likelihood_type,
-        log_mmm_evaluation_metrics,
-        log_model_graph,
-        log_sample_diagnostics,
-    )
+from pymc_marketing.mlflow import (
+    autolog,
+    create_log_callback,
+    log_error,
+    log_likelihood_type,
+    log_mmm_evaluation_metrics,
+    log_model_graph,
+    log_sample_diagnostics,
+)
 from pymc_marketing.mmm import MMM, GeometricAdstock, LogisticSaturation
 from pymc_marketing.mmm.multidimensional import MMM as MultiDimensionalMMM
 from pymc_marketing.version import __version__


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

This module as be release for ~2 years so removing this warning.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2281.org.readthedocs.build/en/2281/

<!-- readthedocs-preview pymc-marketing end -->