### PR TITLE
Add Input Validation for CLV Models

### DIFF
--- a/pymc_marketing/clv/models/basic.py
+++ b/pymc_marketing/clv/models/basic.py
@@ -18,6 +18,7 @@ from collections.abc import Sequence
 from typing import Literal, cast
 
 import arviz as az
+import numpy as np
 import pandas as pd
 import pymc as pm
 import xarray as xr
@@ -77,6 +78,41 @@ class CLVModel(ModelBuilder):
             if col in must_be_homogenous:
                 if data[col].nunique() != 1:
                     raise ValueError(f"Column {col} has non-homogeneous entries")
+
+    def _validate_frequency(self, data: pd.DataFrame) -> None:
+        """Validate frequency column values shared across BTYD and Gamma-Gamma models."""
+        if (data["frequency"] < 0).any():
+            raise ValueError("Column frequency has negative values")
+
+        if not (np.mod(data["frequency"], 1) == 0).all():
+            raise ValueError("frequency column must contain only integer values")
+
+    def _validate_rfm_data(self, data: pd.DataFrame) -> None:
+        """Validate frequency, recency, and T columns shared by BTYD transaction models."""
+        self._validate_cols(data, required_cols=["frequency", "recency", "T"])
+        self._validate_frequency(data)
+
+        if (data["recency"] < 0).any():
+            raise ValueError("Column recency has negative values")
+        if (data["T"] < 0).any():
+            raise ValueError("Column T has negative values")
+
+        if ((data["frequency"] == 0) & (data["recency"] > 0)).any():
+            raise ValueError("recency cannot be greater than 0 if frequency is 0")
+
+        if (data["recency"] > data["T"]).any():
+            raise ValueError("recency cannot be greater than T")
+
+        if (data["T"] == 0).any():
+            warnings.warn(
+                "T=0 is mathematically valid but practically useless.",
+                UserWarning,
+                stacklevel=2,
+            )
+
+    def _validate_data(self, data: pd.DataFrame) -> None:
+        """Validate model input data. Child classes should override and call super()."""
+        self._validate_rfm_data(data)
 
     def __repr__(self) -> str:
         """Representation of the model."""

--- a/pymc_marketing/clv/models/beta_geo.py
+++ b/pymc_marketing/clv/models/beta_geo.py
@@ -193,9 +193,9 @@ class BetaGeoModel(CLVModel):
         """All covariate column names."""
         return self.purchase_covariate_cols + self.dropout_covariate_cols
 
-    # TODO: This placeholder will be superceded by https://github.com/pymc-labs/pymc-marketing/pull/2305
     def _validate_data(self, data: pd.DataFrame) -> None:
         """Validate BG/NBD-specific data requirements."""
+        super()._validate_data(data)
         self._validate_cols(
             data,
             required_cols=[

--- a/pymc_marketing/clv/models/beta_geo_beta_binom.py
+++ b/pymc_marketing/clv/models/beta_geo_beta_binom.py
@@ -168,9 +168,9 @@ class BetaGeoBetaBinomModel(CLVModel):
             "kappa_dropout": Prior("Pareto", alpha=1, m=1),
         }
 
-    # TODO: This placeholder will be superceded by https://github.com/pymc-labs/pymc-marketing/pull/2305
     def _validate_data(self, data: pd.DataFrame) -> None:
         """Validate BG/BB-specific data requirements."""
+        super()._validate_data(data)
         self._validate_cols(
             data,
             required_cols=[

--- a/pymc_marketing/clv/models/gamma_gamma.py
+++ b/pymc_marketing/clv/models/gamma_gamma.py
@@ -13,6 +13,8 @@
 #   limitations under the License.
 """Gamma-Gamma Model for expected future monetary value."""
 
+import warnings
+
 import numpy as np
 import pandas
 import pymc as pm
@@ -182,7 +184,8 @@ class BaseGammaGammaModel(CLVModel):
         Parameters
         ----------
         transaction_model : ~CLVModel
-            Predictive model for future transactions. `BetaGeoModel` and `ParetoNBDModel` are currently supported.
+            Predictive model for future transactions. `BetaGeoModel`,
+            `ModifiedBetaGeoModel`, and `ParetoNBDModel` are currently supported.
         data : ~pandas.DataFrame
             DataFrame containing the following columns:
 
@@ -322,7 +325,6 @@ class GammaGammaModel(BaseGammaGammaModel):
     ):
         super().__init__(model_config=model_config, sampler_config=sampler_config)
 
-    # TODO: This placeholder will be superceded by https://github.com/pymc-labs/pymc-marketing/pull/2305
     def _validate_data(self, data: pandas.DataFrame) -> None:
         """Validate Gamma-Gamma-specific data requirements."""
         self._validate_cols(
@@ -330,6 +332,13 @@ class GammaGammaModel(BaseGammaGammaModel):
             required_cols=["customer_id", "monetary_value", "frequency"],
             must_be_unique=["customer_id"],
         )
+        self._validate_frequency(data)
+        if (data["monetary_value"] <= 0).any():
+            warnings.warn(
+                "Non-positive monetary values are practically problematic.",
+                UserWarning,
+                stacklevel=2,
+            )
 
     def build_model(self, data: pandas.DataFrame) -> None:  # type: ignore[override]
         """Build the model.
@@ -468,6 +477,14 @@ class GammaGammaModelIndividual(BaseGammaGammaModel):
         self._validate_cols(
             data, required_cols=["customer_id", "individual_transaction_value"]
         )
+        if (data["individual_transaction_value"] < 0).any():
+            raise ValueError("Column individual_transaction_value has negative values")
+        if (data["individual_transaction_value"] <= 0).any():
+            warnings.warn(
+                "Non-positive individual transaction values are practically problematic.",
+                UserWarning,
+                stacklevel=2,
+            )
 
     def build_model(self, data: pandas.DataFrame) -> None:  # type: ignore[override]
         """Build the model.

--- a/pymc_marketing/clv/models/pareto_nbd.py
+++ b/pymc_marketing/clv/models/pareto_nbd.py
@@ -236,9 +236,9 @@ class ParetoNBDModel(CLVModel):
         """All covariate column names."""
         return self.purchase_covariate_cols + self.dropout_covariate_cols
 
-    # TODO: This placeholder will be superceded by https://github.com/pymc-labs/pymc-marketing/pull/2305
     def _validate_data(self, data: pd.DataFrame) -> None:
         """Validate Pareto/NBD-specific data requirements."""
+        super()._validate_data(data)
         self._validate_cols(
             data,
             required_cols=[

--- a/pymc_marketing/clv/models/shifted_beta_geo.py
+++ b/pymc_marketing/clv/models/shifted_beta_geo.py
@@ -277,10 +277,12 @@ class ShiftedBetaGeoModel(CLVModel):
             must_be_unique=["customer_id"],
         )
 
-        if np.any(
-            (data["recency"] < 1) | (data["recency"] > data["T"]) | (data["T"] < 2)
-        ):
-            raise ValueError("Model fitting requires 1 <= recency <= T, and T >= 2.")
+        if (data["recency"] < 1).any():
+            raise ValueError("Column recency must be at least 1")
+        if (data["recency"] > data["T"]).any():
+            raise ValueError("recency cannot be greater than T")
+        if (data["T"] < 2).any():
+            raise ValueError("Column T must be at least 2")
 
         self._validate_cohorts(data, check_param_dims=("alpha", "beta"))
 

--- a/pymc_marketing/clv/utils.py
+++ b/pymc_marketing/clv/utils.py
@@ -62,7 +62,8 @@ def customer_lifetime_value(
     Parameters
     ----------
     transaction_model : ~CLVModel
-        Predictive model for future transactions. `BetaGeoModel` and `ParetoNBDModel` are currently supported.
+        Predictive model for future transactions. `BetaGeoModel`,
+        `ModifiedBetaGeoModel`, and `ParetoNBDModel` are currently supported.
     data : ~pandas.DataFrame
         DataFrame containing the following columns:
 

--- a/tests/clv/models/test_shifted_beta_geo.py
+++ b/tests/clv/models/test_shifted_beta_geo.py
@@ -385,9 +385,7 @@ class TestShiftedBetaGeoModel:
                 "cohort": np.asarray(["A", "A"]),
             }
         )
-        with pytest.raises(
-            ValueError, match=r"Model fitting requires 1 <= recency <= T, and T >= 2."
-        ):
+        with pytest.raises(ValueError, match=r"recency cannot be greater than T"):
             model = ShiftedBetaGeoModel()
             model.build_model(data=data)
 
@@ -400,9 +398,7 @@ class TestShiftedBetaGeoModel:
                 "cohort": np.asarray(["A", "A"]),
             }
         )
-        with pytest.raises(
-            ValueError, match=r"Model fitting requires 1 <= recency <= T, and T >= 2."
-        ):
+        with pytest.raises(ValueError, match=r"Column T must be at least 2"):
             model = ShiftedBetaGeoModel()
             model.build_model(data=data)
 

--- a/tests/clv/test_models.py
+++ b/tests/clv/test_models.py
@@ -18,7 +18,10 @@ from pymc_extras.prior import Prior
 from pymc_marketing.clv.models.basic import CLVModel
 from pymc_marketing.clv.models.beta_geo import BetaGeoModel
 from pymc_marketing.clv.models.beta_geo_beta_binom import BetaGeoBetaBinomModel
-from pymc_marketing.clv.models.gamma_gamma import GammaGammaModel
+from pymc_marketing.clv.models.gamma_gamma import (
+    GammaGammaModel,
+    GammaGammaModelIndividual,
+)
 from pymc_marketing.clv.models.modified_beta_geo import ModifiedBetaGeoModel
 from pymc_marketing.clv.models.pareto_nbd import ParetoNBDModel
 from pymc_marketing.clv.models.shifted_beta_geo import ShiftedBetaGeoModel
@@ -302,6 +305,52 @@ def test_gamma_gamma_model_validate_data_warnings(data, expected_warning, match)
 )
 def test_gamma_gamma_model_validate_data_errors(data, expected_error, match):
     model = GammaGammaModel.__new__(GammaGammaModel)
+    model.model_config = {}
+    with pytest.raises(expected_error, match=match):
+        model._validate_data(data)
+
+
+@pytest.mark.parametrize(
+    "data, expected_warning, match",
+    [
+        (
+            pd.DataFrame(
+                {
+                    "customer_id": [1],
+                    "individual_transaction_value": [0],
+                }
+            ),
+            UserWarning,
+            "Non-positive individual transaction values are practically problematic.",
+        ),
+    ],
+)
+def test_gamma_gamma_model_individual_validate_data_warnings(
+    data, expected_warning, match
+):
+    model = GammaGammaModelIndividual.__new__(GammaGammaModelIndividual)
+    model.model_config = {}
+    with pytest.warns(expected_warning, match=match):
+        model._validate_data(data)
+
+
+@pytest.mark.parametrize(
+    "data, expected_error, match",
+    [
+        (
+            pd.DataFrame(
+                {
+                    "customer_id": [1],
+                    "individual_transaction_value": [-1],
+                }
+            ),
+            ValueError,
+            "Column individual_transaction_value has negative values",
+        ),
+    ],
+)
+def test_gamma_gamma_model_individual_validate_data_errors(data, expected_error, match):
+    model = GammaGammaModelIndividual.__new__(GammaGammaModelIndividual)
     model.model_config = {}
     with pytest.raises(expected_error, match=match):
         model._validate_data(data)

--- a/tests/clv/test_models.py
+++ b/tests/clv/test_models.py
@@ -1,0 +1,307 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+import pandas as pd
+import pytest
+from pymc_extras.prior import Prior
+
+from pymc_marketing.clv.models.basic import CLVModel
+from pymc_marketing.clv.models.beta_geo import BetaGeoModel
+from pymc_marketing.clv.models.beta_geo_beta_binom import BetaGeoBetaBinomModel
+from pymc_marketing.clv.models.gamma_gamma import GammaGammaModel
+from pymc_marketing.clv.models.modified_beta_geo import ModifiedBetaGeoModel
+from pymc_marketing.clv.models.pareto_nbd import ParetoNBDModel
+from pymc_marketing.clv.models.shifted_beta_geo import ShiftedBetaGeoModel
+
+
+class CLVModelTest(CLVModel):
+    _model_type = "CLVModelTest"
+
+    @property
+    def default_model_config(self):
+        return {"x": Prior("Normal", mu=0, sigma=1)}
+
+    def build_model(self):
+        pass
+
+
+@pytest.mark.parametrize(
+    "data, expected_error, match",
+    [
+        (
+            pd.DataFrame({"recency": [1], "T": [2]}),
+            ValueError,
+            r"The following required columns are missing from the input data: \['frequency'\]",
+        ),
+        (
+            pd.DataFrame({"frequency": [-1], "recency": [1], "T": [2]}),
+            ValueError,
+            "Column frequency has negative values",
+        ),
+        (
+            pd.DataFrame({"frequency": [1], "recency": [-1], "T": [2]}),
+            ValueError,
+            "Column recency has negative values",
+        ),
+        (
+            pd.DataFrame({"frequency": [1], "recency": [1], "T": [-1]}),
+            ValueError,
+            "Column T has negative values",
+        ),
+        (
+            pd.DataFrame({"frequency": [0], "recency": [1], "T": [2]}),
+            ValueError,
+            "recency cannot be greater than 0 if frequency is 0",
+        ),
+        (
+            pd.DataFrame({"frequency": [1], "recency": [3], "T": [2]}),
+            ValueError,
+            "recency cannot be greater than T",
+        ),
+        (
+            pd.DataFrame({"frequency": [1.5], "recency": [1], "T": [2]}),
+            ValueError,
+            "frequency column must contain only integer values",
+        ),
+    ],
+)
+def test_base_clv_model_validate_data_errors(data, expected_error, match):
+    model = CLVModelTest.__new__(CLVModelTest)
+    model.model_config = {}
+    with pytest.raises(expected_error, match=match):
+        model._validate_data(data)
+
+
+@pytest.mark.parametrize(
+    "data, expected_warning, match",
+    [
+        (
+            pd.DataFrame({"frequency": [0], "recency": [0], "T": [0]}),
+            UserWarning,
+            "T=0 is mathematically valid but practically useless.",
+        ),
+    ],
+)
+def test_base_clv_model_validate_data_warnings(data, expected_warning, match):
+    model = CLVModelTest.__new__(CLVModelTest)
+    model.model_config = {}
+    with pytest.warns(expected_warning, match=match):
+        model._validate_data(data)
+
+
+@pytest.mark.parametrize(
+    "model_cls",
+    [BetaGeoModel, ParetoNBDModel, ModifiedBetaGeoModel],
+)
+@pytest.mark.parametrize(
+    "data, expected_error, match",
+    [
+        (
+            pd.DataFrame({"recency": [1], "T": [2]}),
+            ValueError,
+            r"The following required columns are missing from the input data: \['frequency'\]",
+        ),
+        (
+            pd.DataFrame(
+                {
+                    "customer_id": [1, 1],
+                    "frequency": [1, 2],
+                    "recency": [1, 1],
+                    "T": [2, 2],
+                }
+            ),
+            ValueError,
+            "Column customer_id has duplicate entries",
+        ),
+        (
+            pd.DataFrame(
+                {
+                    "customer_id": [1, 2],
+                    "frequency": [-1, 2],
+                    "recency": [1, 1],
+                    "T": [2, 2],
+                }
+            ),
+            ValueError,
+            "Column frequency has negative values",
+        ),
+    ],
+)
+def test_rfm_models_validate_data_errors(model_cls, data, expected_error, match):
+    model = model_cls.__new__(model_cls)
+    model.model_config = {"purchase_covariate_cols": [], "dropout_covariate_cols": []}
+    with pytest.raises(expected_error, match=match):
+        model._validate_data(data)
+
+
+@pytest.mark.parametrize(
+    "data, expected_error, match",
+    [
+        (
+            pd.DataFrame(
+                {
+                    "customer_id": [1, 2],
+                    "frequency": [1, 2],
+                    "recency": [1, 1],
+                    "T": [2, 3],
+                }
+            ),
+            ValueError,
+            "Column T has non-homogeneous entries",
+        ),
+        (
+            pd.DataFrame(
+                {
+                    "customer_id": [1],
+                    "frequency": [1],
+                    "recency": [3],
+                    "T": [2],
+                }
+            ),
+            ValueError,
+            "recency cannot be greater than T",
+        ),
+    ],
+)
+def test_beta_geo_beta_binom_validate_data_errors(data, expected_error, match):
+    model = BetaGeoBetaBinomModel.__new__(BetaGeoBetaBinomModel)
+    model.model_config = {}
+    with pytest.raises(expected_error, match=match):
+        model._validate_data(data)
+
+
+@pytest.mark.parametrize(
+    "data, expected_error, match",
+    [
+        (
+            pd.DataFrame(
+                {
+                    "customer_id": [1, 2],
+                    "recency": [1, 1],
+                    "T": [2, 2],
+                }
+            ),
+            ValueError,
+            r"The following required columns are missing from the input data: \['cohort'\]",
+        ),
+        (
+            pd.DataFrame(
+                {
+                    "customer_id": [1, 2],
+                    "recency": [0, 1],
+                    "T": [2, 2],
+                    "cohort": ["A", "A"],
+                }
+            ),
+            ValueError,
+            "Column recency must be at least 1",
+        ),
+        (
+            pd.DataFrame(
+                {
+                    "customer_id": [1, 2],
+                    "recency": [1, 3],
+                    "T": [2, 2],
+                    "cohort": ["A", "A"],
+                }
+            ),
+            ValueError,
+            "recency cannot be greater than T",
+        ),
+        (
+            pd.DataFrame(
+                {
+                    "customer_id": [1, 2],
+                    "recency": [1, 1],
+                    "T": [1, 1],
+                    "cohort": ["A", "A"],
+                }
+            ),
+            ValueError,
+            "Column T must be at least 2",
+        ),
+    ],
+)
+def test_shifted_beta_geo_validate_data_errors(data, expected_error, match):
+    model = ShiftedBetaGeoModel.__new__(ShiftedBetaGeoModel)
+    model.model_config = {"dropout_covariate_cols": []}
+    with pytest.raises(expected_error, match=match):
+        model._validate_data(data)
+
+
+@pytest.mark.parametrize(
+    "data, expected_warning, match",
+    [
+        (
+            pd.DataFrame(
+                {
+                    "customer_id": [1],
+                    "frequency": [1],
+                    "monetary_value": [0],
+                }
+            ),
+            UserWarning,
+            "Non-positive monetary values are practically problematic.",
+        ),
+        (
+            pd.DataFrame(
+                {
+                    "customer_id": [1],
+                    "frequency": [1],
+                    "monetary_value": [-1],
+                }
+            ),
+            UserWarning,
+            "Non-positive monetary values are practically problematic.",
+        ),
+    ],
+)
+def test_gamma_gamma_model_validate_data_warnings(data, expected_warning, match):
+    model = GammaGammaModel.__new__(GammaGammaModel)
+    model.model_config = {}
+    with pytest.warns(expected_warning, match=match):
+        model._validate_data(data)
+
+
+@pytest.mark.parametrize(
+    "data, expected_error, match",
+    [
+        (
+            pd.DataFrame(
+                {
+                    "customer_id": [1],
+                    "frequency": [-1],
+                    "monetary_value": [10.0],
+                }
+            ),
+            ValueError,
+            "Column frequency has negative values",
+        ),
+        (
+            pd.DataFrame(
+                {
+                    "customer_id": [1],
+                    "frequency": [1.5],
+                    "monetary_value": [10.0],
+                }
+            ),
+            ValueError,
+            "frequency column must contain only integer values",
+        ),
+    ],
+)
+def test_gamma_gamma_model_validate_data_errors(data, expected_error, match):
+    model = GammaGammaModel.__new__(GammaGammaModel)
+    model.model_config = {}
+    with pytest.raises(expected_error, match=match):
+        model._validate_data(data)


### PR DESCRIPTION
## Description
Addresses issue #175.

Following maintainer feedback, this PR implements a shared `_check_inputs` utility method in the base `CLVModel` rather than limiting it to `BetaGeoModel`. This centralizes data validation (`frequency`, `recency`, `T`) for all models that share identical input requirements (BG/NBD, Pareto/NBD, MBG/NBD). 

It also includes parameter handling to support the specific condition variations required by models like `ShiftedBetaGeoModel`.

Previously, invalid data (e.g., negative inputs or `recency > T`) would cause obscure errors downstream during model fitting or sampling. Now, the base model catches these early and raises a clear, descriptive `ValueError`.

## Changes
* Added `_check_inputs` to the base `CLVModel` to validate `frequency`, `recency`, and `T`.
* Added parameter support to accommodate specific edge cases (e.g., for `ShiftedBetaGeoModel`).
* Updated relevant CLV models to utilize this shared base validation.
* Updated unit tests in `tests/clv/` covering:
    * Negative values for frequency, recency, and T.
    * The invalid case where `recency > T`.
    * Ensure base model validation logic covers multiple CLV models.

## Related Issue
- [x] Closes #175 
- [ ] Related to #

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] If you are a pro: each commit corresponds to a [relevant logical change]

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2305.org.readthedocs.build/en/2305/

<!-- readthedocs-preview pymc-marketing end -->