### PR TITLE
remove superfluous use of `arbitrary_types_allowed` in  annotations

### DIFF
--- a/pymc_marketing/mmm/budget_optimizer.py
+++ b/pymc_marketing/mmm/budget_optimizer.py
@@ -641,7 +641,6 @@ class BudgetOptimizer(BaseModel):
     mmm_model: InstanceOf[OptimizerCompatibleModelWrapper] = Field(
         ...,
         description="The marketing mix model to optimize.",
-        arbitrary_types_allowed=True,
         alias="model",
     )
 
@@ -653,7 +652,6 @@ class BudgetOptimizer(BaseModel):
     utility_function: UtilityFunctionType = Field(
         default=average_response,
         description="Utility function to maximize.",
-        arbitrary_types_allowed=True,
     )
 
     budgets_to_optimize: DataArray | None = Field(
@@ -664,7 +662,6 @@ class BudgetOptimizer(BaseModel):
     custom_constraints: Sequence[Constraint] = Field(
         default=(),
         description="Custom constraints for the optimizer.",
-        arbitrary_types_allowed=True,
     )
 
     default_constraints: bool = Field(

--- a/pymc_marketing/mmm/causal.py
+++ b/pymc_marketing/mmm/causal.py
@@ -31,7 +31,7 @@ import pandas as pd
 import pymc as pm
 import pytensor
 import pytensor.tensor as pt
-from pydantic import Field, InstanceOf, validate_call
+from pydantic import ConfigDict, Field, InstanceOf, validate_call
 from pymc_extras.prior import Prior
 
 try:
@@ -654,7 +654,7 @@ class TBFPC:
     - Kass, R. & Raftery, A. (1995). "Bayes Factors."
     """
 
-    @validate_call(config=dict(arbitrary_types_allowed=True))
+    @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
     def __init__(
         self,
         target: Annotated[

--- a/pymc_marketing/mmm/multidimensional.py
+++ b/pymc_marketing/mmm/multidimensional.py
@@ -162,7 +162,7 @@ import pymc as pm
 import pymc.dims as pmd
 import pytensor.xtensor as ptx
 import xarray as xr
-from pydantic import Field, InstanceOf, StrictBool, validate_call
+from pydantic import ConfigDict, Field, InstanceOf, StrictBool, validate_call
 from pymc.model.fgraph import clone_model as cm
 from pymc.util import RandomState
 from pymc_extras.deserialize import deserialize
@@ -2348,7 +2348,7 @@ class MMM(RegressionModelBuilder):
 
         return posterior_predictive_samples
 
-    @validate_call(config={"arbitrary_types_allowed": True})
+    @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
     def sample_saturation_curve(
         self,
         max_value: float = Field(
@@ -2506,7 +2506,7 @@ class MMM(RegressionModelBuilder):
 
         return curve
 
-    @validate_call(config={"arbitrary_types_allowed": True})
+    @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
     def sample_adstock_curve(
         self,
         amount: float = Field(


### PR DESCRIPTION
`arbitrary_types_allowed` is (correctly) used in the model config dictionary, but it is not a kwarg that does anything specific when used inside `Field()` annotations. The usage of this in `budget_optimizer.py` is raising warnings about extra kwargs in `Field`.

## Description
- removed usage of `arbitrary_types_allowed` in `Field()` annotations
- standardised use of `arbitrary_types_allowed` across codebase

## Related Issue
- [x] Closes #2402

## Checklist
- [] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2403.org.readthedocs.build/en/2403/

<!-- readthedocs-preview pymc-marketing end -->