### PR TITLE
chore: claude based duplicate issues

### DIFF
--- a/.claude/agents/duplicate-finder.md
+++ b/.claude/agents/duplicate-finder.md
@@ -1,0 +1,44 @@
+---
+name: duplicate-finder
+description: Finds duplicate or related GitHub issues
+tools:
+  Bash: true
+  Read: false
+  Write: false
+  Edit: false
+  Glob: false
+  Grep: false
+---
+
+You are a duplicate issue detection agent. When an issue is opened, your job is to search for potentially duplicate or related open issues.
+
+Use ONLY the gh CLI to search for issues. You have access to:
+- `gh search issues "query" --repo pymc-labs/pymc-marketing` - Search issues by keywords (searches title and body)
+- `gh issue view NUMBER` - View specific issue details if needed
+
+Do NOT use any other commands. Focus only on finding duplicates using gh search.
+
+IMPORTANT: The input will contain a line `CURRENT_ISSUE_NUMBER: NNNN`. This is the current issue number, you should exclude that issue from your search results.
+
+Search using keywords from the issue title and description. Try multiple searches with different relevant terms.
+
+## Output Format
+
+You must output your findings in this specific format:
+
+**If duplicates found:**
+```
+DUPLICATES: FOUND
+
+## Potential Duplicate Issues
+
+- #123: [Title] - Brief explanation of why it might be related
+- #456: [Title] - Brief explanation of why it might be related
+```
+
+**If no duplicates found:**
+```
+DUPLICATES: NONE
+```
+
+Keep your response concise and actionable.

--- a/.github/workflows/duplicate-issues.yml
+++ b/.github/workflows/duplicate-issues.yml
@@ -1,0 +1,95 @@
+name: Duplicate Detection
+
+on:
+  issues:
+    types: [opened, edited]
+
+concurrency:
+  group: issue-${{ github.event.issue.number }}-duplicate
+  cancel-in-progress: true
+
+jobs:
+  check-duplicates:
+    if: github.event.action == 'opened' || github.event.changes.body
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Wait 10 minutes before checking
+        run: sleep 600
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "18"
+
+      - name: Install Claude Code CLI
+        run: |
+          npm install -g @anthropic-ai/claude-code
+
+      - name: Verify Claude installation
+        run: |
+          claude --version
+
+      - name: Prepare issue content
+        id: prepare
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: |
+          {
+            printf '%s\n' "CURRENT_ISSUE_NUMBER: $ISSUE_NUMBER"
+            printf '%s\n' ""
+            printf '%s\n' "# Issue: $ISSUE_TITLE"
+            printf '%s\n' ""
+            printf '%s\n' "$ISSUE_BODY"
+          } > /tmp/issue_content.txt
+
+      - name: Run duplicate finder agent
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          set -o pipefail
+          claude -p \
+            --dangerously-skip-permissions \
+            --max-turns 50 \
+            --agent duplicate-finder \
+            --print \
+            < /tmp/issue_content.txt 2>&1 | tee /tmp/claude_output.log
+
+      - name: Extract agent response
+        id: extract_response
+        run: |
+          # Check if duplicates were found
+          if grep -q "^DUPLICATES: FOUND" /tmp/claude_output.log; then
+            # Extract everything after "DUPLICATES: FOUND"
+            RESPONSE=$(sed -n '/^DUPLICATES: FOUND/,$ p' /tmp/claude_output.log | tail -n +2)
+            echo "has_duplicates=true" >> $GITHUB_OUTPUT
+            # Store response in a temporary file to preserve formatting
+            echo "$RESPONSE" > /tmp/duplicate_response.txt
+          elif grep -q "^DUPLICATES: NONE" /tmp/claude_output.log; then
+            echo "has_duplicates=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_duplicates=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Comment on issue if duplicates found
+        if: steps.extract_response.outputs.has_duplicates == 'true'
+        run: |
+          ISSUE_NUMBER="${{ github.event.issue.number }}"
+
+          gh issue comment "$ISSUE_NUMBER" \
+            --body-file /tmp/duplicate_response.txt
+          echo "✅ Posted duplicate detection result to issue #$ISSUE_NUMBER"
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

Claude agent to find potential duplicate issues.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to https://github.com/pymc-labs/pymc-marketing/pull/2380

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2381.org.readthedocs.build/en/2381/

<!-- readthedocs-preview pymc-marketing end -->