### PR TITLE
Raise explicitly when trying to optimize or measure incrementality of discrete channel data

### DIFF
--- a/pymc_marketing/mmm/budget_optimizer.py
+++ b/pymc_marketing/mmm/budget_optimizer.py
@@ -661,10 +661,6 @@ class BudgetOptimizer(BaseModel):
             self.num_periods
         )  # TODO: Once multidimensional class becomes the main class.
 
-        # Ensure channel_data is float so pt.grad can differentiate through
-        # the do() replacement. Integer dtypes have zero gradient for pt.cast.
-        self._ensure_float_channel_data(pymc_model)
-
         # 2. Shared variable for total_budget: Use annotation to avoid type checking
         self._total_budget: SharedVariable = shared(
             np.array(0.0, dtype="float64"), name="total_budget"
@@ -897,22 +893,6 @@ class BudgetOptimizer(BaseModel):
 
         return repeated_budgets
 
-    @staticmethod
-    def _ensure_float_channel_data(pymc_model: Model) -> None:
-        """Cast channel_data to float64 in-place if it has an integer dtype.
-
-        Integer channel_data produces zero gradients through ``pt.cast``,
-        which prevents the optimizer from moving away from x0.
-        """
-        from pytensor.tensor.type import TensorType
-
-        cd = pymc_model["channel_data"]
-        if "int" in str(cd.dtype):
-            new_type = TensorType("float64", shape=cd.type.shape)
-            cd.type = new_type
-            cd.container.type = new_type
-            cd.set_value(cd.get_value().astype("float64"))
-
     def _replace_channel_data_by_optimization_variable(self, model: Model) -> Model:
         """Replace `channel_data` in the model graph with our newly created `_budgets` variable."""
         num_periods = self.num_periods
@@ -920,6 +900,11 @@ class BudgetOptimizer(BaseModel):
         channel_data_dims = model.named_vars_to_dims["channel_data"]
         date_dim_idx = list(channel_data_dims).index("date")
         channel_scales = self.mmm_model._channel_scales
+        channel_data_dtype = model["channel_data"].dtype
+        if np.dtype(channel_data_dtype).kind != "f":
+            raise ValueError(
+                f"Optimization requires channel data of float type, got {channel_data_dtype}"
+            )
 
         # Scale budgets by channel_scales
         budgets = self._budgets

--- a/pymc_marketing/mmm/incrementality.py
+++ b/pymc_marketing/mmm/incrementality.py
@@ -352,10 +352,14 @@ class Incrementality:
         # Use float64 for evaluation to avoid integer truncation when
         # counterfactual_spend_factor produces fractional values (e.g. 1.01).
         data_shared = self.model.model["channel_data"]
-        eval_dtype = "float64"
+        data_dtype = data_shared.dtype
+        if np.dtype(data_dtype).kind != "f":
+            raise ValueError(
+                f"Incrementality requires channel data of float type, got {data_dtype}"
+            )
         batched_input = pt.tensor(
             name="channel_data_batched",
-            dtype=eval_dtype,
+            dtype=data_shared.dtype,
             shape=(None, *data_shared.type.shape),
         )
         replace_dict: dict = {data_shared: batched_input}
@@ -383,7 +387,7 @@ class Incrementality:
         # Evaluate baseline on full dataset (once)
         baseline_array = self.data.get_channel_spend().values
         baseline_eval_args: list[np.ndarray] = [
-            baseline_array[np.newaxis].astype(eval_dtype)
+            baseline_array[np.newaxis].astype(data_dtype)
         ]
         if has_time_index:
             baseline_eval_args.append(
@@ -427,7 +431,7 @@ class Incrementality:
             l_max=l_max,
             freq_offset=freq_offset,
             extra_shape=extra_shape,
-            dtype=eval_dtype,
+            dtype=data_dtype,
         )
 
         # Evaluate all counterfactuals at once

--- a/tests/mmm/conftest.py
+++ b/tests/mmm/conftest.py
@@ -66,7 +66,7 @@ def _make_mmm_data(
     np.random.seed(seed)
 
     channels = {
-        f"channel_{i + 1}": np.random.randint(100, 500, size=len(date_range))
+        f"channel_{i + 1}": np.random.uniform(100, 500, size=len(date_range))
         for i in range(n_channels)
     }
 
@@ -195,7 +195,7 @@ def simple_fitted_mmm(simple_mmm_data):
 
 
 @pytest.fixture
-def simple_fitted_mmm_float(simple_mmm_data):
+def simple_fitted_mmm_int(simple_mmm_data):
     """Like simple_fitted_mmm but with float channel data (same values).
 
     Used to obtain correct marginal incrementality when factor produces
@@ -207,7 +207,7 @@ def simple_fitted_mmm_float(simple_mmm_data):
     y = simple_mmm_data["y"]
     # Convert channel columns to float so counterfactual factor preserves fractions
     for col in ["channel_1", "channel_2", "channel_3"]:
-        X[col] = X[col].astype(np.float64)
+        X[col] = X[col].astype(np.int64)
 
     mmm = MMM(
         channel_columns=["channel_1", "channel_2", "channel_3"],

--- a/tests/mmm/test_budget_optimizer.py
+++ b/tests/mmm/test_budget_optimizer.py
@@ -32,7 +32,6 @@ from pymc_marketing.mmm.budget_optimizer import (
 from pymc_marketing.mmm.components.adstock import GeometricAdstock
 from pymc_marketing.mmm.components.saturation import LogisticSaturation
 from pymc_marketing.mmm.constraints import Constraint
-from pymc_marketing.mmm.multidimensional import MultiDimensionalBudgetOptimizerWrapper
 from pymc_marketing.mmm.utility import _check_samples_dimensionality
 
 
@@ -969,59 +968,3 @@ def test_custom_protocol_model_budget_optimizer_works(mock_pymc_sample):
     assert list(optimal_budgets.coords["channel"].values) == channels
     assert result.success
     assert np.isclose(optimal_budgets.sum().item(), 100.0)
-
-
-def _run_budget_optimization(mmm, total_budget=1000.0):
-    """Helper: build optimizer from a fitted MMM and allocate budget."""
-    wrapper = MultiDimensionalBudgetOptimizerWrapper(
-        model=mmm, start_date="2025-01-06", end_date="2025-02-03"
-    )
-    with pytest.warns(UserWarning, match="Using default equality constraint"):
-        optimizer = BudgetOptimizer(
-            model=wrapper,
-            num_periods=wrapper.num_periods,
-            response_variable="total_media_contribution_original_scale",
-        )
-    budget_bounds = {ch: (0.0, total_budget) for ch in mmm.channel_columns}
-    optimal_budgets, _result = optimizer.allocate_budget(
-        total_budget=total_budget,
-        budget_bounds=budget_bounds,
-    )
-    return optimizer, optimal_budgets
-
-
-def test_int_and_float_channel_data_produce_same_allocation(
-    simple_fitted_mmm, simple_fitted_mmm_float
-):
-    """Budget optimizer should produce identical allocations regardless of channel_data dtype."""
-    total_budget = 5000.0
-
-    _float_optimizer, float_budgets = _run_budget_optimization(
-        simple_fitted_mmm_float, total_budget
-    )
-    _int_optimizer, int_budgets = _run_budget_optimization(
-        simple_fitted_mmm, total_budget
-    )
-
-    float_alloc = float_budgets.values
-    int_alloc = int_budgets.values
-    equal_share = total_budget / len(float_alloc)
-
-    # Precondition: the float model (which has working gradients) must
-    # actually deviate from the equal split, otherwise the comparison is
-    # vacuous.
-    assert not np.allclose(float_alloc, equal_share, atol=0.01), (
-        f"Float model stayed at equal split {float_alloc} — "
-        f"test is inconclusive because there is no asymmetry to detect."
-    )
-
-    np.testing.assert_allclose(
-        int_alloc,
-        float_alloc,
-        atol=1.0,
-        err_msg=(
-            f"Int-dtype model allocations {int_alloc} differ from "
-            f"float-dtype model allocations {float_alloc}. "
-            f"Integer channel_data likely breaks gradient flow via pt.cast."
-        ),
-    )

--- a/tests/mmm/test_budget_optimizer_multidimensional.py
+++ b/tests/mmm/test_budget_optimizer_multidimensional.py
@@ -1373,3 +1373,53 @@ def test_multidimensional_optimize_budget_callback_parametrized(
     assert hasattr(opt_result, "success")
     assert hasattr(opt_result, "x")
     assert hasattr(opt_result, "fun")
+
+
+def test_int_channel_data_cannot_be_optimized(simple_fitted_mmm_int):
+    # TODO: We could work with discrete optimizers in this case
+    # Or we convert channel data to float regardless of input (may not always make sense)
+
+    wrapper = MultiDimensionalBudgetOptimizerWrapper(
+        model=simple_fitted_mmm_int, start_date="2025-01-06", end_date="2025-02-03"
+    )
+    with pytest.raises(
+        ValueError, match=r"Optimization requires channel data of float type, got int*"
+    ):
+        BudgetOptimizer(
+            model=wrapper,
+            num_periods=wrapper.num_periods,
+            response_variable="total_media_contribution_original_scale",
+        )
+
+
+def test_float_channel_data_optimized(simple_fitted_mmm):
+    """Budget optimizer should produce identical allocations regardless of channel_data dtype."""
+    total_budget = 5000.0
+
+    wrapper = MultiDimensionalBudgetOptimizerWrapper(
+        model=simple_fitted_mmm, start_date="2025-01-06", end_date="2025-02-03"
+    )
+    with pytest.warns(UserWarning, match="Using default equality constraint"):
+        optimizer = BudgetOptimizer(
+            model=wrapper,
+            num_periods=wrapper.num_periods,
+            response_variable="total_media_contribution_original_scale",
+        )
+    budget_bounds = {
+        ch: (0.0, total_budget) for ch in simple_fitted_mmm.channel_columns
+    }
+    optimal_budgets, _result = optimizer.allocate_budget(
+        total_budget=total_budget,
+        budget_bounds=budget_bounds,
+    )
+
+    float_alloc = optimal_budgets.values
+    equal_share = total_budget / len(float_alloc)
+
+    # Precondition: the float model (which has working gradients) must
+    # actually deviate from the equal split, otherwise the comparison is
+    # vacuous.
+    assert not np.allclose(float_alloc, equal_share, atol=0.01), (
+        f"Float model stayed at equal split {float_alloc} — "
+        f"test is inconclusive because there is no asymmetry to detect."
+    )

--- a/tests/mmm/test_incrementality.py
+++ b/tests/mmm/test_incrementality.py
@@ -102,7 +102,7 @@ def compute_ground_truth_incremental_by_period(
             f"counterfactual_spend_factor={counterfactual_spend_factor} produces "
             "fractional values, but the model's channel_data has integer dtype. "
             "pm.set_data rejects float for integer shared variables. Use a model "
-            "fit with float channel_data (e.g. simple_fitted_mmm_float) for "
+            "fit with float channel_data (e.g. simple_fitted_mmm) for "
             "marginal incrementality ground truth."
         )
 
@@ -209,7 +209,7 @@ class TestIncrementality:
             ("simple_fitted_mmm", "monthly", True, 0.0),
             ("simple_fitted_mmm", "all_time", True, 0.0),
             ("simple_fitted_mmm", "monthly", False, 0.0),
-            ("simple_fitted_mmm_float", "monthly", True, 1.01),
+            ("simple_fitted_mmm", "monthly", True, 1.01),
             ("panel_fitted_mmm", "monthly", True, 0.0),
             ("panel_fitted_mmm", "all_time", True, 1.01),
             ("monthly_fitted_mmm", "original", True, 0.0),
@@ -251,27 +251,18 @@ class TestIncrementality:
         assert not np.isnan(gt).any()  # sanity check
         xr.testing.assert_allclose(result, gt, rtol=1e-4)
 
-    def test_marginal_incrementality_with_integer_channel_data_preserves_fractional_perturbation(
-        self, simple_fitted_mmm, simple_fitted_mmm_float
+    def test_marginal_incrementality_with_integer_channel_fails(
+        self, simple_fitted_mmm_int
     ):
-        """Marginal incrementality must not truncate fractional perturbations."""
-        # Float model: no truncation possible → correct reference
-        result_float = (
-            simple_fitted_mmm_float.incrementality.compute_incremental_contribution(
+        with pytest.raises(
+            ValueError,
+            match=r"Incrementality requires channel data of float type, got int*",
+        ):
+            simple_fitted_mmm_int.incrementality.compute_incremental_contribution(
                 frequency="all_time",
                 counterfactual_spend_factor=1.01,
                 include_carryover=True,
             )
-        )
-
-        result_int = simple_fitted_mmm.incrementality.compute_incremental_contribution(
-            frequency="all_time",
-            counterfactual_spend_factor=1.01,
-            include_carryover=True,
-        )
-
-        assert not np.isnan(result_float).any()
-        xr.testing.assert_allclose(result_int, result_float, rtol=1e-4)
 
     def test_negative_counterfactual_factor_raises_error(self, incrementality_lite):
         """Test that negative counterfactual factor raises ValueError."""

--- a/tests/mmm/test_multidimensional.py
+++ b/tests/mmm/test_multidimensional.py
@@ -67,10 +67,10 @@ def df(target_column) -> pd.DataFrame:
     dates = pd.date_range("2025-01-01", periods=3, freq="W-MON").rename("date")
     df = pd.DataFrame(
         {
-            ("A", "C1"): [1, 2, 3],
-            ("B", "C1"): [4, 5, 6],
-            ("A", "C2"): [7, 8, 9],
-            ("B", "C2"): [10, 11, 12],
+            ("A", "C1"): [1, 2, 3.0],
+            ("B", "C1"): [4, 5, 6.0],
+            ("A", "C2"): [7, 8, 9.0],
+            ("B", "C2"): [10, 11, 12.0],
         },
         index=dates,
     )

--- a/tests/test_pytensor_utils.py
+++ b/tests/test_pytensor_utils.py
@@ -54,8 +54,8 @@ def sample_multidim_data():
             {
                 "date": dates,
                 "country": country,
-                "C1": np.random.randint(10, 50, n_obs_per_country),
-                "C2": np.random.randint(5, 40, n_obs_per_country),
+                "C1": np.random.uniform(10, 50, n_obs_per_country),
+                "C2": np.random.uniform(5, 40, n_obs_per_country),
                 "control": np.random.normal(10, 2, n_obs_per_country),
             }
         )


### PR DESCRIPTION
Closes #2336 

If we want this to be supported we either:
1. Create / cast original channel_data always to float type
2. Use discrete optimizer without gradients
3. Do an unsafe `clone_replace(rebuild_strict=False)` and hope it does the right thing. 

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2337.org.readthedocs.build/en/2337/

<!-- readthedocs-preview pymc-marketing end -->