### PR TITLE
Pin Upper Bound PyMC-Extras because of Prior class breaking changes

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ dependencies:
   # NOTE: Keep minimum pymc version in sync with ci.yml `OLDEST_PYMC_VERSION`
   - pymc>=5.23.0
   - pytensor>=2.31.3
-  - pymc-extras>=0.2.7
+  - pymc-extras>=0.2.7,<0.9
   - nutpie>=0.15.1
   - blackjax>=1.2.4
   - scikit-learn>=1.1.1

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - pyprojroot
   - plotly>=6.3.0
   # NOTE: Keep minimum pymc version in sync with ci.yml `OLDEST_PYMC_VERSION`
-  - pymc>=5.23.0
+  - pymc>=5.27.1
   - pytensor>=2.31.3
   - pymc-extras>=0.2.7,<0.9
   - nutpie>=0.15.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "xarray>=2024.1.0",
     "xarray-einstats>=0.5.1",
     "pyprojroot",
-    "pymc-extras>=0.4.0",
+    "pymc-extras>=0.4.0,<0.9",
     "preliz>=0.20.0",
     "pyyaml",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "pandas",
     "pydantic>=2.1.0",
     # NOTE: Used as minimum pymc version with test.yml `OLDEST_PYMC_VERSION`
-    "pymc>=5.27.0",
+    "pymc>=5.27.1",
     "pytensor>=2.36.3",
     "scikit-learn>=1.1.1",
     "seaborn>=0.12.2",


### PR DESCRIPTION
pin pymc-extra<0.9 since it cause tests to fail (see https://github.com/pymc-devs/pymc-extras/issues/655).
also had to update PyMC>=5.27.1 to pass the tests. 