### PR TITLE
chore: remove local file system test for mlflow module

### DIFF
--- a/tests/test_mlflow.py
+++ b/tests/test_mlflow.py
@@ -15,7 +15,6 @@ import json
 import logging
 import warnings
 from collections import namedtuple
-from pathlib import Path
 
 import arviz as az
 import mlflow
@@ -164,25 +163,6 @@ def basic_logging_checks(run_data: RunData) -> None:
     assert len(run_data.metrics) > 0
     assert run_data.tags == {}
     assert len(run_data.artifacts) > 0
-
-
-def test_file_system_uri_supported(model_with_likelihood) -> None:
-    mlflow.set_tracking_uri(uri=Path("./mlruns"))
-    mlflow.set_experiment("pymc-marketing-test-suite-local-file")
-    with mlflow.start_run() as run:
-        pm.sample(
-            model=model_with_likelihood,
-            chains=1,
-            tune=25,
-            draws=30,
-        )
-
-    assert mlflow.get_tracking_uri().startswith("file:///")
-    assert mlflow.active_run() is None
-
-    run_id = run.info.run_id
-    run_data = get_run_data(run_id)
-    basic_logging_checks(run_data)
 
 
 def test_log_with_data_in_likelihood(model_with_data_in_likelihood) -> None:


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

This is being deprecated with mlflow so removing this before it fails.

Reference: https://github.com/mlflow/mlflow/issues/18534

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2282.org.readthedocs.build/en/2282/

<!-- readthedocs-preview pymc-marketing end -->