### PR TITLE
Group the custom components notebooks

### DIFF
--- a/docs/source/gallery/gallery.md
+++ b/docs/source/gallery/gallery.md
@@ -26,11 +26,6 @@ Welcome to the PyMC-Marketing example gallery! This gallery provides visual navi
 :link: ../notebooks/mmm/mmm_example.html
 :::
 
-:::{grid-item-card} Beyond MMMs: adding GAMs or anything else to your model.
-:img-top: ../gallery/images/mmm_example.png
-:link: ../notebooks/mmm/mmm_gam_options.html
-:::
-
 :::{grid-item-card} MMM Multidimensional Example Notebook (e.g. Geo-MMM)
 :img-top: ../gallery/images/mmm_multidimensional_example.png
 :link: ../notebooks/mmm/mmm_multidimensional_example.html
@@ -74,6 +69,11 @@ Welcome to the PyMC-Marketing example gallery! This gallery provides visual navi
 :::{grid-item-card} Custom Geo-Hierarchical MMM with Splines
 :img-top: ../gallery/images/mmm_custom_splines.png
 :link: ../notebooks/mmm/mmm_custom_splines.html
+:::
+
+:::{grid-item-card} Beyond MMMs: adding GAMs or anything else to your model.
+:img-top: ../gallery/images/mmm_example.png
+:link: ../notebooks/mmm/mmm_gam_options.html
 :::
 ::::
 


### PR DESCRIPTION
I noticed this notebook was up in the fundamentals section. It would make more sense to group it with the other custom component notebooks. It's also very much a power-user notebook so potentially confusing to have it a section that targets beginners.

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2362.org.readthedocs.build/en/2362/

<!-- readthedocs-preview pymc-marketing end -->