### PR TITLE
chore: mock some additional tests

### DIFF
--- a/tests/mmm/builders/test_yaml.py
+++ b/tests/mmm/builders/test_yaml.py
@@ -278,7 +278,7 @@ def test_apply_calibration_propagates_failure(failing_mmm, tmp_path):
         _apply_and_validate_calibration_steps(failing_mmm, cfg, tmp_path)
 
 
-def test_special_prior_in_yaml(tmp_path):
+def test_special_prior_in_yaml(tmp_path, mock_pymc_sample):
     """Test that SpecialPrior (LogNormalPrior) works in YAML config."""
     # Create test data
     X = pd.DataFrame(

--- a/tests/mmm/test_budget_optimizer.py
+++ b/tests/mmm/test_budget_optimizer.py
@@ -909,7 +909,7 @@ def test_budget_distribution_over_period_integration(dummy_df, dummy_idata):
     assert result_without_factors.dims == ("channel",)
 
 
-def test_custom_protocol_model_budget_optimizer_works():
+def test_custom_protocol_model_budget_optimizer_works(mock_pymc_sample):
     """Validate the optimizer works with the built-in CustomModelWrapper.
 
     This serves as an example for users wanting to plug in their own PyMC models via

--- a/tests/mmm/test_budget_optimizer_multidimensional.py
+++ b/tests/mmm/test_budget_optimizer_multidimensional.py
@@ -58,7 +58,7 @@ def dummy_df():
 
 
 @pytest.fixture(scope="module")
-def fitted_mmm(dummy_df):
+def fitted_mmm(dummy_df, mock_pymc_sample):
     """Create and fit a model once for all tests."""
     df_kwargs, X_dummy, y_dummy = dummy_df
 

--- a/tests/mmm/test_tvp.py
+++ b/tests/mmm/test_tvp.py
@@ -53,7 +53,7 @@ def model_config(request) -> dict[str, HSGPKwargs]:
     }
 
 
-def test_time_varying_prior(coords):
+def test_time_varying_prior(coords, mock_pymc_sample):
     with pm.Model(coords=coords) as model:
         X = pm.Data("X", np.array([0, 1, 2, 3, 4]), dims="date")
         hsgp_kwargs = HSGPKwargs(m=3, L=10, eta_lam=1, ls_sigma=5)
@@ -78,10 +78,8 @@ def test_time_varying_prior(coords):
 
         # Test that model can compile and sample
         pm.Normal("obs", mu=f, sigma=1, observed=np.random.randn(5))
-        try:
-            pm.sample(50, tune=50, chains=1)
-        except pm.SamplingError:
-            pytest.fail("Time varying parameter didn't sample")
+        idata = pm.sample(50, tune=50, chains=1)
+        assert idata is not None
 
 
 def test_calling_without_default_args(coords):
@@ -101,7 +99,7 @@ def test_calling_without_default_args(coords):
         assert "test_raw_hsgp_coefs" in model.named_vars
 
 
-def test_multidimensional(coords):
+def test_multidimensional(coords, mock_pymc_sample):
     with pm.Model(coords=coords) as model:
         X = pm.Data("X", np.array([0, 1, 2, 3, 4]), dims="date")
         m = 7
@@ -125,10 +123,8 @@ def test_multidimensional(coords):
             observed=np.random.randn(5, 3),
             dims=("date", "channel"),
         )
-        try:
-            pm.sample(50, tune=50, chains=1)
-        except pm.SamplingError:
-            pytest.fail("Time varying parameter didn't sample")
+        idata = pm.sample(50, tune=50, chains=1)
+        assert idata is not None
 
 
 def test_calling_without_model():


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

Using the mock_sample fixture for the other slow tests.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2291.org.readthedocs.build/en/2291/

<!-- readthedocs-preview pymc-marketing end -->