### PR TITLE
Design for an MMMPlotSuite overall

### DIFF
--- a/docs/plans/2026-03-10-mmmplotsuite-comprehensive-issues.md
+++ b/docs/plans/2026-03-10-mmmplotsuite-comprehensive-issues.md
@@ -24,7 +24,7 @@
 
 ## I. Structural / Architectural Issues
 
-arvizThese are systemic problems not captured by any single GitHub issue.
+These are systemic problems not captured by any single GitHub issue.
 
 ### I.1 God Class — 5,150 lines, 21+ public methods
 

--- a/docs/plans/2026-03-10-mmmplotsuite-comprehensive-issues.md
+++ b/docs/plans/2026-03-10-mmmplotsuite-comprehensive-issues.md
@@ -24,22 +24,24 @@
 
 ## I. Structural / Architectural Issues
 
-These are systemic problems not captured by any single GitHub issue.
+arvizThese are systemic problems not captured by any single GitHub issue.
 
 ### I.1 God Class — 5,150 lines, 21+ public methods
 
 `MMMPlotSuite` violates the Single Responsibility Principle. It handles seven distinct
 plotting families:
 
-| Family | Methods |
-|--------|---------|
-| Time-series diagnostics | `posterior_predictive`, `prior_predictive`, `residuals_over_time`, `residuals_posterior_distribution` |
-| Distribution diagnostics | `posterior_distribution`, `channel_parameter`, `prior_vs_posterior` |
-| Saturation/response curves | `saturation_scatterplot`, `saturation_curves`, `saturation_curves_scatter` (deprecated) |
-| Budget allocation | `budget_allocation`, `allocated_contribution_by_channel_over_time` |
-| Sensitivity/uplift/marginal | `sensitivity_analysis`, `uplift_curve`, `marginal_curve` |
-| Decomposition | `waterfall_components_decomposition`, `contributions_over_time`, `channel_contribution_share_hdi` |
-| Cross-validation | `cv_predictions`, `param_stability`, `cv_crps` |
+
+| Family                      | Methods                                                                                               |
+| --------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Time-series diagnostics     | `posterior_predictive`, `prior_predictive`, `residuals_over_time`, `residuals_posterior_distribution` |
+| Distribution diagnostics    | `posterior_distribution`, `channel_parameter`, `prior_vs_posterior`                                   |
+| Saturation/response curves  | `saturation_scatterplot`, `saturation_curves`, `saturation_curves_scatter` (deprecated)               |
+| Budget allocation           | `budget_allocation`, `allocated_contribution_by_channel_over_time`                                    |
+| Sensitivity/uplift/marginal | `sensitivity_analysis`, `uplift_curve`, `marginal_curve`                                              |
+| Decomposition               | `waterfall_components_decomposition`, `contributions_over_time`, `channel_contribution_share_hdi`     |
+| Cross-validation            | `cv_predictions`, `param_stability`, `cv_crps`                                                        |
+
 
 Each of these families could be a separate module or mixin. The monolithic class makes
 the file extremely difficult to navigate, test, and extend.
@@ -86,13 +88,15 @@ that operate on an external `samples` dataset would need a small adapter.
 Several methods contain complex nested functions (50–90 lines) that are hard to test,
 debug, and reuse:
 
-| Method | Nested function | Lines |
-|--------|----------------|-------|
-| `cv_predictions` | `_align_y_to_df` | ~15 lines |
-| `cv_predictions` | `_plot_hdi_from_sel` | ~50 lines |
-| `cv_crps` | `_pred_matrix_for_rows` | ~90 lines |
-| `cv_crps` | `_filter_rows_and_y` | ~15 lines |
-| `sensitivity_analysis` | `_plot_line` | ~57 lines |
+
+| Method                 | Nested function         | Lines     |
+| ---------------------- | ----------------------- | --------- |
+| `cv_predictions`       | `_align_y_to_df`        | ~15 lines |
+| `cv_predictions`       | `_plot_hdi_from_sel`    | ~50 lines |
+| `cv_crps`              | `_pred_matrix_for_rows` | ~90 lines |
+| `cv_crps`              | `_filter_rows_and_y`    | ~15 lines |
+| `sensitivity_analysis` | `_plot_line`            | ~57 lines |
+
 
 These should be class methods, private module functions, or factored into helper
 classes.
@@ -115,11 +119,13 @@ HDI band drawing, legend assembly, and time-series line/fill layering.
 
 Currently three different subplot-creation patterns coexist:
 
-| Pattern | Used by |
-|---------|---------|
-| `self._init_subplots()` (standardized helper) | Most methods |
-| `plt.subplots()` directly | `saturation_scatterplot`, `saturation_curves`, `allocated_contribution`, `cv_predictions`, `param_stability`, `residuals_posterior_distribution` |
-| Manual axes normalization after `plt.subplots()` | `saturation_curves` (2277–2282), `allocated_contribution` (3033–3040), `waterfall` (4094–4102) |
+
+| Pattern                                          | Used by                                                                                                                                          |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `self._init_subplots()` (standardized helper)    | Most methods                                                                                                                                     |
+| `plt.subplots()` directly                        | `saturation_scatterplot`, `saturation_curves`, `allocated_contribution`, `cv_predictions`, `param_stability`, `residuals_posterior_distribution` |
+| Manual axes normalization after `plt.subplots()` | `saturation_curves` (2277–2282), `allocated_contribution` (3033–3040), `waterfall` (4094–4102)                                                   |
+
 
 The duplicated axes-normalization code (flatten + wrap in ndarray) appears in at least
 three methods, each with slightly different implementations.
@@ -146,13 +152,15 @@ These correspond to GitHub issues #2369–#2378 and #2388, plus additional findi
 
 Methods return at least **five different shapes**:
 
-| Return type | Methods |
-|-------------|---------|
-| `tuple[Figure, NDArray[Axes]]` | Most methods |
-| `Figure` (bare) | `channel_parameter` |
-| `plt.Axes` or `tuple[Figure, NDArray[Axes]]` (union) | `sensitivity_analysis`, `uplift_curve`, `marginal_curve` |
+
+| Return type                                                     | Methods                                                                                                  |
+| --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `tuple[Figure, NDArray[Axes]]`                                  | Most methods                                                                                             |
+| `Figure` (bare)                                                 | `channel_parameter`                                                                                      |
+| `plt.Axes` or `tuple[Figure, NDArray[Axes]]` (union)            | `sensitivity_analysis`, `uplift_curve`, `marginal_curve`                                                 |
 | `tuple[Figure, Axes]` or `tuple[Figure, NDArray[Axes]]` (union) | `budget_allocation`, `waterfall_components_decomposition`, `allocated_contribution_by_channel_over_time` |
-| `tuple[Figure, Axes]` (single) | `param_stability` (declared as `NDArray[Axes]`, actually returns single `Axes`) |
+| `tuple[Figure, Axes]` (single)                                  | `param_stability` (declared as `NDArray[Axes]`, actually returns single `Axes`)                          |
+
 
 **Additional finding:** `cv_predictions` declares return `tuple[Figure, NDArray[Axes]]`
 but when `n_axes == 1`, it wraps axes in a Python `list`, not an `NDArray`. The type
@@ -165,21 +173,25 @@ returns `tuple[Figure, Axes]` (single Axes, not array) in most branches.
 
 ### II.2 Inconsistent `original_scale` default (GitHub #2371)
 
-| Default | Methods |
-|---------|---------|
-| `True` | `contributions_over_time`, `waterfall_components_decomposition`, `allocated_contribution_by_channel_over_time` |
-| `False` | `saturation_scatterplot`, `saturation_curves` |
-| Not exposed | `channel_contribution_share_hdi` |
+
+| Default     | Methods                                                                                                        |
+| ----------- | -------------------------------------------------------------------------------------------------------------- |
+| `True`      | `contributions_over_time`, `waterfall_components_decomposition`, `allocated_contribution_by_channel_over_time` |
+| `False`     | `saturation_scatterplot`, `saturation_curves`                                                                  |
+| Not exposed | `channel_contribution_share_hdi`                                                                               |
+
 
 > **Backward Compatible:** No (changing defaults alters behavior for existing callers; requires deprecation cycle) — **LOE:** M
 
 ### II.3 `plt.show()` and figure discarding in `param_stability` / `cv_predictions` (GitHub #2373)
 
-| Method | `plt.show()` calls |
-|--------|--------------------|
-| `cv_predictions` | 1 (line 4641) |
+
+| Method            | `plt.show()` calls             |
+| ----------------- | ------------------------------ |
+| `cv_predictions`  | 1 (line 4641)                  |
 | `param_stability` | **3** (lines 4762, 4794, 4813) |
-| All other methods | 0 |
+| All other methods | 0                              |
+
 
 `param_stability` is especially problematic — when `dims` is provided, it creates a
 *separate figure per dimension value* in a for-loop, calling `plt.show()` on each.
@@ -201,14 +213,16 @@ block. Thread-unsafe, mutates shared state.
 
 ### II.5 Parameter naming and type inconsistencies (GitHub #1751, #2375)
 
-| Parameter | Inconsistency |
-|-----------|---------------|
-| `var` vs `var_names` | `posterior_predictive` takes `list[str]`, `prior_predictive` takes `str`; neither uses ArviZ's `var_names` convention (GitHub #1751) |
-| `hdi_prob` vs `hdi_probs` | Singular everywhere except `saturation_curves` (plural + accepts `list[float]`) |
-| `figsize` | `tuple[float, float]` in most places; `tuple[int, int]` in `waterfall_components_decomposition`; bare `tuple` in `channel_contribution_share_hdi` |
-| `subplot_kwargs` | `saturation_curves` uses a less-precise annotation |
-| `dims` type | `param_stability` uses a more restrictive type than other methods |
-| `rc_params` | Only available on `saturation_curves` |
+
+| Parameter                 | Inconsistency                                                                                                                                     |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `var` vs `var_names`      | `posterior_predictive` takes `list[str]`, `prior_predictive` takes `str`; neither uses ArviZ's `var_names` convention (GitHub #1751)              |
+| `hdi_prob` vs `hdi_probs` | Singular everywhere except `saturation_curves` (plural + accepts `list[float]`)                                                                   |
+| `figsize`                 | `tuple[float, float]` in most places; `tuple[int, int]` in `waterfall_components_decomposition`; bare `tuple` in `channel_contribution_share_hdi` |
+| `subplot_kwargs`          | `saturation_curves` uses a less-precise annotation                                                                                                |
+| `dims` type               | `param_stability` uses a more restrictive type than other methods                                                                                 |
+| `rc_params`               | Only available on `saturation_curves`                                                                                                             |
+
 
 > **Backward Compatible:** No (renaming parameters breaks keyword callers; requires deprecation aliases) — **LOE:** M
 
@@ -226,13 +240,15 @@ have no option to subset by channel — all channels are always plotted.
 
 ### II.7 Inconsistent figure customization surface (GitHub #822, #2378)
 
-| Customization | Coverage |
-|---------------|----------|
-| `figsize` | 14/21 methods |
-| `ax` parameter | 4/21 methods (`budget_allocation`, `sensitivity_analysis`, `uplift_curve`, `marginal_curve`) |
-| `**kwargs` | Varies — sometimes to `plt.subplots()`, sometimes to plot calls |
-| `rc_params` | 1/21 methods (`saturation_curves` only) |
-| `title` control | Sensitivity family only |
+
+| Customization   | Coverage                                                                                     |
+| --------------- | -------------------------------------------------------------------------------------------- |
+| `figsize`       | 14/21 methods                                                                                |
+| `ax` parameter  | 4/21 methods (`budget_allocation`, `sensitivity_analysis`, `uplift_curve`, `marginal_curve`) |
+| `**kwargs`      | Varies — sometimes to `plt.subplots()`, sometimes to plot calls                              |
+| `rc_params`     | 1/21 methods (`saturation_curves` only)                                                      |
+| `title` control | Sensitivity family only                                                                      |
+
 
 7 methods offer **zero** figure customization parameters.
 
@@ -244,12 +260,14 @@ have no option to subset by channel — all channels are always plotted.
 
 ### III.1 Four legacy methods not in the suite (GitHub #2128)
 
-| Legacy method | File | Suite equivalent |
-|---------------|------|-----------------|
-| `plot_grouped_contribution_breakdown_over_time` | `base.py:1068` | **None** (GitHub #2052) |
-| `plot_prior_vs_posterior` | `base.py:1225` | Exists in suite but legacy has different features |
-| `plot_channel_contribution_grid` | `mmm.py:1805` | **None** (GitHub #2053) |
-| `plot_new_spend_contributions` | `mmm.py:2007` | **None** (GitHub #2241) |
+
+| Legacy method                                   | File           | Suite equivalent                                  |
+| ----------------------------------------------- | -------------- | ------------------------------------------------- |
+| `plot_grouped_contribution_breakdown_over_time` | `base.py:1068` | **None** (GitHub #2052)                           |
+| `plot_prior_vs_posterior`                       | `base.py:1225` | Exists in suite but legacy has different features |
+| `plot_channel_contribution_grid`                | `mmm.py:1805`  | **None** (GitHub #2053)                           |
+| `plot_new_spend_contributions`                  | `mmm.py:2007`  | **None** (GitHub #2241)                           |
+
 
 > **Backward Compatible:** Yes (additive — new methods) — **LOE:** L
 
@@ -298,10 +316,10 @@ Copy-pasted from `_get_posterior_predictive_data` without updating.
 **Additional locations of the same copy-paste problem:**
 
 - Line 587–614: The `prior_predictive` method's own docstring says "Plot time series
-  from the **posterior** predictive distribution" and references
-  `self.idata.posterior_predictive`.
+from the **posterior** predictive distribution" and references
+`self.idata.posterior_predictive`.
 - Line 662: The fallback title string reads "Posterior Predictive Time Series" when it
-  should say "Prior Predictive Time Series".
+should say "Prior Predictive Time Series".
 
 **Testing gap:** There is a test for `_get_posterior_predictive_data` error handling but
 not for the prior equivalent `_get_prior_predictive_data`. A regression test should be
@@ -462,14 +480,16 @@ Based on analysis of `tests/mmm/test_plot.py` (~5,336 lines).
 
 ### V.1 Methods with zero or near-zero dedicated tests
 
-| Method | Test count | Quality |
-|--------|-----------|---------|
-| `prior_predictive` | **0** unit tests | Only tested indirectly via legacy `test_plotting.py` |
-| `posterior_predictive` | 1 integration test | No mocked unit tests; missing hdi_prob, original_scale, multi-dim |
-| `budget_allocation` | 2 tests | Type-check only; missing figsize, error paths, bar labels |
-| `uplift_curve` | 1 test | "Doesn't crash" quality |
-| `marginal_curve` | 1 test | "Doesn't crash" quality |
-| `saturation_curves_scatter` | 1 test | Only checks deprecation warning |
+
+| Method                      | Test count         | Quality                                                           |
+| --------------------------- | ------------------ | ----------------------------------------------------------------- |
+| `prior_predictive`          | **0** unit tests   | Only tested indirectly via legacy `test_plotting.py`              |
+| `posterior_predictive`      | 1 integration test | No mocked unit tests; missing hdi_prob, original_scale, multi-dim |
+| `budget_allocation`         | 2 tests            | Type-check only; missing figsize, error paths, bar labels         |
+| `uplift_curve`              | 1 test             | "Doesn't crash" quality                                           |
+| `marginal_curve`            | 1 test             | "Doesn't crash" quality                                           |
+| `saturation_curves_scatter` | 1 test             | Only checks deprecation warning                                   |
+
 
 > **Backward Compatible:** N/A (test-only) — **LOE:** L
 
@@ -477,6 +497,7 @@ Based on analysis of `tests/mmm/test_plot.py` (~5,336 lines).
 
 Many tests only assert `isinstance(fig, Figure)` or `fig is not None`. They don't
 check:
+
 - Axis labels, titles, legend entries
 - Number of axes matches expected dimensions
 - Data plotted matches expected values
@@ -487,6 +508,7 @@ check:
 ### V.3 No edge case tests
 
 No tests cover:
+
 - Single channel scenario (1 media channel)
 - Single geo scenario (1 dimension value)
 - NaN/missing values in contributions or posterior data
@@ -559,15 +581,16 @@ Enhancement to visualize how media effects change over time (time-varying coeffi
 The branch introduces a multi-backend architecture powered by `arviz_plots`:
 
 - **Config system:** `MMMPlotConfig` singleton (modeled after ArviZ `rcParams`) with
-  `plot.backend`, `plot.use_v2`, `plot.show_warnings` settings
+`plot.backend`, `plot.use_v2`, `plot.show_warnings` settings
 - **Legacy extraction:** Original `MMMPlotSuite` renamed to `LegacyMMMPlotSuite` and
-  moved to `legacy_plot.py`
+moved to `legacy_plot.py`
 - **Version dispatch:** `MMM.plot` property returns v1 or v2 suite based on config flag
 - **Deprecation timeline:** v0.18.0 (introduce), v0.19.0 (default), v0.20.0 (remove legacy)
 
 ### Migration progress: ~60–65% complete
 
 **Converted to arviz-plots (9 methods):**
+
 - `posterior_predictive`, `contributions_over_time`
 - `saturation_scatterplot`, `saturation_curves`
 - `budget_allocation_roas` (new method, no legacy equivalent)
@@ -575,36 +598,40 @@ The branch introduces a multi-backend architecture powered by `arviz_plots`:
 - `sensitivity_analysis`, `uplift_curve`, `marginal_curve`
 
 **Still matplotlib-only stubs (4 methods):**
+
 - `prior_predictive`, `residuals_over_time`, `residuals_posterior_distribution`,
-  `posterior_distribution`
+`posterior_distribution`
 
 **Missing entirely (7+ methods from current main):**
+
 - `channel_parameter`, `prior_vs_posterior`, `waterfall_components_decomposition`,
-  `channel_contribution_share_hdi`, `cv_predictions`, `param_stability`, `cv_crps`
+`channel_contribution_share_hdi`, `cv_predictions`, `param_stability`, `cv_crps`
 
 ### Key arviz-plots APIs used
 
-| API | Purpose |
-|-----|---------|
-| `PlotCollection.wrap()` | Time-series layouts (dim-based subplots) |
-| `PlotCollection.grid()` | Grid layouts (rows × cols) |
-| `pc.map()` | Layering visual elements |
-| `pc.add_legend()` | Channel legends |
-| `visuals.fill_between_y` | HDI bands |
-| `visuals.line_xy` | Median/mean lines |
-| `visuals.scatter_xy` | Scatter plots |
-| `visuals.multiple_lines` | Sampled posterior curves |
-| `xr.DataArray.azstats.hdi()` | HDI computation on xarray |
-| `arviz_base.convert_to_datatree` | DataArray → DataTree for `plot_dist` |
+
+| API                              | Purpose                                  |
+| -------------------------------- | ---------------------------------------- |
+| `PlotCollection.wrap()`          | Time-series layouts (dim-based subplots) |
+| `PlotCollection.grid()`          | Grid layouts (rows × cols)               |
+| `pc.map()`                       | Layering visual elements                 |
+| `pc.add_legend()`                | Channel legends                          |
+| `visuals.fill_between_y`         | HDI bands                                |
+| `visuals.line_xy`                | Median/mean lines                        |
+| `visuals.scatter_xy`             | Scatter plots                            |
+| `visuals.multiple_lines`         | Sampled posterior curves                 |
+| `xr.DataArray.azstats.hdi()`     | HDI computation on xarray                |
+| `arviz_base.convert_to_datatree` | DataArray → DataTree for `plot_dist`     |
+
 
 ### Design decisions worth preserving
 
 1. **Every method accepts `plot_collection` and `backend` parameters** — composable
-   plots and per-call backend override
+  plots and per-call backend override
 2. **Shared `_sensitivity_analysis_plot` helper** — eliminated the monkey-patching
-   anti-pattern from `uplift_curve`/`marginal_curve`
+  anti-pattern from `uplift_curve`/`marginal_curve`
 3. **Data injection pattern** — methods accept explicit data parameters with fallback
-   to `self.idata`, enabling testability
+  to `self.idata`, enabling testability
 
 ### Why the branch is stale
 
@@ -619,65 +646,74 @@ conflicts in the existing ones.
 
 ### Critical (blocks other work or causes user-facing bugs)
 
-| ID | Issue | Reason | BC | LOE |
-|----|-------|--------|----|-----|
-| IV.1 | Copy-paste bug in `_get_prior_predictive_data` | Wrong error message misleads users | Yes | XS |
-| II.3 | `plt.show()` + figure discarding in `param_stability` / `cv_predictions` | Silent data loss; prevents customization | No | M |
-| II.4 | Monkey-patching is thread-unsafe | Corrupts state under concurrency | Yes | M |
-| I.2 | Constructor accepts `None, None` | Deferred crash instead of fail-fast | Yes | XS |
+
+| ID   | Issue                                                                    | Reason                                   | BC  | LOE |
+| ---- | ------------------------------------------------------------------------ | ---------------------------------------- | --- | --- |
+| IV.1 | Copy-paste bug in `_get_prior_predictive_data`                           | Wrong error message misleads users       | Yes | XS  |
+| II.3 | `plt.show()` + figure discarding in `param_stability` / `cv_predictions` | Silent data loss; prevents customization | No  | M   |
+| II.4 | Monkey-patching is thread-unsafe                                         | Corrupts state under concurrency         | Yes | M   |
+| I.2  | Constructor accepts `None, None`                                         | Deferred crash instead of fail-fast      | Yes | XS  |
+
 
 ### High (API inconsistencies that confuse users)
 
-| ID | Issue | Reason | BC | LOE |
-|----|-------|--------|----|-----|
-| I.1 | 5,150-line god class | Unmaintainable, hard to extend | Yes | XL |
-| I.3 | MMMIDataWrapper largely bypassed (incl. #2370) | Wrapper bypassed; 5 contrib-var strategies, `StopIteration` bug | Yes | L |
-| II.1 | Return type roulette (5 shapes) | Callers can't write generic code | No | L |
-| II.2 | Inconsistent `original_scale` default | Surprising behavior differences | No | M |
-| II.5 | Parameter naming inconsistencies (incl. `var_names`, #1751) | Confusing API surface | No | M |
-| II.6 | No subsetting on predictive/media methods | 50-geo or many-channel models produce unusable output | Yes | S |
-| II.7 | Inconsistent figure customization | 7 methods have zero customization | Yes | L |
-| I.6 | Duplicated subplot logic — delegate to arviz-plots | Major code reduction opportunity | Yes | XL |
+
+| ID   | Issue                                                       | Reason                                                          | BC  | LOE |
+| ---- | ----------------------------------------------------------- | --------------------------------------------------------------- | --- | --- |
+| I.1  | 5,150-line god class                                        | Unmaintainable, hard to extend                                  | Yes | XL  |
+| I.3  | MMMIDataWrapper largely bypassed (incl. #2370)              | Wrapper bypassed; 5 contrib-var strategies, `StopIteration` bug | Yes | L   |
+| II.1 | Return type roulette (5 shapes)                             | Callers can't write generic code                                | No  | L   |
+| II.2 | Inconsistent `original_scale` default                       | Surprising behavior differences                                 | No  | M   |
+| II.5 | Parameter naming inconsistencies (incl. `var_names`, #1751) | Confusing API surface                                           | No  | M   |
+| II.6 | No subsetting on predictive/media methods                   | 50-geo or many-channel models produce unusable output           | Yes | S   |
+| II.7 | Inconsistent figure customization                           | 7 methods have zero customization                               | Yes | L   |
+| I.6  | Duplicated subplot logic — delegate to arviz-plots          | Major code reduction opportunity                                | Yes | XL  |
+
 
 ### Medium (missing functionality, performance, testing)
 
-| ID | Issue | Reason | BC | LOE |
-|----|-------|--------|----|-----|
-| III.1–III.5 | Missing methods (#2128, #2054, #2242, #2153) | Feature gaps | Yes | S–L |
-| IV.6 | Per-date HDI computation loop | Performance bottleneck | Yes | M |
-| IV.7 | O(n×m) loop in `cv_crps` | Performance bottleneck | Yes | M |
-| IV.10 | Broad exception catching | Masks real bugs | Partial | M |
-| V.1 | `prior_predictive` has 0 tests | Risk of regressions | N/A | L |
-| V.2 | Weak test assertions | False confidence in test suite | N/A | M |
-| I.5 | No shared color palette / mapping | Inconsistent colors across plots | Yes | M |
-| IV.18 | `_compute_residuals` hardcodes `y_original_scale` | Limits residual analysis | Yes | S |
+
+| ID          | Issue                                             | Reason                           | BC      | LOE |
+| ----------- | ------------------------------------------------- | -------------------------------- | ------- | --- |
+| III.1–III.5 | Missing methods (#2128, #2054, #2242, #2153)      | Feature gaps                     | Yes     | S–L |
+| IV.6        | Per-date HDI computation loop                     | Performance bottleneck           | Yes     | M   |
+| IV.7        | O(n×m) loop in `cv_crps`                          | Performance bottleneck           | Yes     | M   |
+| IV.10       | Broad exception catching                          | Masks real bugs                  | Partial | M   |
+| V.1         | `prior_predictive` has 0 tests                    | Risk of regressions              | N/A     | L   |
+| V.2         | Weak test assertions                              | False confidence in test suite   | N/A     | M   |
+| I.5         | No shared color palette / mapping                 | Inconsistent colors across plots | Yes     | M   |
+| IV.18       | `_compute_residuals` hardcodes `y_original_scale` | Limits residual analysis         | Yes     | S   |
+
 
 ### Lower (cleanup, nice-to-have)
 
-| ID | Issue | Reason | BC | LOE |
-|----|-------|--------|----|-----|
-| IV.2 | `plt.gcf()` fragility | Unlikely in practice but architecturally wrong | Yes | S |
-| IV.9 | `**kwargs` + `**subplot_kwargs` conflict | Edge case | Yes | XS |
-| IV.11 | Dead `_cache` in MMMIDataWrapper | Dead code | Yes | XS |
-| IV.12 | `_reduce_and_stack` silently sums | Subtle data bug risk | Partial | XS |
-| IV.13 | Redundant local imports (2 locations) | Noise | Yes | XS |
-| IV.15 | Seaborn dependency for 2 methods | Optional optimization | Yes | S |
-| IV.16 | Error message formatting (raw `\n` in f-strings) | Cosmetic | Yes | XS |
-| IV.17 | No validation of `agg` parameter (hardcoded anyway) | Dead code path | Yes | XS |
-| VI.1 | Plotting gallery (#820) | Documentation | N/A | L |
-| VII.1–VII.3 | Older issues (#76, #765, #1183) | Low urgency | Mixed | S–L |
+
+| ID          | Issue                                               | Reason                                         | BC      | LOE |
+| ----------- | --------------------------------------------------- | ---------------------------------------------- | ------- | --- |
+| IV.2        | `plt.gcf()` fragility                               | Unlikely in practice but architecturally wrong | Yes     | S   |
+| IV.9        | `**kwargs` + `**subplot_kwargs` conflict            | Edge case                                      | Yes     | XS  |
+| IV.11       | Dead `_cache` in MMMIDataWrapper                    | Dead code                                      | Yes     | XS  |
+| IV.12       | `_reduce_and_stack` silently sums                   | Subtle data bug risk                           | Partial | XS  |
+| IV.13       | Redundant local imports (2 locations)               | Noise                                          | Yes     | XS  |
+| IV.15       | Seaborn dependency for 2 methods                    | Optional optimization                          | Yes     | S   |
+| IV.16       | Error message formatting (raw `\n` in f-strings)    | Cosmetic                                       | Yes     | XS  |
+| IV.17       | No validation of `agg` parameter (hardcoded anyway) | Dead code path                                 | Yes     | XS  |
+| VI.1        | Plotting gallery (#820)                             | Documentation                                  | N/A     | L   |
+| VII.1–VII.3 | Older issues (#76, #765, #1183)                     | Low urgency                                    | Mixed   | S–L |
+
 
 ---
 
 ## Appendix: Issue Count Summary
 
-| Category | GitHub Issues | Code-Review Findings | Total |
-|----------|--------------|---------------------|-------|
-| Structural / Architectural | — | 6 | 6 |
-| API Consistency | 9 (#822, #1751, #2369, #2371, #2373–#2376, #2378) | 0 | 7 |
-| Missing Functionality | 7 (#2052–#2242, #2153) | 1 | 5 |
-| Code Quality & Bugs | — | 18 | 18 |
-| Test Coverage Gaps | — | 5 | 5 |
-| Documentation | 1 (#820) | 0 | 1 |
-| Older / Miscellaneous | 3 (#76, #765, #1183) | 0 | 3 |
-| **Total** | **20** | **30** | **45** |
+
+| Category                   | GitHub Issues                                     | Code-Review Findings | Total  |
+| -------------------------- | ------------------------------------------------- | -------------------- | ------ |
+| Structural / Architectural | —                                                 | 6                    | 6      |
+| API Consistency            | 9 (#822, #1751, #2369, #2371, #2373–#2376, #2378) | 0                    | 7      |
+| Missing Functionality      | 7 (#2052–#2242, #2153)                            | 1                    | 5      |
+| Code Quality & Bugs        | —                                                 | 18                   | 18     |
+| Test Coverage Gaps         | —                                                 | 5                    | 5      |
+| Documentation              | 1 (#820)                                          | 0                    | 1      |
+| Older / Miscellaneous      | 3 (#76, #765, #1183)                              | 0                    | 3      |
+| **Total**                  | **20**                                            | **30**               | **45** |

--- a/docs/plans/2026-03-10-mmmplotsuite-comprehensive-issues.md
+++ b/docs/plans/2026-03-10-mmmplotsuite-comprehensive-issues.md
@@ -1,0 +1,683 @@
+# MMMPlotSuite — Comprehensive Issue Analysis
+
+> Critical code review of `pymc_marketing/mmm/plot.py` (5,150 lines, 21 public methods).
+> Covers 20 open GitHub issues plus additional problems discovered via code audit.
+> Prepared 2026-03-10.
+>
+> **LOE Scale:** XS (< 1 hour) · S (1–4 hours) · M (1–3 days) · L (1–2 weeks) · XL (2+ weeks)
+
+---
+
+## Table of Contents
+
+- [I. Structural / Architectural Issues](#i-structural--architectural-issues)
+- [II. API Consistency Issues (GitHub #822, #2369, #2371, #2373–#2376, #2378)](#ii-api-consistency-issues)
+- [III. Missing Functionality (GitHub #2052–#2242, #2153)](#iii-missing-functionality)
+- [IV. Code Quality & Bugs (Not on GitHub)](#iv-code-quality--bugs-not-on-github)
+- [V. Test Coverage Gaps](#v-test-coverage-gaps)
+- [VI. Documentation (GitHub #820)](#vi-documentation)
+- [VII. Older / Miscellaneous (GitHub #76, #765, #1183)](#vii-older--miscellaneous)
+- [VIII. Stale Branch Assessment (`feature/mmmplotsuite-arviz`)](#viii-stale-branch-assessment)
+- [IX. Priority Matrix](#ix-priority-matrix)
+
+---
+
+## I. Structural / Architectural Issues
+
+These are systemic problems not captured by any single GitHub issue.
+
+### I.1 God Class — 5,150 lines, 21+ public methods
+
+`MMMPlotSuite` violates the Single Responsibility Principle. It handles seven distinct
+plotting families:
+
+| Family | Methods |
+|--------|---------|
+| Time-series diagnostics | `posterior_predictive`, `prior_predictive`, `residuals_over_time`, `residuals_posterior_distribution` |
+| Distribution diagnostics | `posterior_distribution`, `channel_parameter`, `prior_vs_posterior` |
+| Saturation/response curves | `saturation_scatterplot`, `saturation_curves`, `saturation_curves_scatter` (deprecated) |
+| Budget allocation | `budget_allocation`, `allocated_contribution_by_channel_over_time` |
+| Sensitivity/uplift/marginal | `sensitivity_analysis`, `uplift_curve`, `marginal_curve` |
+| Decomposition | `waterfall_components_decomposition`, `contributions_over_time`, `channel_contribution_share_hdi` |
+| Cross-validation | `cv_predictions`, `param_stability`, `cv_crps` |
+
+Each of these families could be a separate module or mixin. The monolithic class makes
+the file extremely difficult to navigate, test, and extend.
+
+> **Backward Compatible:** Yes (refactor into modules/mixins preserving public API) — **LOE:** XL
+
+### I.2 Constructor allows invalid state
+
+```python
+MMMPlotSuite(idata=None, data=None)
+```
+
+When both are `None` (line 232–233), the constructor `cast`s `None` to
+`az.InferenceData` and `MMMIDataWrapper`. This creates an object where every method
+will crash with an `AttributeError` on first use, instead of failing fast at
+construction time. (GitHub #2388)
+
+> **Backward Compatible:** Yes (no real usage relies on None-None construction; both paths crash on first use anyway) — **LOE:** XS
+
+### I.3 MMMIDataWrapper largely bypassed
+
+The wrapper (`self.data`) provides validated, type-safe access to idata groups. However,
+~90% of methods bypass it and reach directly into `self.idata.posterior`,
+`self.idata.constant_data`, etc. Only `saturation_curves`, `sensitivity_analysis`, and
+a few helpers use `self.data`.
+
+This means the validation, scaling, and filtering capabilities of the wrapper are
+wasted. If the wrapper's contract changes, 17+ methods won't benefit.
+
+**Key example — contribution variable name resolution (GitHub #2370):** Because methods
+bypass the wrapper, five different strategies exist for choosing between
+`"channel_contribution"` and `"channel_contribution_original_scale"`: ternary string
+selection, `next()` generator scan (throws `StopIteration` instead of `ValueError`),
+prefer-original-then-fallback, hardcoded `_original_scale` only, and manual
+original-scale suffix iteration. All five would collapse into a single call to
+`self.data.get_channel_contributions(original_scale)`, which already handles name
+resolution, fallback computation, and scaling in one place. The optimizer/budget methods
+that operate on an external `samples` dataset would need a small adapter.
+
+> **Backward Compatible:** Yes (internal refactoring only) — **LOE:** L
+
+### I.4 Deep nested functions instead of methods
+
+Several methods contain complex nested functions (50–90 lines) that are hard to test,
+debug, and reuse:
+
+| Method | Nested function | Lines |
+|--------|----------------|-------|
+| `cv_predictions` | `_align_y_to_df` | ~15 lines |
+| `cv_predictions` | `_plot_hdi_from_sel` | ~50 lines |
+| `cv_crps` | `_pred_matrix_for_rows` | ~90 lines |
+| `cv_crps` | `_filter_rows_and_y` | ~15 lines |
+| `sensitivity_analysis` | `_plot_line` | ~57 lines |
+
+These should be class methods, private module functions, or factored into helper
+classes.
+
+> **Backward Compatible:** Yes (internal refactoring only) — **LOE:** M
+
+### I.5 No shared color palette or mapping
+
+Each method picks colors independently (`"C0"`, `"C3"`, channel-indexed colors from the
+default matplotlib cycle, etc.). There is no shared palette, color mapping, or
+channel→color assignment. This means the same channel can appear as different colors
+across different plots, making it harder for users to visually correlate information.
+
+> **Backward Compatible:** Yes (additive; visual output changes but no API breakage) — **LOE:** M
+
+### I.6 Duplicated subplot creation and population logic — delegate to arviz-plots
+
+Multiple methods duplicate boilerplate for subplot grid creation, axes normalization,
+HDI band drawing, legend assembly, and time-series line/fill layering.
+
+Currently three different subplot-creation patterns coexist:
+
+| Pattern | Used by |
+|---------|---------|
+| `self._init_subplots()` (standardized helper) | Most methods |
+| `plt.subplots()` directly | `saturation_scatterplot`, `saturation_curves`, `allocated_contribution`, `cv_predictions`, `param_stability`, `residuals_posterior_distribution` |
+| Manual axes normalization after `plt.subplots()` | `saturation_curves` (2277–2282), `allocated_contribution` (3033–3040), `waterfall` (4094–4102) |
+
+The duplicated axes-normalization code (flatten + wrap in ndarray) appears in at least
+three methods, each with slightly different implementations.
+
+All of this is already handled by `arviz_plots`' `PlotCollection` API
+(`PlotCollection.wrap()` for dimension-based layouts, `PlotCollection.grid()` for
+row×col grids, `pc.map()` for layering visual elements, `pc.add_legend()` for legends,
+and built-in visuals like `fill_between_y`, `line_xy`, `scatter_xy`).
+
+The stale `feature/mmmplotsuite-arviz` branch demonstrated this approach for 9 methods,
+eliminating hundreds of lines of manual subplot management. Adopting this across all 21
+methods — without pursuing multi-backend support — would significantly reduce code
+volume and consolidate the three subplot-creation patterns into one.
+
+> **Backward Compatible:** Yes (internal refactoring; public API and return types unchanged) — **LOE:** XL
+
+---
+
+## II. API Consistency Issues
+
+These correspond to GitHub issues #2369–#2378 and #2388, plus additional findings.
+
+### II.1 Return type roulette (GitHub #822, #2369)
+
+Methods return at least **five different shapes**:
+
+| Return type | Methods |
+|-------------|---------|
+| `tuple[Figure, NDArray[Axes]]` | Most methods |
+| `Figure` (bare) | `channel_parameter` |
+| `plt.Axes` or `tuple[Figure, NDArray[Axes]]` (union) | `sensitivity_analysis`, `uplift_curve`, `marginal_curve` |
+| `tuple[Figure, Axes]` or `tuple[Figure, NDArray[Axes]]` (union) | `budget_allocation`, `waterfall_components_decomposition`, `allocated_contribution_by_channel_over_time` |
+| `tuple[Figure, Axes]` (single) | `param_stability` (declared as `NDArray[Axes]`, actually returns single `Axes`) |
+
+**Additional finding:** `cv_predictions` declares return `tuple[Figure, NDArray[Axes]]`
+but when `n_axes == 1`, it wraps axes in a Python `list`, not an `NDArray`. The type
+annotation is incorrect.
+
+**Additional finding:** `param_stability` declares `tuple[Figure, NDArray[Axes]]` but
+returns `tuple[Figure, Axes]` (single Axes, not array) in most branches.
+
+> **Backward Compatible:** No (changing return types breaks callers; requires deprecation cycle) — **LOE:** L
+
+### II.2 Inconsistent `original_scale` default (GitHub #2371)
+
+| Default | Methods |
+|---------|---------|
+| `True` | `contributions_over_time`, `waterfall_components_decomposition`, `allocated_contribution_by_channel_over_time` |
+| `False` | `saturation_scatterplot`, `saturation_curves` |
+| Not exposed | `channel_contribution_share_hdi` |
+
+> **Backward Compatible:** No (changing defaults alters behavior for existing callers; requires deprecation cycle) — **LOE:** M
+
+### II.3 `plt.show()` and figure discarding in `param_stability` / `cv_predictions` (GitHub #2373)
+
+| Method | `plt.show()` calls |
+|--------|--------------------|
+| `cv_predictions` | 1 (line 4641) |
+| `param_stability` | **3** (lines 4762, 4794, 4813) |
+| All other methods | 0 |
+
+`param_stability` is especially problematic — when `dims` is provided, it creates a
+*separate figure per dimension value* in a for-loop, calling `plt.show()` on each.
+It returns only the **last** `(fig, ax)` pair, silently discarding all previous figures.
+This makes all figures except the last unreachable programmatically — a silent data loss
+bug. Fixing this requires both removing the `plt.show()` calls and changing the return
+type to include all figures (the latter is a breaking change requiring a deprecation
+cycle).
+
+> **Backward Compatible:** No (removing `plt.show()` is BC, but returning all figures changes the API contract) — **LOE:** M
+
+### II.4 Monkey-patching `self.idata.sensitivity_analysis` (GitHub #2374)
+
+`uplift_curve` (line 3544) and `marginal_curve` (line 3642) temporarily replace
+`self.idata.sensitivity_analysis` with synthetic data, then restore in a `finally`
+block. Thread-unsafe, mutates shared state.
+
+> **Backward Compatible:** Yes (internal refactoring; public API unchanged) — **LOE:** M
+
+### II.5 Parameter naming and type inconsistencies (GitHub #1751, #2375)
+
+| Parameter | Inconsistency |
+|-----------|---------------|
+| `var` vs `var_names` | `posterior_predictive` takes `list[str]`, `prior_predictive` takes `str`; neither uses ArviZ's `var_names` convention (GitHub #1751) |
+| `hdi_prob` vs `hdi_probs` | Singular everywhere except `saturation_curves` (plural + accepts `list[float]`) |
+| `figsize` | `tuple[float, float]` in most places; `tuple[int, int]` in `waterfall_components_decomposition`; bare `tuple` in `channel_contribution_share_hdi` |
+| `subplot_kwargs` | `saturation_curves` uses a less-precise annotation |
+| `dims` type | `param_stability` uses a more restrictive type than other methods |
+| `rc_params` | Only available on `saturation_curves` |
+
+> **Backward Compatible:** No (renaming parameters breaks keyword callers; requires deprecation aliases) — **LOE:** M
+
+### II.6 No subsetting on predictive/residual or media methods (GitHub #822, #2376)
+
+`posterior_predictive`, `prior_predictive`, `residuals_over_time`, and
+`residuals_posterior_distribution` auto-detect extra dimensions and create subplot grids,
+but offer **no** `dims` parameter. A 50-geo model generates 50+ subplots with no way to
+select a subset.
+
+Additionally, media transformation plots (`saturation_scatterplot`, `saturation_curves`)
+have no option to subset by channel — all channels are always plotted.
+
+> **Backward Compatible:** Yes (additive — new optional parameter) — **LOE:** S
+
+### II.7 Inconsistent figure customization surface (GitHub #822, #2378)
+
+| Customization | Coverage |
+|---------------|----------|
+| `figsize` | 14/21 methods |
+| `ax` parameter | 4/21 methods (`budget_allocation`, `sensitivity_analysis`, `uplift_curve`, `marginal_curve`) |
+| `**kwargs` | Varies — sometimes to `plt.subplots()`, sometimes to plot calls |
+| `rc_params` | 1/21 methods (`saturation_curves` only) |
+| `title` control | Sensitivity family only |
+
+7 methods offer **zero** figure customization parameters.
+
+> **Backward Compatible:** Yes (additive — new optional parameters) — **LOE:** L
+
+---
+
+## III. Missing Functionality
+
+### III.1 Four legacy methods not in the suite (GitHub #2128)
+
+| Legacy method | File | Suite equivalent |
+|---------------|------|-----------------|
+| `plot_grouped_contribution_breakdown_over_time` | `base.py:1068` | **None** (GitHub #2052) |
+| `plot_prior_vs_posterior` | `base.py:1225` | Exists in suite but legacy has different features |
+| `plot_channel_contribution_grid` | `mmm.py:1805` | **None** (GitHub #2053) |
+| `plot_new_spend_contributions` | `mmm.py:2007` | **None** (GitHub #2241) |
+
+> **Backward Compatible:** Yes (additive — new methods) — **LOE:** L
+
+### III.2 Gradient/HDI bands for posterior predictive (GitHub #2054)
+
+Status: `implementation-done`, `plan-done`. May already be merged.
+
+> **Backward Compatible:** Yes (enhancement) — **LOE:** S (possibly already done)
+
+### III.3 Missing: aggregated channel contributions (GitHub #2242)
+
+`contributions_over_time` shows individual channels. No option to aggregate channels
+into a single stacked view.
+
+> **Backward Compatible:** Yes (additive — new aggregation option on existing method) — **LOE:** S
+
+### III.4 Missing: out-of-sample plotting methods (GitHub #2153)
+
+Users must manually write train/test split visualization code. No built-in
+out-of-sample assessment plots.
+
+> **Backward Compatible:** Yes (new method) — **LOE:** M
+
+### III.5 Missing: parametric fit overlay on saturation scatter (Not on GitHub)
+
+`MMM.plot_direct_contribution_curves()` (mmm.py:2292) draws scatter plus a parametric
+saturation fit curve via `_plot_response_curve_fit()`. The suite's
+`saturation_scatterplot()` only covers the scatter part — the fit overlay has no
+equivalent.
+
+> **Backward Compatible:** Yes (additive feature on existing method) — **LOE:** S
+
+---
+
+## IV. Code Quality & Bugs (Not on GitHub)
+
+These are issues found during code review that have no corresponding GitHub issue.
+
+### IV.1 Copy-paste bugs in `prior_predictive` and its helper
+
+Line 370–377: The error message in `_get_prior_predictive_data` says
+"posterior_predictive" but should say "prior_predictive". The code comment also says
+"check if self.idata has posterior_predictive" when it should say "prior_predictive".
+Copy-pasted from `_get_posterior_predictive_data` without updating.
+
+**Additional locations of the same copy-paste problem:**
+
+- Line 587–614: The `prior_predictive` method's own docstring says "Plot time series
+  from the **posterior** predictive distribution" and references
+  `self.idata.posterior_predictive`.
+- Line 662: The fallback title string reads "Posterior Predictive Time Series" when it
+  should say "Prior Predictive Time Series".
+
+**Testing gap:** There is a test for `_get_posterior_predictive_data` error handling but
+not for the prior equivalent `_get_prior_predictive_data`. A regression test should be
+added alongside the fix.
+
+> **Backward Compatible:** Yes (bug fix — correcting wrong error messages and strings) — **LOE:** XS
+
+### IV.2 `plt.gcf()` fragility in `channel_contribution_share_hdi`
+
+Line 4265: After `az.plot_forest` creates a figure, the code grabs the current figure
+via `plt.gcf()`. If another thread or callback creates a figure between the
+`az.plot_forest` call and `plt.gcf()`, the wrong figure is returned.
+
+> **Backward Compatible:** Yes (internal fix) — **LOE:** S
+
+### IV.3 `_validate_dims` always validates against `self.idata.posterior`
+
+Line 427–450: This helper always validates dimension names against `posterior.coords`,
+even when called by methods that operate on non-posterior data (e.g., `budget_allocation`
+validates against `samples.dims`).
+
+> **Backward Compatible:** Yes (bug fix) — **LOE:** S
+
+### IV.4 `color_cycle` iteration bug in `sensitivity_analysis`
+
+Lines 3319+3398: `color_cycle = itertools.cycle(hue_colors)` is created once outside the
+panel loop but consumed inside nested loops. For multi-panel plots, the cycle continues
+from where the previous panel left off, meaning different panels get different color
+assignments for the same hue values.
+
+This can be fixed as part of I.5 (shared color palette/mapping) or as a standalone XS
+bug fix by resetting the cycle at the start of each panel iteration.
+
+> **Backward Compatible:** Yes (bug fix — visual output correction) — **LOE:** XS
+
+### IV.5 `title` parameter shadowing in `sensitivity_analysis`
+
+Line 3435: The local `title` variable from `_build_subplot_title` overwrites the `title`
+parameter. Then at line 3449, `if add_figure_title and title is not None` checks the
+*last subplot's* title, not the original parameter.
+
+> **Backward Compatible:** Yes (bug fix) — **LOE:** XS
+
+### IV.6 Per-date HDI computation loop
+
+`_plot_single_allocated_contribution` (lines 2863–2867): Computes HDI per-date in a
+Python for-loop instead of vectorized. For 365 dates, this is 365 separate `az.hdi()`
+calls. Extremely slow for large datasets.
+
+> **Backward Compatible:** Yes (performance improvement; same output) — **LOE:** M
+
+### IV.7 O(n×m) inner loop in `cv_crps`
+
+`_pred_matrix_for_rows` (line 4914): Iterates over every row of `rows_df` and does
+`.sel()` per row. For large datasets this is very slow.
+
+> **Backward Compatible:** Yes (performance improvement; same output) — **LOE:** M
+
+### IV.8 Index-as-coordinate bug in `_plot_single_waterfall`
+
+Line 3897: `index` is the pandas DataFrame index value (not necessarily a sequential
+integer position), but `ax.text()` uses it as a y-coordinate. If the DataFrame has been
+filtered, the index may not be sequential, causing misplaced text labels.
+
+> **Backward Compatible:** Yes (bug fix) — **LOE:** XS
+
+### IV.9 `**kwargs` + `**subplot_kwargs` duplicate-key risk
+
+Lines 3029, 4058: Both `allocated_contribution_by_channel_over_time` and
+`waterfall_components_decomposition` unpack `**subplot_kwargs` and `**kwargs` into
+`plt.subplots()`. If a user passes `figsize` in both, a `TypeError` occurs.
+
+> **Backward Compatible:** Yes (adding key-conflict validation) — **LOE:** XS
+
+### IV.10 Broad exception catching masks real bugs
+
+Multiple locations catch `except Exception` or `except (KeyError, ValueError, TypeError)`
+and emit warnings instead of raising:
+
+- `sensitivity_analysis` line 3189: catches all exceptions during float casting
+- `cv_predictions` lines 4430, 4467, 4485, 4534: catch broad exception tuples
+- `cv_crps` multiple locations: silently warn on data issues
+
+This hides real data problems from users.
+
+> **Backward Compatible:** Partially (previously silent errors will now surface; correctness fix but behavior change) — **LOE:** M
+
+### IV.11 Dead code: `MMMIDataWrapper._cache`
+
+Line 69 in `mmm_wrapper.py`: `self._cache: dict[str, Any] = {}` is initialized but never
+read or written to anywhere in the class.
+
+> **Backward Compatible:** Yes (removing dead code) — **LOE:** XS
+
+### IV.12 `_reduce_and_stack` silently sums over unknown dimensions
+
+Lines 325–340: When a variable has dimensions beyond `date`, `chain`, `draw`, and
+`channel`, this helper sums over them silently. This could mask data bugs — if a user
+adds an unexpected dimension, contributions will be silently aggregated without warning.
+
+> **Backward Compatible:** Partially (adding a warning is BC; raising an error would break code relying on implicit aggregation) — **LOE:** XS
+
+### IV.13 Redundant local imports
+
+`sensitivity_analysis` line 3191: `import warnings` is redundant — already imported at
+module level (line 187). A second instance exists in `saturation_curves_scatter` at
+line 2424 — same redundant `import warnings`.
+
+> **Backward Compatible:** Yes (cleanup) — **LOE:** XS
+
+### IV.14 `ax` unpacking fragility in `channel_contribution_share_hdi`
+
+Line 4253: `ax, *_ = az.plot_forest(...)` — the unpacking silently discards extra axes.
+If ArviZ's `plot_forest` returns multiple axes (e.g., for multi-group data), the extra
+information is lost.
+
+> **Backward Compatible:** Yes (internal fix) — **LOE:** XS
+
+### IV.15 Seaborn dependency for only 2 methods
+
+The entire `seaborn` import (line 195) is used by only `posterior_distribution` (violin
+plots) and `prior_vs_posterior` (KDE). The rest of the module is pure matplotlib. This
+is a heavy dependency for limited use.
+
+> **Backward Compatible:** Yes (convert to lazy import; no API change) — **LOE:** S
+
+### IV.16 Error message formatting in `saturation_scatterplot` / `saturation_curves`
+
+Lines 2058–2067, 2210–2218: Error messages use raw `f"""...\n..."""` with literal `\n`
+characters in the string, producing poorly formatted multi-line messages with extra
+whitespace and misaligned indentation when displayed to the user.
+
+> **Backward Compatible:** Yes (cosmetic fix) — **LOE:** XS
+
+### IV.17 No validation of `agg` parameter in `waterfall_components_decomposition`
+
+Line 3921: The method accepts `agg` indirectly via `_prepare_waterfall_data` →
+`build_contributions`, but there is no validation that `agg` is one of `"mean"` or
+`"median"`. The method signature doesn't even expose `agg` — it is hardcoded to
+`"mean"` at line 4034, making the parameter pathway dead code.
+
+> **Backward Compatible:** Yes (dead code cleanup) — **LOE:** XS
+
+### IV.18 `_compute_residuals` hardcodes `y_original_scale`
+
+Lines 670–711: The residuals computation hardcodes `y_original_scale` as the prediction
+variable and `target_data` as the observed variable. There is no way to compute
+residuals from different variables (e.g., in scaled space), limiting the usefulness of
+`residuals_over_time` and `residuals_posterior_distribution`.
+
+> **Backward Compatible:** Yes (additive — new optional parameter with backward-compatible default) — **LOE:** S
+
+---
+
+## V. Test Coverage Gaps
+
+Based on analysis of `tests/mmm/test_plot.py` (~5,336 lines).
+
+### V.1 Methods with zero or near-zero dedicated tests
+
+| Method | Test count | Quality |
+|--------|-----------|---------|
+| `prior_predictive` | **0** unit tests | Only tested indirectly via legacy `test_plotting.py` |
+| `posterior_predictive` | 1 integration test | No mocked unit tests; missing hdi_prob, original_scale, multi-dim |
+| `budget_allocation` | 2 tests | Type-check only; missing figsize, error paths, bar labels |
+| `uplift_curve` | 1 test | "Doesn't crash" quality |
+| `marginal_curve` | 1 test | "Doesn't crash" quality |
+| `saturation_curves_scatter` | 1 test | Only checks deprecation warning |
+
+> **Backward Compatible:** N/A (test-only) — **LOE:** L
+
+### V.2 Assertion quality is weak in many tests
+
+Many tests only assert `isinstance(fig, Figure)` or `fig is not None`. They don't
+check:
+- Axis labels, titles, legend entries
+- Number of axes matches expected dimensions
+- Data plotted matches expected values
+- Correct number of lines/bars/patches
+
+> **Backward Compatible:** N/A (test-only) — **LOE:** M
+
+### V.3 No edge case tests
+
+No tests cover:
+- Single channel scenario (1 media channel)
+- Single geo scenario (1 dimension value)
+- NaN/missing values in contributions or posterior data
+- Empty/zero contribution values
+- Very large number of geos (performance)
+- Custom date frequencies (quarterly, daily)
+- `original_scale=True` with missing `*_original_scale` variables
+
+> **Backward Compatible:** N/A (test-only) — **LOE:** L
+
+### V.4 Legacy test migration incomplete (GitHub #86)
+
+`test_plotting.py` (~373 lines) tests old `BaseMMM`/`MMM` plotting methods (not
+MMMPlotSuite) with weak assertions (`isinstance(func(**kwargs), plt.Figure)`). These
+should be migrated to test `MMMPlotSuite` directly with richer assertions.
+
+> **Backward Compatible:** N/A (test-only) — **LOE:** M
+
+### V.5 Thread-safety of monkey-patching not tested
+
+`uplift_curve` and `marginal_curve` monkey-patching is not tested for concurrent access.
+
+> **Backward Compatible:** N/A (test-only) — **LOE:** S
+
+---
+
+## VI. Documentation
+
+### VI.1 Plotting gallery (GitHub #820)
+
+No comprehensive gallery of all available plots. Users must read docstrings to discover
+what's available.
+
+> **Backward Compatible:** N/A (documentation) — **LOE:** L
+
+---
+
+## VII. Older / Miscellaneous
+
+### VII.1 Coord name `x` → `channel` (GitHub #1183)
+
+`plot_channel_contribution_share_hdi` uses `x` as coordinate name instead of `channel`.
+
+> **Backward Compatible:** No (changing coordinate names may break downstream code; requires deprecation) — **LOE:** S
+
+### VII.2 Rely more on `xarray.DataArray.to_dataframe` (GitHub #76)
+
+Legacy issue. Multiple methods manually extract data from xarray instead of using
+`to_dataframe()`.
+
+**Concrete example — `_process_decomposition_components`:** Lines 3692–3703 assume
+specific column ordering after `stack()`. If xarray changes its stacking behavior or the
+data has unexpected dimensions, the rename will break silently. Using `to_dataframe()`
+with named column access would eliminate this fragility.
+
+> **Backward Compatible:** Yes (internal refactoring) — **LOE:** M
+
+### VII.3 Time-varying media visualization (GitHub #765)
+
+Enhancement to visualize how media effects change over time (time-varying coefficients).
+
+> **Backward Compatible:** Yes (new method) — **LOE:** L
+
+---
+
+## VIII. Stale Branch Assessment (`feature/mmmplotsuite-arviz`)
+
+### What was attempted
+
+The branch introduces a multi-backend architecture powered by `arviz_plots`:
+
+- **Config system:** `MMMPlotConfig` singleton (modeled after ArviZ `rcParams`) with
+  `plot.backend`, `plot.use_v2`, `plot.show_warnings` settings
+- **Legacy extraction:** Original `MMMPlotSuite` renamed to `LegacyMMMPlotSuite` and
+  moved to `legacy_plot.py`
+- **Version dispatch:** `MMM.plot` property returns v1 or v2 suite based on config flag
+- **Deprecation timeline:** v0.18.0 (introduce), v0.19.0 (default), v0.20.0 (remove legacy)
+
+### Migration progress: ~60–65% complete
+
+**Converted to arviz-plots (9 methods):**
+- `posterior_predictive`, `contributions_over_time`
+- `saturation_scatterplot`, `saturation_curves`
+- `budget_allocation_roas` (new method, no legacy equivalent)
+- `allocated_contribution_by_channel_over_time`
+- `sensitivity_analysis`, `uplift_curve`, `marginal_curve`
+
+**Still matplotlib-only stubs (4 methods):**
+- `prior_predictive`, `residuals_over_time`, `residuals_posterior_distribution`,
+  `posterior_distribution`
+
+**Missing entirely (7+ methods from current main):**
+- `channel_parameter`, `prior_vs_posterior`, `waterfall_components_decomposition`,
+  `channel_contribution_share_hdi`, `cv_predictions`, `param_stability`, `cv_crps`
+
+### Key arviz-plots APIs used
+
+| API | Purpose |
+|-----|---------|
+| `PlotCollection.wrap()` | Time-series layouts (dim-based subplots) |
+| `PlotCollection.grid()` | Grid layouts (rows × cols) |
+| `pc.map()` | Layering visual elements |
+| `pc.add_legend()` | Channel legends |
+| `visuals.fill_between_y` | HDI bands |
+| `visuals.line_xy` | Median/mean lines |
+| `visuals.scatter_xy` | Scatter plots |
+| `visuals.multiple_lines` | Sampled posterior curves |
+| `xr.DataArray.azstats.hdi()` | HDI computation on xarray |
+| `arviz_base.convert_to_datatree` | DataArray → DataTree for `plot_dist` |
+
+### Design decisions worth preserving
+
+1. **Every method accepts `plot_collection` and `backend` parameters** — composable
+   plots and per-call backend override
+2. **Shared `_sensitivity_analysis_plot` helper** — eliminated the monkey-patching
+   anti-pattern from `uplift_curve`/`marginal_curve`
+3. **Data injection pattern** — methods accept explicit data parameters with fallback
+   to `self.idata`, enabling testability
+
+### Why the branch is stale
+
+31 commits behind `main`. The branch was created when `MMMPlotSuite` was ~1,937 lines.
+It is now 5,150 lines (main has added 8+ new methods since the branch was created).
+Merging would require re-implementing the conversion for all new methods and resolving
+conflicts in the existing ones.
+
+---
+
+## IX. Priority Matrix
+
+### Critical (blocks other work or causes user-facing bugs)
+
+| ID | Issue | Reason | BC | LOE |
+|----|-------|--------|----|-----|
+| IV.1 | Copy-paste bug in `_get_prior_predictive_data` | Wrong error message misleads users | Yes | XS |
+| II.3 | `plt.show()` + figure discarding in `param_stability` / `cv_predictions` | Silent data loss; prevents customization | No | M |
+| II.4 | Monkey-patching is thread-unsafe | Corrupts state under concurrency | Yes | M |
+| I.2 | Constructor accepts `None, None` | Deferred crash instead of fail-fast | Yes | XS |
+
+### High (API inconsistencies that confuse users)
+
+| ID | Issue | Reason | BC | LOE |
+|----|-------|--------|----|-----|
+| I.1 | 5,150-line god class | Unmaintainable, hard to extend | Yes | XL |
+| I.3 | MMMIDataWrapper largely bypassed (incl. #2370) | Wrapper bypassed; 5 contrib-var strategies, `StopIteration` bug | Yes | L |
+| II.1 | Return type roulette (5 shapes) | Callers can't write generic code | No | L |
+| II.2 | Inconsistent `original_scale` default | Surprising behavior differences | No | M |
+| II.5 | Parameter naming inconsistencies (incl. `var_names`, #1751) | Confusing API surface | No | M |
+| II.6 | No subsetting on predictive/media methods | 50-geo or many-channel models produce unusable output | Yes | S |
+| II.7 | Inconsistent figure customization | 7 methods have zero customization | Yes | L |
+| I.6 | Duplicated subplot logic — delegate to arviz-plots | Major code reduction opportunity | Yes | XL |
+
+### Medium (missing functionality, performance, testing)
+
+| ID | Issue | Reason | BC | LOE |
+|----|-------|--------|----|-----|
+| III.1–III.5 | Missing methods (#2128, #2054, #2242, #2153) | Feature gaps | Yes | S–L |
+| IV.6 | Per-date HDI computation loop | Performance bottleneck | Yes | M |
+| IV.7 | O(n×m) loop in `cv_crps` | Performance bottleneck | Yes | M |
+| IV.10 | Broad exception catching | Masks real bugs | Partial | M |
+| V.1 | `prior_predictive` has 0 tests | Risk of regressions | N/A | L |
+| V.2 | Weak test assertions | False confidence in test suite | N/A | M |
+| I.5 | No shared color palette / mapping | Inconsistent colors across plots | Yes | M |
+| IV.18 | `_compute_residuals` hardcodes `y_original_scale` | Limits residual analysis | Yes | S |
+
+### Lower (cleanup, nice-to-have)
+
+| ID | Issue | Reason | BC | LOE |
+|----|-------|--------|----|-----|
+| IV.2 | `plt.gcf()` fragility | Unlikely in practice but architecturally wrong | Yes | S |
+| IV.9 | `**kwargs` + `**subplot_kwargs` conflict | Edge case | Yes | XS |
+| IV.11 | Dead `_cache` in MMMIDataWrapper | Dead code | Yes | XS |
+| IV.12 | `_reduce_and_stack` silently sums | Subtle data bug risk | Partial | XS |
+| IV.13 | Redundant local imports (2 locations) | Noise | Yes | XS |
+| IV.15 | Seaborn dependency for 2 methods | Optional optimization | Yes | S |
+| IV.16 | Error message formatting (raw `\n` in f-strings) | Cosmetic | Yes | XS |
+| IV.17 | No validation of `agg` parameter (hardcoded anyway) | Dead code path | Yes | XS |
+| VI.1 | Plotting gallery (#820) | Documentation | N/A | L |
+| VII.1–VII.3 | Older issues (#76, #765, #1183) | Low urgency | Mixed | S–L |
+
+---
+
+## Appendix: Issue Count Summary
+
+| Category | GitHub Issues | Code-Review Findings | Total |
+|----------|--------------|---------------------|-------|
+| Structural / Architectural | — | 6 | 6 |
+| API Consistency | 9 (#822, #1751, #2369, #2371, #2373–#2376, #2378) | 0 | 7 |
+| Missing Functionality | 7 (#2052–#2242, #2153) | 1 | 5 |
+| Code Quality & Bugs | — | 18 | 18 |
+| Test Coverage Gaps | — | 5 | 5 |
+| Documentation | 1 (#820) | 0 | 1 |
+| Older / Miscellaneous | 3 (#76, #765, #1183) | 0 | 3 |
+| **Total** | **20** | **30** | **45** |

--- a/docs/plans/2026-03-10-mmmplotsuite-decomposition-approaches.md
+++ b/docs/plans/2026-03-10-mmmplotsuite-decomposition-approaches.md
@@ -29,8 +29,8 @@
 `MMMPlotSuite` in `pymc_marketing/mmm/plot.py` is a single class that handles seven
 distinct plotting families. At 5,150 lines it violates the Single Responsibility
 Principle and is painful to navigate, test, and extend. A comprehensive audit
-identified 63 issues across structural, API consistency, code quality, and test
-coverage dimensions (see `2026-03-10-mmmplotsuite-comprehensive-issues.md`).
+identified 45 issues across structural, API consistency, code quality, and test
+coverage dimensions (see [comprehensive issues list](./2026-03-10-mmmplotsuite-comprehensive-issues.md)).
 
 ### The Seven Plotting Families
 

--- a/docs/plans/2026-03-10-mmmplotsuite-decomposition-approaches.md
+++ b/docs/plans/2026-03-10-mmmplotsuite-decomposition-approaches.md
@@ -1,0 +1,458 @@
+# MMMPlotSuite Decomposition — Approach Analysis
+
+> Exploration of four architectural approaches for breaking up the `MMMPlotSuite`
+> god class (5,150 lines, 21 public methods, 19 private helpers).
+>
+> Prepared 2026-03-10.
+
+---
+
+## Table of Contents
+
+- [Context](#context)
+  - [The Problem](#the-problem)
+  - [The Seven Plotting Families](#the-seven-plotting-families)
+  - [Constraints](#constraints)
+  - [Relevant Codebase Patterns](#relevant-codebase-patterns)
+- [Approach A: Standalone Functions in a `plotting/` Package](#approach-a-standalone-functions-in-a-plotting-package)
+- [Approach B: Mixin-Based Decomposition](#approach-b-mixin-based-decomposition)
+- [Approach C: Domain-Aligned Placement](#approach-c-domain-aligned-placement)
+- [Approach D: Namespace Sub-Objects (Structured Facade)](#approach-d-namespace-sub-objects-structured-facade)
+- [Comparison Matrix](#comparison-matrix)
+
+---
+
+## Context
+
+### The Problem
+
+`MMMPlotSuite` in `pymc_marketing/mmm/plot.py` is a single class that handles seven
+distinct plotting families. At 5,150 lines it violates the Single Responsibility
+Principle and is painful to navigate, test, and extend. A comprehensive audit
+identified 63 issues across structural, API consistency, code quality, and test
+coverage dimensions (see `2026-03-10-mmmplotsuite-comprehensive-issues.md`).
+
+### The Seven Plotting Families
+
+| Family | Methods |
+|--------|---------|
+| Time-series diagnostics | `posterior_predictive`, `prior_predictive`, `residuals_over_time`, `residuals_posterior_distribution` |
+| Distribution diagnostics | `posterior_distribution`, `channel_parameter`, `prior_vs_posterior` |
+| Saturation / response curves | `saturation_scatterplot`, `saturation_curves`, `saturation_curves_scatter` (deprecated) |
+| Budget allocation | `budget_allocation`, `allocated_contribution_by_channel_over_time` |
+| Sensitivity / uplift / marginal | `sensitivity_analysis`, `uplift_curve`, `marginal_curve` |
+| Decomposition | `waterfall_components_decomposition`, `contributions_over_time`, `channel_contribution_share_hdi` |
+| Cross-validation | `cv_predictions`, `param_stability`, `cv_crps` |
+
+### Constraints
+
+- **Breaking changes are acceptable** — this is a major refactor; a migration guide
+  will be provided but backward compatibility is not required.
+- **Scope is MMMPlotSuite (matplotlib) only** — the Plotly factory
+  (`MMMPlotlyFactory`) is a separate concern.
+- **Goals are weighted equally:** maintainability, extensibility, testability.
+
+### Relevant Codebase Patterns
+
+| Pattern | Location | Notes |
+|---------|----------|-------|
+| Shared plot helpers | `pymc_marketing/plot.py` | `plot_curve`, `plot_hdi`, `plot_samples` — used by components |
+| Validation mixins | `mmm/validating.py` | `ValidateTargetColumn`, `ValidateDateColumn`, etc. composed into `MMM` |
+| `ModelIO` mixin | `model_builder.py` | Handles save/load via mixin |
+| `MMMIDataWrapper` | `data/idata/mmm_wrapper.py` | Type-safe access to idata; largely bypassed by current plot methods |
+| `.plot` property | `mmm/multidimensional.py:1145` | Returns `MMMPlotSuite(data=self.data)` |
+| `.plot` property | `mmm/time_slice_cross_validation.py:166` | Returns `MMMPlotSuite(idata=self.idata)` |
+
+---
+
+## Approach A: Standalone Functions in a `plotting/` Package
+
+### Concept
+
+Convert each plotting family into a module of standalone functions inside a new
+`pymc_marketing/mmm/plotting/` package. Shared helpers (subplot creation, color
+mapping, HDI bands) go into `_helpers.py`. A thin `MMMPlotSuite` facade delegates
+to these functions, preserving the `mmm.plot.*` access pattern that users rely on.
+
+### File Layout
+
+```
+mmm/plotting/
+    __init__.py            # re-exports all public functions + MMMPlotSuite facade
+    _helpers.py            # _init_subplots, color mapping, _add_median_and_hdi, etc.
+    suite.py               # MMMPlotSuite facade — delegates to standalone functions
+    time_series.py         # posterior_predictive, prior_predictive, residuals_*
+    distributions.py       # posterior_distribution, channel_parameter, prior_vs_posterior
+    saturation.py          # saturation_scatterplot, saturation_curves
+    budget.py              # budget_allocation, allocated_contribution_by_channel_over_time
+    sensitivity.py         # sensitivity_analysis, uplift_curve, marginal_curve
+    decomposition.py       # waterfall, contributions_over_time, channel_contribution_share_hdi
+    cross_validation.py    # cv_predictions, param_stability, cv_crps
+```
+
+### Example Signature
+
+```python
+# mmm/plotting/time_series.py
+def posterior_predictive(
+    idata: az.InferenceData,
+    var: list[str] | None = None,
+    hdi_prob: float = 0.94,
+    figsize: tuple[float, float] = (15, 5),
+    original_scale: bool = True,
+    dims: dict[str, Any] | None = None,
+    **subplot_kwargs,
+) -> tuple[Figure, NDArray[Axes]]:
+    ...
+```
+
+### Facade (preserves `mmm.plot.*`)
+
+The `MMMPlotSuite` facade is retained so that `mmm.plot.posterior_predictive()`
+continues to work. Each method is a thin delegation that passes `self.idata` /
+`self.data` into the corresponding standalone function:
+
+```python
+# mmm/plotting/suite.py
+from pymc_marketing.mmm.plotting import time_series, sensitivity, ...
+
+class MMMPlotSuite:
+    def __init__(self, idata=None, data=None):
+        self.idata = idata
+        self.data = data
+
+    def posterior_predictive(self, **kwargs):
+        return time_series.posterior_predictive(self.idata, **kwargs)
+
+    def sensitivity_analysis(self, **kwargs):
+        return sensitivity.sensitivity_analysis(self.idata, self.data, **kwargs)
+
+    # ... one-liner delegation for each of the 21 methods
+```
+
+The `multidimensional.MMM.plot` property and
+`TimeSliceCrossValidator.plot` property continue to return a
+`MMMPlotSuite` instance, so user code like `mmm.plot.posterior_predictive()`
+is unchanged.
+
+### Pros
+
+1. **Independently testable** — each function can be tested with a mock `idata`
+   without constructing a `MMMPlotSuite` instance.
+2. **Explicit dependencies** — every function declares what it needs in its
+   signature; no hidden `self.idata` contracts.
+3. **Maximum composability** — advanced users call functions directly; casual
+   users use the facade.
+4. **Natural file split** — 7 families map to 7 files averaging ~700 lines each.
+5. **Low migration cost to domain modules** — moving a function from
+   `plotting/sensitivity.py` to `sensitivity_analysis.py` later is trivial.
+6. **Shared helpers are clean** — `_helpers.py` replaces the current 3 different
+   subplot-creation patterns with one.
+
+### Cons
+
+1. **Explicit `idata`/`data` parameter on every standalone function** — more
+   boilerplate compared to `self.idata` (mitigated by the facade for end users).
+2. **Facade is delegation boilerplate** — ~21 one-liner pass-throughs in
+   `suite.py`, though each is trivial.
+3. **Shared helpers become an internal API** — changes to `_helpers.py` can
+   ripple across all 7 modules.
+4. **Two entry points to maintain** — both `mmm.plot.*` (facade) and direct
+   function imports are public; signatures must stay in sync, and docstrings need to be maintained in two places.
+
+### Summary
+
+Strongest on testability. Retains the `mmm.plot.*` access pattern via the facade.
+Serves as a natural foundation for Approach C or D later without requiring a
+second refactor.
+
+---
+
+## Approach B: Mixin-Based Decomposition
+
+### Concept
+
+Each plotting family becomes a mixin class. `MMMPlotSuite` inherits from all seven
+mixins, gaining their methods. The file splits into 7 mixin files plus a suite file,
+but the public API stays as a single class.
+
+### File Layout
+
+```
+mmm/plotting/
+    __init__.py
+    _helpers.py
+    time_series_mixin.py
+    distributions_mixin.py
+    saturation_mixin.py
+    budget_mixin.py
+    sensitivity_mixin.py
+    decomposition_mixin.py
+    cross_validation_mixin.py
+    suite.py               # MMMPlotSuite inherits from all mixins
+```
+
+### Example Structure
+
+```python
+# mmm/plotting/sensitivity_mixin.py
+class SensitivityPlotsMixin:
+    idata: az.InferenceData      # type annotation for IDE support
+    data: MMMIDataWrapper
+
+    def sensitivity_analysis(self, ...): ...
+    def uplift_curve(self, ...): ...
+    def marginal_curve(self, ...): ...
+
+# mmm/plotting/suite.py
+class MMMPlotSuite(
+    TimeSeriesPlotsMixin,
+    DistributionPlotsMixin,
+    SaturationPlotsMixin,
+    BudgetPlotsMixin,
+    SensitivityPlotsMixin,
+    DecompositionPlotsMixin,
+    CrossValidationPlotsMixin,
+):
+    def __init__(self, idata=None, data=None): ...
+```
+
+### Pros
+
+1. **Smallest API change** — `mmm.plot.sensitivity_analysis()` continues to work
+   with exactly the same call site.
+2. **Natural shared state** — `self.idata` and `self.data` are available
+   implicitly; no parameter threading.
+3. **Solves the file-size problem** — each mixin is its own file.
+4. **Good extensibility** — new family = new mixin + add to inheritance list.
+5. **Precedent exists** — validation mixins (`ValidateTargetColumn`, etc.) and
+   `ModelIO` already use this pattern in the codebase.
+
+### Cons
+
+1. **Tight coupling** — all mixins depend on the same implicit `self` contract
+   (`self.idata`, `self.data`, shared helpers). This contract is not enforced by
+   the type system.
+2. **Testing still requires instantiation** — you need a `MMMPlotSuite` (or
+   carefully mock `self`) to test any mixin method.
+3. **IDE support is weaker** — harder to trace which mixin a method comes from;
+   "Go to definition" on `mmm.plot.sensitivity_analysis()` may land in the
+   wrong place.
+4. **Diamond inheritance risk** — if two mixins share a helper method name,
+   MRO resolution becomes subtle.
+5. **Doesn't address domain coupling** — CV plots still live with saturation
+   plots in the same class, just in different files.
+6. **Mixins are considered an anti-pattern** by a portion of the Python
+   community, and can be confusing for contributors unfamiliar with the pattern.
+
+### Summary
+
+Lowest migration cost of all approaches. Preserves the existing API surface
+exactly. Weakest on testability since methods still require a class instance.
+Well-suited when API stability is the dominant concern.
+
+---
+
+## Approach C: Domain-Aligned Placement
+
+### Concept
+
+Move each plotting family to the module that owns its data domain. Sensitivity
+plots go to `sensitivity_analysis.py`, CV plots go to
+`time_slice_cross_validation.py`, budget plots go to `budget_optimizer.py`.
+Methods that don't have a clear domain home (time-series, distributions,
+decomposition) stay in a smaller general plotting module.
+
+### File Layout
+
+```
+mmm/
+    sensitivity_analysis.py        # existing + plot functions added
+    time_slice_cross_validation.py # existing + plot functions added
+    budget_optimizer.py            # existing + plot functions added
+    plotting/
+        __init__.py
+        _helpers.py
+        time_series.py             # posterior_predictive, prior_predictive, residuals_*
+        distributions.py           # posterior_distribution, channel_parameter, prior_vs_posterior
+        saturation.py              # saturation_scatterplot, saturation_curves
+        decomposition.py           # waterfall, contributions_over_time, channel_contribution_share_hdi
+```
+
+### Example
+
+```python
+# mmm/sensitivity_analysis.py
+class SensitivityAnalysis:
+    def run_sweep(self, ...): ...
+
+    def plot(self, figsize=..., ax=None, ...):
+        """Plot sensitivity analysis results."""
+        ...
+
+    def plot_uplift(self, figsize=..., ax=None, ...):
+        """Plot uplift curve."""
+        ...
+
+    def plot_marginal(self, figsize=..., ax=None, ...):
+        """Plot marginal curve."""
+        ...
+```
+
+### Pros
+
+1. **Most natural grouping** — sensitivity plots live right next to sensitivity
+   computation code.
+2. **Self-contained domain modules** — each module handles both computation and
+   visualization.
+3. **Reduced cross-module imports** — `sensitivity_analysis.py` doesn't need to
+   know about CV or budget allocation.
+
+### Cons
+
+1. **Breaks the unified access pattern entirely** — there is no single
+   `mmm.plot.*` namespace. Users must know which module owns each plot.
+2. **~60% of methods have no clear domain home** — time-series diagnostics,
+   distribution diagnostics, decomposition, and saturation plots don't belong
+   to a specific compute module. You still need a "general plots" module.
+3. **Domain modules grow significantly** — `sensitivity_analysis.py` goes from
+   526 to ~800+ lines; `time_slice_cross_validation.py` from 670 to ~1,100+
+   lines.
+4. **Cross-cutting concerns remain** — shared color palettes, subplot creation,
+   HDI bands still need a common location.
+5. **Discoverability suffers** — users can't tab-complete `mmm.plot.<TAB>` to
+   see all available plots.
+6. **Testing is fragmented** — plot tests are spread across domain test files
+   rather than focused plotting test files.
+
+### Summary
+
+Strongest cohesion for the 3 families with clear domain homes (sensitivity,
+CV, budget). The remaining 4 families still need a general plotting module.
+Breaks the unified `mmm.plot.*` access pattern. Can also serve as a follow-up
+step after Approach A or B rather than a standalone strategy.
+
+---
+
+## Approach D: Namespace Sub-Objects (Structured Facade)
+
+### Concept
+
+Instead of a flat `mmm.plot.sensitivity_analysis()`, group related plots under
+sub-namespace objects: `mmm.plot.sensitivity.analysis()`. Each namespace is a
+lightweight class holding a reference to `idata`/`data` and exposing only its
+family's methods. The plotting logic lives directly in the namespace class
+methods.
+
+### File Layout
+
+```
+mmm/plotting/
+    __init__.py              # MMMPlotSuite with namespace sub-objects
+    _helpers.py              # shared helpers
+    time_series.py           # TimeSeriesPlots namespace class
+    distributions.py         # DistributionPlots namespace class
+    saturation.py            # SaturationPlots namespace class
+    budget.py                # BudgetPlots namespace class
+    sensitivity.py           # SensitivityPlots namespace class
+    decomposition.py         # DecompositionPlots namespace class
+    cross_validation.py      # CrossValidationPlots namespace class
+```
+
+### Example Structure
+
+```python
+# mmm/plotting/sensitivity.py
+class SensitivityPlots:
+    def __init__(self, idata, data):
+        self._idata = idata
+        self._data = data
+
+    def analysis(self, channels=None, figsize=..., ax=None, ...):
+        """Plot sensitivity analysis results."""
+        ...
+
+    def uplift(self, figsize=..., ax=None, ...):
+        """Plot uplift curve."""
+        ...
+
+    def marginal(self, figsize=..., ax=None, ...):
+        """Plot marginal curve."""
+        ...
+
+
+# mmm/plotting/__init__.py
+class MMMPlotSuite:
+    def __init__(self, idata=None, data=None):
+        self.sensitivity = SensitivityPlots(idata, data)
+        self.cv = CrossValidationPlots(idata, data)
+        self.diagnostics = DiagnosticsPlots(idata, data)
+        self.distributions = DistributionPlots(idata, data)
+        self.saturation = SaturationPlots(idata, data)
+        self.budget = BudgetPlots(idata, data)
+        self.decomposition = DecompositionPlots(idata, data)
+```
+
+### User Experience
+
+```python
+mmm.plot.sensitivity.analysis(channels=["tv", "radio"])
+mmm.plot.cv.predictions(results)
+mmm.plot.diagnostics.posterior_predictive(var=["y"])
+```
+
+### Pros
+
+1. **Excellent discoverability** — `mmm.plot.<TAB>` shows 7 families, then
+   `mmm.plot.sensitivity.<TAB>` shows the 3 methods in that family.
+2. **Logical grouping** — related plots are always together; users don't need
+   to scan 21 flat methods to find what they need.
+3. **Small, focused namespace classes** — each has 2–4 methods, easy to
+   understand.
+4. **Guides users naturally** — the namespace structure teaches users about
+   the plotting families without requiring documentation.
+5. **Single public API** — only the namespace access pattern is exposed,
+   keeping the surface area manageable.
+
+### Cons
+
+1. **Deeper call chain** — `mmm.plot.sensitivity.analysis()` is more verbose
+   than `mmm.plot.sensitivity_analysis()`.
+2. **More boilerplate** — 7 namespace classes + the suite class.
+3. **Grouping disputes** — some plots may not fit neatly into one family
+   (e.g., does `contributions_over_time` belong in "decomposition" or
+   "diagnostics"?).
+4. **Method renaming required** — `sensitivity_analysis` becomes
+   `mmm.plot.sensitivity.analysis` which is a different name than today.
+5. **Testing requires instantiation** — methods live on classes, so tests
+   need to construct namespace objects (though each is small and focused).
+
+### Variant: D + A
+
+Approach D can be combined with Approach A by backing each namespace method
+with a standalone function. This adds a direct function access layer
+(e.g., `from pymc_marketing.mmm.plotting.sensitivity import sensitivity_analysis`)
+for users who prefer working with functions and for easier unit testing. The
+trade-off is two public API surfaces to maintain.
+
+### Summary
+
+Most polished user experience with grouped discoverability. Requires method
+renaming (e.g., `sensitivity_analysis` → `sensitivity.analysis`). Each
+namespace class is small and focused but testing still requires class
+instantiation unless combined with Approach A.
+
+---
+
+## Comparison Matrix
+
+| Criterion | A: Standalone Fns | B: Mixins | C: Domain-Aligned | D: Namespace Sub-Objects |
+|-----------|-------------------|-----------|-------------------|--------------------------|
+| **Maintainability** | High — 7 focused files | Medium — files split but coupled via `self` | Medium — 4 families still need general module | High — 7 focused files + thin namespaces |
+| **Extensibility** | High — add a function | High — add a mixin | Medium — must decide which module | High — add a function + update namespace |
+| **Testability** | High — no class needed | Low — requires `self` | High — functions in domain modules | Medium — small classes to instantiate |
+| **API change** | Moderate — flat functions or facade | Minimal — same `mmm.plot.*` | Large — no unified access | Moderate — nested namespaces |
+| **Discoverability** | Medium — flat list or imports | Medium — flat list on class | Low — spread across modules | High — grouped namespaces |
+| **Complexity** | Low | Medium (MRO, implicit contracts) | Medium (fragmented) | Medium (two API layers) |
+| **Migration effort** | Medium | Low | High | Medium |
+| **Future-proof** | Good — easy to move fns later | Locked into class shape | Already domain-aligned | Good — functions are portable |

--- a/docs/plans/2026-03-11-figure-customization-design.md
+++ b/docs/plans/2026-03-11-figure-customization-design.md
@@ -1,0 +1,390 @@
+# Figure Customization Surface Design (Issue II.7 + arviz-plots Integration)
+
+> Resolves issue II.7 (inconsistent figure customization) from the
+> [comprehensive audit](./2026-03-10-mmmplotsuite-comprehensive-issues.md)
+> by adopting arviz-plots as the rendering engine and exposing its
+> customization model directly.
+>
+> **Key change to the attack plan:** Issue I.6 (arviz-plots adoption) is
+> moved from "deferred follow-up" into the major release. II.7 is solved
+> organically through arviz-plots' customization model rather than by
+> adding matplotlib-specific `figsize + ax` parameters.
+>
+> Prepared 2026-03-11.
+
+---
+
+## Table of Contents
+
+- [Context](#context)
+- [Decisions](#decisions)
+- [Standard Customization Parameters](#standard-customization-parameters)
+- [Parameter Interaction Rules](#parameter-interaction-rules)
+- [Concrete Method Signatures](#concrete-method-signatures)
+- [Shared Infrastructure](#shared-infrastructure)
+- [arviz-plots Coverage Gaps](#arviz-plots-coverage-gaps)
+- [Impact on Attack Plan](#impact-on-attack-plan)
+
+---
+
+## Context
+
+### The Problem (II.7)
+
+The current `MMMPlotSuite` has wildly inconsistent figure customization:
+
+| Customization   | Coverage                                           |
+|-----------------|----------------------------------------------------|
+| `figsize`       | 14/21 methods                                      |
+| `ax` parameter  | 4/21 methods                                       |
+| `**kwargs`      | Varies — sometimes to `plt.subplots()`, sometimes to plot calls |
+| `rc_params`     | 1/21 methods (`saturation_curves` only)            |
+| `title` control | Sensitivity family only                            |
+| No customization at all | 7 methods                                 |
+
+### Why arviz-plots Changes the Answer
+
+The original attack plan proposed adding `figsize + ax` to all methods as a
+minimal consistent surface. However, the planned adoption of arviz-plots
+introduces its own customization model (`PlotCollection`, `visuals`,
+`aes_by_visuals`, `backend`, `**pc_kwargs`). These two models are
+incompatible — `ax` doesn't exist in arviz-plots, and `figsize` is a nested
+key inside `figure_kwargs`.
+
+Rather than solving II.7 with matplotlib-native args now and breaking the API
+again when arviz-plots arrives, this design **moves arviz-plots adoption into
+the major release** and solves both issues in one break.
+
+### Approaches Considered
+
+1. **Flat — all arviz-plots params explicit (chosen):** Every method lists
+   `figsize`, `plot_collection`, `backend`, `visuals`, `aes_by_visuals`, and
+   `**pc_kwargs` as named keyword arguments. Matches arviz-plots' own
+   function signature convention.
+
+2. **Layered — common params explicit, advanced via pc_kwargs:** Only
+   `figsize` and `backend` are named; everything else flows through
+   `**pc_kwargs`. Cleaner signatures but advanced params are invisible to
+   IDE autocomplete.
+
+3. **Config object — PlotConfig dataclass:** All rendering params bundled
+   into a `PlotConfig` object. Clean separation but introduces a new type
+   that doesn't exist in the arviz ecosystem.
+
+---
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| arviz-plots timing | **Included in major release** (un-defer I.6) | Avoids a second breaking change; one clean break |
+| Customization approach | **Flat — explicit params** (Approach 1) | Matches arviz-plots conventions; maximum IDE discoverability |
+| `ax` parameter | **Removed** | Doesn't exist in arviz-plots; replaced by `plot_collection` |
+| `figsize` | **Kept as top-level convenience** | Most commonly used param (14/21 today); translated to `figure_kwargs` internally |
+| Return type | **`tuple[Figure, NDArray[Axes]]` by default**; `PlotCollection` opt-in via `return_as_pc=True` | Backward-friendly default; power users get full arviz-plots composability |
+| Bar-plot methods | **Replace with arviz-plots-compatible visuals where possible**; matplotlib fallback for `waterfall` | Minimizes methods stuck on matplotlib-only |
+
+---
+
+## Standard Customization Parameters
+
+Every public method in every namespace exposes these six standard
+customization parameters, always in this order, always after the
+method-specific data parameters:
+
+| # | Parameter | Type | Default | Purpose |
+|---|-----------|------|---------|---------|
+| 1 | `figsize` | `tuple[float, float] \| None` | `None` | Convenience for `figure_kwargs={"figsize": ...}`. Ignored when `plot_collection` is provided. |
+| 2 | `plot_collection` | `PlotCollection \| None` | `None` | Plot onto an existing collection instead of creating a new one. |
+| 3 | `backend` | `str \| None` | `None` | Rendering backend: `"matplotlib"`, `"plotly"`, `"bokeh"`. |
+| 4 | `visuals` | `dict[str, Any] \| None` | `None` | Element-level customization. Keys are visual element names (method-specific), values are backend kwargs or `False` to disable. |
+| 5 | `aes_by_visuals` | `dict[str, list[str]] \| None` | `None` | Controls which aesthetics apply to which visual elements. |
+| 6 | `**pc_kwargs` | | | Forwarded to `PlotCollection.wrap()` or `.grid()`. |
+
+Plus one control parameter:
+
+| Parameter | Type | Default | Purpose |
+|-----------|------|---------|---------|
+| `return_as_pc` | `bool` | `False` | When `True`, return `PlotCollection`. When `False`, return `tuple[Figure, NDArray[Axes]]`. |
+
+### Parameter Ordering Convention
+
+```python
+def method(
+    self,
+    # 1. Method-specific data params (varies per method)
+    channels=None, hdi_prob=0.94, original_scale=True,
+    # 2. Dimension subsetting (standard)
+    dims=None,
+    # 3. Figure customization (standard — identical across all methods)
+    figsize=None,
+    plot_collection=None,
+    backend=None,
+    visuals=None,
+    aes_by_visuals=None,
+    # 4. Return control (standard)
+    return_as_pc=False,
+    # 5. PlotCollection kwargs catch-all (standard)
+    **pc_kwargs,
+):
+```
+
+---
+
+## Parameter Interaction Rules
+
+1. **`plot_collection` overrides `figsize` and layout kwargs:** When
+   `plot_collection` is provided, `figsize`, `backend`, and layout-related
+   `pc_kwargs` are ignored (the collection already has a figure/grid).
+   A warning is emitted if `figsize` is also set.
+
+2. **`figsize` is injected into `figure_kwargs`:** When `figsize` is
+   provided without `plot_collection`, it's set as
+   `pc_kwargs["figure_kwargs"]["figsize"]`. If `figure_kwargs` is also in
+   `pc_kwargs` with its own `figsize`, the top-level `figsize` parameter
+   takes precedence (with a warning).
+
+3. **`return_as_pc=False` requires matplotlib backend:** When
+   `return_as_pc=False` and `backend` is not `"matplotlib"` (or `None`),
+   raise `ValueError` — non-matplotlib backends can't produce
+   `(Figure, NDArray[Axes])`.
+
+4. **`visuals` disabling:** Setting a visual key to `False` disables that
+   visual element (e.g., `visuals={"hdi_band": False}` removes the HDI
+   band). Setting it to a dict passes those kwargs to the backend plotting
+   function for that element.
+
+---
+
+## Concrete Method Signatures
+
+### Time-Series — `diagnostics.posterior_predictive`
+
+```python
+def posterior_predictive(
+    self,
+    var_names: list[str] | None = None,
+    hdi_prob: float = 0.94,
+    original_scale: bool = True,
+    dims: dict[str, Any] | None = None,
+    figsize: tuple[float, float] | None = None,
+    plot_collection: PlotCollection | None = None,
+    backend: str | None = None,
+    visuals: dict[str, Any] | None = None,
+    aes_by_visuals: dict[str, list[str]] | None = None,
+    return_as_pc: bool = False,
+    **pc_kwargs,
+) -> tuple[Figure, NDArray[Axes]] | PlotCollection:
+```
+
+Visual element keys: `"line"` (median), `"hdi_band"` (HDI fill),
+`"observed"` (scatter of actuals), `"title"`.
+
+### Saturation — `saturation.curves`
+
+```python
+def curves(
+    self,
+    curve: xr.DataArray,
+    original_scale: bool = True,
+    n_samples: int = 10,
+    hdi_prob: float = 0.94,
+    random_seed: np.random.Generator | None = None,
+    colors: Iterable[str] | None = None,
+    apply_cost_per_unit: bool = True,
+    dims: dict[str, Any] | None = None,
+    figsize: tuple[float, float] | None = None,
+    plot_collection: PlotCollection | None = None,
+    backend: str | None = None,
+    visuals: dict[str, Any] | None = None,
+    aes_by_visuals: dict[str, list[str]] | None = None,
+    return_as_pc: bool = False,
+    **pc_kwargs,
+) -> tuple[Figure, NDArray[Axes]] | PlotCollection:
+```
+
+Visual element keys: `"samples"` (posterior curves), `"hdi_band"`,
+`"median"`, `"title"`.
+
+### Sensitivity — `sensitivity.analysis`
+
+```python
+def analysis(
+    self,
+    channels: list[str] | None = None,
+    hdi_prob: float = 0.94,
+    original_scale: bool = True,
+    dims: dict[str, Any] | None = None,
+    figsize: tuple[float, float] | None = None,
+    plot_collection: PlotCollection | None = None,
+    backend: str | None = None,
+    visuals: dict[str, Any] | None = None,
+    aes_by_visuals: dict[str, list[str]] | None = None,
+    return_as_pc: bool = False,
+    **pc_kwargs,
+) -> tuple[Figure, NDArray[Axes]] | PlotCollection:
+```
+
+Visual element keys: `"line"` (sensitivity curve), `"hdi_band"`,
+`"reference"` (zero/baseline line), `"title"`.
+
+### Decomposition — `decomposition.waterfall`
+
+```python
+def waterfall(
+    self,
+    original_scale: bool = True,
+    dims: dict[str, Any] | None = None,
+    figsize: tuple[float, float] | None = None,
+    plot_collection: PlotCollection | None = None,
+    backend: str | None = None,
+    visuals: dict[str, Any] | None = None,
+    aes_by_visuals: dict[str, list[str]] | None = None,
+    return_as_pc: bool = False,
+    **pc_kwargs,
+) -> tuple[Figure, NDArray[Axes]] | PlotCollection:
+```
+
+Visual element keys: `"bar"`, `"connector"` (lines between bars),
+`"label"` (value text), `"title"`.
+
+---
+
+## Shared Infrastructure
+
+### `_process_plot_params` — Validates and normalizes standard params
+
+```python
+# mmm/plotting/_helpers.py
+
+def _process_plot_params(
+    figsize: tuple[float, float] | None,
+    plot_collection: PlotCollection | None,
+    backend: str | None,
+    return_as_pc: bool,
+    **pc_kwargs,
+) -> dict:
+    if plot_collection is not None and figsize is not None:
+        warnings.warn("figsize is ignored when plot_collection is provided")
+
+    if not return_as_pc and backend is not None and backend != "matplotlib":
+        raise ValueError(
+            f"backend='{backend}' requires return_as_pc=True. "
+            "Non-matplotlib backends cannot return (Figure, NDArray[Axes])."
+        )
+
+    if figsize is not None and plot_collection is None:
+        fig_kwargs = pc_kwargs.pop("figure_kwargs", {})
+        if "figsize" in fig_kwargs:
+            warnings.warn(
+                "figsize parameter overrides figure_kwargs['figsize']"
+            )
+        fig_kwargs["figsize"] = figsize
+        pc_kwargs["figure_kwargs"] = fig_kwargs
+
+    return pc_kwargs
+```
+
+### `_extract_matplotlib_result` — Converts PlotCollection to tuple
+
+```python
+def _extract_matplotlib_result(
+    pc: PlotCollection,
+    return_as_pc: bool,
+) -> tuple[Figure, NDArray[Axes]] | PlotCollection:
+    if return_as_pc:
+        return pc
+
+    fig = pc.viz["plot"].item().figure
+    axes = np.array([ax.item() for ax in pc.viz["plot"].values()])
+    return fig, axes
+```
+
+### Usage pattern in each method
+
+```python
+def analysis(self, channels=None, ..., figsize=None, plot_collection=None,
+             backend=None, visuals=None, aes_by_visuals=None,
+             return_as_pc=False, **pc_kwargs):
+
+    pc_kwargs = _process_plot_params(
+        figsize, plot_collection, backend, return_as_pc, **pc_kwargs
+    )
+
+    data = self._data.get_sensitivity_data(channels=channels, dims=dims)
+
+    if plot_collection is None:
+        pc = PlotCollection.wrap(data, backend=backend, **pc_kwargs)
+    else:
+        pc = plot_collection
+
+    pc.map("line", line_xy, ...)
+    pc.map("hdi_band", fill_between_y, ...)
+
+    return _extract_matplotlib_result(pc, return_as_pc)
+```
+
+---
+
+## arviz-plots Coverage Gaps
+
+### Methods requiring bar-type visuals
+
+arviz-plots does not currently support bar plots. Four methods are affected:
+
+| Method | Current visual | Strategy |
+|--------|---------------|----------|
+| `decomposition.waterfall` | Horizontal bar chart | **Matplotlib fallback** — inherently a bar chart; no good alternative |
+| `budget.allocation` | Bar chart | **Replace with dot/lollipop plot** — cleaner for comparing values with uncertainty |
+| `decomposition.channel_share_hdi` | `az.plot_forest` | **Replace with arviz-plots `plot_forest`** — arviz-plots has native forest plot support |
+| `decomposition.contributions_over_time` | Stacked area/bar | **Replace with stacked `fill_between_y`** — stacked area is better suited for time series |
+
+### Fallback rules
+
+For methods that must fall back to matplotlib:
+
+- **Same API signature** — all 6 standard customization params are present
+- `backend` other than `"matplotlib"` raises `NotImplementedError` with a
+  message explaining bar plot support is pending in arviz-plots
+- `plot_collection` is still accepted (for matplotlib composability)
+- `visuals` keys map to matplotlib kwargs for these methods
+- When arviz-plots adds bar support, the implementation switches to
+  `PlotCollection` with no API change
+
+---
+
+## Impact on Attack Plan
+
+### Changes to scope
+
+| Aspect | Original plan | Updated plan |
+|--------|--------------|--------------|
+| I.6 (arviz-plots) | Deferred to follow-up release | **Included in major release** |
+| II.7 (figure customization) | `figsize + ax` on all methods | 6 standard params via arviz-plots |
+| `ax` parameter | Added to all methods | **Removed** — replaced by `plot_collection` |
+| Return type | Always `tuple[Figure, NDArray[Axes]]` | Default `tuple[Figure, NDArray[Axes]]`, opt-in `PlotCollection` via `return_as_pc=True` |
+| PR 1 (Foundation) | Subplot creation, color mapping, HDI helpers | + `_process_plot_params`, `_extract_matplotlib_result`, arviz-plots imports |
+| Family PRs (2–8) | Port methods, add figsize+ax | Port methods, **rewrite with PlotCollection** |
+| LOE per family PR | M–L | L–XL (~50% more work, but significantly less code output) |
+
+### Changes to the standardized API contract
+
+Replace the "Required Parameters" table in the attack plan:
+
+| Parameter | Type | Default | Notes |
+|-----------|------|---------|-------|
+| `figsize` | `tuple[float, float] \| None` | `None` | Convenience for `figure_kwargs`; ignored with `plot_collection` |
+| `plot_collection` | `PlotCollection \| None` | `None` | Plot onto existing collection |
+| `backend` | `str \| None` | `None` | `"matplotlib"`, `"plotly"`, `"bokeh"` |
+| `visuals` | `dict[str, Any] \| None` | `None` | Element-level customization |
+| `aes_by_visuals` | `dict[str, list[str]] \| None` | `None` | Aesthetic mapping per visual |
+| `dims` | `dict[str, Any] \| None` | `None` | Subset dimensions |
+| `return_as_pc` | `bool` | `False` | Opt-in to `PlotCollection` return |
+| `**pc_kwargs` | | | Forwarded to `PlotCollection.wrap/grid` |
+
+### Removed from contract
+
+| Old parameter | Reason |
+|---------------|--------|
+| `ax: plt.Axes \| None` | Doesn't exist in arviz-plots; replaced by `plot_collection` |
+| `**kwargs` to primary plot call | Replaced by `visuals` dict |

--- a/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
+++ b/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
@@ -25,18 +25,127 @@
 
 ## Decisions
 
-| Decision | Choice | Rationale |
-|----------|--------|-----------|
-| Decomposition approach | **D: Namespace Sub-Objects** | Best discoverability (`mmm.plot.sensitivity.analysis()`); aligns with 6 plotting families; each namespace is small and focused |
-| Transformations namespace | **`transformations` instead of `saturation`** | Saturation and adstock are both channel transformations. Grouping under `transformations` provides a natural home for future adstock plots without another namespace addition. Current saturation methods are prefixed (`saturation_scatterplot`, `saturation_curves`) to stay unambiguous when adstock methods join later. |
-| Suite separation | **Two separate suites: `MMMPlotSuite` + `MMMCVPlotSuite`** | 5 of 20 methods don't need `idata` at all (3 CV + 2 budget). CV methods share zero meaningful code with idata methods — only 4 subplot-plumbing helpers, all of which are replaced by arviz-plots. `mmm.plot` should not expose CV methods; `cv.plot` should not expose model-fit methods. Clean separation of concerns. |
-| arviz-plots adoption | **Included** in major release | Avoids a second breaking change for figure customization; II.7 is solved by exposing arviz-plots' native customization model. See [figure customization design](./2026-03-11-figure-customization-design.md) |
-| Release strategy | **Major release** for breaking changes + decomposition (each PR ships with tests); **follow-up minor releases** for missing features, performance, edge-case tests, docs | Keeps the major release focused and reviewable; no test debt at ship time |
-| Backward compatibility | **Hard break** — old method names stop working | Migration guide provides the full old→new mapping; no deprecation shims |
-| PR strategy | **Family-by-family clean rooms** — one PR per namespace, each family is "born clean" with tests | Focused, reviewable PRs; each ships code + tests together; parallelizable across contributors |
-| Namespace constructor arg | **`data: MMMIDataWrapper` only** — no separate `idata` arg | `MMMIDataWrapper` already holds `idata` as a public attribute; passing both creates a redundant access path that undermines I.3 (all access through wrapper). `MMM.plot` already constructs `MMMPlotSuite(data=data)` without a separate `idata`. Applies only to `MMMPlotSuite` namespaces; `MMMCVPlotSuite` takes no constructor data. |
-| Optional `idata` override on methods | **Every method that accesses `self._data` accepts `idata: az.InferenceData \| None = None`** | Users work with `InferenceData` directly — this is the object they have in hand. When provided, the method constructs `MMMIDataWrapper(idata)` and uses that for all access (both `.idata` and wrapper helpers like `get_channel_spend()`). Makes methods fully reusable with different fitted models without constructing a new suite. Consistent pattern — currently only `posterior_predictive` and `prior_predictive` accept an ad-hoc `idata` override; the rest silently bind to `self._data`. With this decision, all data-dependent methods get the same override. Resolution: `data = MMMIDataWrapper(idata) if idata is not None else self._data`. |
-| `MMMPlotlyFactory` | **Out of scope** for this release | The `backend` parameter provides a migration path to Plotly via arviz-plots. Deprecation of `MMMPlotlyFactory` can be evaluated once arviz-plots Plotly support stabilizes. |
+1. **Decompose the god class into namespace sub-objects.**
+   The current `MMMPlotSuite` is a 5,150-line monolith with 20 public methods spanning
+   6 unrelated plotting families. The rewrite decomposes it into 6 small namespace classes
+   (`DiagnosticsPlots`, `DistributionPlots`, `TransformationPlots`, `BudgetPlots`,
+   `SensitivityPlots`, `DecompositionPlots`), each mounted as a sub-object on `MMMPlotSuite`.
+   Users access methods via `mmm.plot.<family>.<method>()` — e.g.,
+   `mmm.plot.sensitivity.analysis()`. This gives IDE discoverability (autocomplete shows
+   6 families, then only the methods in that family), keeps each namespace small and focused,
+   and aligns the code layout with the 6 natural plotting families.
+   See [Target Architecture](#target-architecture) for the file layout, user experience,
+   and suite wrapper details.
+   Analysis of all four decomposition approaches:
+   [Approach D: Namespace Sub-Objects](./2026-03-10-mmmplotsuite-decomposition-approaches.md#approach-d-namespace-sub-objects-structured-facade).
+   Discussion: [pymc-devs Discord thread](https://discord.com/channels/745261709622771773/948587000464834580/1481289904192356396).
+
+2. **Separate cross-validation plots into their own suite (`MMMCVPlotSuite`).**
+   Of the 20 current methods, 3 are cross-validation methods (`cv_predictions`,
+   `param_stability`, `cv_crps`) that share zero domain-specific code with the other 17.
+   They don't need `idata` or `MMMIDataWrapper` at all — they receive all data via a
+   `results: az.InferenceData` argument (the output of `TimeSliceCrossValidator.run()`).
+   The only overlap with the idata methods was 4 subplot-plumbing helpers, all of which
+   are replaced by arviz-plots' `PlotCollection`. A separate `MMMCVPlotSuite` ensures
+   `mmm.plot` never exposes CV methods and `cv.plot` never exposes model-fit methods.
+   `MMMCVPlotSuite` is stateless — no constructor data, no `self._data`.
+   See [Suite Wrappers](#suite-wrappers) for the class design,
+   [MMMCVPlotSuite Contract](#mmmcvplotsuite-contract) for the API rules,
+   [Caller Integration](#caller-integration) for how `cv.plot` is wired up,
+   and [PR 8 — MMMCVPlotSuite](#pr-8--mmmcvplotsuite) for implementation details.
+   Original issue: [I.2 Constructor allows invalid state](./2026-03-10-mmmplotsuite-comprehensive-issues.md#i2-constructor-allows-invalid-state).
+
+3. **Adopt arviz-plots (`PlotCollection`) in the major release, not later.**
+   All 17 `MMMPlotSuite` methods and 3 `MMMCVPlotSuite` methods will use `PlotCollection`
+   internally for subplot creation, layout, dimension iteration, and rendering. This
+   replaces 5 hand-rolled subplot-scaffolding helpers (`_init_subplots`,
+   `_build_subplot_title`, `_dim_list_handler`, `_get_additional_dim_combinations`,
+   `_add_median_and_hdi`). Bundling this with the major release avoids imposing a second
+   breaking change later for figure customization. It also solves inconsistent figure
+   customization (issue II.7) by exposing arviz-plots' native customization model: 6
+   standard parameters (`figsize`, `plot_collection`, `backend`, `visuals`,
+   `aes_by_visuals`, `**pc_kwargs`) on every method. Bar-plot methods that cannot use
+   arviz-plots fall back to matplotlib with the same parameter signature.
+   See [Helper Function Removal Plan](#helper-function-removal-plan) for what `PlotCollection` replaces.
+   Full customization API: [figure customization design](./2026-03-11-figure-customization-design.md).
+   Original issues:
+   [I.6 Duplicated subplot logic](./2026-03-10-mmmplotsuite-comprehensive-issues.md#i6-duplicated-subplot-creation-and-population-logic--delegate-to-arviz-plots),
+   [II.7 Inconsistent figure customization](./2026-03-10-mmmplotsuite-comprehensive-issues.md#ii7-inconsistent-figure-customization-surface-github-822-2378).
+   Prior art: [Stale Branch Assessment](./2026-03-10-mmmplotsuite-comprehensive-issues.md#viii-stale-branch-assessment-featuremmmplotsuite-arviz).
+
+4. **Pass only `data: MMMIDataWrapper` to namespace constructors — no separate `idata` arg.**
+   Each `MMMPlotSuite` namespace class (`DiagnosticsPlots`, etc.) receives a single
+   `data: MMMIDataWrapper` in its constructor. `MMMIDataWrapper` is a typed wrapper
+   around `az.InferenceData` that provides validated, domain-aware access to model
+   results. Instead of manually navigating `idata.posterior.channel_contribution`,
+   `idata.constant_data.channel_data`, etc. (which requires knowing the exact variable
+   names and group locations), the wrapper exposes semantic methods like
+   `data.get_contributions(original_scale=True)`, `data.get_channel_spend()`,
+   `data.get_target()`, and `data.get_channel_scale()`. It also handles scale
+   conversions, contribution variable resolution (which has 5 different strategies in
+   the current code), and coordinate validation. The wrapper already holds `idata` as a
+   public attribute (`data.idata`) for cases where raw access is needed, so accepting a
+   separate `idata` would create a redundant access path and undermine the rule that all
+   data access goes through the wrapper. The `MMM.plot` property already constructs
+   `MMMPlotSuite(data=self.data)` without a separate `idata`. This decision applies only
+   to `MMMPlotSuite` namespaces; `MMMCVPlotSuite` takes no constructor data at all
+   (see decision 2).
+   See [Suite Wrappers](#suite-wrappers) design notes,
+   [Namespace Class Pattern](#namespace-class-pattern) for the concrete `__init__` signature,
+   and [Caller Integration](#caller-integration) for how `MMM.plot` constructs the suite.
+   Original issue: [I.3 MMMIDataWrapper largely bypassed](./2026-03-10-mmmplotsuite-comprehensive-issues.md#i3-mmmdatawrapper-largely-bypassed).
+
+5. **Every data-dependent method accepts an `idata` override parameter.**
+   All 17 `MMMPlotSuite` methods that access `self._data` accept
+   `idata: az.InferenceData | None = None`. When provided, the method constructs
+   `MMMIDataWrapper(idata)` and uses that local wrapper for all subsequent access —
+   both `data.idata` and wrapper helpers like `data.get_channel_spend()`. This makes
+   individual methods fully reusable with different fitted models (e.g., comparing two
+   model fits side-by-side) without constructing a new suite instance. The parameter
+   type is `az.InferenceData` (not `MMMIDataWrapper`) because that is the object users
+   have in hand — the wrapper construction is an internal detail. Currently only
+   `posterior_predictive` and `prior_predictive` have an ad-hoc `idata` override; this
+   decision standardizes the pattern across all 17 data-dependent methods. Resolution
+   at the top of every method: `data = MMMIDataWrapper(idata) if idata is not None else self._data`.
+   See [Standardized API Contract](#standardized-api-contract) for the full parameter table,
+   [Behavioral Rules](#behavioral-rules) for the resolution pattern,
+   and [Namespace Class Pattern](#namespace-class-pattern) for a concrete method signature example.
+
+6. **Hard break — old method names stop working, no deprecation shims.**
+   The old flat API (`mmm.plot.posterior_predictive()`, etc.) is removed entirely.
+   Calling removed names raises `AttributeError`. The old import path
+   (`from pymc_marketing.mmm.plot import MMMPlotSuite`) is replaced with a stub that
+   raises `ImportError` with an actionable migration message. A full migration guide
+   provides the complete old-to-new method mapping, parameter renames, default changes,
+   and before/after code examples. No deprecation warnings or shims — this is a major
+   version bump.
+   See [Migration Guide Outline](#migration-guide-outline) for the full old-to-new mapping.
+
+7. **Major release for breaking changes; follow-up minors for additive work.**
+   All breaking API changes (decomposition, return-type standardization, parameter renames,
+   default changes, method removals) ship together in one major release. Every PR in the
+   major release ships with its own tests — no test debt at ship time. Additive features
+   (missing methods, performance optimizations, edge-case tests, plotting gallery, docs)
+   are deferred to follow-up minor releases to keep the major release focused and reviewable.
+   See [Scope Split: Major Release vs Follow-up](#scope-split-major-release-vs-follow-up)
+   for the full 29-issue / 16-issue breakdown.
+
+8. **Family-by-family clean-room PRs — one PR per namespace, each born clean with tests.**
+   Each of the 6 namespace families gets its own PR (PRs 2–7), plus one for
+   `MMMCVPlotSuite` (PR 8). Every family PR writes its namespace class from scratch
+   (no incremental refactoring of the old monolith), ships code and tests together,
+   and is independently reviewable. PR 4 (Transformations) ships first as the template —
+   it demonstrates every structural pattern (namespace class, standard params,
+   `PlotCollection`, `idata` override, tests) in a concrete, copy-able form.
+   Remaining family PRs follow the template in parallel.
+   See [PR Sequence](#pr-sequence) for the dependency graph, LOE estimates, and
+   per-PR scope.
+
+9. **`MMMPlotlyFactory` is out of scope for this release.**
+   The new `backend` parameter on every method provides a migration path to Plotly via
+   arviz-plots' native multi-backend support. Deprecation of the existing
+   `MMMPlotlyFactory` class can be evaluated once arviz-plots' Plotly backend stabilizes.
+   No changes to `MMMPlotlyFactory` in this release.
 
 ---
 
@@ -60,6 +169,8 @@ mmm/plotting/
 ```
 
 ### User Experience
+
+**Basic — namespace access (all methods, default settings):**
 
 ```python
 # MMMPlotSuite — model-fit plots (requires fitted model with idata)
@@ -90,11 +201,6 @@ mmm.plot.decomposition.channel_share_hdi()
 cv.plot.predictions(results)
 cv.plot.param_stability(results)
 cv.plot.crps(results)
-
-# Optional idata override — use a different fitted model's InferenceData
-other_idata: az.InferenceData = other_mmm.idata
-mmm.plot.diagnostics.posterior_predictive(idata=other_idata)
-mmm.plot.decomposition.waterfall(idata=other_idata)
 ```
 
 ### Suite Wrappers
@@ -182,26 +288,30 @@ class TimeSliceCrossValidator:
 Each namespace follows the same structure (see [figure customization design](./2026-03-11-figure-customization-design.md)):
 
 ```python
-# mmm/plotting/sensitivity.py
-class SensitivityPlots:
+class SomethingPlots:
     def __init__(self, data: MMMIDataWrapper):
         self._data = data
 
-    def analysis(
+
+    def method(
         self,
-        channels: list[str] | None = None,
-        hdi_prob: float = 0.94,
-        original_scale: bool = True,
-        idata: az.InferenceData | None = None,
-        dims: dict[str, Any] | None = None,
-        figsize: tuple[float, float] | None = None,
-        plot_collection: PlotCollection | None = None,
-        backend: str | None = None,
-        visuals: dict[str, Any] | None = None,
-        aes_by_visuals: dict[str, list[str]] | None = None,
-        return_as_pc: bool = False,
+        # 1. Method-specific data params (varies per method)
+        channels=None,
+        hdi_prob=0.94,
+        original_scale=True,
+        # 2. Dimension subsetting (standard)
+        dims=None,
+        # 3. Figure customization (standard — identical across all methods)
+        figsize=None,
+        plot_collection=None,
+        backend=None,
+        visuals=None,
+        aes_by_visuals=None,
+        # 4. Return control (standard)
+        return_as_pc=False,
+        # 5. PlotCollection kwargs catch-all (standard)
         **pc_kwargs,
-    ) -> tuple[Figure, NDArray[Axes]] | PlotCollection:
+    ):
         ...
 ```
 
@@ -248,6 +358,81 @@ Every method accepts at minimum (see [figure customization design](./2026-03-11-
 |-----------|-----------------|
 | `original_scale` | `True` everywhere (II.2) |
 | `hdi_prob` | `0.94` |
+
+### Examples
+
+**Figsize, domain params, and dimension subsetting:**
+
+`figsize` and `dims` are standard parameters on every method (see
+[Required Parameters](#required-parameters)).
+
+```python
+# figsize replaces the old plt.rcParams["figure.figsize"] global pattern
+fig, axes = mmm.plot.diagnostics.posterior_predictive(figsize=(14, 6))
+
+# Geo-level model: subset to specific markets with dims
+fig, axes = mmm.plot.decomposition.waterfall(
+    dims={"geo": ["CA", "NY"]}, figsize=(12, 8)
+)
+```
+
+**Visual element customization:**
+
+```python
+# Style individual visual elements with backend kwargs
+fig, axes = mmm.plot.diagnostics.posterior_predictive(
+    visuals={
+        "line": {"color": "darkblue", "linewidth": 2},
+        "hdi_band": {"alpha": 0.15},
+        "observed": {"marker": "o", "s": 12, "color": "black"},
+    },
+)
+
+```
+
+**idata override — plot with a different fitted model's data:**
+
+```python
+other_idata: az.InferenceData = other_mmm.idata
+mmm.plot.diagnostics.posterior_predictive(idata=other_idata)
+mmm.plot.decomposition.waterfall(idata=other_idata)
+```
+
+**PlotCollection — compose plots and post-process:**
+
+```python
+from arviz_plots import PlotCollection
+
+# Plot onto a pre-built grid (replaces manual plt.subplots composition)
+pc = PlotCollection.grid(data, cols=["channel"], figsize=(16, 4))
+mmm.plot.sensitivity.analysis(
+    channels=["tv", "radio"], plot_collection=pc)
+
+# Get PlotCollection back for further manipulation
+pc = mmm.plot.sensitivity.analysis(
+    channels=["tv", "radio"], return_as_pc=True
+)
+pc.map("reference_line", hline, y=0, color="red", linestyle="--")
+```
+
+**Backend and layout kwargs:**
+
+```python
+# Render with Plotly instead of matplotlib (requires return_as_pc=True)
+pc = mmm.plot.sensitivity.analysis(
+    channels=["tv", "radio"],
+    backend="plotly",
+    return_as_pc=True,
+)
+
+# pc_kwargs flow through to PlotCollection for layout control
+fig, axes = mmm.plot.sensitivity.analysis(
+    channels=["tv", "radio", "social", "search"],
+    cols=["channel"],
+    col_wrap=2, # <- goes through pc_kwargs
+    figsize=(14, 10),
+)
+```
 
 ### Behavioral Rules
 

--- a/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
+++ b/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
@@ -356,7 +356,9 @@ Every method accepts at minimum (see [figure customization design](./2026-03-11-
 
 | Old name | New name | Reason |
 |----------|----------|--------|
-| `var` (str or list) | `var_names` (list[str]) | ArviZ convention (II.5, #1751) |
+| `var` (predictive methods) | `target_var: str = "y"` | Identifies target variable; not a filter (II.5) |
+| `var` (single posterior selector) | `var_name: str` | Singular; method accepts exactly one variable (II.5) |
+| `var` / `parameter` / `param_name` (multi posterior filter) | `var_names: list[str]` | ArviZ convention; multi-select filter (II.5) |
 | `hdi_probs` (plural, list) | `hdi_prob` (singular, float) | Consistency; single HDI level per call |
 | `figsize: tuple[int, int]` | `figsize: tuple[float, float]` | Consistency across all methods |
 

--- a/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
+++ b/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
@@ -44,7 +44,7 @@ mmm/plotting/
     __init__.py              # re-exports MMMPlotSuite
     _helpers.py              # shared: subplot creation, color mapping, HDI bands, type defs
     suite.py                 # MMMPlotSuite — namespace wrapper with 7 sub-objects
-    time_series.py           # TimeSeriesPlots namespace (4 methods)
+    diagnostics.py           # DiagnosticsPlots namespace (4 methods)
     distributions.py         # DistributionPlots namespace (3 methods)
     saturation.py            # SaturationPlots namespace (2 methods)
     budget.py                # BudgetPlots namespace (2 methods)
@@ -92,7 +92,7 @@ mmm.plot.decomposition.channel_share_hdi()
 class MMMPlotSuite:
     def __init__(self, data: MMMIDataWrapper):
 
-        self.diagnostics = TimeSeriesPlots(data)
+        self.diagnostics = DiagnosticsPlots(data)
         self.distributions = DistributionPlots(data)
         self.saturation = SaturationPlots(data)
         self.budget = BudgetPlots(data)
@@ -191,7 +191,7 @@ Every method accepts at minimum (see [figure customization design](./2026-03-11-
 
 ## Scope Split: Major Release vs Follow-up
 
-### Major Release (28 issues)
+### Major Release (29 issues)
 
 **Breaking API changes:**
 
@@ -201,9 +201,10 @@ Every method accepts at minimum (see [figure customization design](./2026-03-11-
 | I.2 | Constructor accepts None | Require valid `data` (wraps `idata`), fail-fast |
 | II.1 | Return type roulette | Always `tuple[Figure, NDArray[Axes]]` |
 | II.2 | Inconsistent `original_scale` default | `True` everywhere |
-| II.3 | `plt.show()` in methods | Remove; `param_stability` returns all figures |
+| II.3 | `plt.show()` in methods | Remove; `param_stability` uses multi-panel figure instead of per-dim loop |
 | II.5 | Parameter naming inconsistencies | `var_names`, `hdi_prob` singular, `figsize: tuple[float, float]` |
-| — | Drop `saturation_curves_scatter` | Already deprecated |
+| VII.1 | Coord name `x` → `channel` | Rename coordinate in `channel_share_hdi` |
+| — | Remove `saturation_curves_scatter` | Already deprecated; hard removal with no shim (callers get `AttributeError`). Migration guide points to `saturation.scatterplot()` |
 
 **Non-breaking, included during decomposition:**
 
@@ -212,10 +213,12 @@ Every method accepts at minimum (see [figure customization design](./2026-03-11-
 | I.3 | MMMIDataWrapper bypassed | All methods use wrapper |
 | I.4 | Deep nested functions | Extract to module-level or namespace methods |
 | I.5 | No shared color palette | Shared channel→color mapping in `_helpers.py` |
+| I.6 | Duplicated subplot logic / arviz-plots | All methods use `PlotCollection`; bar-plot methods fall back to matplotlib |
 | II.4 | Monkey-patching idata | Pass data as parameter to shared helper |
 | II.6 | No dims filtering on predictive/media | Add `dims` parameter |
-| II.7 | Inconsistent figure customization | `figsize` + `ax` on all methods |
+| II.7 | Inconsistent figure customization | 6 standard params via arviz-plots (see [figure customization design](./2026-03-11-figure-customization-design.md)) |
 | IV.1 | Copy-paste bug in prior_predictive | Fix error messages and docstrings |
+| IV.2 | `plt.gcf()` fragility in `channel_share_hdi` | Replace with explicit figure reference |
 | IV.3 | `_validate_dims` hardcoded to posterior | Validate against correct dataset |
 | IV.4 | color_cycle iteration bug | Reset cycle per panel |
 | IV.5 | title parameter shadowing | Rename local variable |
@@ -250,11 +253,6 @@ Every method accepts at minimum (see [figure customization design](./2026-03-11-
 | VI.1 | Plotting gallery | Documentation |
 | VII.2 | Use `xarray.to_dataframe` more | Internal refactoring |
 | VII.3 | Time-varying media visualization | New feature |
-
-**Note:** VII.1 (coord name `x` → `channel`) is a breaking change and could be
-included in the major release. It is scoped to one method
-(`channel_contribution_share_hdi`) and the fix is trivial. Consider including it
-in the Decomposition namespace PR.
 
 ---
 
@@ -291,7 +289,7 @@ in the Decomposition namespace PR.
 - IV.18 — Add optional parameter to `_compute_residuals`
 - II.5 — `var` → `var_names` (list[str] for both methods)
 - II.6 — Add `dims` parameter
-- II.7 — Add `figsize` + `ax`
+- II.7 — Add 6 standard customization params (arviz-plots)
 
 **LOE:** L (4 methods, establishes the pattern for all subsequent PRs)
 
@@ -307,7 +305,7 @@ in the Decomposition namespace PR.
 **Fixes included:**
 - II.1 — `channel_parameter` currently returns bare `Figure`; fix to standard return
 - IV.15 — Lazy seaborn import (only `posterior_distribution` and `prior_vs_posterior`)
-- II.7 — Add `figsize` + `ax`
+- II.7 — Add 6 standard customization params (arviz-plots)
 
 **LOE:** M
 
@@ -318,7 +316,7 @@ in the Decomposition namespace PR.
 **Methods:**
 - `saturation_scatterplot` → `mmm.plot.saturation.scatterplot()`
 - `saturation_curves` → `mmm.plot.saturation.curves()`
-- Drop `saturation_curves_scatter` (already deprecated)
+- Remove `saturation_curves_scatter` entirely (already deprecated; not carried into new namespace)
 
 **Fixes included:**
 - II.2 — `original_scale` default → `True`
@@ -345,8 +343,7 @@ in the Decomposition namespace PR.
 - IV.14 — Handle multi-axes return from `az.plot_forest`
 - IV.17 — Remove dead `agg` parameter path
 - II.5 — `figsize: tuple[int, int]` → `tuple[float, float]` in waterfall
-
-**Optional:** Include VII.1 (coord `x` → `channel` in `channel_share_hdi`)
+- VII.1 — Rename coord `x` → `channel` in `channel_share_hdi`
 
 **LOE:** L
 
@@ -361,7 +358,7 @@ in the Decomposition namespace PR.
 **Fixes included:**
 - II.1 — Standardize return type
 - IV.9 — kwargs conflict detection
-- II.7 — Consistent `figsize` + `ax`
+- II.7 — Add 6 standard customization params (arviz-plots)
 
 **LOE:** M
 
@@ -394,16 +391,10 @@ in the Decomposition namespace PR.
 
 **Fixes included:**
 - II.3 — Remove all `plt.show()` calls
-- II.3 — `param_stability` returns all figures (not just the last one) — return type becomes `list[tuple[Figure, NDArray[Axes]]]` or a dict keyed by dim value
+- II.3 — `param_stability` combines all dimension values into a single multi-panel figure (one panel per dim value) instead of creating separate figures in a loop. Returns standard `tuple[Figure, NDArray[Axes]]`. Users can subset via `dims` to control figure size.
 - II.1 — Fix `cv_predictions` wrapping axes in list instead of ndarray
 - II.1 — Fix `param_stability` returning single `Axes` instead of `NDArray[Axes]`
 - I.4 — Extract nested functions (`_align_y_to_df`, `_plot_hdi_from_sel`, `_pred_matrix_for_rows`, `_filter_rows_and_y`, `_plot_line`)
-
-**Design decision needed:** `param_stability` currently creates one figure per
-dimension value. Options:
-1. Return `list[tuple[Figure, NDArray[Axes]]]` — one entry per dimension
-2. Return `dict[str, tuple[Figure, NDArray[Axes]]]` — keyed by dim value
-3. Combine all dims into a single multi-panel figure
 
 **LOE:** L
 
@@ -544,7 +535,7 @@ All methods now accept a consistent set of customization parameters
 ## Behavioral Changes
 
 - No method calls `plt.show()` — you control when to display
-- `param_stability` returns all figures, not just the last one
+- `param_stability` combines all dimension values into a single multi-panel figure (use `dims` to subset)
 - Constructor requires valid `data: MMMIDataWrapper` (no more `MMMPlotSuite(idata=None)`)
 - All methods use arviz-plots `PlotCollection` internally
 - Multi-backend support: pass `backend="plotly"` with `return_as_pc=True`
@@ -575,7 +566,7 @@ Every issue from the comprehensive audit mapped to its resolution:
 | II.4 | Monkey-patching idata | Shared helper with data parameter | 7 |
 | II.5 | Parameter naming inconsistencies | `var_names`, `hdi_prob`, `figsize` types | 2–8 |
 | II.6 | No dims filtering | Add `dims` on all methods | 2–8 |
-| II.7 | Inconsistent figure customization | `figsize` + `ax` on all methods | 2–8 |
+| II.7 | Inconsistent figure customization | 6 standard params via arviz-plots (see [figure customization design](./2026-03-11-figure-customization-design.md)) | 2–8 |
 | III.1–III.5 | Missing methods | **Deferred** — follow-up release | — |
 | IV.1 | Copy-paste bug in prior_predictive | Fix messages and docstrings | 2 |
 | IV.2 | `plt.gcf()` fragility | Explicit figure reference | 5 |
@@ -597,6 +588,6 @@ Every issue from the comprehensive audit mapped to its resolution:
 | IV.18 | `_compute_residuals` hardcoded var | Add optional parameter | 2 |
 | V.1–V.5 | Test coverage gaps | **Deferred** (partially addressed in PR 11) | 11 |
 | VI.1 | Plotting gallery | **Deferred** — follow-up release | — |
-| VII.1 | Coord `x` → `channel` | Optional inclusion in PR 5 | 5? |
+| VII.1 | Coord `x` → `channel` | Rename coordinate in `channel_share_hdi` | 5 |
 | VII.2 | Use `xarray.to_dataframe` | **Deferred** — follow-up release | — |
 | VII.3 | Time-varying media visualization | **Deferred** — follow-up release | — |

--- a/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
+++ b/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
@@ -919,7 +919,13 @@ separate `MMMCVPlotSuite`, accessed via `cv.plot`.
 
 | Old | New | Affected methods |
 |-----|-----|-----------------|
-| `var: str` or `var: list[str]` | `var_names: list[str]` | `posterior_predictive`, `prior_predictive` |
+| `var: list[str] \| None` | `target_var: str = "y"` | `posterior_predictive` |
+| `var: str \| None` | `target_var: str = "y"` | `prior_predictive` |
+| `var: str` (required) | `var_name: str` | `posterior_distribution`, `prior_vs_posterior` |
+| `param_name: str` | `var_name: str` | `channel_parameter` |
+| `var: list[str]` (required) | `var_names: list[str]` | `contributions_over_time` |
+| `var: list[str] \| None` | `var_names: list[str] \| None` | `waterfall_components_decomposition` |
+| `parameter: list[str]` | `var_names: list[str]` | `param_stability` |
 | `hdi_probs: list[float]` | `hdi_prob: float` | `transformations.saturation_curves` |
 | `figsize: tuple[int, int]` | `figsize: tuple[float, float]` | `decomposition.waterfall` |
 | `idata: xr.Dataset \| None` (ad-hoc, 2 methods) | `idata: az.InferenceData \| None` (consistent, all data-dependent methods) | All `MMMPlotSuite` methods that access `self._data` |

--- a/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
+++ b/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
@@ -866,7 +866,7 @@ These are resolved in PR 1 (Foundation) and enforced by every subsequent PR:
 | I.6 — arviz-plots adoption | All methods use `PlotCollection` internally; bar-plot methods fall back to matplotlib |
 | II.1 — Standard return type | `tuple[Figure, NDArray[Axes]]` by default; `PlotCollection` opt-in via `return_as_pc=True` |
 | II.2 — `original_scale=True` | Default on every method that exposes the parameter |
-| II.5 — Consistent param names | `var_names`, `hdi_prob`, `figsize: tuple[float, float]` |
+| II.5 — Consistent param names | `target_var` (predictive group methods), `var_name` (single posterior), `var_names` (multi posterior); `hdi_prob`; `figsize: tuple[float, float]` |
 | II.6 — `dims` on all methods | Every method accepts `dims: dict[str, Any] | None` |
 | II.7 — Figure customization | 5 standard params: `figsize`, `backend`, per-element `*_kwargs`, `return_as_pc`, `**pc_kwargs` (see [design](./2026-03-11-figure-customization-design.md)) |
 

--- a/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
+++ b/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
@@ -14,6 +14,7 @@
 - [Decisions](#decisions)
 - [Target Architecture](#target-architecture)
 - [Standardized API Contract](#standardized-api-contract)
+- [Helper Function Removal Plan](#helper-function-removal-plan)
 - [Scope Split: Major Release vs Follow-up](#scope-split-major-release-vs-follow-up)
 - [PR Sequence](#pr-sequence)
 - [Cross-Cutting Concerns](#cross-cutting-concerns)
@@ -26,12 +27,13 @@
 
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
-| Decomposition approach | **D: Namespace Sub-Objects** | Best discoverability (`mmm.plot.sensitivity.analysis()`); aligns with 7 plotting families; each namespace is small and focused |
+| Decomposition approach | **D: Namespace Sub-Objects** | Best discoverability (`mmm.plot.sensitivity.analysis()`); aligns with 6 plotting families; each namespace is small and focused |
+| Suite separation | **Two separate suites: `MMMPlotSuite` + `MMMCVPlotSuite`** | 5 of 20 methods don't need `idata` at all (3 CV + 2 budget). CV methods share zero meaningful code with idata methods — only 4 subplot-plumbing helpers, all of which are replaced by arviz-plots. `mmm.plot` should not expose CV methods; `cv.plot` should not expose model-fit methods. Clean separation of concerns. |
 | arviz-plots adoption | **Included** in major release | Avoids a second breaking change for figure customization; II.7 is solved by exposing arviz-plots' native customization model. See [figure customization design](./2026-03-11-figure-customization-design.md) |
 | Release strategy | **Major release** for breaking changes + decomposition; **follow-up minor releases** for missing features, performance, tests, docs | Keeps the major release focused and reviewable |
 | Backward compatibility | **Hard break** — old method names stop working | Migration guide provides the full old→new mapping; no deprecation shims |
 | PR strategy | **Family-by-family clean rooms** — one PR per namespace, each family is "born clean" | Focused, reviewable PRs (~300–700 lines each); parallelizable across contributors |
-| Namespace constructor arg | **`data: MMMIDataWrapper` only** — no separate `idata` arg | `MMMIDataWrapper` already holds `idata` as a public attribute; passing both creates a redundant access path that undermines I.3 (all access through wrapper). `MMM.plot` already constructs `MMMPlotSuite(data=data)` without a separate `idata`. |
+| Namespace constructor arg | **`data: MMMIDataWrapper` only** — no separate `idata` arg | `MMMIDataWrapper` already holds `idata` as a public attribute; passing both creates a redundant access path that undermines I.3 (all access through wrapper). `MMM.plot` already constructs `MMMPlotSuite(data=data)` without a separate `idata`. Applies only to `MMMPlotSuite` namespaces; `MMMCVPlotSuite` takes no constructor data. |
 
 ---
 
@@ -41,30 +43,23 @@
 
 ```
 mmm/plotting/
-    __init__.py              # re-exports MMMPlotSuite
-    _helpers.py              # shared: subplot creation, color mapping, HDI bands, type defs
-    suite.py                 # MMMPlotSuite — namespace wrapper with 7 sub-objects
+    __init__.py              # re-exports MMMPlotSuite, MMMCVPlotSuite
+    _helpers.py              # shared: _process_plot_params, _extract_matplotlib_result,
+                             #   _validate_dims, channel_color_map
+    suite.py                 # MMMPlotSuite — namespace wrapper with 6 sub-objects
+    cv_suite.py              # MMMCVPlotSuite — 3 flat CV methods, no data dependency
     diagnostics.py           # DiagnosticsPlots namespace (4 methods)
     distributions.py         # DistributionPlots namespace (3 methods)
     saturation.py            # SaturationPlots namespace (2 methods)
     budget.py                # BudgetPlots namespace (2 methods)
     sensitivity.py           # SensitivityPlots namespace (3 methods)
     decomposition.py         # DecompositionPlots namespace (3 methods)
-    cross_validation.py      # CrossValidationPlots namespace (3 methods)
 ```
 
 ### User Experience
 
 ```python
-# Grouped discovery via tab-completion
-mmm.plot.sensitivity.analysis(channels=["tv", "radio"])
-mmm.plot.sensitivity.uplift(channel="tv")
-mmm.plot.sensitivity.marginal(channel="tv")
-
-mmm.plot.cv.predictions(results)
-mmm.plot.cv.param_stability(results)
-mmm.plot.cv.crps(results)
-
+# MMMPlotSuite — model-fit plots (requires fitted model with idata)
 mmm.plot.diagnostics.posterior_predictive(var_names=["y"])
 mmm.plot.diagnostics.prior_predictive(var_names=["y"])
 mmm.plot.diagnostics.residuals()
@@ -80,33 +75,85 @@ mmm.plot.saturation.curves()
 mmm.plot.budget.allocation(samples)
 mmm.plot.budget.contribution_over_time(samples)
 
+mmm.plot.sensitivity.analysis(channels=["tv", "radio"])
+mmm.plot.sensitivity.uplift(channel="tv")
+mmm.plot.sensitivity.marginal(channel="tv")
+
 mmm.plot.decomposition.waterfall()
 mmm.plot.decomposition.contributions_over_time()
 mmm.plot.decomposition.channel_share_hdi()
+
+# MMMCVPlotSuite — cross-validation plots (no model data needed)
+cv.plot.predictions(results)
+cv.plot.param_stability(results)
+cv.plot.crps(results)
 ```
 
-### Suite Wrapper
+### Suite Wrappers
 
 ```python
 # mmm/plotting/suite.py
 class MMMPlotSuite:
+    """Model-fit plotting. Requires valid MMMIDataWrapper."""
     def __init__(self, data: MMMIDataWrapper):
-
         self.diagnostics = DiagnosticsPlots(data)
         self.distributions = DistributionPlots(data)
         self.saturation = SaturationPlots(data)
         self.budget = BudgetPlots(data)
         self.sensitivity = SensitivityPlots(data)
         self.decomposition = DecompositionPlots(data)
-        self.cv = CrossValidationPlots(data)
 ```
 
-> **Design note:** Namespace classes receive only `data: MMMIDataWrapper`, not
-> a separate `idata` argument. The wrapper already holds `idata` as a public
-> attribute (`data.idata`), so passing it separately would create a redundant
-> access path and undermine the rule that all data access goes through the
-> wrapper (I.3). The real-world caller (`MMM.plot`) already constructs
-> `MMMPlotSuite(data=data)` without a separate `idata`.
+```python
+# mmm/plotting/cv_suite.py
+class MMMCVPlotSuite:
+    """Cross-validation plotting. No model data dependency.
+
+    All data comes from the `results` argument on each method —
+    the combined InferenceData returned by TimeSliceCrossValidator.run().
+    """
+    def predictions(self, results: az.InferenceData, ...) -> ...: ...
+    def param_stability(self, results: az.InferenceData, ...) -> ...: ...
+    def crps(self, results: az.InferenceData, ...) -> ...: ...
+```
+
+> **Design note — MMMPlotSuite:** Namespace classes receive only
+> `data: MMMIDataWrapper`, not a separate `idata` argument. The wrapper
+> already holds `idata` as a public attribute (`data.idata`), so passing
+> it separately would create a redundant access path and undermine the
+> rule that all data access goes through the wrapper (I.3).
+>
+> **Design note — MMMCVPlotSuite:** This suite has no constructor data
+> dependency. The 3 CV methods receive all their plotting data via the
+> `results` argument (the combined `InferenceData` from
+> `TimeSliceCrossValidator.run()`). Analysis showed that these methods
+> share zero domain-specific code with the idata-dependent methods — the
+> only overlap was 4 subplot-plumbing helpers, all of which are replaced
+> by arviz-plots' `PlotCollection`.
+>
+> **Design note — Budget methods on MMMPlotSuite:** `budget.allocation()`
+> and `budget.contribution_over_time()` receive external data via their
+> `samples` argument, but budget optimization always occurs in the
+> context of a fitted model, so placing them on `MMMPlotSuite` is
+> contextually correct.
+
+### Caller Integration
+
+```python
+# multidimensional.py — returns MMMPlotSuite (requires fitted model)
+class MMM:
+    @property
+    def plot(self) -> MMMPlotSuite:
+        self._validate_model_was_built()
+        self._validate_idata_exists()
+        return MMMPlotSuite(data=self.data)
+
+# time_slice_cross_validation.py — returns MMMCVPlotSuite (no data needed)
+class TimeSliceCrossValidator:
+    @property
+    def plot(self) -> MMMCVPlotSuite:
+        return MMMCVPlotSuite()
+```
 
 ### Namespace Class Pattern
 
@@ -187,6 +234,78 @@ Every method accepts at minimum (see [figure customization design](./2026-03-11-
 - All methods use `PlotCollection` internally for rendering (I.6)
 - Bar-plot methods that cannot use arviz-plots fall back to matplotlib with the same parameter signature (see [figure customization design](./2026-03-11-figure-customization-design.md#arviz-plots-coverage-gaps))
 
+### MMMCVPlotSuite Contract
+
+`MMMCVPlotSuite` methods follow the same standard customization parameters
+as `MMMPlotSuite` methods (figsize, plot_collection, backend, visuals,
+aes_by_visuals, return_as_pc, **pc_kwargs). Differences:
+
+- No `self._data` — all plotting data comes from the `results` argument
+- `dims` validation runs against the `results` data, not a model's `idata`
+- `_validate_dims` is called as a standalone function from `_helpers.py`,
+  passing the relevant dataset from `results` (not `self.idata.posterior`)
+
+---
+
+## Helper Function Removal Plan
+
+The current `MMMPlotSuite` has ~15 private helper methods. With the move
+to arviz-plots (`PlotCollection`) and the two-suite separation, most
+subplot-scaffolding helpers become redundant. This section maps each
+helper to its fate.
+
+### Helpers replaced by arviz-plots
+
+These helpers exist because the current code manually manages matplotlib
+subplot grids, title generation, and dimension iteration. `PlotCollection`
+handles all of this natively.
+
+| Helper | Current purpose | Replaced by | Removed in PR |
+|--------|----------------|-------------|---------------|
+| `_init_subplots` | `fig, axes = plt.subplots(nrows, ncols, figsize)` with layout math | `PlotCollection.wrap()` / `.grid()` handles subplot creation, layout, and sizing | 2–8 (each family PR drops usage) |
+| `_build_subplot_title` | Builds `"geo=CA, region=West"` from dim names + combo tuple | `PlotCollection.grid(cols=[...], rows=[...])` auto-labels panels from xarray coords | 2–8 |
+| `_dim_list_handler` | Extracts dim keys/values, generates `itertools.product` combinations | `PlotCollection` handles dimension-aware layout natively via xarray coords | 2–8 |
+| `_get_additional_dim_combinations` | Identifies non-standard dims and their cartesian product | Same as `_dim_list_handler` — subsumed by `PlotCollection` dimension handling | 2–8 |
+| `_add_median_and_hdi` | Plots median line + HDI fill_between on an `Axes` | `pc.map("line", ...)` + `pc.map("hdi_band", fill_between_y, ...)` | 2 (diagnostics) |
+
+### Helpers refactored to standalone functions in `_helpers.py`
+
+These helpers perform validation or data manipulation that is independent
+of the plotting library. They move from instance methods on `MMMPlotSuite`
+to standalone functions.
+
+| Helper | Current issue | New form in `_helpers.py` | PR |
+|--------|--------------|--------------------------|-----|
+| `_validate_dims` | Hardcoded to `self.idata.posterior.coords` (IV.3) | `_validate_dims(dataset: xr.Dataset, dims: dict)` — accepts target dataset as parameter. Usable by both suites. | 1 |
+| `_filter_df_by_indexer` | Instance method only used by `cv_predictions` | Module-level function in `cv_suite.py` (CV-specific) | 8 |
+
+### Helpers that stay (data access / computation)
+
+These helpers perform data extraction or computation, not subplot
+scaffolding. They move into their respective namespace classes or into
+`MMMIDataWrapper`.
+
+| Helper | Current purpose | New location | PR |
+|--------|----------------|-------------|-----|
+| `_get_posterior_predictive_data` | Retrieves `posterior_predictive` group | `DiagnosticsPlots` private method or inline (only 2 callers) | 2 |
+| `_get_prior_predictive_data` | Retrieves `prior_predictive` group | `DiagnosticsPlots` private method or inline (only 2 callers) | 2 |
+| `_compute_residuals` | Computes `y_pred - y_obs` (IV.18: hardcoded var) | `DiagnosticsPlots` private method; fix IV.18 | 2 |
+| `_reduce_and_stack` | Sums leftover dims, stacks chain+draw (IV.12: silent sum) | Module-level in `decomposition.py` (only decomposition methods use it); fix IV.12 | 5 |
+| `_spend_or_data_label` | Returns `"spend"` or `"data"` label | Inline in saturation namespace (trivial, 2 callers) | 4 |
+| `_select_channel_x_for_indexers` | Picks spend vs raw channel data | Saturation namespace private method | 4 |
+| `_plot_budget_allocation_bars` | Renders budget bar chart | `BudgetPlots` private method | 6 |
+| `_prepare_allocated_contribution_data` | Extracts allocation data from samples | `BudgetPlots` private method | 6 |
+| `_plot_single_allocated_contribution` | Renders single allocation panel | `BudgetPlots` private method | 6 |
+
+### Summary
+
+| Category | Count | Action |
+|----------|-------|--------|
+| Replaced by arviz-plots | 5 | Delete — `PlotCollection` handles subplot creation, layout, titles, dimension iteration |
+| Refactored to standalone | 2 | Move to `_helpers.py` or `cv_suite.py` as module-level functions |
+| Stay (data/computation) | 9 | Move into respective namespace classes |
+| **Total** | **16** | |
+
 ---
 
 ## Scope Split: Major Release vs Follow-up
@@ -197,8 +316,8 @@ Every method accepts at minimum (see [figure customization design](./2026-03-11-
 
 | ID | Issue | Change |
 |----|-------|--------|
-| I.1 | God class decomposition | 7 namespace sub-objects |
-| I.2 | Constructor accepts None | Require valid `data` (wraps `idata`), fail-fast |
+| I.1 | God class decomposition | 6 namespace sub-objects on `MMMPlotSuite` + separate `MMMCVPlotSuite` |
+| I.2 | Constructor accepts None | `MMMPlotSuite` requires valid `data` (wraps `idata`), fail-fast. `MMMCVPlotSuite` takes no data — methods receive `results` as argument. |
 | II.1 | Return type roulette | Always `tuple[Figure, NDArray[Axes]]` |
 | II.2 | Inconsistent `original_scale` default | `True` everywhere |
 | II.3 | `plt.show()` in methods | Remove; `param_stability` uses multi-panel figure instead of per-dim loop |
@@ -266,9 +385,15 @@ Every method accepts at minimum (see [figure customization design](./2026-03-11-
 - `_process_plot_params()` — validates and normalizes the 6 standard customization params
 - `_extract_matplotlib_result()` — converts `PlotCollection` to `tuple[Figure, NDArray[Axes]]`
 - Shared channel→color mapping (I.5)
-- `_validate_dims` that accepts the target dataset (IV.3)
+- `_validate_dims(dataset, dims)` as standalone function accepting target dataset (IV.3)
 - Contribution variable resolution helper (consolidates 5 strategies)
 - arviz-plots imports and version compatibility checks
+
+**Does NOT include** (see [Helper Function Removal Plan](#helper-function-removal-plan)):
+Old subplot-scaffolding helpers (`_init_subplots`, `_build_subplot_title`,
+`_dim_list_handler`, `_get_additional_dim_combinations`, `_add_median_and_hdi`)
+are not ported — `PlotCollection` replaces all of them. Each family PR
+rewrites its methods using `PlotCollection` directly.
 
 **Resolves:** I.5, I.6 (partially — infrastructure created; each family PR adopts it), IV.3 (partially)
 
@@ -382,33 +507,43 @@ Every method accepts at minimum (see [figure customization design](./2026-03-11-
 
 ---
 
-### PR 8 — Cross-Validation Namespace
+### PR 8 — MMMCVPlotSuite
 
-**Methods:**
-- `cv_predictions` → `mmm.plot.cv.predictions()`
-- `param_stability` → `mmm.plot.cv.param_stability()`
-- `cv_crps` → `mmm.plot.cv.crps()`
+**Content:** `cv_suite.py` — the separate cross-validation plot suite.
+
+**Methods (flat on `MMMCVPlotSuite`, no namespace nesting):**
+- `cv_predictions` → `cv.plot.predictions(results)`
+- `param_stability` → `cv.plot.param_stability(results)`
+- `cv_crps` → `cv.plot.crps(results)`
+
+**Key design points:**
+- `MMMCVPlotSuite` has no constructor data dependency — all plotting data
+  comes from the `results: az.InferenceData` argument on each method
+- `_validate_dims` called as standalone function from `_helpers.py`,
+  passing the relevant dataset from `results` (not `self.idata.posterior`)
+- `_filter_df_by_indexer` moves to `cv_suite.py` as a module-level function
 
 **Fixes included:**
 - II.3 — Remove all `plt.show()` calls
 - II.3 — `param_stability` combines all dimension values into a single multi-panel figure (one panel per dim value) instead of creating separate figures in a loop. Returns standard `tuple[Figure, NDArray[Axes]]`. Users can subset via `dims` to control figure size.
 - II.1 — Fix `cv_predictions` wrapping axes in list instead of ndarray
 - II.1 — Fix `param_stability` returning single `Axes` instead of `NDArray[Axes]`
-- I.4 — Extract nested functions (`_align_y_to_df`, `_plot_hdi_from_sel`, `_pred_matrix_for_rows`, `_filter_rows_and_y`, `_plot_line`)
+- I.4 — Extract nested functions (`_align_y_to_df`, `_plot_hdi_from_sel`, `_pred_matrix_for_rows`, `_filter_rows_and_y`, `_plot_line`) to module-level functions in `cv_suite.py`
 
 **LOE:** L
 
 ---
 
-### PR 9 — Suite Wrapper + Cleanup
+### PR 9 — Suite Wrappers + Cleanup
 
 **Content:**
-- `MMMPlotSuite` class with 7 namespace sub-objects
-- Constructor validation: `data` required, must wrap valid `idata` (I.2)
+- `MMMPlotSuite` class with 6 namespace sub-objects (no CV namespace)
+- `MMMCVPlotSuite` re-exported from `__init__.py`
+- Constructor validation: `MMMPlotSuite(data)` requires valid `MMMIDataWrapper` (I.2)
 - Remove dead `_cache` from `MMMIDataWrapper` (IV.11)
 - Delete old `mmm/plot.py`
-- Update `multidimensional.py` `.plot` property
-- Update `time_slice_cross_validation.py` `.plot` property
+- Update `multidimensional.py` `.plot` property → returns `MMMPlotSuite(data=self.data)`
+- Update `time_slice_cross_validation.py` `.plot` property → returns `MMMCVPlotSuite()`
 - Update all imports across the codebase
 
 **LOE:** M
@@ -445,7 +580,9 @@ These are resolved in PR 1 (Foundation) and enforced by every subsequent PR:
 
 | Concern | Resolution |
 |---------|-----------|
-| I.3 — All methods use `MMMIDataWrapper` | Namespace classes receive only `data: MMMIDataWrapper` (no separate `idata` arg); no raw `self._data.idata.posterior` access |
+| Suite separation | `MMMPlotSuite` for model-fit plots (requires `data`); `MMMCVPlotSuite` for CV plots (stateless). `mmm.plot` returns the former; `cv.plot` returns the latter. No cross-contamination. |
+| Helper removal | 5 subplot-scaffolding helpers (`_init_subplots`, `_build_subplot_title`, `_dim_list_handler`, `_get_additional_dim_combinations`, `_add_median_and_hdi`) are **not ported** — `PlotCollection` replaces them. See [Helper Function Removal Plan](#helper-function-removal-plan). |
+| I.3 — All methods use `MMMIDataWrapper` | `MMMPlotSuite` namespace classes receive only `data: MMMIDataWrapper` (no separate `idata` arg); no raw `self._data.idata.posterior` access. `MMMCVPlotSuite` has no `self._data` at all. |
 | I.4 — No nested functions | Extract to module-level private functions or namespace private methods |
 | I.5 — Shared color palette | `_helpers.channel_color_map(channels)` returns consistent channel→color dict |
 | I.6 — arviz-plots adoption | All methods use `PlotCollection` internally; bar-plot methods fall back to matplotlib |
@@ -464,8 +601,9 @@ These are resolved in PR 1 (Foundation) and enforced by every subsequent PR:
 
 ## Overview
 MMMPlotSuite has been reorganized from a flat API into grouped namespaces
-for better discoverability. All methods are now accessed through family
-sub-objects on `mmm.plot`.
+for better discoverability. Model-fit methods are accessed through family
+sub-objects on `mmm.plot`. Cross-validation methods have moved to a
+separate `MMMCVPlotSuite`, accessed via `cv.plot`.
 
 ## Method Name Mapping
 
@@ -489,9 +627,9 @@ sub-objects on `mmm.plot`.
 | `mmm.plot.sensitivity_analysis()` | `mmm.plot.sensitivity.analysis()` |
 | `mmm.plot.uplift_curve()` | `mmm.plot.sensitivity.uplift()` |
 | `mmm.plot.marginal_curve()` | `mmm.plot.sensitivity.marginal()` |
-| `mmm.plot.cv_predictions()` | `mmm.plot.cv.predictions()` |
-| `mmm.plot.param_stability()` | `mmm.plot.cv.param_stability()` |
-| `mmm.plot.cv_crps()` | `mmm.plot.cv.crps()` |
+| `mmm.plot.cv_predictions()` | `cv.plot.predictions()` (moved to `MMMCVPlotSuite`) |
+| `mmm.plot.param_stability()` | `cv.plot.param_stability()` (moved to `MMMCVPlotSuite`) |
+| `mmm.plot.cv_crps()` | `cv.plot.crps()` (moved to `MMMCVPlotSuite`) |
 
 ## Parameter Changes
 
@@ -536,7 +674,9 @@ All methods now accept a consistent set of customization parameters
 
 - No method calls `plt.show()` — you control when to display
 - `param_stability` combines all dimension values into a single multi-panel figure (use `dims` to subset)
-- Constructor requires valid `data: MMMIDataWrapper` (no more `MMMPlotSuite(idata=None)`)
+- `MMMPlotSuite` constructor requires valid `data: MMMIDataWrapper` (no more `MMMPlotSuite(idata=None)`)
+- CV methods moved to separate `MMMCVPlotSuite` — access via `cv.plot` instead of `mmm.plot`
+- `cv.plot` no longer exposes model-fit methods; `mmm.plot` no longer exposes CV methods
 - All methods use arviz-plots `PlotCollection` internally
 - Multi-backend support: pass `backend="plotly"` with `return_as_pc=True`
 
@@ -544,6 +684,7 @@ All methods now accept a consistent set of customization parameters
 
 - `saturation_curves_scatter` — use `mmm.plot.saturation.scatterplot()` instead
 - `ax` parameter — use `plot_collection` for composing onto existing figures
+- `MMMPlotSuite(idata=None)` pattern — CV methods no longer need it (they live on `MMMCVPlotSuite`)
 ```
 
 ---
@@ -554,15 +695,15 @@ Every issue from the comprehensive audit mapped to its resolution:
 
 | ID | Issue | Resolution | PR |
 |----|-------|-----------|-----|
-| I.1 | God class (5,150 lines) | Decompose into 7 namespace sub-objects | 2–9 |
-| I.2 | Constructor allows invalid state | Require valid `data` (wraps `idata`) | 9 |
+| I.1 | God class (5,150 lines) | Decompose into 6 namespace sub-objects (`MMMPlotSuite`) + separate `MMMCVPlotSuite` (3 methods) | 2–9 |
+| I.2 | Constructor allows invalid state | `MMMPlotSuite` requires valid `data`; `MMMCVPlotSuite` is stateless (no data needed) | 8, 9 |
 | I.3 | MMMIDataWrapper bypassed | All methods use wrapper | 1–8 |
 | I.4 | Deep nested functions | Extract to module-level | 2–8 |
 | I.5 | No shared color palette | `_helpers.channel_color_map()` | 1 |
-| I.6 | Duplicated subplot logic / arviz-plots | All methods use `PlotCollection`; bar-plot methods fall back to matplotlib | 1–8 |
+| I.6 | Duplicated subplot logic / arviz-plots | All methods use `PlotCollection`; bar-plot methods fall back to matplotlib. 5 subplot-scaffolding helpers removed (see [Helper Function Removal Plan](#helper-function-removal-plan)). | 1–8 |
 | II.1 | Return type roulette | `tuple[Figure, NDArray[Axes]]` always | 2–8 |
 | II.2 | Inconsistent `original_scale` default | `True` everywhere | 4 |
-| II.3 | `plt.show()` + figure discarding | Remove; return all figures | 8 |
+| II.3 | `plt.show()` + figure discarding | Remove; return all figures | 8 (MMMCVPlotSuite) |
 | II.4 | Monkey-patching idata | Shared helper with data parameter | 7 |
 | II.5 | Parameter naming inconsistencies | `var_names`, `hdi_prob`, `figsize` types | 2–8 |
 | II.6 | No dims filtering | Add `dims` on all methods | 2–8 |

--- a/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
+++ b/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
@@ -548,7 +548,7 @@ scaffolding. They move into their respective namespace classes or into
 | I.6 | Duplicated subplot logic / arviz-plots | All methods use `PlotCollection`; bar-plot methods fall back to matplotlib |
 | II.4 | Monkey-patching idata | Pass data as parameter to shared helper |
 | II.6 | No dims filtering on predictive/media | Add `dims` parameter |
-| II.7 | Inconsistent figure customization | 6 standard params via arviz-plots (see [figure customization design](./2026-03-11-figure-customization-design.md)) |
+| II.7 | Inconsistent figure customization | 5 standard params on every method: `figsize`, `backend`, per-element `*_kwargs`, `return_as_pc`, `**pc_kwargs` (see [figure customization design](./2026-03-11-figure-customization-design.md)) |
 | IV.1 | Copy-paste bug in prior_predictive | Fix error messages and docstrings |
 | IV.2 | `plt.gcf()` fragility in `channel_share_hdi` | Replace with explicit figure reference |
 | IV.3 | `_validate_dims` hardcoded to posterior | Validate against correct dataset |
@@ -628,10 +628,12 @@ adds parametrized cross-cutting tests that verify the standard API contract
 **Content:** `_helpers.py` with shared infrastructure.
 
 **Includes:**
-- `_process_plot_params()` — validates and normalizes the 6 standard customization params
+- `_process_plot_params(figsize, backend, return_as_pc, **pc_kwargs)` — validates and normalizes the 5 standard customization params
 - `_extract_matplotlib_result()` — converts `PlotCollection` to `tuple[Figure, NDArray[Axes]]`
 - Shared channel→color mapping (I.5)
 - `_validate_dims(dataset, dims)` as standalone function accepting target dataset (IV.3)
+- `_dims_to_sel_kwargs(dataset, dims)` — converts validated `dims` dict to `.sel()` kwargs
+- `_select_dims(data, dims)` — combines validate + convert + `.sel()` in one call; accepts `xr.Dataset` or `xr.DataArray`
 - Contribution variable resolution helper (consolidates 5 strategies)
 - arviz-plots imports and version compatibility checks
 
@@ -660,7 +662,7 @@ rewrites its methods using `PlotCollection` directly.
 - IV.18 — Add optional parameter to `_compute_residuals`
 - II.5 — `var` → `var_names` (list[str] for both methods)
 - II.6 — Add `dims` parameter
-- II.7 — Add 6 standard customization params (arviz-plots)
+- II.7 — Add 5 standard customization params (`figsize`, `backend`, per-element `*_kwargs`, `return_as_pc`, `**pc_kwargs`)
 
 **LOE:** L (4 methods; follows the pattern established by PR 4)
 
@@ -676,7 +678,7 @@ rewrites its methods using `PlotCollection` directly.
 **Fixes included:**
 - II.1 — `channel_parameter` currently returns bare `Figure`; fix to standard return
 - IV.15 — Lazy seaborn import (only `posterior_distribution` and `prior_vs_posterior`)
-- II.7 — Add 6 standard customization params (arviz-plots)
+- II.7 — Add 5 standard customization params (`figsize`, `backend`, per-element `*_kwargs`, `return_as_pc`, `**pc_kwargs`)
 
 **LOE:** M
 
@@ -690,15 +692,17 @@ rewrites its methods using `PlotCollection` directly.
 > copy-able form:
 >
 > 1. Namespace class structure (`class TransformationPlots`, `__init__(self, data)`, `self._data`)
-> 2. Full standard signature (all 6 customization params + `idata` override + `return_as_pc` + `**pc_kwargs`)
-> 3. `data = MMMIDataWrapper(idata) if idata is not None else self._data` resolution at the top of each method
+> 2. Full standard signature: `idata`, `dims`, `figsize`, `backend`, `return_as_pc`, per-element `*_kwargs` (method-specific), `**pc_kwargs`
+> 3. `data = MMMIDataWrapper(idata, schema=self._data.schema) if idata is not None else self._data` resolution at the top of each method
 > 4. `_process_plot_params()` call to validate/normalize params
-> 5. `_validate_dims()` call against the correct dataset
-> 6. `PlotCollection.wrap()` / `.grid()` creation from xarray data
-> 7. `pc.map(...)` for rendering (line + HDI band in `saturation_curves`, scatter in `saturation_scatterplot`)
-> 8. `_extract_matplotlib_result()` conversion to `tuple[Figure, NDArray[Axes]]`
-> 9. All access exclusively through resolved local `data` (no `self._data` after resolution)
-> 10. Test file with return-type checks, axis-count assertions, `dims` filtering, `idata` override, `return_as_pc=True`
+> 5. `_select_dims(data, dims)` call — combined validate + filter in one step
+> 6. `PlotCollection.grid()` or `.wrap()` creation from xarray data — method chooses best fit
+> 7. Native `azp.visuals.*` functions for rendering (`scatter_xy`, `line_xy`, `fill_between_y`, `labelled_*`); custom module-level callbacks only when no native visual exists
+> 8. Per-element `*_kwargs` forwarded directly to the corresponding `azp.visuals.*` call
+> 9. DRY composition via `return_as_pc=True`: `saturation_curves` calls `saturation_scatterplot(return_as_pc=True)` to reuse the scatter layer instead of duplicating setup code
+> 10. `_extract_matplotlib_result()` conversion to `tuple[Figure, NDArray[Axes]]`
+> 11. All access exclusively through resolved local `data` (no `self._data` after resolution)
+> 12. Test file with return-type checks, axis-count assertions, `dims` filtering, `idata` override, `return_as_pc=True`
 
 **Methods:**
 - `saturation_scatterplot` → `mmm.plot.transformations.saturation_scatterplot()`
@@ -707,9 +711,14 @@ rewrites its methods using `PlotCollection` directly.
 
 **Fixes included:**
 - II.2 — `original_scale` default → `True`
-- II.5 — `hdi_probs` → `hdi_prob` (singular, single float)
+- II.5 — `hdi_probs` → `hdi_prob` (singular, single float); `curve` (singular) → `curves` (plural, reflects that the DataArray contains multiple posterior samples)
 - IV.16 — Fix error message formatting (raw `\n`)
 - II.6 — Add channel subsetting via `dims`
+
+**Additional patterns introduced in this PR (available to subsequent family PRs):**
+- `_ensure_chain_draw_dims` — module-level helper in `transformations.py` that normalises curve dimension format: `(chain, draw, ...)` returned as-is; `sample` MultiIndex over `(chain, draw)` unstacked; plain `sample` integer index expanded to `chain=0, draw=0..N-1`. Bridges the gap between `mmm.sample_saturation_curve()` output and the `(chain, draw)` format expected by arviz-plots HDI computation.
+- Mean curve as a dedicated visual layer — `mean_curve_kwargs` parameter renders the posterior mean as a visually prominent solid line, separate from individual sample lines and the HDI band.
+- Scale mismatch warning — heuristic `UserWarning` when `curves.max()` magnitude appears inconsistent with the `original_scale` flag; available as a template for any method accepting externally-scaled data.
 
 **LOE:** M (2 methods; ships first to unblock parallel work on PRs 2, 3, 5, 6, 7)
 
@@ -745,7 +754,7 @@ rewrites its methods using `PlotCollection` directly.
 **Fixes included:**
 - II.1 — Standardize return type
 - IV.9 — kwargs conflict detection
-- II.7 — Add 6 standard customization params (arviz-plots)
+- II.7 — Add 5 standard customization params (`figsize`, `backend`, per-element `*_kwargs`, `return_as_pc`, `**pc_kwargs`)
 
 **LOE:** M
 
@@ -849,7 +858,7 @@ These are resolved in PR 1 (Foundation) and enforced by every subsequent PR:
 |---------|-----------|
 | Suite separation | `MMMPlotSuite` for model-fit plots (requires `data`); `MMMCVPlotSuite` for CV plots (stateless). `mmm.plot` returns the former; `cv.plot` returns the latter. No cross-contamination. |
 | Helper removal | 5 subplot-scaffolding helpers (`_init_subplots`, `_build_subplot_title`, `_dim_list_handler`, `_get_additional_dim_combinations`, `_add_median_and_hdi`) are **not ported** — `PlotCollection` replaces them. See [Helper Function Removal Plan](#helper-function-removal-plan). |
-| I.3 — All methods use `MMMIDataWrapper` | `MMMPlotSuite` namespace classes receive only `data: MMMIDataWrapper` (no separate `idata` arg); no raw `self._data.idata.posterior` access. `MMMCVPlotSuite` has no `self._data` at all. Every data-dependent method accepts `idata: az.InferenceData | None = None` and resolves `data = MMMIDataWrapper(idata) if idata is not None else self._data` — all access goes through the resolved local `data`. |
+| I.3 — All methods use `MMMIDataWrapper` | `MMMPlotSuite` namespace classes receive only `data: MMMIDataWrapper` (no separate `idata` arg); no raw `self._data.idata.posterior` access. `MMMCVPlotSuite` has no `self._data` at all. Every data-dependent method accepts `idata: az.InferenceData | None = None` and resolves `data = MMMIDataWrapper(idata, schema=self._data.schema) if idata is not None else self._data` — all access goes through the resolved local `data`. |
 | I.4 — No nested functions | Extract to module-level private functions or namespace private methods |
 | I.5 — Shared color palette | `_helpers.channel_color_map(channels)` returns consistent channel→color dict |
 | I.6 — arviz-plots adoption | All methods use `PlotCollection` internally; bar-plot methods fall back to matplotlib |
@@ -857,7 +866,7 @@ These are resolved in PR 1 (Foundation) and enforced by every subsequent PR:
 | II.2 — `original_scale=True` | Default on every method that exposes the parameter |
 | II.5 — Consistent param names | `var_names`, `hdi_prob`, `figsize: tuple[float, float]` |
 | II.6 — `dims` on all methods | Every method accepts `dims: dict[str, Any] | None` |
-| II.7 — Figure customization | 6 standard params: `figsize`, `plot_collection`, `backend`, `visuals`, `aes_by_visuals`, `**pc_kwargs` (see [design](./2026-03-11-figure-customization-design.md)) |
+| II.7 — Figure customization | 5 standard params: `figsize`, `backend`, per-element `*_kwargs`, `return_as_pc`, `**pc_kwargs` (see [design](./2026-03-11-figure-customization-design.md)) |
 
 ---
 
@@ -932,11 +941,11 @@ All methods now accept a consistent set of customization parameters
 
 | Old | New | Notes |
 |-----|-----|-------|
-| `ax: plt.Axes` (4 methods) | `plot_collection: PlotCollection` | arviz-plots composability |
-| `**kwargs` (varies) | `visuals: dict` + `**pc_kwargs` | Element-level control via `visuals`; collection-level via `pc_kwargs` |
+| `ax: plt.Axes` (4 methods) | `return_as_pc=True` | Get `PlotCollection` back for post-processing; or use `**pc_kwargs` for layout |
+| `**kwargs` (varies) | per-element `*_kwargs` + `**pc_kwargs` | Element-level control via `scatter_kwargs`, `hdi_kwargs`, etc.; collection-level via `pc_kwargs` |
 | `rc_params` (1 method) | `**pc_kwargs` | Pass as `figure_kwargs` in `pc_kwargs` |
 | `subplot_kwargs` (1 method) | `**pc_kwargs` | Forwarded to `PlotCollection.wrap/grid` |
-| No customization (7 methods) | Full standard params | All methods now have `figsize`, `backend`, `visuals`, etc. |
+| No customization (7 methods) | Full standard params | All methods now have `figsize`, `backend`, per-element `*_kwargs`, etc. |
 
 ## Behavioral Changes
 
@@ -953,7 +962,7 @@ All methods now accept a consistent set of customization parameters
 
 - **Import path changed:** `from pymc_marketing.mmm.plot import MMMPlotSuite` → `from pymc_marketing.mmm.plotting import MMMPlotSuite`. The old `mmm/plot.py` module is replaced with a stub that raises `ImportError` with migration guidance.
 - `saturation_curves_scatter` — use `mmm.plot.transformations.saturation_scatterplot()` instead
-- `ax` parameter — use `plot_collection` for composing onto existing figures
+- `ax` parameter — use `return_as_pc=True` to get a `PlotCollection` back for post-processing
 - `MMMPlotSuite(idata=None)` pattern — CV methods no longer need it (they live on `MMMCVPlotSuite`)
 ```
 
@@ -977,7 +986,7 @@ Every issue from the comprehensive audit mapped to its resolution:
 | II.4 | Monkey-patching idata | Shared helper with data parameter | 7 |
 | II.5 | Parameter naming inconsistencies | `var_names`, `hdi_prob`, `figsize` types | 2–8 |
 | II.6 | No dims filtering | Add `dims` on all methods | 2–8 |
-| II.7 | Inconsistent figure customization | 6 standard params via arviz-plots (see [figure customization design](./2026-03-11-figure-customization-design.md)) | 2–8 |
+| II.7 | Inconsistent figure customization | 5 standard params on every method: `figsize`, `backend`, per-element `*_kwargs`, `return_as_pc`, `**pc_kwargs` (see [figure customization design](./2026-03-11-figure-customization-design.md)) | 2–8 |
 | III.1–III.5 | Missing methods | **Deferred** — follow-up release | — |
 | IV.1 | Copy-paste bug in prior_predictive | Fix messages and docstrings | 2 |
 | IV.2 | `plt.gcf()` fragility | Explicit figure reference | 5 |

--- a/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
+++ b/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
@@ -181,8 +181,8 @@ mmm/plotting/
 
 ```python
 # MMMPlotSuite — model-fit plots (requires fitted model with idata)
-mmm.plot.diagnostics.posterior_predictive(var_names=["y"])
-mmm.plot.diagnostics.prior_predictive(var_names=["y"])
+mmm.plot.diagnostics.posterior_predictive(target_var="y")
+mmm.plot.diagnostics.prior_predictive(target_var="y")
 mmm.plot.diagnostics.residuals()
 mmm.plot.diagnostics.residuals_distribution()
 

--- a/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
+++ b/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
@@ -34,6 +34,7 @@
 | Backward compatibility | **Hard break** — old method names stop working | Migration guide provides the full old→new mapping; no deprecation shims |
 | PR strategy | **Family-by-family clean rooms** — one PR per namespace, each family is "born clean" | Focused, reviewable PRs (~300–700 lines each); parallelizable across contributors |
 | Namespace constructor arg | **`data: MMMIDataWrapper` only** — no separate `idata` arg | `MMMIDataWrapper` already holds `idata` as a public attribute; passing both creates a redundant access path that undermines I.3 (all access through wrapper). `MMM.plot` already constructs `MMMPlotSuite(data=data)` without a separate `idata`. Applies only to `MMMPlotSuite` namespaces; `MMMCVPlotSuite` takes no constructor data. |
+| `MMMPlotlyFactory` | **Out of scope** for this release | The `backend` parameter provides a migration path to Plotly via arviz-plots. Deprecation of `MMMPlotlyFactory` can be evaluated once arviz-plots Plotly support stabilizes. |
 
 ---
 
@@ -377,6 +378,17 @@ scaffolding. They move into their respective namespace classes or into
 
 ## PR Sequence
 
+> **LOE scale:** S (1–4 hours) · M (1–3 days) · L (1–2 weeks).
+> See [comprehensive audit](./2026-03-10-mmmplotsuite-comprehensive-issues.md) for full scale.
+
+**Dependency graph:**
+
+```
+PR 1 (Foundation) → PRs 2–8 (parallelizable, all depend only on PR 1)
+PRs 2–8 → PR 9 (Suite Wrappers, depends on all family PRs)
+PR 9 → PR 10 (Migration Guide) → PR 11 (Test Overhaul)
+```
+
 ### PR 1 — Foundation
 
 **Content:** `_helpers.py` with shared infrastructure.
@@ -541,10 +553,12 @@ rewrites its methods using `PlotCollection` directly.
 - `MMMCVPlotSuite` re-exported from `__init__.py`
 - Constructor validation: `MMMPlotSuite(data)` requires valid `MMMIDataWrapper` (I.2)
 - Remove dead `_cache` from `MMMIDataWrapper` (IV.11)
-- Delete old `mmm/plot.py`
+- Delete old `mmm/plot.py` and replace with a stub that raises `ImportError` with a message:
+  `"MMMPlotSuite has moved to pymc_marketing.mmm.plotting. See the migration guide."`
+  This keeps the hard break but gives users an actionable error instead of a bare `ModuleNotFoundError`.
 - Update `multidimensional.py` `.plot` property → returns `MMMPlotSuite(data=self.data)`
 - Update `time_slice_cross_validation.py` `.plot` property → returns `MMMCVPlotSuite()`
-- Update all imports across the codebase
+- Update all imports across the codebase (including notebooks)
 
 **LOE:** M
 
@@ -682,6 +696,7 @@ All methods now accept a consistent set of customization parameters
 
 ## Removed
 
+- **Import path changed:** `from pymc_marketing.mmm.plot import MMMPlotSuite` → `from pymc_marketing.mmm.plotting import MMMPlotSuite`. The old `mmm/plot.py` module is replaced with a stub that raises `ImportError` with migration guidance.
 - `saturation_curves_scatter` — use `mmm.plot.saturation.scatterplot()` instead
 - `ax` parameter — use `plot_collection` for composing onto existing figures
 - `MMMPlotSuite(idata=None)` pattern — CV methods no longer need it (they live on `MMMCVPlotSuite`)

--- a/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
+++ b/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
@@ -30,9 +30,9 @@
 | Decomposition approach | **D: Namespace Sub-Objects** | Best discoverability (`mmm.plot.sensitivity.analysis()`); aligns with 6 plotting families; each namespace is small and focused |
 | Suite separation | **Two separate suites: `MMMPlotSuite` + `MMMCVPlotSuite`** | 5 of 20 methods don't need `idata` at all (3 CV + 2 budget). CV methods share zero meaningful code with idata methods — only 4 subplot-plumbing helpers, all of which are replaced by arviz-plots. `mmm.plot` should not expose CV methods; `cv.plot` should not expose model-fit methods. Clean separation of concerns. |
 | arviz-plots adoption | **Included** in major release | Avoids a second breaking change for figure customization; II.7 is solved by exposing arviz-plots' native customization model. See [figure customization design](./2026-03-11-figure-customization-design.md) |
-| Release strategy | **Major release** for breaking changes + decomposition; **follow-up minor releases** for missing features, performance, tests, docs | Keeps the major release focused and reviewable |
+| Release strategy | **Major release** for breaking changes + decomposition (each PR ships with tests); **follow-up minor releases** for missing features, performance, edge-case tests, docs | Keeps the major release focused and reviewable; no test debt at ship time |
 | Backward compatibility | **Hard break** — old method names stop working | Migration guide provides the full old→new mapping; no deprecation shims |
-| PR strategy | **Family-by-family clean rooms** — one PR per namespace, each family is "born clean" | Focused, reviewable PRs (~300–700 lines each); parallelizable across contributors |
+| PR strategy | **Family-by-family clean rooms** — one PR per namespace, each family is "born clean" with tests | Focused, reviewable PRs; each ships code + tests together; parallelizable across contributors |
 | Namespace constructor arg | **`data: MMMIDataWrapper` only** — no separate `idata` arg | `MMMIDataWrapper` already holds `idata` as a public attribute; passing both creates a redundant access path that undermines I.3 (all access through wrapper). `MMM.plot` already constructs `MMMPlotSuite(data=data)` without a separate `idata`. Applies only to `MMMPlotSuite` namespaces; `MMMCVPlotSuite` takes no constructor data. |
 | `MMMPlotlyFactory` | **Out of scope** for this release | The `backend` parameter provides a migration path to Plotly via arviz-plots. Deprecation of `MMMPlotlyFactory` can be evaluated once arviz-plots Plotly support stabilizes. |
 
@@ -250,7 +250,7 @@ aes_by_visuals, return_as_pc, **pc_kwargs). Differences:
 
 ## Helper Function Removal Plan
 
-The current `MMMPlotSuite` has ~15 private helper methods. With the move
+The current `MMMPlotSuite` has 16 private helper methods. With the move
 to arviz-plots (`PlotCollection`) and the two-suite separation, most
 subplot-scaffolding helpers become redundant. This section maps each
 helper to its fate.
@@ -365,11 +365,11 @@ scaffolding. They move into their respective namespace classes or into
 | IV.6 | Per-date HDI computation loop | Performance optimization |
 | IV.7 | O(n×m) loop in cv_crps | Performance optimization |
 | IV.10 | Broad exception catching | Behavior change; needs careful rollout |
-| V.1 | Methods with zero tests | Test-only |
-| V.2 | Weak test assertions | Test-only |
-| V.3 | No edge case tests | Test-only |
-| V.4 | Legacy test migration | Test-only |
-| V.5 | Thread-safety tests | Test-only |
+| V.1 | Methods with zero tests | Partially addressed in PRs 2–8 (each ships with tests); follow-up for comprehensive coverage |
+| V.2 | Weak test assertions | Partially addressed in PRs 2–8; follow-up for exhaustive checks |
+| V.3 | No edge case tests | Follow-up: single channel, single geo, missing data, etc. |
+| V.4 | Legacy test migration | Addressed in PR 9 (legacy `test_plotting.py` removal) |
+| V.5 | Thread-safety tests | Follow-up: verify `PlotCollection`-based methods are thread-safe |
 | VI.1 | Plotting gallery | Documentation |
 | VII.2 | Use `xarray.to_dataframe` more | Internal refactoring |
 | VII.3 | Time-varying media visualization | New feature |
@@ -385,9 +385,15 @@ scaffolding. They move into their respective namespace classes or into
 
 ```
 PR 1 (Foundation) → PRs 2–8 (parallelizable, all depend only on PR 1)
-PRs 2–8 → PR 9 (Suite Wrappers, depends on all family PRs)
-PR 9 → PR 10 (Migration Guide) → PR 11 (Test Overhaul)
+PRs 2–8 → PR 9 (Suite Wrappers + Cleanup, depends on all family PRs)
+PR 9 → PR 10 (Migration Guide)
 ```
+
+> **Testing strategy:** Every family PR (2–8) ships with its own tests —
+> return-type checks, axis-count assertions, parameter variations, and
+> basic edge cases. PR 9 removes legacy `test_plotting.py` tests and
+> parametrized cross-cutting  tests that verify the standard API contract
+> (return type, standard params, `dims` filtering) across all namespaces.
 
 ### PR 1 — Foundation
 
@@ -546,7 +552,7 @@ rewrites its methods using `PlotCollection` directly.
 
 ---
 
-### PR 9 — Suite Wrappers + Cleanup
+### PR 9 — Suite Wrappers + Cleanup + Cross-Cutting Tests
 
 **Content:**
 - `MMMPlotSuite` class with 6 namespace sub-objects (no CV namespace)
@@ -559,6 +565,19 @@ rewrites its methods using `PlotCollection` directly.
 - Update `multidimensional.py` `.plot` property → returns `MMMPlotSuite(data=self.data)`
 - Update `time_slice_cross_validation.py` `.plot` property → returns `MMMCVPlotSuite()`
 - Update all imports across the codebase (including notebooks)
+
+**Tests included:**
+- Remove legacy `test_plotting.py` tests that duplicate new coverage
+- Add cross-cutting parametrized tests that verify the standard API contract
+  across all namespaces (unify repeated assertions from PRs 2–8):
+  - `@pytest.mark.parametrize` over all public methods: return type is
+    `tuple[Figure, NDArray[Axes]]`
+  - `@pytest.mark.parametrize` over all public methods: `return_as_pc=True`
+    returns `PlotCollection`
+  - `@pytest.mark.parametrize` over all public methods: `dims` parameter
+    accepted and filters correctly
+  - Constructor validation: `MMMPlotSuite(data=None)` raises (I.2)
+  - Old import path raises `ImportError` with migration message
 
 **LOE:** M
 
@@ -573,18 +592,6 @@ rewrites its methods using `PlotCollection` directly.
 - Removed methods (`saturation_curves_scatter`)
 
 **LOE:** S
-
----
-
-### PR 11 — Test Overhaul
-
-**Content:**
-- Tests for each namespace class
-- Richer assertions (axis labels, titles, legend entries, data values)
-- Edge cases (single channel, single geo, missing data)
-- Remove legacy `test_plotting.py` tests that duplicate new coverage
-
-**LOE:** L
 
 ---
 
@@ -742,7 +749,7 @@ Every issue from the comprehensive audit mapped to its resolution:
 | IV.16 | Error message formatting | Fix raw `\n` | 4 |
 | IV.17 | Dead `agg` parameter | Remove dead code | 5 |
 | IV.18 | `_compute_residuals` hardcoded var | Add optional parameter | 2 |
-| V.1–V.5 | Test coverage gaps | **Deferred** (partially addressed in PR 11) | 11 |
+| V.1–V.5 | Test coverage gaps | Partially addressed: each family PR (2–8) ships with tests; PR 9 removes legacy tests and adds cross-cutting parametrized tests. Follow-up for edge cases (V.3) and thread-safety (V.5). | 2–9 |
 | VI.1 | Plotting gallery | **Deferred** — follow-up release | — |
 | VII.1 | Coord `x` → `channel` | Rename coordinate in `channel_share_hdi` | 5 |
 | VII.2 | Use `xarray.to_dataframe` | **Deferred** — follow-up release | — |

--- a/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
+++ b/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
@@ -28,12 +28,14 @@
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
 | Decomposition approach | **D: Namespace Sub-Objects** | Best discoverability (`mmm.plot.sensitivity.analysis()`); aligns with 6 plotting families; each namespace is small and focused |
+| Transformations namespace | **`transformations` instead of `saturation`** | Saturation and adstock are both channel transformations. Grouping under `transformations` provides a natural home for future adstock plots without another namespace addition. Current saturation methods are prefixed (`saturation_scatterplot`, `saturation_curves`) to stay unambiguous when adstock methods join later. |
 | Suite separation | **Two separate suites: `MMMPlotSuite` + `MMMCVPlotSuite`** | 5 of 20 methods don't need `idata` at all (3 CV + 2 budget). CV methods share zero meaningful code with idata methods — only 4 subplot-plumbing helpers, all of which are replaced by arviz-plots. `mmm.plot` should not expose CV methods; `cv.plot` should not expose model-fit methods. Clean separation of concerns. |
 | arviz-plots adoption | **Included** in major release | Avoids a second breaking change for figure customization; II.7 is solved by exposing arviz-plots' native customization model. See [figure customization design](./2026-03-11-figure-customization-design.md) |
 | Release strategy | **Major release** for breaking changes + decomposition (each PR ships with tests); **follow-up minor releases** for missing features, performance, edge-case tests, docs | Keeps the major release focused and reviewable; no test debt at ship time |
 | Backward compatibility | **Hard break** — old method names stop working | Migration guide provides the full old→new mapping; no deprecation shims |
 | PR strategy | **Family-by-family clean rooms** — one PR per namespace, each family is "born clean" with tests | Focused, reviewable PRs; each ships code + tests together; parallelizable across contributors |
 | Namespace constructor arg | **`data: MMMIDataWrapper` only** — no separate `idata` arg | `MMMIDataWrapper` already holds `idata` as a public attribute; passing both creates a redundant access path that undermines I.3 (all access through wrapper). `MMM.plot` already constructs `MMMPlotSuite(data=data)` without a separate `idata`. Applies only to `MMMPlotSuite` namespaces; `MMMCVPlotSuite` takes no constructor data. |
+| Optional `idata` override on methods | **Every method that accesses `self._data` accepts `idata: az.InferenceData \| None = None`** | Users work with `InferenceData` directly — this is the object they have in hand. When provided, the method constructs `MMMIDataWrapper(idata)` and uses that for all access (both `.idata` and wrapper helpers like `get_channel_spend()`). Makes methods fully reusable with different fitted models without constructing a new suite. Consistent pattern — currently only `posterior_predictive` and `prior_predictive` accept an ad-hoc `idata` override; the rest silently bind to `self._data`. With this decision, all data-dependent methods get the same override. Resolution: `data = MMMIDataWrapper(idata) if idata is not None else self._data`. |
 | `MMMPlotlyFactory` | **Out of scope** for this release | The `backend` parameter provides a migration path to Plotly via arviz-plots. Deprecation of `MMMPlotlyFactory` can be evaluated once arviz-plots Plotly support stabilizes. |
 
 ---
@@ -51,7 +53,7 @@ mmm/plotting/
     cv_suite.py              # MMMCVPlotSuite — 3 flat CV methods, no data dependency
     diagnostics.py           # DiagnosticsPlots namespace (4 methods)
     distributions.py         # DistributionPlots namespace (3 methods)
-    saturation.py            # SaturationPlots namespace (2 methods)
+    transformations.py       # TransformationPlots namespace (2 saturation methods; future home for adstock plots)
     budget.py                # BudgetPlots namespace (2 methods)
     sensitivity.py           # SensitivityPlots namespace (3 methods)
     decomposition.py         # DecompositionPlots namespace (3 methods)
@@ -70,8 +72,8 @@ mmm.plot.distributions.posterior()
 mmm.plot.distributions.channel_parameter()
 mmm.plot.distributions.prior_vs_posterior()
 
-mmm.plot.saturation.scatterplot()
-mmm.plot.saturation.curves()
+mmm.plot.transformations.saturation_scatterplot()
+mmm.plot.transformations.saturation_curves()
 
 mmm.plot.budget.allocation(samples)
 mmm.plot.budget.contribution_over_time(samples)
@@ -88,6 +90,11 @@ mmm.plot.decomposition.channel_share_hdi()
 cv.plot.predictions(results)
 cv.plot.param_stability(results)
 cv.plot.crps(results)
+
+# Optional idata override — use a different fitted model's InferenceData
+other_idata: az.InferenceData = other_mmm.idata
+mmm.plot.diagnostics.posterior_predictive(idata=other_idata)
+mmm.plot.decomposition.waterfall(idata=other_idata)
 ```
 
 ### Suite Wrappers
@@ -99,7 +106,7 @@ class MMMPlotSuite:
     def __init__(self, data: MMMIDataWrapper):
         self.diagnostics = DiagnosticsPlots(data)
         self.distributions = DistributionPlots(data)
-        self.saturation = SaturationPlots(data)
+        self.transformations = TransformationPlots(data)
         self.budget = BudgetPlots(data)
         self.sensitivity = SensitivityPlots(data)
         self.decomposition = DecompositionPlots(data)
@@ -123,6 +130,20 @@ class MMMCVPlotSuite:
 > already holds `idata` as a public attribute (`data.idata`), so passing
 > it separately would create a redundant access path and undermine the
 > rule that all data access goes through the wrapper (I.3).
+>
+> **Design note — method-level `idata` override:** Every method that
+> accesses `self._data` accepts `idata: az.InferenceData | None = None`
+> and resolves `data = MMMIDataWrapper(idata) if idata is not None else self._data`
+> at the top. All subsequent access in the method goes through the resolved
+> local `data` — both `data.idata` and wrapper helpers like
+> `data.get_channel_spend()`. This makes individual methods fully reusable
+> with different fitted models (e.g., comparing two model fits side-by-side)
+> without constructing a new suite instance. Currently only
+> `posterior_predictive` and `prior_predictive` have an ad-hoc `idata`
+> override; this decision standardizes the pattern across all 17
+> data-dependent methods. The parameter is `az.InferenceData` (not
+> `MMMIDataWrapper`) because that is the object users have in hand —
+> the wrapper construction is an internal detail.
 >
 > **Design note — MMMCVPlotSuite:** This suite has no constructor data
 > dependency. The 3 CV methods receive all their plotting data via the
@@ -171,6 +192,7 @@ class SensitivityPlots:
         channels: list[str] | None = None,
         hdi_prob: float = 0.94,
         original_scale: bool = True,
+        idata: az.InferenceData | None = None,
         dims: dict[str, Any] | None = None,
         figsize: tuple[float, float] | None = None,
         plot_collection: PlotCollection | None = None,
@@ -202,6 +224,7 @@ Every method accepts at minimum (see [figure customization design](./2026-03-11-
 
 | Parameter | Type | Default | Notes |
 |-----------|------|---------|-------|
+| `idata` | `az.InferenceData \| None` | `None` | Override instance data; method resolves `data = MMMIDataWrapper(idata) if idata is not None else self._data`. Only on `MMMPlotSuite` methods that access `self._data`. |
 | `dims` | `dict[str, Any] \| None` | `None` | Subset dimensions (e.g., `{"geo": ["CA", "NY"]}`) |
 | `figsize` | `tuple[float, float] \| None` | `None` | Convenience for `figure_kwargs`; ignored with `plot_collection` |
 | `plot_collection` | `PlotCollection \| None` | `None` | Plot onto existing arviz-plots collection |
@@ -234,6 +257,7 @@ Every method accepts at minimum (see [figure customization design](./2026-03-11-
 - All data access goes through `MMMIDataWrapper` methods
 - All methods use `PlotCollection` internally for rendering (I.6)
 - Bar-plot methods that cannot use arviz-plots fall back to matplotlib with the same parameter signature (see [figure customization design](./2026-03-11-figure-customization-design.md#arviz-plots-coverage-gaps))
+- Every method that accesses `self._data` resolves `data = MMMIDataWrapper(idata) if idata is not None else self._data` at the top of the method body. All subsequent access in the method uses the resolved local `data` (both `data.idata` and wrapper helpers like `data.get_channel_spend()`), never `self._data` directly.
 
 ### MMMCVPlotSuite Contract
 
@@ -242,6 +266,7 @@ as `MMMPlotSuite` methods (figsize, plot_collection, backend, visuals,
 aes_by_visuals, return_as_pc, **pc_kwargs). Differences:
 
 - No `self._data` — all plotting data comes from the `results` argument
+- **No `idata` override parameter** — since there is no `self._data`, the `idata` parameter does not apply. CV methods already receive all their data via the `results` argument.
 - `dims` validation runs against the `results` data, not a model's `idata`
 - `_validate_dims` is called as a standalone function from `_helpers.py`,
   passing the relevant dataset from `results` (not `self.idata.posterior`)
@@ -292,8 +317,8 @@ scaffolding. They move into their respective namespace classes or into
 | `_get_prior_predictive_data` | Retrieves `prior_predictive` group | `DiagnosticsPlots` private method or inline (only 2 callers) | 2 |
 | `_compute_residuals` | Computes `y_pred - y_obs` (IV.18: hardcoded var) | `DiagnosticsPlots` private method; fix IV.18 | 2 |
 | `_reduce_and_stack` | Sums leftover dims, stacks chain+draw (IV.12: silent sum) | Module-level in `decomposition.py` (only decomposition methods use it); fix IV.12 | 5 |
-| `_spend_or_data_label` | Returns `"spend"` or `"data"` label | Inline in saturation namespace (trivial, 2 callers) | 4 |
-| `_select_channel_x_for_indexers` | Picks spend vs raw channel data | Saturation namespace private method | 4 |
+| `_spend_or_data_label` | Returns `"spend"` or `"data"` label | Inline in transformations namespace (trivial, 2 callers) | 4 |
+| `_select_channel_x_for_indexers` | Picks spend vs raw channel data | Transformations namespace private method | 4 |
 | `_plot_budget_allocation_bars` | Renders budget bar chart | `BudgetPlots` private method | 6 |
 | `_prepare_allocated_contribution_data` | Extracts allocation data from samples | `BudgetPlots` private method | 6 |
 | `_plot_single_allocated_contribution` | Renders single allocation panel | `BudgetPlots` private method | 6 |
@@ -324,7 +349,7 @@ scaffolding. They move into their respective namespace classes or into
 | II.3 | `plt.show()` in methods | Remove; `param_stability` uses multi-panel figure instead of per-dim loop |
 | II.5 | Parameter naming inconsistencies | `var_names`, `hdi_prob` singular, `figsize: tuple[float, float]` |
 | VII.1 | Coord name `x` → `channel` | Rename coordinate in `channel_share_hdi` |
-| — | Remove `saturation_curves_scatter` | Already deprecated; hard removal with no shim (callers get `AttributeError`). Migration guide points to `saturation.scatterplot()` |
+| — | Remove `saturation_curves_scatter` | Already deprecated; hard removal with no shim (callers get `AttributeError`). Migration guide points to `transformations.saturation_scatterplot()` |
 
 **Non-breaking, included during decomposition:**
 
@@ -384,16 +409,32 @@ scaffolding. They move into their respective namespace classes or into
 **Dependency graph:**
 
 ```
-PR 1 (Foundation) → PRs 2–8 (parallelizable, all depend only on PR 1)
-PRs 2–8 → PR 9 (Suite Wrappers + Cleanup, depends on all family PRs)
-PR 9 → PR 10 (Migration Guide)
+PR 1 (Foundation)
+ ├→ PR 4 (Transformations — template PR, ships first)
+ │   └→ PRs 2, 3, 5, 6, 7 (parallel, follow PR 4's established pattern)
+ ├→ PR 8 (MMMCVPlotSuite — parallel with PR 4; different architecture, no shared template)
+ │
+ All family PRs (2–8) → PR 9 (Suite Wrappers + Cleanup)
+                          └→ PR 10 (Migration Guide)
 ```
 
-> **Testing strategy:** Every family PR (2–8) ships with its own tests —
-> return-type checks, axis-count assertions, parameter variations, and
-> basic edge cases. PR 9 removes legacy `test_plotting.py` tests and
-> parametrized cross-cutting  tests that verify the standard API contract
-> (return type, standard params, `dims` filtering) across all namespaces.
+**Why PR 4 is the template:** One family PR must ship first to prove
+the structural pattern (namespace class, standard params, `PlotCollection`,
+tests) in production code. PR 4 is the best candidate: M LOE (2 methods,
+~471 lines) ships faster than PR 2's L LOE (4 methods, ~512 lines);
+covers both core plot types (line + HDI band, scatter); and has minimal
+domain-specific complications — the work is almost entirely the
+structural pattern itself.
+
+PR 8 (`MMMCVPlotSuite`) is independently parallel because it has a
+fundamentally different architecture — no `self._data`, all plotting
+data arrives via the `results` argument, and it's a separate suite
+class. It doesn't benefit from the same template as PRs 2–7.
+**Testing strategy:** Every family PR (2–8) ships with its own tests —
+return-type checks, axis-count assertions, parameter variations, and
+basic edge cases. PR 9 removes legacy `test_plotting.py` tests and
+adds parametrized cross-cutting tests that verify the standard API contract
+(return type, standard params, `dims` filtering) across all namespaces.
 
 ### PR 1 — Foundation
 
@@ -434,7 +475,7 @@ rewrites its methods using `PlotCollection` directly.
 - II.6 — Add `dims` parameter
 - II.7 — Add 6 standard customization params (arviz-plots)
 
-**LOE:** L (4 methods, establishes the pattern for all subsequent PRs)
+**LOE:** L (4 methods; follows the pattern established by PR 4)
 
 ---
 
@@ -454,11 +495,27 @@ rewrites its methods using `PlotCollection` directly.
 
 ---
 
-### PR 4 — Saturation Namespace
+### PR 4 — Transformations Namespace ⟵ template PR
+
+> **Template role:** This is the first family PR to land. It establishes
+> the concrete reference implementation that PRs 2, 3, 5, 6, 7 follow.
+> The PR must demonstrate every structural pattern in a reviewable,
+> copy-able form:
+>
+> 1. Namespace class structure (`class TransformationPlots`, `__init__(self, data)`, `self._data`)
+> 2. Full standard signature (all 6 customization params + `idata` override + `return_as_pc` + `**pc_kwargs`)
+> 3. `data = MMMIDataWrapper(idata) if idata is not None else self._data` resolution at the top of each method
+> 4. `_process_plot_params()` call to validate/normalize params
+> 5. `_validate_dims()` call against the correct dataset
+> 6. `PlotCollection.wrap()` / `.grid()` creation from xarray data
+> 7. `pc.map(...)` for rendering (line + HDI band in `saturation_curves`, scatter in `saturation_scatterplot`)
+> 8. `_extract_matplotlib_result()` conversion to `tuple[Figure, NDArray[Axes]]`
+> 9. All access exclusively through resolved local `data` (no `self._data` after resolution)
+> 10. Test file with return-type checks, axis-count assertions, `dims` filtering, `idata` override, `return_as_pc=True`
 
 **Methods:**
-- `saturation_scatterplot` → `mmm.plot.saturation.scatterplot()`
-- `saturation_curves` → `mmm.plot.saturation.curves()`
+- `saturation_scatterplot` → `mmm.plot.transformations.saturation_scatterplot()`
+- `saturation_curves` → `mmm.plot.transformations.saturation_curves()`
 - Remove `saturation_curves_scatter` entirely (already deprecated; not carried into new namespace)
 
 **Fixes included:**
@@ -467,7 +524,7 @@ rewrites its methods using `PlotCollection` directly.
 - IV.16 — Fix error message formatting (raw `\n`)
 - II.6 — Add channel subsetting via `dims`
 
-**LOE:** M
+**LOE:** M (2 methods; ships first to unblock parallel work on PRs 2, 3, 5, 6, 7)
 
 ---
 
@@ -576,6 +633,8 @@ rewrites its methods using `PlotCollection` directly.
     returns `PlotCollection`
   - `@pytest.mark.parametrize` over all public methods: `dims` parameter
     accepted and filters correctly
+  - `@pytest.mark.parametrize` over all data-dependent methods: `idata`
+    override accepted and used instead of `self._data`
   - Constructor validation: `MMMPlotSuite(data=None)` raises (I.2)
   - Old import path raises `ImportError` with migration message
 
@@ -603,7 +662,7 @@ These are resolved in PR 1 (Foundation) and enforced by every subsequent PR:
 |---------|-----------|
 | Suite separation | `MMMPlotSuite` for model-fit plots (requires `data`); `MMMCVPlotSuite` for CV plots (stateless). `mmm.plot` returns the former; `cv.plot` returns the latter. No cross-contamination. |
 | Helper removal | 5 subplot-scaffolding helpers (`_init_subplots`, `_build_subplot_title`, `_dim_list_handler`, `_get_additional_dim_combinations`, `_add_median_and_hdi`) are **not ported** — `PlotCollection` replaces them. See [Helper Function Removal Plan](#helper-function-removal-plan). |
-| I.3 — All methods use `MMMIDataWrapper` | `MMMPlotSuite` namespace classes receive only `data: MMMIDataWrapper` (no separate `idata` arg); no raw `self._data.idata.posterior` access. `MMMCVPlotSuite` has no `self._data` at all. |
+| I.3 — All methods use `MMMIDataWrapper` | `MMMPlotSuite` namespace classes receive only `data: MMMIDataWrapper` (no separate `idata` arg); no raw `self._data.idata.posterior` access. `MMMCVPlotSuite` has no `self._data` at all. Every data-dependent method accepts `idata: az.InferenceData | None = None` and resolves `data = MMMIDataWrapper(idata) if idata is not None else self._data` — all access goes through the resolved local `data`. |
 | I.4 — No nested functions | Extract to module-level private functions or namespace private methods |
 | I.5 — Shared color palette | `_helpers.channel_color_map(channels)` returns consistent channel→color dict |
 | I.6 — arviz-plots adoption | All methods use `PlotCollection` internally; bar-plot methods fall back to matplotlib |
@@ -637,9 +696,9 @@ separate `MMMCVPlotSuite`, accessed via `cv.plot`.
 | `mmm.plot.posterior_distribution()` | `mmm.plot.distributions.posterior()` |
 | `mmm.plot.channel_parameter()` | `mmm.plot.distributions.channel_parameter()` |
 | `mmm.plot.prior_vs_posterior()` | `mmm.plot.distributions.prior_vs_posterior()` |
-| `mmm.plot.saturation_scatterplot()` | `mmm.plot.saturation.scatterplot()` |
-| `mmm.plot.saturation_curves()` | `mmm.plot.saturation.curves()` |
-| `mmm.plot.saturation_curves_scatter()` | **Removed** (use `saturation.scatterplot`) |
+| `mmm.plot.saturation_scatterplot()` | `mmm.plot.transformations.saturation_scatterplot()` |
+| `mmm.plot.saturation_curves()` | `mmm.plot.transformations.saturation_curves()` |
+| `mmm.plot.saturation_curves_scatter()` | **Removed** (use `transformations.saturation_scatterplot`) |
 | `mmm.plot.waterfall_components_decomposition()` | `mmm.plot.decomposition.waterfall()` |
 | `mmm.plot.contributions_over_time()` | `mmm.plot.decomposition.contributions_over_time()` |
 | `mmm.plot.channel_contribution_share_hdi()` | `mmm.plot.decomposition.channel_share_hdi()` |
@@ -657,14 +716,15 @@ separate `MMMCVPlotSuite`, accessed via `cv.plot`.
 | Old | New | Affected methods |
 |-----|-----|-----------------|
 | `var: str` or `var: list[str]` | `var_names: list[str]` | `posterior_predictive`, `prior_predictive` |
-| `hdi_probs: list[float]` | `hdi_prob: float` | `saturation.curves` |
+| `hdi_probs: list[float]` | `hdi_prob: float` | `transformations.saturation_curves` |
 | `figsize: tuple[int, int]` | `figsize: tuple[float, float]` | `decomposition.waterfall` |
+| `idata: xr.Dataset \| None` (ad-hoc, 2 methods) | `idata: az.InferenceData \| None` (consistent, all data-dependent methods) | All `MMMPlotSuite` methods that access `self._data` |
 
 ## Default Changes
 
 | Parameter | Old default | New default | Affected methods |
 |-----------|------------|-------------|-----------------|
-| `original_scale` | `False` | `True` | `saturation.scatterplot`, `saturation.curves` |
+| `original_scale` | `False` | `True` | `transformations.saturation_scatterplot`, `transformations.saturation_curves` |
 
 ## Return Type Changes
 
@@ -696,6 +756,7 @@ All methods now accept a consistent set of customization parameters
 - No method calls `plt.show()` — you control when to display
 - `param_stability` combines all dimension values into a single multi-panel figure (use `dims` to subset)
 - `MMMPlotSuite` constructor requires valid `data: MMMIDataWrapper` (no more `MMMPlotSuite(idata=None)`)
+- All data-dependent methods accept `idata: az.InferenceData | None = None` to override instance data (e.g., plot with a different fitted model's InferenceData without constructing a new suite — the wrapper is constructed internally)
 - CV methods moved to separate `MMMCVPlotSuite` — access via `cv.plot` instead of `mmm.plot`
 - `cv.plot` no longer exposes model-fit methods; `mmm.plot` no longer exposes CV methods
 - All methods use arviz-plots `PlotCollection` internally
@@ -704,7 +765,7 @@ All methods now accept a consistent set of customization parameters
 ## Removed
 
 - **Import path changed:** `from pymc_marketing.mmm.plot import MMMPlotSuite` → `from pymc_marketing.mmm.plotting import MMMPlotSuite`. The old `mmm/plot.py` module is replaced with a stub that raises `ImportError` with migration guidance.
-- `saturation_curves_scatter` — use `mmm.plot.saturation.scatterplot()` instead
+- `saturation_curves_scatter` — use `mmm.plot.transformations.saturation_scatterplot()` instead
 - `ax` parameter — use `plot_collection` for composing onto existing figures
 - `MMMPlotSuite(idata=None)` pattern — CV methods no longer need it (they live on `MMMCVPlotSuite`)
 ```

--- a/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
+++ b/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
@@ -998,7 +998,7 @@ Every issue from the comprehensive audit mapped to its resolution:
 | II.2 | Inconsistent `original_scale` default | `True` everywhere | 4 |
 | II.3 | `plt.show()` + figure discarding | Remove; return all figures | 8 (MMMCVPlotSuite) |
 | II.4 | Monkey-patching idata | Shared helper with data parameter | 7 |
-| II.5 | Parameter naming inconsistencies | `var_names`, `hdi_prob`, `figsize` types | 2–8 |
+| II.5 | Parameter naming inconsistencies | `target_var` (predictive), `var_name` (single posterior), `var_names` (multi posterior), `hdi_prob`, `figsize` types | 2, 3, 5, 8 |
 | II.6 | No dims filtering | Add `dims` on all methods | 2–8 |
 | II.7 | Inconsistent figure customization | 5 standard params on every method: `figsize`, `backend`, per-element `*_kwargs`, `return_as_pc`, `**pc_kwargs` (see [figure customization design](./2026-03-11-figure-customization-design.md)) | 2–8 |
 | III.1–III.5 | Missing methods | **Deferred** — follow-up release | — |

--- a/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
+++ b/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
@@ -62,10 +62,13 @@
    `_build_subplot_title`, `_dim_list_handler`, `_get_additional_dim_combinations`,
    `_add_median_and_hdi`). Bundling this with the major release avoids imposing a second
    breaking change later for figure customization. It also solves inconsistent figure
-   customization (issue II.7) by exposing arviz-plots' native customization model: 6
-   standard parameters (`figsize`, `plot_collection`, `backend`, `visuals`,
-   `aes_by_visuals`, `**pc_kwargs`) on every method. Bar-plot methods that cannot use
-   arviz-plots fall back to matplotlib with the same parameter signature.
+   customization (issue II.7) by exposing a consistent customization model: 5
+   standard parameters (`figsize`, `backend`, per-element `*_kwargs`, `return_as_pc`,
+   `**pc_kwargs`) on every method. Each visual element gets its own explicit keyword
+   argument (e.g., `scatter_kwargs`, `hdi_kwargs`, `line_kwargs`) rather than a
+   single opaque `visuals` dict — this makes available kwargs discoverable via IDE
+   autocomplete. Bar-plot methods that cannot use arviz-plots fall back to matplotlib
+   with the same parameter signature.
    See [Helper Function Removal Plan](#helper-function-removal-plan) for what `PlotCollection` replaces.
    Full customization API: [figure customization design](./2026-03-11-figure-customization-design.md).
    Original issues:
@@ -98,15 +101,18 @@
 5. **Every data-dependent method accepts an `idata` override parameter.**
    All 17 `MMMPlotSuite` methods that access `self._data` accept
    `idata: az.InferenceData | None = None`. When provided, the method constructs
-   `MMMIDataWrapper(idata)` and uses that local wrapper for all subsequent access —
-   both `data.idata` and wrapper helpers like `data.get_channel_spend()`. This makes
-   individual methods fully reusable with different fitted models (e.g., comparing two
-   model fits side-by-side) without constructing a new suite instance. The parameter
-   type is `az.InferenceData` (not `MMMIDataWrapper`) because that is the object users
-   have in hand — the wrapper construction is an internal detail. Currently only
-   `posterior_predictive` and `prior_predictive` have an ad-hoc `idata` override; this
-   decision standardizes the pattern across all 17 data-dependent methods. Resolution
-   at the top of every method: `data = MMMIDataWrapper(idata) if idata is not None else self._data`.
+   `MMMIDataWrapper(idata, schema=self._data.schema)` and uses that local wrapper for
+   all subsequent access — both `data.idata` and wrapper helpers like
+   `data.get_channel_spend()`. Schema propagation is required so the override wrapper
+   knows the model's variable naming conventions (e.g., contribution variable names,
+   dimension structure). This makes individual methods fully reusable with different
+   fitted models (e.g., comparing two model fits side-by-side) without constructing a
+   new suite instance. The parameter type is `az.InferenceData` (not `MMMIDataWrapper`)
+   because that is the object users have in hand — the wrapper construction is an
+   internal detail. Currently only `posterior_predictive` and `prior_predictive` have
+   an ad-hoc `idata` override; this decision standardizes the pattern across all 17
+   data-dependent methods. Resolution at the top of every method:
+   `data = MMMIDataWrapper(idata, schema=self._data.schema) if idata is not None else self._data`.
    See [Standardized API Contract](#standardized-api-contract) for the full parameter table,
    [Behavioral Rules](#behavioral-rules) for the resolution pattern,
    and [Namespace Class Pattern](#namespace-class-pattern) for a concrete method signature example.
@@ -157,7 +163,8 @@
 mmm/plotting/
     __init__.py              # re-exports MMMPlotSuite, MMMCVPlotSuite
     _helpers.py              # shared: _process_plot_params, _extract_matplotlib_result,
-                             #   _validate_dims, channel_color_map
+                             #   _validate_dims, _dims_to_sel_kwargs, _select_dims,
+                             #   channel_color_map
     suite.py                 # MMMPlotSuite — namespace wrapper with 6 sub-objects
     cv_suite.py              # MMMCVPlotSuite — 3 flat CV methods, no data dependency
     diagnostics.py           # DiagnosticsPlots namespace (4 methods)
@@ -239,15 +246,16 @@ class MMMCVPlotSuite:
 >
 > **Design note — method-level `idata` override:** Every method that
 > accesses `self._data` accepts `idata: az.InferenceData | None = None`
-> and resolves `data = MMMIDataWrapper(idata) if idata is not None else self._data`
-> at the top. All subsequent access in the method goes through the resolved
-> local `data` — both `data.idata` and wrapper helpers like
-> `data.get_channel_spend()`. This makes individual methods fully reusable
-> with different fitted models (e.g., comparing two model fits side-by-side)
-> without constructing a new suite instance. Currently only
-> `posterior_predictive` and `prior_predictive` have an ad-hoc `idata`
-> override; this decision standardizes the pattern across all 17
-> data-dependent methods. The parameter is `az.InferenceData` (not
+> and resolves `data = MMMIDataWrapper(idata, schema=self._data.schema) if idata is not None else self._data`
+> at the top. Schema propagation is required so the override wrapper knows
+> the model's variable naming conventions. All subsequent access in the
+> method goes through the resolved local `data` — both `data.idata` and
+> wrapper helpers like `data.get_channel_spend()`. This makes individual
+> methods fully reusable with different fitted models (e.g., comparing two
+> model fits side-by-side) without constructing a new suite instance.
+> Currently only `posterior_predictive` and `prior_predictive` have an
+> ad-hoc `idata` override; this decision standardizes the pattern across
+> all 17 data-dependent methods. The parameter is `az.InferenceData` (not
 > `MMMIDataWrapper`) because that is the object users have in hand —
 > the wrapper construction is an internal detail.
 >
@@ -296,6 +304,7 @@ class SomethingPlots:
     def method(
         self,
         # 1. Method-specific data params (varies per method)
+        idata: az.InferenceData | None = None,
         channels=None,
         hdi_prob=0.94,
         original_scale=True,
@@ -303,13 +312,14 @@ class SomethingPlots:
         dims=None,
         # 3. Figure customization (standard — identical across all methods)
         figsize=None,
-        plot_collection=None,
         backend=None,
-        visuals=None,
-        aes_by_visuals=None,
         # 4. Return control (standard)
         return_as_pc=False,
-        # 5. PlotCollection kwargs catch-all (standard)
+        # 5. Per-element visual kwargs (method-specific)
+        scatter_kwargs=None,
+        hdi_kwargs=None,
+        # ... other *_kwargs matching the method's visual elements
+        # 6. PlotCollection kwargs catch-all (standard)
         **pc_kwargs,
     ):
         ...
@@ -334,13 +344,11 @@ Every method accepts at minimum (see [figure customization design](./2026-03-11-
 
 | Parameter | Type | Default | Notes |
 |-----------|------|---------|-------|
-| `idata` | `az.InferenceData \| None` | `None` | Override instance data; method resolves `data = MMMIDataWrapper(idata) if idata is not None else self._data`. Only on `MMMPlotSuite` methods that access `self._data`. |
+| `idata` | `az.InferenceData \| None` | `None` | Override instance data; method resolves `data = MMMIDataWrapper(idata, schema=self._data.schema) if idata is not None else self._data`. Only on `MMMPlotSuite` methods that access `self._data`. |
 | `dims` | `dict[str, Any] \| None` | `None` | Subset dimensions (e.g., `{"geo": ["CA", "NY"]}`) |
-| `figsize` | `tuple[float, float] \| None` | `None` | Convenience for `figure_kwargs`; ignored with `plot_collection` |
-| `plot_collection` | `PlotCollection \| None` | `None` | Plot onto existing arviz-plots collection |
+| `figsize` | `tuple[float, float] \| None` | `None` | Passed to `PlotCollection` figure creation |
 | `backend` | `str \| None` | `None` | `"matplotlib"`, `"plotly"`, `"bokeh"` |
-| `visuals` | `dict[str, Any] \| None` | `None` | Element-level customization (method-specific keys) |
-| `aes_by_visuals` | `dict[str, list[str]] \| None` | `None` | Aesthetic mapping per visual element |
+| `<element>_kwargs` | `dict[str, Any] \| None` | `None` | Per-element visual kwargs — one param per visual element (method-specific names, e.g., `scatter_kwargs`, `hdi_kwargs`, `line_kwargs`). Forwarded directly to the corresponding `azp.visuals.*` call. |
 | `return_as_pc` | `bool` | `False` | Opt-in to `PlotCollection` return |
 | `**pc_kwargs` | | | Forwarded to `PlotCollection.wrap()` or `.grid()` |
 
@@ -379,15 +387,13 @@ fig, axes = mmm.plot.decomposition.waterfall(
 **Visual element customization:**
 
 ```python
-# Style individual visual elements with backend kwargs
+# Style individual visual elements with per-element kwargs
+# Each *_kwargs dict is forwarded directly to the corresponding azp.visuals.* call
 fig, axes = mmm.plot.diagnostics.posterior_predictive(
-    visuals={
-        "line": {"color": "darkblue", "linewidth": 2},
-        "hdi_band": {"alpha": 0.15},
-        "observed": {"marker": "o", "s": 12, "color": "black"},
-    },
+    line_kwargs={"color": "darkblue", "linewidth": 2},
+    hdi_kwargs={"alpha": 0.15},
+    observed_kwargs={"marker": "o", "s": 12, "color": "black"},
 )
-
 ```
 
 **idata override — plot with a different fitted model's data:**
@@ -398,21 +404,14 @@ mmm.plot.diagnostics.posterior_predictive(idata=other_idata)
 mmm.plot.decomposition.waterfall(idata=other_idata)
 ```
 
-**PlotCollection — compose plots and post-process:**
+**PlotCollection — get back for post-processing:**
 
 ```python
-from arviz_plots import PlotCollection
-
-# Plot onto a pre-built grid (replaces manual plt.subplots composition)
-pc = PlotCollection.grid(data, cols=["channel"], figsize=(16, 4))
-mmm.plot.sensitivity.analysis(
-    channels=["tv", "radio"], plot_collection=pc)
-
-# Get PlotCollection back for further manipulation
+# Get PlotCollection back for further manipulation via return_as_pc=True
 pc = mmm.plot.sensitivity.analysis(
     channels=["tv", "radio"], return_as_pc=True
 )
-pc.map("reference_line", hline, y=0, color="red", linestyle="--")
+pc.map(azp.visuals.line_xy, x=reference_x, y=reference_y, color="red", linestyle="--")
 ```
 
 **Backend and layout kwargs:**
@@ -442,13 +441,13 @@ fig, axes = mmm.plot.sensitivity.analysis(
 - All data access goes through `MMMIDataWrapper` methods
 - All methods use `PlotCollection` internally for rendering (I.6)
 - Bar-plot methods that cannot use arviz-plots fall back to matplotlib with the same parameter signature (see [figure customization design](./2026-03-11-figure-customization-design.md#arviz-plots-coverage-gaps))
-- Every method that accesses `self._data` resolves `data = MMMIDataWrapper(idata) if idata is not None else self._data` at the top of the method body. All subsequent access in the method uses the resolved local `data` (both `data.idata` and wrapper helpers like `data.get_channel_spend()`), never `self._data` directly.
+- Every method that accesses `self._data` resolves `data = MMMIDataWrapper(idata, schema=self._data.schema) if idata is not None else self._data` at the top of the method body. All subsequent access in the method uses the resolved local `data` (both `data.idata` and wrapper helpers like `data.get_channel_spend()`), never `self._data` directly.
 
 ### MMMCVPlotSuite Contract
 
 `MMMCVPlotSuite` methods follow the same standard customization parameters
-as `MMMPlotSuite` methods (figsize, plot_collection, backend, visuals,
-aes_by_visuals, return_as_pc, **pc_kwargs). Differences:
+as `MMMPlotSuite` methods (`figsize`, `backend`, per-element `*_kwargs`,
+`return_as_pc`, `**pc_kwargs`). Differences:
 
 - No `self._data` — all plotting data comes from the `results` argument
 - **No `idata` override parameter** — since there is no `self._data`, the `idata` parameter does not apply. CV methods already receive all their data via the `results` argument.
@@ -488,6 +487,8 @@ to standalone functions.
 | Helper | Current issue | New form in `_helpers.py` | PR |
 |--------|--------------|--------------------------|-----|
 | `_validate_dims` | Hardcoded to `self.idata.posterior.coords` (IV.3) | `_validate_dims(dataset: xr.Dataset, dims: dict)` — accepts target dataset as parameter. Usable by both suites. | 1 |
+| `_dims_to_sel_kwargs` | Not present | New: converts validated `dims` dict to `.sel()` kwargs. Can be used independently when only the conversion step is needed. | 1 |
+| `_select_dims` | Not present | New: combines `_validate_dims` + `_dims_to_sel_kwargs` + `.sel()` into a single call. Accepts both `xr.Dataset` and `xr.DataArray`. Use `_select_dims(data, dims)` instead of the three-step pattern. | 1 |
 | `_filter_df_by_indexer` | Instance method only used by `cv_predictions` | Module-level function in `cv_suite.py` (CV-specific) | 8 |
 
 ### Helpers that stay (data access / computation)
@@ -515,7 +516,8 @@ scaffolding. They move into their respective namespace classes or into
 | Replaced by arviz-plots | 5 | Delete — `PlotCollection` handles subplot creation, layout, titles, dimension iteration |
 | Refactored to standalone | 2 | Move to `_helpers.py` or `cv_suite.py` as module-level functions |
 | Stay (data/computation) | 9 | Move into respective namespace classes |
-| **Total** | **16** | |
+| **Total (existing helpers)** | **16** | |
+| New standalone functions (PR 1) | 2 | `_dims_to_sel_kwargs`, `_select_dims` — new functions added to `_helpers.py` |
 
 ---
 

--- a/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
+++ b/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
@@ -807,6 +807,7 @@ rewrites its methods using `PlotCollection` directly.
 - II.1 — Fix `cv_predictions` wrapping axes in list instead of ndarray
 - II.1 — Fix `param_stability` returning single `Axes` instead of `NDArray[Axes]`
 - I.4 — Extract nested functions (`_align_y_to_df`, `_plot_hdi_from_sel`, `_pred_matrix_for_rows`, `_filter_rows_and_y`, `_plot_line`) to module-level functions in `cv_suite.py`
+- II.5 — `parameter: list[str]` → `var_names: list[str]` in `param_stability`
 
 **LOE:** L
 

--- a/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
+++ b/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
@@ -682,6 +682,8 @@ rewrites its methods using `PlotCollection` directly.
 - II.1 — `channel_parameter` currently returns bare `Figure`; fix to standard return
 - IV.15 — Lazy seaborn import (only `posterior_distribution` and `prior_vs_posterior`)
 - II.7 — Add 5 standard customization params (`figsize`, `backend`, per-element `*_kwargs`, `return_as_pc`, `**pc_kwargs`)
+- II.5 — `var: str` → `var_name: str` in `posterior_distribution` and `prior_vs_posterior`;
+         `param_name: str` → `var_name: str` in `channel_parameter`
 
 **LOE:** M
 

--- a/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
+++ b/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
@@ -744,6 +744,8 @@ rewrites its methods using `PlotCollection` directly.
 - IV.14 — Handle multi-axes return from `az.plot_forest`
 - IV.17 — Remove dead `agg` parameter path
 - II.5 — `figsize: tuple[int, int]` → `tuple[float, float]` in waterfall
+- II.5 — `var: list[str] | None` → `var_names: list[str] | None` in `waterfall_components_decomposition`;
+         `var: list[str]` → `var_names: list[str]` in `contributions_over_time`
 - VII.1 — Rename coord `x` → `channel` in `channel_share_hdi`
 
 **LOE:** L

--- a/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
+++ b/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
@@ -662,7 +662,8 @@ rewrites its methods using `PlotCollection` directly.
 **Fixes included:**
 - IV.1 — Copy-paste bug (wrong error messages in prior_predictive)
 - IV.18 — Add optional parameter to `_compute_residuals`
-- II.5 — `var` → `var_names` (list[str] for both methods)
+- II.5 — `var` → `target_var: str = "y"` for `posterior_predictive` and `prior_predictive`;
+         tighten `posterior_predictive` from `list[str] | None` to `str`
 - II.6 — Add `dims` parameter
 - II.7 — Add 5 standard customization params (`figsize`, `backend`, per-element `*_kwargs`, `return_as_pc`, `**pc_kwargs`)
 

--- a/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
+++ b/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
@@ -536,7 +536,7 @@ scaffolding. They move into their respective namespace classes or into
 | II.1 | Return type roulette | Always `tuple[Figure, NDArray[Axes]]` |
 | II.2 | Inconsistent `original_scale` default | `True` everywhere |
 | II.3 | `plt.show()` in methods | Remove; `param_stability` uses multi-panel figure instead of per-dim loop |
-| II.5 | Parameter naming inconsistencies | `var_names`, `hdi_prob` singular, `figsize: tuple[float, float]` |
+| II.5 | Parameter naming inconsistencies | `target_var` (predictive), `var_name` (single posterior), `var_names` (multi posterior); `hdi_prob` singular; `figsize: tuple[float, float]` |
 | VII.1 | Coord name `x` → `channel` | Rename coordinate in `channel_share_hdi` |
 | — | Remove `saturation_curves_scatter` | Already deprecated; hard removal with no shim (callers get `AttributeError`). Migration guide points to `transformations.saturation_scatterplot()` |
 

--- a/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
+++ b/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md
@@ -1,0 +1,602 @@
+# MMMPlotSuite v2 — Attack Plan Design
+
+> Design document for the major-release rewrite of `MMMPlotSuite`.
+> Addresses 29 of the 45 issues identified in the
+> [comprehensive audit](./2026-03-10-mmmplotsuite-comprehensive-issues.md).
+> The remaining 16 issues ship in follow-up minor releases.
+>
+> Prepared 2026-03-11.
+
+---
+
+## Table of Contents
+
+- [Decisions](#decisions)
+- [Target Architecture](#target-architecture)
+- [Standardized API Contract](#standardized-api-contract)
+- [Scope Split: Major Release vs Follow-up](#scope-split-major-release-vs-follow-up)
+- [PR Sequence](#pr-sequence)
+- [Cross-Cutting Concerns](#cross-cutting-concerns)
+- [Migration Guide Outline](#migration-guide-outline)
+- [Issue Traceability](#issue-traceability)
+
+---
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Decomposition approach | **D: Namespace Sub-Objects** | Best discoverability (`mmm.plot.sensitivity.analysis()`); aligns with 7 plotting families; each namespace is small and focused |
+| arviz-plots adoption | **Included** in major release | Avoids a second breaking change for figure customization; II.7 is solved by exposing arviz-plots' native customization model. See [figure customization design](./2026-03-11-figure-customization-design.md) |
+| Release strategy | **Major release** for breaking changes + decomposition; **follow-up minor releases** for missing features, performance, tests, docs | Keeps the major release focused and reviewable |
+| Backward compatibility | **Hard break** — old method names stop working | Migration guide provides the full old→new mapping; no deprecation shims |
+| PR strategy | **Family-by-family clean rooms** — one PR per namespace, each family is "born clean" | Focused, reviewable PRs (~300–700 lines each); parallelizable across contributors |
+| Namespace constructor arg | **`data: MMMIDataWrapper` only** — no separate `idata` arg | `MMMIDataWrapper` already holds `idata` as a public attribute; passing both creates a redundant access path that undermines I.3 (all access through wrapper). `MMM.plot` already constructs `MMMPlotSuite(data=data)` without a separate `idata`. |
+
+---
+
+## Target Architecture
+
+### File Layout
+
+```
+mmm/plotting/
+    __init__.py              # re-exports MMMPlotSuite
+    _helpers.py              # shared: subplot creation, color mapping, HDI bands, type defs
+    suite.py                 # MMMPlotSuite — namespace wrapper with 7 sub-objects
+    time_series.py           # TimeSeriesPlots namespace (4 methods)
+    distributions.py         # DistributionPlots namespace (3 methods)
+    saturation.py            # SaturationPlots namespace (2 methods)
+    budget.py                # BudgetPlots namespace (2 methods)
+    sensitivity.py           # SensitivityPlots namespace (3 methods)
+    decomposition.py         # DecompositionPlots namespace (3 methods)
+    cross_validation.py      # CrossValidationPlots namespace (3 methods)
+```
+
+### User Experience
+
+```python
+# Grouped discovery via tab-completion
+mmm.plot.sensitivity.analysis(channels=["tv", "radio"])
+mmm.plot.sensitivity.uplift(channel="tv")
+mmm.plot.sensitivity.marginal(channel="tv")
+
+mmm.plot.cv.predictions(results)
+mmm.plot.cv.param_stability(results)
+mmm.plot.cv.crps(results)
+
+mmm.plot.diagnostics.posterior_predictive(var_names=["y"])
+mmm.plot.diagnostics.prior_predictive(var_names=["y"])
+mmm.plot.diagnostics.residuals()
+mmm.plot.diagnostics.residuals_distribution()
+
+mmm.plot.distributions.posterior()
+mmm.plot.distributions.channel_parameter()
+mmm.plot.distributions.prior_vs_posterior()
+
+mmm.plot.saturation.scatterplot()
+mmm.plot.saturation.curves()
+
+mmm.plot.budget.allocation(samples)
+mmm.plot.budget.contribution_over_time(samples)
+
+mmm.plot.decomposition.waterfall()
+mmm.plot.decomposition.contributions_over_time()
+mmm.plot.decomposition.channel_share_hdi()
+```
+
+### Suite Wrapper
+
+```python
+# mmm/plotting/suite.py
+class MMMPlotSuite:
+    def __init__(self, data: MMMIDataWrapper):
+
+        self.diagnostics = TimeSeriesPlots(data)
+        self.distributions = DistributionPlots(data)
+        self.saturation = SaturationPlots(data)
+        self.budget = BudgetPlots(data)
+        self.sensitivity = SensitivityPlots(data)
+        self.decomposition = DecompositionPlots(data)
+        self.cv = CrossValidationPlots(data)
+```
+
+> **Design note:** Namespace classes receive only `data: MMMIDataWrapper`, not
+> a separate `idata` argument. The wrapper already holds `idata` as a public
+> attribute (`data.idata`), so passing it separately would create a redundant
+> access path and undermine the rule that all data access goes through the
+> wrapper (I.3). The real-world caller (`MMM.plot`) already constructs
+> `MMMPlotSuite(data=data)` without a separate `idata`.
+
+### Namespace Class Pattern
+
+Each namespace follows the same structure (see [figure customization design](./2026-03-11-figure-customization-design.md)):
+
+```python
+# mmm/plotting/sensitivity.py
+class SensitivityPlots:
+    def __init__(self, data: MMMIDataWrapper):
+        self._data = data
+
+    def analysis(
+        self,
+        channels: list[str] | None = None,
+        hdi_prob: float = 0.94,
+        original_scale: bool = True,
+        dims: dict[str, Any] | None = None,
+        figsize: tuple[float, float] | None = None,
+        plot_collection: PlotCollection | None = None,
+        backend: str | None = None,
+        visuals: dict[str, Any] | None = None,
+        aes_by_visuals: dict[str, list[str]] | None = None,
+        return_as_pc: bool = False,
+        **pc_kwargs,
+    ) -> tuple[Figure, NDArray[Axes]] | PlotCollection:
+        ...
+```
+
+---
+
+## Standardized API Contract
+
+Every public method in every namespace must follow these rules. These resolve
+issues II.1, II.2, II.5, II.6, and II.7.
+
+### Return Type
+
+`tuple[Figure, NDArray[Axes]]` by default. When `return_as_pc=True`, returns
+`PlotCollection` for full arviz-plots composability. Even single-axes methods
+wrap the axes in a 1-element ndarray when returning the tuple form.
+
+### Required Parameters
+
+Every method accepts at minimum (see [figure customization design](./2026-03-11-figure-customization-design.md) for full details):
+
+| Parameter | Type | Default | Notes |
+|-----------|------|---------|-------|
+| `dims` | `dict[str, Any] \| None` | `None` | Subset dimensions (e.g., `{"geo": ["CA", "NY"]}`) |
+| `figsize` | `tuple[float, float] \| None` | `None` | Convenience for `figure_kwargs`; ignored with `plot_collection` |
+| `plot_collection` | `PlotCollection \| None` | `None` | Plot onto existing arviz-plots collection |
+| `backend` | `str \| None` | `None` | `"matplotlib"`, `"plotly"`, `"bokeh"` |
+| `visuals` | `dict[str, Any] \| None` | `None` | Element-level customization (method-specific keys) |
+| `aes_by_visuals` | `dict[str, list[str]] \| None` | `None` | Aesthetic mapping per visual element |
+| `return_as_pc` | `bool` | `False` | Opt-in to `PlotCollection` return |
+| `**pc_kwargs` | | | Forwarded to `PlotCollection.wrap()` or `.grid()` |
+
+### Naming Conventions
+
+| Old name | New name | Reason |
+|----------|----------|--------|
+| `var` (str or list) | `var_names` (list[str]) | ArviZ convention (II.5, #1751) |
+| `hdi_probs` (plural, list) | `hdi_prob` (singular, float) | Consistency; single HDI level per call |
+| `figsize: tuple[int, int]` | `figsize: tuple[float, float]` | Consistency across all methods |
+
+### Defaults
+
+| Parameter | Standard default |
+|-----------|-----------------|
+| `original_scale` | `True` everywhere (II.2) |
+| `hdi_prob` | `0.94` |
+
+### Behavioral Rules
+
+- No method calls `plt.show()` (II.3)
+- No method monkey-patches `self._data.idata` (II.4)
+- No method bypasses `self._data` to access raw `self._data.idata.posterior` etc. (I.3)
+- All data access goes through `MMMIDataWrapper` methods
+- All methods use `PlotCollection` internally for rendering (I.6)
+- Bar-plot methods that cannot use arviz-plots fall back to matplotlib with the same parameter signature (see [figure customization design](./2026-03-11-figure-customization-design.md#arviz-plots-coverage-gaps))
+
+---
+
+## Scope Split: Major Release vs Follow-up
+
+### Major Release (28 issues)
+
+**Breaking API changes:**
+
+| ID | Issue | Change |
+|----|-------|--------|
+| I.1 | God class decomposition | 7 namespace sub-objects |
+| I.2 | Constructor accepts None | Require valid `data` (wraps `idata`), fail-fast |
+| II.1 | Return type roulette | Always `tuple[Figure, NDArray[Axes]]` |
+| II.2 | Inconsistent `original_scale` default | `True` everywhere |
+| II.3 | `plt.show()` in methods | Remove; `param_stability` returns all figures |
+| II.5 | Parameter naming inconsistencies | `var_names`, `hdi_prob` singular, `figsize: tuple[float, float]` |
+| — | Drop `saturation_curves_scatter` | Already deprecated |
+
+**Non-breaking, included during decomposition:**
+
+| ID | Issue | Change |
+|----|-------|--------|
+| I.3 | MMMIDataWrapper bypassed | All methods use wrapper |
+| I.4 | Deep nested functions | Extract to module-level or namespace methods |
+| I.5 | No shared color palette | Shared channel→color mapping in `_helpers.py` |
+| II.4 | Monkey-patching idata | Pass data as parameter to shared helper |
+| II.6 | No dims filtering on predictive/media | Add `dims` parameter |
+| II.7 | Inconsistent figure customization | `figsize` + `ax` on all methods |
+| IV.1 | Copy-paste bug in prior_predictive | Fix error messages and docstrings |
+| IV.3 | `_validate_dims` hardcoded to posterior | Validate against correct dataset |
+| IV.4 | color_cycle iteration bug | Reset cycle per panel |
+| IV.5 | title parameter shadowing | Rename local variable |
+| IV.8 | Index-as-coordinate bug in waterfall | Use positional index |
+| IV.9 | `**kwargs` + `**subplot_kwargs` conflict | Merge with conflict detection |
+| IV.11 | Dead `_cache` in MMMIDataWrapper | Remove |
+| IV.12 | `_reduce_and_stack` silent sum | Add warning for unknown dimensions |
+| IV.13 | Redundant local imports | Remove |
+| IV.14 | `ax` unpacking fragility | Handle multi-axes return |
+| IV.15 | Seaborn dependency for 2 methods | Convert to lazy import |
+| IV.16 | Error message formatting | Fix raw `\n` in f-strings |
+| IV.17 | Dead `agg` parameter path | Remove dead code |
+| IV.18 | `_compute_residuals` hardcoded var | Add optional parameter |
+
+### Follow-up Minor Releases (16 issues)
+
+| ID | Issue | Why deferred |
+|----|-------|-------------|
+| III.1 | Four legacy methods not in suite | Additive feature |
+| III.2 | Gradient/HDI bands for posterior predictive | Additive enhancement (may already be done) |
+| III.3 | Aggregated channel contributions | Additive option |
+| III.4 | Out-of-sample plotting | New method |
+| III.5 | Parametric fit overlay on saturation scatter | Additive feature |
+| IV.6 | Per-date HDI computation loop | Performance optimization |
+| IV.7 | O(n×m) loop in cv_crps | Performance optimization |
+| IV.10 | Broad exception catching | Behavior change; needs careful rollout |
+| V.1 | Methods with zero tests | Test-only |
+| V.2 | Weak test assertions | Test-only |
+| V.3 | No edge case tests | Test-only |
+| V.4 | Legacy test migration | Test-only |
+| V.5 | Thread-safety tests | Test-only |
+| VI.1 | Plotting gallery | Documentation |
+| VII.2 | Use `xarray.to_dataframe` more | Internal refactoring |
+| VII.3 | Time-varying media visualization | New feature |
+
+**Note:** VII.1 (coord name `x` → `channel`) is a breaking change and could be
+included in the major release. It is scoped to one method
+(`channel_contribution_share_hdi`) and the fix is trivial. Consider including it
+in the Decomposition namespace PR.
+
+---
+
+## PR Sequence
+
+### PR 1 — Foundation
+
+**Content:** `_helpers.py` with shared infrastructure.
+
+**Includes:**
+- `_process_plot_params()` — validates and normalizes the 6 standard customization params
+- `_extract_matplotlib_result()` — converts `PlotCollection` to `tuple[Figure, NDArray[Axes]]`
+- Shared channel→color mapping (I.5)
+- `_validate_dims` that accepts the target dataset (IV.3)
+- Contribution variable resolution helper (consolidates 5 strategies)
+- arviz-plots imports and version compatibility checks
+
+**Resolves:** I.5, I.6 (partially — infrastructure created; each family PR adopts it), IV.3 (partially)
+
+**LOE:** L
+
+---
+
+### PR 2 — Time-Series Namespace (`diagnostics`)
+
+**Methods:**
+- `posterior_predictive` → `mmm.plot.diagnostics.posterior_predictive()`
+- `prior_predictive` → `mmm.plot.diagnostics.prior_predictive()`
+- `residuals_over_time` → `mmm.plot.diagnostics.residuals()`
+- `residuals_posterior_distribution` → `mmm.plot.diagnostics.residuals_distribution()`
+
+**Fixes included:**
+- IV.1 — Copy-paste bug (wrong error messages in prior_predictive)
+- IV.18 — Add optional parameter to `_compute_residuals`
+- II.5 — `var` → `var_names` (list[str] for both methods)
+- II.6 — Add `dims` parameter
+- II.7 — Add `figsize` + `ax`
+
+**LOE:** L (4 methods, establishes the pattern for all subsequent PRs)
+
+---
+
+### PR 3 — Distributions Namespace
+
+**Methods:**
+- `posterior_distribution` → `mmm.plot.distributions.posterior()`
+- `channel_parameter` → `mmm.plot.distributions.channel_parameter()`
+- `prior_vs_posterior` → `mmm.plot.distributions.prior_vs_posterior()`
+
+**Fixes included:**
+- II.1 — `channel_parameter` currently returns bare `Figure`; fix to standard return
+- IV.15 — Lazy seaborn import (only `posterior_distribution` and `prior_vs_posterior`)
+- II.7 — Add `figsize` + `ax`
+
+**LOE:** M
+
+---
+
+### PR 4 — Saturation Namespace
+
+**Methods:**
+- `saturation_scatterplot` → `mmm.plot.saturation.scatterplot()`
+- `saturation_curves` → `mmm.plot.saturation.curves()`
+- Drop `saturation_curves_scatter` (already deprecated)
+
+**Fixes included:**
+- II.2 — `original_scale` default → `True`
+- II.5 — `hdi_probs` → `hdi_prob` (singular, single float)
+- IV.16 — Fix error message formatting (raw `\n`)
+- II.6 — Add channel subsetting via `dims`
+
+**LOE:** M
+
+---
+
+### PR 5 — Decomposition Namespace
+
+**Methods:**
+- `waterfall_components_decomposition` → `mmm.plot.decomposition.waterfall()`
+- `contributions_over_time` → `mmm.plot.decomposition.contributions_over_time()`
+- `channel_contribution_share_hdi` → `mmm.plot.decomposition.channel_share_hdi()`
+
+**Fixes included:**
+- IV.2 — Replace `plt.gcf()` with explicit figure reference
+- IV.8 — Fix index-as-coordinate bug in waterfall
+- IV.9 — Merge kwargs with conflict detection
+- IV.12 — Add warning when `_reduce_and_stack` sums unknown dims
+- IV.14 — Handle multi-axes return from `az.plot_forest`
+- IV.17 — Remove dead `agg` parameter path
+- II.5 — `figsize: tuple[int, int]` → `tuple[float, float]` in waterfall
+
+**Optional:** Include VII.1 (coord `x` → `channel` in `channel_share_hdi`)
+
+**LOE:** L
+
+---
+
+### PR 6 — Budget Namespace
+
+**Methods:**
+- `budget_allocation` → `mmm.plot.budget.allocation()`
+- `allocated_contribution_by_channel_over_time` → `mmm.plot.budget.contribution_over_time()`
+
+**Fixes included:**
+- II.1 — Standardize return type
+- IV.9 — kwargs conflict detection
+- II.7 — Consistent `figsize` + `ax`
+
+**LOE:** M
+
+---
+
+### PR 7 — Sensitivity Namespace
+
+**Methods:**
+- `sensitivity_analysis` → `mmm.plot.sensitivity.analysis()`
+- `uplift_curve` → `mmm.plot.sensitivity.uplift()`
+- `marginal_curve` → `mmm.plot.sensitivity.marginal()`
+
+**Fixes included:**
+- II.4 — Replace monkey-patching with shared `_sensitivity_plot()` helper that accepts data as parameter
+- IV.4 — Reset color cycle per panel
+- IV.5 — Rename local `title` variable to avoid shadowing parameter
+- IV.13 — Remove redundant `import warnings`
+- II.1 — Return `tuple[Figure, NDArray[Axes]]` always (not bare `Axes`)
+
+**LOE:** L
+
+---
+
+### PR 8 — Cross-Validation Namespace
+
+**Methods:**
+- `cv_predictions` → `mmm.plot.cv.predictions()`
+- `param_stability` → `mmm.plot.cv.param_stability()`
+- `cv_crps` → `mmm.plot.cv.crps()`
+
+**Fixes included:**
+- II.3 — Remove all `plt.show()` calls
+- II.3 — `param_stability` returns all figures (not just the last one) — return type becomes `list[tuple[Figure, NDArray[Axes]]]` or a dict keyed by dim value
+- II.1 — Fix `cv_predictions` wrapping axes in list instead of ndarray
+- II.1 — Fix `param_stability` returning single `Axes` instead of `NDArray[Axes]`
+- I.4 — Extract nested functions (`_align_y_to_df`, `_plot_hdi_from_sel`, `_pred_matrix_for_rows`, `_filter_rows_and_y`, `_plot_line`)
+
+**Design decision needed:** `param_stability` currently creates one figure per
+dimension value. Options:
+1. Return `list[tuple[Figure, NDArray[Axes]]]` — one entry per dimension
+2. Return `dict[str, tuple[Figure, NDArray[Axes]]]` — keyed by dim value
+3. Combine all dims into a single multi-panel figure
+
+**LOE:** L
+
+---
+
+### PR 9 — Suite Wrapper + Cleanup
+
+**Content:**
+- `MMMPlotSuite` class with 7 namespace sub-objects
+- Constructor validation: `data` required, must wrap valid `idata` (I.2)
+- Remove dead `_cache` from `MMMIDataWrapper` (IV.11)
+- Delete old `mmm/plot.py`
+- Update `multidimensional.py` `.plot` property
+- Update `time_slice_cross_validation.py` `.plot` property
+- Update all imports across the codebase
+
+**LOE:** M
+
+---
+
+### PR 10 — Migration Guide
+
+**Content:**
+- Full old→new method name mapping table
+- Breaking changes summary (return types, defaults, parameter renames)
+- Code migration examples (before/after)
+- Removed methods (`saturation_curves_scatter`)
+
+**LOE:** S
+
+---
+
+### PR 11 — Test Overhaul
+
+**Content:**
+- Tests for each namespace class
+- Richer assertions (axis labels, titles, legend entries, data values)
+- Edge cases (single channel, single geo, missing data)
+- Remove legacy `test_plotting.py` tests that duplicate new coverage
+
+**LOE:** L
+
+---
+
+## Cross-Cutting Concerns
+
+These are resolved in PR 1 (Foundation) and enforced by every subsequent PR:
+
+| Concern | Resolution |
+|---------|-----------|
+| I.3 — All methods use `MMMIDataWrapper` | Namespace classes receive only `data: MMMIDataWrapper` (no separate `idata` arg); no raw `self._data.idata.posterior` access |
+| I.4 — No nested functions | Extract to module-level private functions or namespace private methods |
+| I.5 — Shared color palette | `_helpers.channel_color_map(channels)` returns consistent channel→color dict |
+| I.6 — arviz-plots adoption | All methods use `PlotCollection` internally; bar-plot methods fall back to matplotlib |
+| II.1 — Standard return type | `tuple[Figure, NDArray[Axes]]` by default; `PlotCollection` opt-in via `return_as_pc=True` |
+| II.2 — `original_scale=True` | Default on every method that exposes the parameter |
+| II.5 — Consistent param names | `var_names`, `hdi_prob`, `figsize: tuple[float, float]` |
+| II.6 — `dims` on all methods | Every method accepts `dims: dict[str, Any] | None` |
+| II.7 — Figure customization | 6 standard params: `figsize`, `plot_collection`, `backend`, `visuals`, `aes_by_visuals`, `**pc_kwargs` (see [design](./2026-03-11-figure-customization-design.md)) |
+
+---
+
+## Migration Guide Outline
+
+```markdown
+# MMMPlotSuite Migration Guide (v0.18 → v0.19)
+
+## Overview
+MMMPlotSuite has been reorganized from a flat API into grouped namespaces
+for better discoverability. All methods are now accessed through family
+sub-objects on `mmm.plot`.
+
+## Method Name Mapping
+
+| Old (v0.18) | New (v0.19) |
+|-------------|-------------|
+| `mmm.plot.posterior_predictive()` | `mmm.plot.diagnostics.posterior_predictive()` |
+| `mmm.plot.prior_predictive()` | `mmm.plot.diagnostics.prior_predictive()` |
+| `mmm.plot.residuals_over_time()` | `mmm.plot.diagnostics.residuals()` |
+| `mmm.plot.residuals_posterior_distribution()` | `mmm.plot.diagnostics.residuals_distribution()` |
+| `mmm.plot.posterior_distribution()` | `mmm.plot.distributions.posterior()` |
+| `mmm.plot.channel_parameter()` | `mmm.plot.distributions.channel_parameter()` |
+| `mmm.plot.prior_vs_posterior()` | `mmm.plot.distributions.prior_vs_posterior()` |
+| `mmm.plot.saturation_scatterplot()` | `mmm.plot.saturation.scatterplot()` |
+| `mmm.plot.saturation_curves()` | `mmm.plot.saturation.curves()` |
+| `mmm.plot.saturation_curves_scatter()` | **Removed** (use `saturation.scatterplot`) |
+| `mmm.plot.waterfall_components_decomposition()` | `mmm.plot.decomposition.waterfall()` |
+| `mmm.plot.contributions_over_time()` | `mmm.plot.decomposition.contributions_over_time()` |
+| `mmm.plot.channel_contribution_share_hdi()` | `mmm.plot.decomposition.channel_share_hdi()` |
+| `mmm.plot.budget_allocation()` | `mmm.plot.budget.allocation()` |
+| `mmm.plot.allocated_contribution_by_channel_over_time()` | `mmm.plot.budget.contribution_over_time()` |
+| `mmm.plot.sensitivity_analysis()` | `mmm.plot.sensitivity.analysis()` |
+| `mmm.plot.uplift_curve()` | `mmm.plot.sensitivity.uplift()` |
+| `mmm.plot.marginal_curve()` | `mmm.plot.sensitivity.marginal()` |
+| `mmm.plot.cv_predictions()` | `mmm.plot.cv.predictions()` |
+| `mmm.plot.param_stability()` | `mmm.plot.cv.param_stability()` |
+| `mmm.plot.cv_crps()` | `mmm.plot.cv.crps()` |
+
+## Parameter Changes
+
+| Old | New | Affected methods |
+|-----|-----|-----------------|
+| `var: str` or `var: list[str]` | `var_names: list[str]` | `posterior_predictive`, `prior_predictive` |
+| `hdi_probs: list[float]` | `hdi_prob: float` | `saturation.curves` |
+| `figsize: tuple[int, int]` | `figsize: tuple[float, float]` | `decomposition.waterfall` |
+
+## Default Changes
+
+| Parameter | Old default | New default | Affected methods |
+|-----------|------------|-------------|-----------------|
+| `original_scale` | `False` | `True` | `saturation.scatterplot`, `saturation.curves` |
+
+## Return Type Changes
+
+All methods now return `tuple[Figure, NDArray[Axes]]` by default.
+Pass `return_as_pc=True` to get a `PlotCollection` for full arviz-plots
+composability.
+
+Previously inconsistent methods:
+- `channel_parameter` returned bare `Figure`
+- `sensitivity_analysis`, `uplift_curve`, `marginal_curve` could return bare `Axes`
+- `budget_allocation`, `waterfall_components_decomposition` could return single `Axes`
+- `param_stability` returned single `Axes` despite declaring `NDArray[Axes]`
+
+## Figure Customization Changes
+
+All methods now accept a consistent set of customization parameters
+(see [figure customization design](./2026-03-11-figure-customization-design.md)):
+
+| Old | New | Notes |
+|-----|-----|-------|
+| `ax: plt.Axes` (4 methods) | `plot_collection: PlotCollection` | arviz-plots composability |
+| `**kwargs` (varies) | `visuals: dict` + `**pc_kwargs` | Element-level control via `visuals`; collection-level via `pc_kwargs` |
+| `rc_params` (1 method) | `**pc_kwargs` | Pass as `figure_kwargs` in `pc_kwargs` |
+| `subplot_kwargs` (1 method) | `**pc_kwargs` | Forwarded to `PlotCollection.wrap/grid` |
+| No customization (7 methods) | Full standard params | All methods now have `figsize`, `backend`, `visuals`, etc. |
+
+## Behavioral Changes
+
+- No method calls `plt.show()` — you control when to display
+- `param_stability` returns all figures, not just the last one
+- Constructor requires valid `data: MMMIDataWrapper` (no more `MMMPlotSuite(idata=None)`)
+- All methods use arviz-plots `PlotCollection` internally
+- Multi-backend support: pass `backend="plotly"` with `return_as_pc=True`
+
+## Removed
+
+- `saturation_curves_scatter` — use `mmm.plot.saturation.scatterplot()` instead
+- `ax` parameter — use `plot_collection` for composing onto existing figures
+```
+
+---
+
+## Issue Traceability
+
+Every issue from the comprehensive audit mapped to its resolution:
+
+| ID | Issue | Resolution | PR |
+|----|-------|-----------|-----|
+| I.1 | God class (5,150 lines) | Decompose into 7 namespace sub-objects | 2–9 |
+| I.2 | Constructor allows invalid state | Require valid `data` (wraps `idata`) | 9 |
+| I.3 | MMMIDataWrapper bypassed | All methods use wrapper | 1–8 |
+| I.4 | Deep nested functions | Extract to module-level | 2–8 |
+| I.5 | No shared color palette | `_helpers.channel_color_map()` | 1 |
+| I.6 | Duplicated subplot logic / arviz-plots | All methods use `PlotCollection`; bar-plot methods fall back to matplotlib | 1–8 |
+| II.1 | Return type roulette | `tuple[Figure, NDArray[Axes]]` always | 2–8 |
+| II.2 | Inconsistent `original_scale` default | `True` everywhere | 4 |
+| II.3 | `plt.show()` + figure discarding | Remove; return all figures | 8 |
+| II.4 | Monkey-patching idata | Shared helper with data parameter | 7 |
+| II.5 | Parameter naming inconsistencies | `var_names`, `hdi_prob`, `figsize` types | 2–8 |
+| II.6 | No dims filtering | Add `dims` on all methods | 2–8 |
+| II.7 | Inconsistent figure customization | `figsize` + `ax` on all methods | 2–8 |
+| III.1–III.5 | Missing methods | **Deferred** — follow-up release | — |
+| IV.1 | Copy-paste bug in prior_predictive | Fix messages and docstrings | 2 |
+| IV.2 | `plt.gcf()` fragility | Explicit figure reference | 5 |
+| IV.3 | `_validate_dims` hardcoded to posterior | Accept target dataset | 1 |
+| IV.4 | color_cycle iteration bug | Reset per panel | 7 |
+| IV.5 | title parameter shadowing | Rename local variable | 7 |
+| IV.6 | Per-date HDI loop | **Deferred** — follow-up release | — |
+| IV.7 | O(n×m) loop in cv_crps | **Deferred** — follow-up release | — |
+| IV.8 | Index-as-coordinate bug | Use positional index | 5 |
+| IV.9 | kwargs + subplot_kwargs conflict | Merge with conflict detection | 5, 6 |
+| IV.10 | Broad exception catching | **Deferred** — follow-up release | — |
+| IV.11 | Dead `_cache` in MMMIDataWrapper | Remove | 9 |
+| IV.12 | `_reduce_and_stack` silent sum | Add warning | 5 |
+| IV.13 | Redundant local imports | Remove | 7 |
+| IV.14 | `ax` unpacking fragility | Handle multi-axes | 5 |
+| IV.15 | Seaborn dependency for 2 methods | Lazy import | 3 |
+| IV.16 | Error message formatting | Fix raw `\n` | 4 |
+| IV.17 | Dead `agg` parameter | Remove dead code | 5 |
+| IV.18 | `_compute_residuals` hardcoded var | Add optional parameter | 2 |
+| V.1–V.5 | Test coverage gaps | **Deferred** (partially addressed in PR 11) | 11 |
+| VI.1 | Plotting gallery | **Deferred** — follow-up release | — |
+| VII.1 | Coord `x` → `channel` | Optional inclusion in PR 5 | 5? |
+| VII.2 | Use `xarray.to_dataframe` | **Deferred** — follow-up release | — |
+| VII.3 | Time-varying media visualization | **Deferred** — follow-up release | — |


### PR DESCRIPTION
## Summary

Design documents for the MMMPlotSuite v2 major-release rewrite. Contains planning docs that lay out the architecture, API contract, and implementation strategy for decomposing the current 5,150-line monolith into a clean namespace-based structure.

## Review focus

Please focus on the **first 3 sections** of the [main design doc](https://github.com/pymc-labs/pymc-marketing/blob/isofer/mmmplotsuite-overall/docs/plans/2026-03-11-mmmplotsuite-v2-attack-plan-design.md) (`mmmplotsuite-v2-attack-plan-design.md`):

1. **Decisions** 
2. **Target Architecture**
3. **Standardized API Contract**


### Files

- **`2026-03-11-mmmplotsuite-v2-attack-plan-design.md`** -- The main design doc. Covers architectural decisions, target file layout, standardized API contract, helper removal plan, scope split (major vs follow-up), PR sequence, migration guide, and issue traceability.

- **`2026-03-10-mmmplotsuite-comprehensive-issues.md`** -- Audit of the current MMMPlotSuite identifying 45 issues across architecture, API consistency, correctness, performance, and testing.

- **`2026-03-10-mmmplotsuite-decomposition-approaches.md`** -- Analysis of 4 decomposition approaches (flat methods, inheritance, mixins, namespace sub-objects) with trade-offs. Concludes with the namespace sub-objects approach.

- **`2026-03-11-figure-customization-design.md`** -- Deep dive into the figure customization API: how arviz-plots' `PlotCollection` integrates, the 6 standard customization parameters, coverage gaps for bar-plot methods, and the `visuals` / `aes_by_visuals` pattern.

