### PR TITLE
fix #2299 (Sensitivity Analysis: Integer Truncation when channel_data is integer and sweep_values are fractional)

### DIFF
--- a/tests/mmm/test_sensitivity_analysis.py
+++ b/tests/mmm/test_sensitivity_analysis.py
@@ -24,6 +24,28 @@ from pymc_marketing.mmm.multidimensional import MMM
 from pymc_marketing.mmm.sensitivity_analysis import SensitivityAnalysis
 
 
+def _make_saturation_model_and_idata(channel_data, n_draws, alpha_val=0.8, lam_val=1.2):
+    """Build a minimal saturation model (alpha*X)/(X+lam) with posterior draws."""
+    n_dates, n_channels = channel_data.shape
+    channel_names = [chr(ord("a") + i) for i in range(n_channels)]
+    coords = {"date": np.arange(n_dates), "channel": channel_names}
+
+    with pm.Model(coords=coords) as model:
+        X = pm.Data("channel_data", channel_data, dims=("date", "channel"))
+        alpha = pm.Gamma("alpha", 1.0, 1.0, dims=("channel",))
+        lam = pm.Gamma("lam", 1.0, 1.0, dims=("channel",))
+        pm.Deterministic(
+            "channel_contribution",
+            (alpha * X) / (X + lam),
+            dims=("date", "channel"),
+        )
+
+    alpha_draws = np.full((1, n_draws, n_channels), alpha_val, dtype=np.float64)
+    lam_draws = np.full((1, n_draws, n_channels), lam_val, dtype=np.float64)
+    idata = az.from_dict(posterior={"alpha": alpha_draws, "lam": lam_draws})
+    return model, idata
+
+
 @pytest.fixture
 def simple_model_and_idata():
     """A minimal PyMC model and an InferenceData posterior compatible with SensitivityAnalysis.
@@ -31,33 +53,8 @@ def simple_model_and_idata():
     Model dims convention: (date, channel). Response is a deterministic depending on pm.Data and two RVs.
     """
     rng = np.random.default_rng(123)
-    n_dates, n_channels, n_draws = 6, 4, 5
-
-    coords = {"date": np.arange(n_dates), "channel": list("abcd")}
-    with pm.Model(coords=coords) as model:
-        X = pm.Data(
-            "channel_data",
-            rng.gamma(2.0, 1.0, size=(n_dates, n_channels)).astype("float64"),
-            dims=("date", "channel"),
-        )
-        alpha = pm.Gamma("alpha", 1.0, 1.0, dims=("channel",))
-        lam = pm.Gamma("lam", 1.0, 1.0, dims=("channel",))
-
-        def saturation(x, alpha_param, lam_param):
-            return (alpha_param * x) / (x + lam_param)
-
-        pm.Deterministic(
-            "channel_contribution",
-            saturation(X, alpha, lam),
-            dims=("date", "channel"),
-        )
-
-    # Build a tiny posterior with shapes matching free RVs: (chain=1, draw=n_draws, channel)
-    alpha_draws = np.full((1, n_draws, n_channels), 0.8, dtype="float64")
-    lam_draws = np.full((1, n_draws, n_channels), 1.2, dtype="float64")
-
-    idata = az.from_dict(posterior={"alpha": alpha_draws, "lam": lam_draws})
-    return model, idata
+    channel_data = rng.gamma(2.0, 1.0, size=(6, 4)).astype(np.float64)
+    return _make_saturation_model_and_idata(channel_data, n_draws=5)
 
 
 @pytest.fixture
@@ -518,28 +515,8 @@ def test_run_sweep_with_2d_mask(simple_model_and_idata):
 def test_run_sweep_integer_channel_data_no_truncation():
     """Fractional sweep_values must not be truncated when channel_data has integer dtype."""
     rng = np.random.default_rng(42)
-    n_dates, n_channels, n_draws = 8, 3, 10
-    coords = {"date": np.arange(n_dates), "channel": list("abc")}
-    channel_data_int = rng.integers(50, 200, size=(n_dates, n_channels)).astype(
-        np.int32
-    )
-
-    with pm.Model(coords=coords) as model:
-        X = pm.Data("channel_data", channel_data_int, dims=("date", "channel"))
-        alpha = pm.Gamma("alpha", 1.0, 1.0, dims=("channel",))
-        lam = pm.Gamma("lam", 1.0, 1.0, dims=("channel",))
-        pm.Deterministic(
-            "channel_contribution",
-            (alpha * X) / (X + lam),
-            dims=("date", "channel"),
-        )
-
-    idata = az.from_dict(
-        posterior={
-            "alpha": np.full((1, n_draws, n_channels), 0.8, dtype=np.float64),
-            "lam": np.full((1, n_draws, n_channels), 1.2, dtype=np.float64),
-        }
-    )
+    channel_data_int = rng.integers(50, 200, size=(8, 3)).astype(np.int32)
+    model, idata = _make_saturation_model_and_idata(channel_data_int, n_draws=10)
 
     sa = SensitivityAnalysis(model, idata)
     sweep_values = np.array([0.5, 1.0, 1.5])


### PR DESCRIPTION
fix #2299 

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2307.org.readthedocs.build/en/2307/

<!-- readthedocs-preview pymc-marketing end -->