### PR TITLE
bug : mlflow uses the name param on versions 3.0.0 and greater

### DIFF
--- a/pymc_marketing/mlflow.py
+++ b/pymc_marketing/mlflow.py
@@ -175,9 +175,9 @@ from pymc_marketing.mmm.evaluation import compute_summary_metrics
 from pymc_marketing.mmm.multidimensional import MMM as MultiDimensionalMMM
 from pymc_marketing.version import __version__
 
-# MLflow 3.0.1+ deprecated artifact_path in favor of name
+# MLflow 3.0.0+ deprecated artifact_path in favor of name
 _MLFLOW_SUPPORTS_NAME_PARAM = version.parse(mlflow.__version__) >= version.parse(
-    "3.0.1"
+    "3.0.0"
 )
 
 FLAVOR_NAME = "pymc"
@@ -884,7 +884,7 @@ def log_mmm(
         original_scale=original_scale,
     )
 
-    # MLflow 3.0.1+ uses 'name' parameter, older versions use 'artifact_path'
+    # MLflow 3.0.0+ uses 'name' parameter, older versions use 'artifact_path'
     log_model_kwargs: dict[str, Any] = {"python_model": mlflow_mmm}
     if _MLFLOW_SUPPORTS_NAME_PARAM:
         log_model_kwargs["name"] = artifact_path

--- a/pymc_marketing/mlflow.py
+++ b/pymc_marketing/mlflow.py
@@ -177,7 +177,7 @@ from pymc_marketing.version import __version__
 
 # MLflow 2.18.0+ deprecated artifact_path in favor of name
 _MLFLOW_SUPPORTS_NAME_PARAM = version.parse(mlflow.__version__) >= version.parse(
-    "2.18.0"
+    "3.0.1"
 )
 
 FLAVOR_NAME = "pymc"

--- a/pymc_marketing/mlflow.py
+++ b/pymc_marketing/mlflow.py
@@ -175,7 +175,7 @@ from pymc_marketing.mmm.evaluation import compute_summary_metrics
 from pymc_marketing.mmm.multidimensional import MMM as MultiDimensionalMMM
 from pymc_marketing.version import __version__
 
-# MLflow 2.18.0+ deprecated artifact_path in favor of name
+# MLflow 3.0.1+ deprecated artifact_path in favor of name
 _MLFLOW_SUPPORTS_NAME_PARAM = version.parse(mlflow.__version__) >= version.parse(
     "3.0.1"
 )
@@ -884,7 +884,7 @@ def log_mmm(
         original_scale=original_scale,
     )
 
-    # MLflow 2.18.0+ uses 'name' parameter, older versions use 'artifact_path'
+    # MLflow 3.0.1+ uses 'name' parameter, older versions use 'artifact_path'
     log_model_kwargs: dict[str, Any] = {"python_model": mlflow_mmm}
     if _MLFLOW_SUPPORTS_NAME_PARAM:
         log_model_kwargs["name"] = artifact_path


### PR DESCRIPTION
This user noticed that https://discourse.pymc.io/t/cant-log-mmm-model-with-pymc-marketing-mlflow-log-mmm/17591 that MLFlow was rejecting the name parameter. We had some defense in the codebase already for this: we check which version of mlflow they are on and dispatch to the correct parameter name. But it seems like we were indexed to the wrong version. I searched through the version history on https://mlflow.org/docs/3.0.1/api_reference/_modules/mlflow/pyfunc.html#log_model and the name parameter only shows up at 3.0.1.


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2339.org.readthedocs.build/en/2339/

<!-- readthedocs-preview pymc-marketing end -->