### PR TITLE
Fix compatibility with latest pytensor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         linker: [cvm, numba]
         config: [ {python-version: "3.11", oldest-pymc: false}, {python-version: "3.13", oldest-pymc: true} ]
@@ -70,6 +71,7 @@ jobs:
   test_slow:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         linker: [cvm, numba]
         group: [1, 2]  # Reduced from 3 to 2 groups for better balance

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
                  --durations-path .test_durations
       - name: Check oldest version of PyMC
         if: ${{ matrix.config.oldest-pymc }}
-        run: python -c "import pymc; assert pymc.__version__ == '${{ env.OLDEST_PYMC_VERSION }}'"
+        run: python -c "import pymc; assert pymc.__version__ == '${{ env.OLDEST_PYMC_VERSION }}', pymc.__version__"
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/test_notebook.yml
+++ b/.github/workflows/test_notebook.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
+      fail-fast: false
       matrix:
         linker: [cvm, numba]
         split:

--- a/pymc_marketing/clv/models/beta_geo_beta_binom.py
+++ b/pymc_marketing/clv/models/beta_geo_beta_binom.py
@@ -264,7 +264,10 @@ class BetaGeoBetaBinomModel(CLVModel):
         values = pt.constant(np.stack((t_x.values, x.values), axis=-1))
         loglike = vectorize_graph(
             dummy_logp,
-            replace={dummy_T: T.values[:, None], dummy_values: values[:, None, :]},
+            replace={
+                dummy_T: pt.as_tensor(T.values[:, None]),
+                dummy_values: pt.as_tensor(values[:, None, :]),
+            },
         ).eval()
         # Unstack chain/draw and put customer in last axis
         loglike = np.moveaxis(

--- a/tests/clv/models/test_beta_geo_beta_binom.py
+++ b/tests/clv/models/test_beta_geo_beta_binom.py
@@ -17,11 +17,12 @@ import arviz as az
 import numpy as np
 import pandas as pd
 import pymc as pm
-import pytensor as pt
 import pytest
 import xarray as xr
 from lifetimes.fitters.beta_geo_beta_binom_fitter import BetaGeoBetaBinomFitter
 from pymc_extras.prior import Prior
+from pytensor.compile import ViewOp
+from pytensor.tensor.elemwise import Elemwise
 
 from pymc_marketing.clv.distributions import BetaGeoBetaBinom
 from pymc_marketing.clv.models import BetaGeoBetaBinomModel
@@ -128,25 +129,25 @@ class TestBetaGeoBetaBinomModel:
             model.build_model()
             assert isinstance(
                 model.model["alpha"].owner.op,
-                pt.tensor.elemwise.Elemwise
+                ViewOp | Elemwise
                 if "alpha" not in model.model_config
                 else model.model_config["alpha"].pymc_distribution,
             )
             assert isinstance(
                 model.model["beta"].owner.op,
-                pt.tensor.elemwise.Elemwise
+                ViewOp | Elemwise
                 if "beta" not in model.model_config
                 else model.model_config["beta"].pymc_distribution,
             )
             assert isinstance(
                 model.model["delta"].owner.op,
-                pt.tensor.elemwise.Elemwise
+                ViewOp | Elemwise
                 if "delta" not in model.model_config
                 else model.model_config["delta"].pymc_distribution,
             )
             assert isinstance(
                 model.model["gamma"].owner.op,
-                pt.tensor.elemwise.Elemwise
+                ViewOp | Elemwise
                 if "gamma" not in model.model_config
                 else model.model_config["gamma"].pymc_distribution,
             )

--- a/tests/clv/models/test_shifted_beta_geo.py
+++ b/tests/clv/models/test_shifted_beta_geo.py
@@ -17,11 +17,12 @@ import arviz as az
 import numpy as np
 import pandas as pd
 import pymc as pm
-import pytensor as pt
 import pytest
 import xarray as xr
 from pymc.distributions.censored import CensoredRV
 from pymc_extras.prior import Prior
+from pytensor.compile import ViewOp
+from pytensor.tensor.elemwise import Elemwise
 from scipy import stats
 
 from pymc_marketing.clv import ShiftedBetaGeoModel, ShiftedBetaGeoModelIndividual
@@ -215,13 +216,13 @@ class TestShiftedBetaGeoModel:
             model.build_model()
             assert isinstance(
                 model.model["alpha"].owner.op,
-                pt.tensor.elemwise.Elemwise
+                ViewOp | Elemwise
                 if "alpha" not in model.model_config
                 else model.model_config["alpha"].pymc_distribution,
             )
             assert isinstance(
                 model.model["beta"].owner.op,
-                pt.tensor.elemwise.Elemwise
+                ViewOp | Elemwise
                 if "beta" not in model.model_config
                 else model.model_config["beta"].pymc_distribution,
             )


### PR DESCRIPTION
vectorize_graph is a bit more strict now, caused CI to fail in #2315 

Also changed ci to fail-fast=False, which was discussed internally

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2316.org.readthedocs.build/en/2316/

<!-- readthedocs-preview pymc-marketing end -->