### PR TITLE
fix cv with rng

### DIFF
--- a/pymc_marketing/model_builder.py
+++ b/pymc_marketing/model_builder.py
@@ -268,7 +268,7 @@ class ModelIO:
         attrs["id"] = self.id
         attrs["model_type"] = self._model_type
         attrs["version"] = self.version
-        attrs["sampler_config"] = json.dumps(self.sampler_config)
+        attrs["sampler_config"] = json.dumps(self.sampler_config, default=_json_default)
         attrs["model_config"] = json.dumps(
             self._serializable_model_config, default=_json_default
         )

--- a/tests/mmm/test_time_slice_cross_validator.py
+++ b/tests/mmm/test_time_slice_cross_validator.py
@@ -243,12 +243,22 @@ class TestTimeSliceCrossValidator:
         assert result.y_test.equals(y_test)
         assert result.idata is not None
 
-    def test_run_method_basic(self, cv, XY, mmm_fixture, mock_pymc_sample):
+    @pytest.mark.parametrize(
+        argnames="random_seed",
+        argvalues=[42, np.random.default_rng(42)],
+        ids=["int", "rng"],
+    )
+    def test_run_method_basic(self, cv, XY, mmm_fixture, mock_pymc_sample, random_seed):
         """Test run method returns correct number of results."""
         X, y = XY
         # run() now returns a combined InferenceData; per-fold results are
         # available on `cv._cv_results` after calling run().
-        _combined = cv.run(X, y, mmm=_MMMBuilder(mmm_fixture))
+        _combined = cv.run(
+            X,
+            y,
+            mmm=_MMMBuilder(mmm_fixture),
+            sampler_config={"random_seed": random_seed},
+        )
 
         expected_splits = cv.get_n_splits(X, y)
         assert hasattr(cv, "_cv_results")

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -1019,7 +1019,7 @@ def test_fit_sampler_config_seed_reproducibility(toy_X, toy_y) -> None:
     assert idata.posterior.equals(idata2.posterior)
 
 
-def test_fit_sampler_config_with_rng_fails(toy_X, toy_y, mock_pymc_sample) -> None:
+def test_fit_sampler_config_with_rng(toy_X, toy_y, mock_pymc_sample) -> None:
     sampler_config = {
         "chains": 1,
         "draws": 10,
@@ -1028,9 +1028,8 @@ def test_fit_sampler_config_with_rng_fails(toy_X, toy_y, mock_pymc_sample) -> No
     }
     model = RegressionModelBuilderTest(sampler_config=sampler_config)
 
-    match = r"Object of type Generator is not JSON serializable"
-    with pytest.raises(TypeError, match=match):
-        model.fit(toy_X, toy_y)
+    idata = model.fit(toy_X, toy_y)
+    assert isinstance(idata, az.InferenceData)
 
 
 def test_unmatched_index(toy_X, toy_y) -> None:


### PR DESCRIPTION
See https://discourse.pymc.io/t/timeslicecrossvalidator-breaks-when-passing-rng-in-sampler/17571/4

**Problem:** `json.dumps(self.sampler_config)` in `model_builder.py:271` fails with `TypeError: Object of type Generator is not JSON serializable` when `sampler_config` contains a `numpy.random.Generator` (e.g. `{"random_seed": np.random.default_rng(42)}`).

**Fix:** Added `default=_json_default` to the `json.dumps` call — the same fallback handler already used on the next line for `model_config`. This converts non-serializable objects to their string representation.

# Before
attrs["sampler_config"] = json.dumps(self.sampler_config)

# After
attrs["sampler_config"] = json.dumps(self.sampler_config, default=_json_default)


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2308.org.readthedocs.build/en/2308/

<!-- readthedocs-preview pymc-marketing end -->