### PR TITLE
Make MMM workflow idempotent

### DIFF
--- a/pymc_marketing/mmm/budget_optimizer.py
+++ b/pymc_marketing/mmm/budget_optimizer.py
@@ -1072,6 +1072,9 @@ class BudgetOptimizer(BaseModel):
             pymc_model=self._pymc_model,
             idata=self.mmm_model.idata,
             response_variable=response_variable,
+            frozen_deterministics=getattr(
+                self.mmm_model, "frozen_deterministics", None
+            ),
         )
 
     def _compile_objective_and_grad(self):

--- a/pymc_marketing/mmm/budget_optimizer.py
+++ b/pymc_marketing/mmm/budget_optimizer.py
@@ -764,7 +764,6 @@ class BudgetOptimizer(BaseModel):
         )
 
         # Fill a zero array, then set only the True positions
-        # TODO: We should be able to implement this with xtensor, once we have `.where`
         budgets_zeros = pt.zeros(self._budget_shape)
         budgets_zeros.name = "budgets_zeros"
         bool_mask = np.asarray(self.budgets_to_optimize).astype(bool)
@@ -996,7 +995,6 @@ class BudgetOptimizer(BaseModel):
 
         # Reconstruct the full shape for each time period
         budgets = ptx.zeros_like(budgets).expand_dims(date=num_periods, axis=0)
-        # Need to go to tensor, as we don't have `.where` yet and xtensor don't support >1D boolean indices
         repeated_budgets = budgets.values[:, bool_mask].set(
             repeated_budgets_flat.values
         )

--- a/pymc_marketing/mmm/incrementality.py
+++ b/pymc_marketing/mmm/incrementality.py
@@ -357,10 +357,12 @@ class Incrementality:
         n_draws = posterior_sub.sizes["draw"]
 
         # Extract response distribution (batched over samples)
+        posterior_predictive_model = self.model.model
         response_graph = extract_response_distribution(
-            pymc_model=self.model.model,
+            pymc_model=posterior_predictive_model,
             idata=az.InferenceData(posterior=posterior_sub),
             response_variable="channel_contribution",
+            frozen_deterministics=self.model.frozen_deterministics,
         )
         # Shape: (sample, date, channel, *custom_dims) where sample = chain x draw
 
@@ -382,7 +384,7 @@ class Incrementality:
         # Compile vectorized evaluator (once, reused for both)
         # Use float64 for evaluation to avoid integer truncation when
         # counterfactual_spend_factor produces fractional values (e.g. 1.01).
-        data_shared = self.model.model["channel_data"]
+        data_shared = posterior_predictive_model["channel_data"]
         data_dtype = data_shared.dtype
         if np.dtype(data_dtype).kind != "f":
             raise ValueError(
@@ -403,12 +405,11 @@ class Incrementality:
         # ``time_index``; otherwise it is unused (e.g. time_varying_intercept
         # without time_varying_media) and would trigger an UnusedInputError.
         has_time_index = (
-            "time_index" in self.model.model.named_vars
-            and self.model.model["time_index"]
-            in ancestors([response_graph], blockers=list())
+            "time_index" in posterior_predictive_model.named_vars
+            and posterior_predictive_model["time_index"] in ancestors([response_graph])
         )
         if has_time_index:
-            time_shared = self.model.model["time_index"]
+            time_shared = posterior_predictive_model["time_index"]
             batched_time = ptx.xtensor(
                 name="time_index_batched",
                 dtype=time_shared.dtype,
@@ -437,7 +438,9 @@ class Incrementality:
         # variable. The PyTensor graph preserves the model's dim order, which
         # may have custom dims (e.g. "country") before "channel".
         cc_dims = list(
-            self.model.model.named_vars_to_dims.get("channel_contribution", ())
+            posterior_predictive_model.named_vars_to_dims.get(
+                "channel_contribution", ()
+            )
         )
         non_date_dims = [d for d in cc_dims if d != "date"]
         extra_shape = baseline_array.shape[1:]  # (channel, *custom_dims)

--- a/pymc_marketing/mmm/multidimensional.py
+++ b/pymc_marketing/mmm/multidimensional.py
@@ -162,7 +162,6 @@ import pymc as pm
 import pymc.dims as pmd
 import xarray as xr
 from pydantic import ConfigDict, Field, InstanceOf, StrictBool, validate_call
-from pymc.model.fgraph import clone_model as cm
 from pymc.util import RandomState
 from pymc_extras.deserialize import deserialize
 from pymc_extras.prior import Prior
@@ -1420,9 +1419,17 @@ class MMM(RegressionModelBuilder):
             **self.saturation.model_config,
         }
 
-    def post_sample_model_transformation(self) -> None:
-        """Post-sample model transformation in order to store the HSGP state from fit."""
-        names = []
+    @property
+    def frozen_deterministics(self) -> list[str]:
+        """Deterministic variables that must be frozen at posterior values.
+
+        These are Deterministics whose computation involves a reduction over
+        a dimension (e.g. date) whose size may change during out-of-sample
+        evaluation.  Recomputing them with a different dimension size would
+        give wrong results; instead their posterior values should be
+        substituted directly.
+        """
+        names: list[str] = []
         if self.time_varying_intercept:
             names.extend(
                 SoftPlusHSGP.deterministics_to_replace("intercept_latent_process")
@@ -1433,10 +1440,7 @@ class MMM(RegressionModelBuilder):
                     "media_temporal_latent_multiplier"
                 )
             )
-        if not names:
-            return
-
-        self.model = deterministics_to_flat(self.model, names=names)
+        return names
 
     def _validate_idata_exists(self) -> None:
         """Validate that the idata exists."""
@@ -1759,7 +1763,6 @@ class MMM(RegressionModelBuilder):
             self._time_index = DataArray(
                 np.arange(0, X[self.date_column].unique().shape[0]), dims=("date",)
             )
-            self._time_index_mid = X[self.date_column].unique().shape[0] // 2
             self._time_resolution = (
                 X[self.date_column].iloc[1] - X[self.date_column].iloc[0]
             ).days
@@ -1896,9 +1899,16 @@ class MMM(RegressionModelBuilder):
         with self.model:
             for v in var:
                 self._validate_contribution_variable(v)
+                name = f"{v}_original_scale"
+                if name in self.model.named_vars:
+                    warnings.warn(
+                        f"{name} already in the model, skipping.",
+                        stacklevel=2,
+                    )
+                    continue
 
                 pmd.Deterministic(
-                    f"{v}_original_scale",
+                    name,
                     (self.model[v] * target_scale).transpose(
                         "date", ..., missing_dims="ignore"
                     ),
@@ -2158,8 +2168,6 @@ class MMM(RegressionModelBuilder):
                 mu_var += mu_effect.create_effect(self)
 
             mu_var.name = "mu"
-            # TODO: Are these dims still needed, they should be implied by mu_var?
-            self.model_config["likelihood"].dims = ("date", *self.dims)
             self.model_config["likelihood"].create_likelihood_variable(
                 name=self.output_var,
                 mu=mu_var,
@@ -2295,23 +2303,25 @@ class MMM(RegressionModelBuilder):
     def _set_xarray_data(
         self,
         dataset_xarray: xr.Dataset,
+        *,
+        model: pm.Model,
         clone_model: bool = True,
     ) -> pm.Model:
-        """Set xarray data into the model.
+        """Set xarray data into the model (inplace).
 
         Parameters
         ----------
         dataset_xarray : xr.Dataset
             Input data for channels and other variables.
-        clone_model : bool, optional
-            Whether to clone the model. Defaults to True.
+        model : pm.Model
+            The model to set data on.
+            If you don't want to mutate the original model, call model.copy() before passing it.
 
         Returns
         -------
-        None
+        pm.Model
+            The model with updated data.
         """
-        model = cm(self.model) if clone_model else self.model
-
         # Get channel data and handle dtype conversion
         channel_values = dataset_xarray._channel.transpose(
             "date", *self.dims, "channel"
@@ -2353,12 +2363,7 @@ class MMM(RegressionModelBuilder):
             else:
                 data["target_data"] = target_values
 
-        self.new_updated_data = data
-        self.new_updated_coords = coords
-        self.new_updated_model = model
-
-        with model:
-            pm.set_data(data, coords=coords)
+        pm.set_data(data, coords=coords, model=model)
 
         return model
 
@@ -2404,24 +2409,35 @@ class MMM(RegressionModelBuilder):
             X=X,
             include_last_observations=include_last_observations,
         )
+        if names := self.frozen_deterministics:
+            # This always clone
+            model = deterministics_to_flat(self.model, names=names)
+        elif clone_model:
+            model = self.model.copy()
         model = self._set_xarray_data(
             dataset_xarray=dataset_xarray,
-            clone_model=clone_model,
+            model=model,
         )
 
         for mu_effect in self.mu_effects:
             mu_effect.set_data(self, model, dataset_xarray)
 
-        with model:
-            post_pred = pm.sample_posterior_predictive(
-                self.idata, **sample_posterior_predictive_kwargs
-            )
+        # Sample from posterior predictive
+        post_pred = pm.sample_posterior_predictive(
+            self.idata,
+            model=model,
+            **sample_posterior_predictive_kwargs,
+        )
 
-            if extend_idata and self.idata is not None:
-                self.idata.add_groups(
-                    posterior_predictive=post_pred.posterior_predictive,
-                    posterior_predictive_constant_data=post_pred.constant_data,
-                )  # type: ignore
+        if extend_idata and self.idata is not None:
+            if hasattr(self.idata, "posterior_predictive"):
+                del self.idata.posterior_predictive
+            if hasattr(self.idata, "posterior_predictive_constant_data"):
+                del self.idata.posterior_predictive_constant_data
+            self.idata.add_groups(
+                posterior_predictive=post_pred.posterior_predictive,
+                posterior_predictive_constant_data=post_pred.constant_data,
+            )
 
         group = "posterior_predictive"
         posterior_predictive_samples = az.extract(post_pred, group, combined=combined)
@@ -2741,7 +2757,9 @@ class MMM(RegressionModelBuilder):
         """
         # Provide the underlying PyMC model, the model's inference data, and dims
         return SensitivityAnalysis(
-            pymc_model=self.model, idata=self.idata, dims=self.dims
+            pymc_model=self.model,
+            idata=self.idata,
+            dims=self.dims,
         )
 
     @property
@@ -3066,6 +3084,16 @@ class MMM(RegressionModelBuilder):
         """
         if not hasattr(self, "model"):
             raise RuntimeError("Model must be built before adding calibration.")
+
+        # Check for existing potentials with the same name_prefix
+        if name_prefix in self.model.named_vars:
+            warnings.warn(
+                f"Cost-per-target potentials with name '{name_prefix}' already exist. "
+                "Skipping to avoid duplicates.",
+                UserWarning,
+                stacklevel=2,
+            )
+            return
 
         # Validate required columns in calibration_data
         if "channel" not in calibration_data.columns:
@@ -3433,7 +3461,7 @@ class MultiDimensionalBudgetOptimizerWrapper(OptimizerCompatibleModelWrapper):
         # Use the model's method to set data
         pymc_model = self._set_xarray_data(
             dataset_xarray=dataset_xarray,
-            clone_model=True,  # Ensure we work on a clone
+            model=self.model.copy(),
         )
 
         # Use the model's mu_effects and set data using the model instance

--- a/pymc_marketing/mmm/sensitivity_analysis.py
+++ b/pymc_marketing/mmm/sensitivity_analysis.py
@@ -323,8 +323,6 @@ class SensitivityAnalysis:
             )
             mask = pt.tensor("mask", shape=mask_array.shape, dtype=bool)
 
-            # Have to go to tensor (.values), because we don't yet have xtensor.where
-
             # We also have to broadcast the mask_tensor because we can't currently vectorize a set_subtensor with slices
             # otherwise this would suffice: resp_graph[..., ~mask_array].set(0)
             mask_bcast, _ = pt.broadcast_arrays(mask, resp_graph.values)

--- a/pymc_marketing/model_builder.py
+++ b/pymc_marketing/model_builder.py
@@ -1031,8 +1031,6 @@ class RegressionModelBuilder(ModelBuilder):
                 idata.posterior, merge_dataset=True
             )
 
-        self.post_sample_model_transformation()
-
         if self.idata:
             self.idata = self.idata.copy()
             self.idata.extend(idata, join="right")

--- a/pymc_marketing/pytensor_utils.py
+++ b/pymc_marketing/pytensor_utils.py
@@ -18,7 +18,6 @@ from collections import Counter
 
 import arviz as az
 import pandas as pd
-import pytensor.tensor as pt
 from arviz import InferenceData
 from pymc.model.core import Model
 from pymc.model.fgraph import (
@@ -29,6 +28,7 @@ from pymc.model.fgraph import (
 )
 from pymc.pytensorf import rvs_in_graph
 from pytensor import as_symbolic
+from pytensor.graph.basic import Variable
 from pytensor.graph.fg import FunctionGraph
 from pytensor.graph.replace import clone_replace
 from pytensor.graph.rewriting import rewrite_graph
@@ -267,7 +267,8 @@ def extract_response_distribution(
     pymc_model: Model,
     idata: InferenceData,
     response_variable: str,
-) -> pt.TensorVariable:
+    frozen_deterministics: list[str] | None = None,
+) -> Variable:
     """Extract the response distribution graph, conditioned on posterior parameters.
 
     Parameters
@@ -278,6 +279,9 @@ def extract_response_distribution(
         The inference data containing posterior samples.
     response_variable : str
         The name of the response variable to extract.
+    frozen_deterministics : list of str, optional
+        Names of Deterministic variables to freeze at their posterior values instead of recomputing from the graph.
+        Some models (e.g, those containing HSGP) need this to to obtain a valid conditional posterior graph.
 
     Returns
     -------
@@ -296,10 +300,20 @@ def extract_response_distribution(
     # The PyMC variable to extract
     response_var = pymc_model[response_variable]
 
-    # Identify which free RVs are needed to compute `response_var`
+    # Identify which free RVs are needed to compute `response_var`.
+    # Frozen deterministics are treated as additional blockers so their
+    # subgraphs are not traversed — their posterior values are substituted
+    # directly, just like free RVs.
     free_rvs = set(pymc_model.free_RVs)
+    frozen_vars: set = set()
+    if frozen_deterministics:
+        for name in frozen_deterministics:
+            if name in pymc_model.named_vars:
+                frozen_vars.add(pymc_model[name])
+
+    blockers = free_rvs | frozen_vars
     needed_rvs = [
-        rv for rv in ancestors([response_var], blockers=free_rvs) if rv in free_rvs
+        rv for rv in ancestors([response_var], blockers=blockers) if rv in blockers
     ]
     placeholder_replace_dict = {pymc_model[rv.name]: rv.clone() for rv in needed_rvs}
 

--- a/tests/mmm/conftest.py
+++ b/tests/mmm/conftest.py
@@ -149,7 +149,7 @@ def mock_fit(model, X: pd.DataFrame, y: pd.Series, random_seed=None, **kwargs):
     # Explicitly set model data via pm.set_data so channel_data has concrete shape,
     # matching real mmm.fit() behavior. Without this, channel_data may retain
     # symbolic shape unlike mmm.fit().
-    model._set_xarray_data(model.xarray_dataset, clone_model=False)
+    model._set_xarray_data(model.xarray_dataset, model=model.model)
 
     if random_seed is None:
         random_seed = rng

--- a/tests/mmm/test_incrementality.py
+++ b/tests/mmm/test_incrementality.py
@@ -23,6 +23,7 @@ import xarray as xr
 from pydantic import ValidationError
 
 from pymc_marketing.mmm.incrementality import Incrementality
+from pymc_marketing.model_graph import deterministics_to_flat
 
 
 def evaluate_channel_contribution(mmm, channel_data_values, original_scale=False):
@@ -36,12 +37,16 @@ def evaluate_channel_contribution(mmm, channel_data_values, original_scale=False
         if original_scale
         else "channel_contribution"
     )
-    model = mmm.model.copy()
+    names = mmm.frozen_deterministics
+    if names:
+        model = deterministics_to_flat(mmm.model, names=names)
+    else:
+        model = mmm.model.copy()
     with model:
         pm.set_data(
             {
                 "channel_data": channel_data_values.astype(
-                    mmm.model["channel_data"].type.dtype
+                    model["channel_data"].type.dtype
                 )
             }
         )

--- a/tests/mmm/test_multidimensional.py
+++ b/tests/mmm/test_multidimensional.py
@@ -3020,7 +3020,7 @@ def test_set_xarray_data_preserves_dtypes(multi_dim_data, mock_pymc_sample):
     assert dataset_xarray._channel.dtype == np.float32
 
     # Apply _set_xarray_data
-    model = mmm._set_xarray_data(dataset_xarray, clone_model=True)
+    model = mmm._set_xarray_data(dataset_xarray, model=mmm.model.copy())
 
     # Check that the data in the model has been converted to the original dtypes
     assert model.named_vars["channel_data"].get_value().dtype == original_channel_dtype
@@ -3055,7 +3055,8 @@ def test_set_xarray_data_preserves_dtypes(multi_dim_data, mock_pymc_sample):
 
     # Apply _set_xarray_data with target
     model_with_target = mmm._set_xarray_data(
-        dataset_xarray_with_target, clone_model=True
+        dataset_xarray_with_target,
+        model=mmm.model.copy(),
     )
 
     # Check that target dtype is preserved
@@ -3134,7 +3135,7 @@ def test_set_xarray_data_with_control_columns_preserves_dtypes(multi_dim_data):
     )
 
     # Apply _set_xarray_data
-    model = mmm._set_xarray_data(dataset_xarray, clone_model=True)
+    model = mmm._set_xarray_data(dataset_xarray, model=mmm.model.copy())
 
     # Check that data types are preserved
     assert model.named_vars["channel_data"].get_value().dtype == original_channel_dtype
@@ -3157,7 +3158,7 @@ def test_set_xarray_data_with_control_columns_preserves_dtypes(multi_dim_data):
 
     # Apply _set_xarray_data with target
     model_with_target = mmm._set_xarray_data(
-        dataset_xarray_with_target, clone_model=True
+        dataset_xarray_with_target, model=mmm.model.copy()
     )
 
     # Check that all data types are preserved
@@ -3207,7 +3208,7 @@ def test_set_xarray_data_without_target_preserves_dtypes(multi_dim_data):
     )
 
     # Apply _set_xarray_data
-    model = mmm._set_xarray_data(dataset_xarray, clone_model=True)
+    model = mmm._set_xarray_data(dataset_xarray, model=mmm.model.copy())
 
     # Check that channel data type is preserved
     assert model.named_vars["channel_data"].get_value().dtype == original_channel_dtype
@@ -3904,8 +3905,8 @@ def test_calibration_spend_with_different_dtypes(multi_dim_data, mock_pymc_sampl
     assert "y" in idata_pred
 
 
-def test_calibration_duplicate_name_error(multi_dim_data, mock_pymc_sample):
-    """Test that attempting to re-register calibration observations raises a duplicate name error."""
+def test_calibration_duplicate_name_warns(multi_dim_data, mock_pymc_sample):
+    """Test that re-registering calibration potentials warns and skips."""
     X, y = multi_dim_data
 
     # Create MMM model
@@ -3947,7 +3948,10 @@ def test_calibration_duplicate_name_error(multi_dim_data, mock_pymc_sample):
         name_prefix="cpt_calibration",
     )
 
-    with pytest.raises(ValueError, match="cpt_calibration"):
+    # Re-registering should warn and skip (idempotent)
+    with pytest.warns(
+        UserWarning, match="Cost-per-target potentials with name 'cpt_calibration'"
+    ):
         mmm.add_cost_per_target_calibration(
             data=spend_df,
             calibration_data=calibration_df,
@@ -4874,8 +4878,95 @@ class TestChannelOrderingIntegration:
         """After sample_posterior_predictive, the data set into the model
         must use user-ordered channel and control coordinates."""
         mmm, df, _ = integration_model
-        mmm.sample_posterior_predictive(
-            X=df, extend_idata=False, combined=True, progressbar=False
+        idata = mmm.sample_posterior_predictive(
+            X=df,
+            extend_idata=False,
+            combined=True,
+            progressbar=False,
+            # Sample variables with channel/control dims
+            var_names=[mmm.output_var, "channel_contribution", "control_contribution"],
         )
-        assert list(mmm.new_updated_coords["channel"]) == self.CHANNELS
-        assert list(mmm.new_updated_coords["control"]) == self.CONTROLS
+        assert (
+            list(idata.coords["channel"])
+            == list(mmm.model.coords["channel"])
+            == self.CHANNELS
+        )
+        assert (
+            list(idata.coords["control"])
+            == list(mmm.model.coords["control"])
+            == self.CONTROLS
+        )
+
+
+def test_add_original_scale_contribution_variable_idempotent(multi_dim_data):
+    """Issue #2367: calling add_original_scale_contribution_variable twice
+    should not create duplicate nodes."""
+    X, y = multi_dim_data
+    mmm = MMM(
+        date_column="date",
+        target_column="target",
+        channel_columns=["channel_1", "channel_2", "channel_3"],
+        dims=("country",),
+        adstock=GeometricAdstock(l_max=2),
+        saturation=LogisticSaturation(),
+    )
+    mmm.build_model(X, y)
+
+    mmm.add_original_scale_contribution_variable(var=["channel_contribution"])
+    assert "channel_contribution_original_scale" in mmm.model.named_vars
+
+    with pytest.warns(
+        UserWarning, match=r"channel_contribution_original_scale already in the model"
+    ):
+        mmm.add_original_scale_contribution_variable(var=["channel_contribution"])
+    assert "channel_contribution_original_scale" in mmm.model.named_vars
+
+
+def test_iterative_workflow(multi_dim_data, mock_pymc_sample):
+    """Issue #2226: calling sample_posterior_predictive() multiple times should not fail."""
+    mmm = MMM(
+        date_column="date",
+        target_column="target",
+        channel_columns=["channel_1", "channel_2", "channel_3"],
+        dims=("country",),
+        adstock=GeometricAdstock(l_max=2),
+        saturation=LogisticSaturation(),
+    )
+
+    X, y = multi_dim_data
+    full_pp_sizes = {"chain": 1, "draw": 10, "date": 7, "country": 3}
+    full_cd_sizes = {"date": 7, "country": 3, "channel": 3}
+    reduced_X = X[::10]
+    reduced_y = y[::10]
+    reduced_pp_sizes = full_pp_sizes | {"date": 3}
+    reduced_cd_sizes = full_cd_sizes | {"date": 3}
+
+    # Test loses most of its meaning if these are not different
+    assert full_pp_sizes != reduced_pp_sizes
+    assert full_cd_sizes != reduced_cd_sizes
+
+    mmm.fit(X, y, chains=1, draws=10)
+    mmm.sample_posterior_predictive(X)
+    assert dict(mmm.idata.posterior_predictive.sizes) == full_pp_sizes
+    assert dict(mmm.idata.posterior_predictive_constant_data.sizes) == full_cd_sizes
+
+    # Second call should succeed (not raise)
+    mmm.sample_posterior_predictive(X)
+    assert dict(mmm.idata.posterior_predictive.sizes) == full_pp_sizes
+    assert dict(mmm.idata.posterior_predictive_constant_data.sizes) == full_cd_sizes
+
+    # Call with new shapes
+    mmm.sample_posterior_predictive(reduced_X)
+    assert dict(mmm.idata.posterior_predictive.sizes) == reduced_pp_sizes
+    assert dict(mmm.idata.posterior_predictive_constant_data.sizes) == reduced_cd_sizes
+
+    # Fit with new shapes
+    mmm.fit(reduced_X, reduced_y)
+    mmm.sample_posterior_predictive(reduced_X)
+    assert dict(mmm.idata.posterior_predictive.sizes) == reduced_pp_sizes
+    assert dict(mmm.idata.posterior_predictive_constant_data.sizes) == reduced_cd_sizes
+
+    # Should still work with different shapes
+    mmm.sample_posterior_predictive(X)
+    assert dict(mmm.idata.posterior_predictive.sizes) == full_pp_sizes
+    assert dict(mmm.idata.posterior_predictive_constant_data.sizes) == full_cd_sizes


### PR DESCRIPTION
Closes #2367 
Closes #2239
Closes #2226

Also closes #2385 in a separate commit. `xtensor.where` actually already exists but doesn't fit the mold. The current strategy is the best I can think of. So I just removed the TODO comments