### PR TITLE
Unblock merges for non-code PRs by always reporting `all_tests` status

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           filters: |
             code:
-              # - ".github/workflows/test.yml"
+              - ".github/workflows/test.yml"
               - "pyproject.toml"
               - "tests/**.py"
               - "pymc_marketing/**"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,18 +3,8 @@ name: Test
 on:
   pull_request:
     branches: [main]
-    paths:
-     - ".github/workflows/test.yml"
-     - "pyproject.toml"
-     - "tests/**.py"
-     - "pymc_marketing/**"
   push:
     branches: [main]
-    paths:
-     - ".github/workflows/test.yml"
-     - "pyproject.toml"
-     - "tests/**.py"
-     - "pymc_marketing/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -29,7 +19,27 @@ env:
   # - Only needed every few weeks or after major test changes
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      should_test: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              # - ".github/workflows/test.yml"
+              - "pyproject.toml"
+              - "tests/**.py"
+              - "pymc_marketing/**"
+
   test:
+    needs: changes
+    if: ${{ needs.changes.outputs.should_test == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -69,6 +79,8 @@ jobs:
           fail_ci_if_error: false
 
   test_slow:
+    needs: changes
+    if: ${{ needs.changes.outputs.should_test == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -104,7 +116,7 @@ jobs:
   all_tests:
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    needs: [test, test_slow]
+    needs: [changes, test, test_slow]
     steps:
       - name: Check build matrix status
         if: ${{ !contains(fromJSON('["success", "skipped"]'), needs.test.result) || !contains(fromJSON('["success", "skipped"]'), needs.test_slow.result) }}


### PR DESCRIPTION
## Problem
The Test workflow used `paths` filters on the `on` trigger to only run when code-relevant files changed (e.g. `pymc_marketing/**`, `tests/**`, `pyproject.toml`). This meant that non-code PRs (like README or docs-only changes) never triggered the workflow at all. Since the workflow never ran, the required `all_tests` status check was never reported to GitHub, and branch protection blocked the merge — even though there was nothing to test.

## Fix
The `paths` filters have been moved from the workflow trigger into a new lightweight `changes` job that uses `dorny/paths-filter` to detect whether any code-relevant files were modified.

- The workflow now **always triggers** on every PR and push to `main` (no more `paths` filter on the trigger).
- A new `changes` job runs first (~10s) and outputs whether code files were changed.
- `test` and `test_slow` depend on `changes` and are **conditionally skipped** when no relevant files changed.
- `all_tests` always runs at the end. 
