### PR TITLE
Validate YAML structure and warn on unknown keys

### DIFF
--- a/data/config_files/original_scale_vars_at_end.yml
+++ b/data/config_files/original_scale_vars_at_end.yml
@@ -1,0 +1,41 @@
+model:
+  class: pymc_marketing.mmm.multidimensional.MMM
+  kwargs:
+    date_column: "date"
+    channel_columns:
+      - channel_1
+      - channel_2
+    target_column: "y"
+
+    adstock:
+      class: pymc_marketing.mmm.GeometricAdstock
+      kwargs: {l_max: 4}
+
+    saturation:
+      class: pymc_marketing.mmm.LogisticSaturation
+      kwargs: {}
+
+    sampler_config:
+      tune: 100
+      draws: 100
+      chains: 2
+      random_seed: 42
+
+calibration:
+  - add_lift_test_measurements:
+      df_lift_test:
+        class: pandas.DataFrame
+        kwargs:
+          data:
+            channel: ["channel_1", "channel_2"]
+            x: [80.0, 50.0]
+            delta_x: [10.0, 6.0]
+            delta_y: [6.0, 4.0]
+            sigma: [1.5, 1.2]
+      name: "lift_test"
+
+# original_scale_vars intentionally placed at the very end to verify
+# that ordering does not affect model building.
+original_scale_vars:
+  - channel_contribution
+  - intercept_contribution

--- a/pymc_marketing/mmm/builders/factories.py
+++ b/pymc_marketing/mmm/builders/factories.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import importlib
+import warnings
 from collections.abc import Mapping, MutableMapping, Sequence
 from typing import Any
 
@@ -28,6 +29,8 @@ import pymc_marketing.prior  # noqa: F401
 REGISTRY: dict[str, Any] = {
     # "Prior": pymc_extras.prior.Prior,   # <— example of a whitelisted alias
 }
+
+KNOWN_SPEC_KEYS = frozenset({"class", "kwargs", "args"})
 
 # -----------------------------------------------------------------------------
 
@@ -74,6 +77,16 @@ def build(spec: Mapping[str, Any]) -> Any:
     if not isinstance(spec["class"], str):
         raise TypeError(
             f"Expected string for 'class' but got {type(spec['class']).__name__}: {spec['class']}"
+        )
+
+    unknown_keys = set(spec.keys()) - KNOWN_SPEC_KEYS
+    if unknown_keys:
+        warnings.warn(
+            f"Unknown keys {unknown_keys} in build spec for "
+            f"'{spec['class']}'. Only {sorted(KNOWN_SPEC_KEYS)} are "
+            f"recognised; other keys are ignored.",
+            UserWarning,
+            stacklevel=2,
         )
 
     cls = locate(spec["class"])

--- a/pymc_marketing/mmm/builders/yaml.py
+++ b/pymc_marketing/mmm/builders/yaml.py
@@ -24,9 +24,20 @@ from typing import Any
 import pandas as pd
 import yaml  # type: ignore
 
-from pymc_marketing.mmm.builders.factories import build, resolve
+from pymc_marketing.mmm.builders.factories import KNOWN_SPEC_KEYS, build, resolve
 from pymc_marketing.mmm.multidimensional import MMM
 from pymc_marketing.utils import from_netcdf
+
+KNOWN_TOP_LEVEL_KEYS = frozenset(
+    {
+        "model",
+        "data",
+        "effects",
+        "original_scale_vars",
+        "calibration",
+        "idata_path",
+    }
+)
 
 
 def _load_df(path: str | Path) -> pd.DataFrame:
@@ -43,10 +54,30 @@ def _load_df(path: str | Path) -> pd.DataFrame:
     raise ValueError(f"Unrecognised tabular format: {path}")
 
 
+def _validate_config_structure(cfg: Mapping[str, Any]) -> None:
+    """Detect common YAML mis-indentation that silently drops config sections."""
+    model_spec = cfg.get("model")
+    if model_spec is None:
+        raise ValueError("YAML config must contain a top-level 'model' key.")
+
+    if not isinstance(model_spec, Mapping):
+        raise TypeError(f"'model' must be a mapping, got {type(model_spec).__name__}.")
+
+    misplaced = set(model_spec.keys()) - KNOWN_SPEC_KEYS
+    candidates = misplaced & KNOWN_TOP_LEVEL_KEYS
+    if candidates:
+        raise ValueError(
+            f"Found {candidates} nested under 'model', but "
+            f"{'it' if len(candidates) == 1 else 'they'} "
+            f"should be at the top level of the YAML file. "
+            f"Check the indentation of your YAML configuration."
+        )
+
+
 def _apply_and_validate_calibration_steps(
     model: MMM, cfg: Mapping[str, Any], base_dir: Path
 ) -> None:
-    calibration_specs = cfg.get("calibration", [])
+    calibration_specs = cfg.get("calibration") or []
     if not calibration_specs:
         return
 
@@ -139,6 +170,8 @@ def build_mmm_from_yaml(
     config_path = Path(config_path)
     cfg: Mapping[str, Any] = yaml.safe_load(config_path.read_text())
 
+    _validate_config_structure(cfg)
+
     # 1 ─────────────────────────────────── shell (no effects yet)
     # Merge model_kwargs into cfg["model"]["kwargs"], with model_kwargs taking precedence
     model_config = {**cfg["model"].get("kwargs", {}), **(model_kwargs or {})}
@@ -149,7 +182,7 @@ def build_mmm_from_yaml(
         model = build(cfg["model"])
 
     # 2 ──────────────────────────────── resolve covariates / target
-    data_cfg: Mapping[str, Any] = cfg.get("data", {})
+    data_cfg: Mapping[str, Any] = cfg.get("data") or {}
     if X is None:
         if "X_path" not in data_cfg:
             raise ValueError("X not provided and no `data.X_path` found in YAML.")
@@ -173,8 +206,7 @@ def build_mmm_from_yaml(
             )
 
     # 3 ───────────────────────────────────── effects (preserve order)
-    # Build and append each effect
-    for eff_spec in cfg.get("effects", []):
+    for eff_spec in cfg.get("effects") or []:
         effect = build(eff_spec)
         model.mu_effects.append(effect)
 
@@ -182,7 +214,7 @@ def build_mmm_from_yaml(
     model.build_model(X, y)  # this **must** precede any idata loading
 
     # 5 ───────────────────────── add original scale contribution variables
-    original_scale_vars = cfg.get("original_scale_vars", [])
+    original_scale_vars = cfg.get("original_scale_vars") or []
     if original_scale_vars:
         model.add_original_scale_contribution_variable(var=original_scale_vars)
 

--- a/tests/mmm/builders/config_files/wrong_nested_calibration.yml
+++ b/tests/mmm/builders/config_files/wrong_nested_calibration.yml
@@ -1,0 +1,27 @@
+# calibration accidentally indented under model (should be top-level)
+model:
+  class: pymc_marketing.mmm.multidimensional.MMM
+  kwargs:
+    date_column: "date"
+    channel_columns:
+      - channel_1
+      - channel_2
+    target_column: "y"
+    adstock:
+      class: pymc_marketing.mmm.GeometricAdstock
+      kwargs: {l_max: 4}
+    saturation:
+      class: pymc_marketing.mmm.LogisticSaturation
+      kwargs: {}
+  calibration:
+    - add_lift_test_measurements:
+        df_lift_test:
+          class: pandas.DataFrame
+          kwargs:
+            data:
+              channel: ["channel_1", "channel_2"]
+              x: [80.0, 50.0]
+              delta_x: [10.0, 6.0]
+              delta_y: [6.0, 4.0]
+              sigma: [1.5, 1.2]
+        name: "lift_test"

--- a/tests/mmm/builders/config_files/wrong_nested_effects.yml
+++ b/tests/mmm/builders/config_files/wrong_nested_effects.yml
@@ -1,0 +1,24 @@
+# effects accidentally indented under model (should be top-level)
+model:
+  class: pymc_marketing.mmm.multidimensional.MMM
+  kwargs:
+    date_column: "date"
+    channel_columns:
+      - channel_1
+      - channel_2
+    target_column: "y"
+    adstock:
+      class: pymc_marketing.mmm.GeometricAdstock
+      kwargs: {l_max: 4}
+    saturation:
+      class: pymc_marketing.mmm.LogisticSaturation
+      kwargs: {}
+  effects:
+    - class: pymc_marketing.mmm.additive_effect.LinearTrendEffect
+      kwargs:
+        trend:
+          class: pymc_marketing.mmm.LinearTrend
+          kwargs:
+            n_changepoints: 2
+            include_intercept: false
+        prefix: "trend"

--- a/tests/mmm/builders/config_files/wrong_nested_original_scale_vars.yml
+++ b/tests/mmm/builders/config_files/wrong_nested_original_scale_vars.yml
@@ -1,0 +1,17 @@
+# original_scale_vars accidentally indented under model (should be top-level)
+model:
+  class: pymc_marketing.mmm.multidimensional.MMM
+  kwargs:
+    date_column: "date"
+    channel_columns:
+      - channel_1
+      - channel_2
+    target_column: "y"
+    adstock:
+      class: pymc_marketing.mmm.GeometricAdstock
+      kwargs: {l_max: 4}
+    saturation:
+      class: pymc_marketing.mmm.LogisticSaturation
+      kwargs: {}
+  original_scale_vars:
+    - channel_contribution

--- a/tests/mmm/builders/test_factories.py
+++ b/tests/mmm/builders/test_factories.py
@@ -11,10 +11,12 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+import warnings
+
 import pytest
 from pymc_extras.prior import Prior
 
-from pymc_marketing.mmm.builders.factories import locate
+from pymc_marketing.mmm.builders.factories import build, locate
 from pymc_marketing.mmm.mmm import MMM
 
 
@@ -27,3 +29,35 @@ from pymc_marketing.mmm.mmm import MMM
 )
 def test_locate(qualname, expected) -> None:
     assert locate(qualname) is expected
+
+
+def test_build_warns_on_unknown_spec_keys():
+    """build() should warn when spec contains keys besides class/kwargs/args."""
+    spec = {
+        "class": "pymc_marketing.mmm.GeometricAdstock",
+        "kwargs": {"l_max": 4},
+        "original_scale_vars": ["channel_contribution"],
+        "calibration": [],
+    }
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        obj = build(spec)
+
+    assert obj is not None
+    warning_messages = [str(w.message) for w in caught]
+    assert any("Unknown keys" in msg for msg in warning_messages)
+    assert any("original_scale_vars" in msg for msg in warning_messages)
+
+
+def test_build_no_warning_for_clean_spec():
+    """build() should not warn for a spec with only class/kwargs/args."""
+    spec = {
+        "class": "pymc_marketing.mmm.GeometricAdstock",
+        "kwargs": {"l_max": 4},
+    }
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        build(spec)
+
+    warning_messages = [str(w.message) for w in caught]
+    assert not any("Unknown keys" in msg for msg in warning_messages)

--- a/tests/mmm/builders/test_yaml.py
+++ b/tests/mmm/builders/test_yaml.py
@@ -24,6 +24,7 @@ import yaml
 
 from pymc_marketing.mmm.builders.yaml import (
     _apply_and_validate_calibration_steps,
+    _validate_config_structure,
     build_mmm_from_yaml,
 )
 from pymc_marketing.model_config import ModelConfigError
@@ -362,3 +363,126 @@ def test_special_prior_in_yaml(tmp_path, mock_pymc_sample):
     # Check that the model has inference data after fitting
     assert model.idata is not None
     assert "posterior" in model.idata
+
+
+# ---------------------------------------------------------------------------
+# Tests for config structure validation (_validate_config_structure)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateConfigStructure:
+    """Tests for _validate_config_structure detecting mis-indented YAML keys."""
+
+    def test_valid_config(self):
+        """No error for a well-formed config."""
+        cfg = {
+            "model": {"class": "some.Class", "kwargs": {}},
+            "original_scale_vars": ["channel_contribution"],
+            "calibration": [],
+            "effects": [],
+        }
+        _validate_config_structure(cfg)
+
+    def test_missing_model_key(self):
+        with pytest.raises(ValueError, match="must contain a top-level 'model' key"):
+            _validate_config_structure({"effects": []})
+
+    def test_model_not_a_mapping(self):
+        with pytest.raises(TypeError, match="'model' must be a mapping"):
+            _validate_config_structure({"model": "not-a-dict"})
+
+    @pytest.mark.parametrize(
+        "misplaced_key",
+        [
+            "original_scale_vars",
+            "calibration",
+            "effects",
+            "data",
+            "idata_path",
+        ],
+    )
+    def test_misplaced_key_under_model(self, misplaced_key):
+        cfg = {
+            "model": {
+                "class": "some.Class",
+                "kwargs": {},
+                misplaced_key: "value",
+            }
+        }
+        with pytest.raises(ValueError, match="nested under 'model'"):
+            _validate_config_structure(cfg)
+
+
+@pytest.mark.parametrize(
+    "config_path",
+    [
+        "tests/mmm/builders/config_files/wrong_nested_original_scale_vars.yml",
+        "tests/mmm/builders/config_files/wrong_nested_calibration.yml",
+        "tests/mmm/builders/config_files/wrong_nested_effects.yml",
+    ],
+)
+def test_build_mmm_rejects_nested_keys(config_path, X_data, y_data):
+    """YAML files with mis-indented top-level keys should raise ValueError."""
+    with pytest.raises(ValueError, match="nested under 'model'"):
+        build_mmm_from_yaml(config_path, X=X_data, y=y_data.squeeze())
+
+
+def test_original_scale_vars_none_is_harmless(tmp_path):
+    """original_scale_vars: (None in YAML) should not crash or skip silently."""
+    X = pd.DataFrame(
+        {
+            "date": pd.date_range("2023-01-01", periods=52, freq="W"),
+            "channel_1": range(52),
+            "channel_2": range(100, 152),
+        }
+    )
+    y = pd.Series(range(52), name="y")
+
+    config = {
+        "model": {
+            "class": "pymc_marketing.mmm.multidimensional.MMM",
+            "kwargs": {
+                "date_column": "date",
+                "channel_columns": ["channel_1", "channel_2"],
+                "target_column": "y",
+                "adstock": {
+                    "class": "pymc_marketing.mmm.GeometricAdstock",
+                    "kwargs": {"l_max": 4},
+                },
+                "saturation": {
+                    "class": "pymc_marketing.mmm.LogisticSaturation",
+                    "kwargs": {},
+                },
+            },
+        },
+        "original_scale_vars": None,
+    }
+
+    config_path = tmp_path / "config.yml"
+    with open(config_path, "w") as f:
+        yaml.dump(config, f)
+
+    model = build_mmm_from_yaml(config_path, X=X, y=y)
+    det_names = [v.name for v in model.model.deterministics]
+    assert "channel_contribution_original_scale" not in det_names
+
+
+def test_calibration_none_is_harmless(dummy_mmm, tmp_path):
+    """calibration: (None in YAML) should not crash."""
+    cfg = {"calibration": None}
+    _apply_and_validate_calibration_steps(dummy_mmm, cfg, tmp_path)
+    assert dummy_mmm.called_with is None
+
+
+def test_original_scale_vars_ordering_does_not_matter(X_data, y_data):
+    """The at-end config must create original_scale variables and apply lift test."""
+    config_path = "data/config_files/original_scale_vars_at_end.yml"
+
+    model = build_mmm_from_yaml(config_path, X=X_data, y=y_data.squeeze())
+
+    det_names = [v.name for v in model.model.deterministics]
+    assert "channel_contribution_original_scale" in det_names
+    assert "intercept_contribution_original_scale" in det_names
+
+    obs_names = [rv.name for rv in model.model.observed_RVs]
+    assert any("lift" in name for name in obs_names)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->
1. Add defensive parsing and validation for YAML configs and spec building. Introduces KNOWN_SPEC_KEYS and makes `build()` warn when a spec contains unknown keys (e.g. accidental top-level keys nested under a class). 
2. Adds _validate_config_structure() to detect common mis-indentation (keys like effects, calibration, original_scale_vars, data, idata_path nested under model) and raise a clear ValueError/TypeError. `build_mmm_from_yaml()` now calls the validator and treats calibration/effects/original_scale_vars/data robustly when they are None, avoiding silent failures. 
3. Tests added/updated to cover the new validation, factory warnings, None handling, and ordering of original_scale_vars, plus example YAML fixtures for mis-indented configs.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2409.org.readthedocs.build/en/2409/

<!-- readthedocs-preview pymc-marketing end -->