### PR TITLE
chore: use pymc.testing in runner script

### DIFF
--- a/scripts/run_notebooks/injected.py
+++ b/scripts/run_notebooks/injected.py
@@ -1,41 +1,19 @@
 """Injected code to the top of each notebook to mock long running code."""
 
+from functools import partial
+
 import numpy as np
 import pymc as pm
-import xarray as xr
+import pymc.testing
 
 
-def mock_sample(*args, **kwargs):
-    random_seed = kwargs.get("random_seed", None)
-    model = kwargs.get("model", None)
-    samples = 10
-    idata = pm.sample_prior_predictive(
-        model=model,
-        random_seed=random_seed,
-        draws=samples,
-    )
-    idata.add_groups(posterior=idata.prior)
-
-    # Create mock sample stats with diverging data
-    if "sample_stats" not in idata:
-        n_chains = 1
-        n_draws = samples
-        sample_stats = xr.Dataset(
-            {
-                "diverging": xr.DataArray(
-                    np.zeros((n_chains, n_draws), dtype=int),
-                    dims=("chain", "draw"),
-                )
-            }
-        )
-        idata.add_groups(sample_stats=sample_stats)
-
-    del idata.prior
-    if "prior_predictive" in idata:
-        del idata.prior_predictive
-    return idata
+def mock_diverging(size):
+    return np.zeros(size, dtype=int)
 
 
-pm.sample = mock_sample
+pm.sample = partial(
+    pymc.testing.mock_sample,
+    sample_stats={"diverging": mock_diverging},
+)
 pm.HalfFlat = pm.HalfNormal
 pm.Flat = pm.Normal


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

The pymc.testing.mock_sample with support for sample_stat is released now.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #2032
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2288.org.readthedocs.build/en/2288/

<!-- readthedocs-preview pymc-marketing end -->