### PR TITLE
Validate YAML with Pydantic

### DIFF
--- a/pymc_marketing/mmm/builders/__init__.py
+++ b/pymc_marketing/mmm/builders/__init__.py
@@ -14,6 +14,7 @@
 """Configuration I/O for PyMC-Marketing."""
 
 from pymc_marketing.mmm.builders.factories import build
+from pymc_marketing.mmm.builders.schema import MMMYamlConfig
 from pymc_marketing.mmm.builders.yaml import build_mmm_from_yaml
 
-__all__ = ["build", "build_mmm_from_yaml"]
+__all__ = ["MMMYamlConfig", "build", "build_mmm_from_yaml"]

--- a/pymc_marketing/mmm/builders/schema.py
+++ b/pymc_marketing/mmm/builders/schema.py
@@ -281,8 +281,12 @@ class MMMYamlConfig(BaseModel):
         try:
             return cls.model_validate(raw)
         except ValidationError as exc:
-            error_msg = "YAML configuration validation failed:\n" + "\n".join(
-                f"  - {e['msg']} (at {' -> '.join(str(x) for x in e['loc'])})"
-                for e in exc.errors()
-            )
+            parts: list[str] = []
+            for e in exc.errors():
+                loc = " -> ".join(str(x) for x in e["loc"])
+                line = f"  - {e['msg']}"
+                if loc:
+                    line += f" (at {loc})"
+                parts.append(line)
+            error_msg = "YAML configuration validation failed:\n" + "\n".join(parts)
             raise ValueError(error_msg) from exc

--- a/pymc_marketing/mmm/builders/schema.py
+++ b/pymc_marketing/mmm/builders/schema.py
@@ -11,11 +11,7 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-"""Pydantic schemas for validating MMM YAML configuration files.
-
-Mirrors the ``validate_or_raise`` / factory-classmethod patterns from
-:mod:`pymc_marketing.data.idata.schema`.
-"""
+"""Pydantic schemas for validating MMM YAML configuration files."""
 
 from __future__ import annotations
 
@@ -76,27 +72,7 @@ def _valid_field_keys(cls: type[BaseModel]) -> set[str]:
 
 
 class BuildSpec(BaseModel):
-    """Schema for an object build specification.
-
-    Parameters
-    ----------
-    class_ : str
-        Fully-qualified Python class name (aliased from ``class`` in YAML).
-    kwargs : dict, default {}
-        Keyword arguments for the class constructor.  Intentionally
-        ``dict[str, Any]`` because values are heterogeneous (plain values,
-        nested build specs, priors, etc.).
-    args : list, default []
-        Positional arguments for the class constructor.
-
-    Examples
-    --------
-    >>> spec = BuildSpec.model_validate(
-    ...     {"class": "pymc_marketing.mmm.GeometricAdstock", "kwargs": {"l_max": 12}}
-    ... )
-    >>> spec.class_
-    'pymc_marketing.mmm.GeometricAdstock'
-    """
+    """Schema for an object build specification."""
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
@@ -129,15 +105,7 @@ class BuildSpec(BaseModel):
 
 
 class DataConfig(BaseModel):
-    """Schema for data path configuration.
-
-    Parameters
-    ----------
-    X_path : str or None
-        Path to the covariate data file.
-    y_path : str or None
-        Path to the target data file.
-    """
+    """Schema for data path configuration."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -146,23 +114,7 @@ class DataConfig(BaseModel):
 
 
 class CalibrationStep(BaseModel):
-    """Schema for a single calibration step.
-
-    In YAML this is written as a single-key mapping, e.g.::
-
-        - add_lift_test_measurements:
-            df_lift_test: ...
-
-    The ``model_validator`` restructures this into ``method_name`` /
-    ``params`` fields.
-
-    Parameters
-    ----------
-    method_name : str
-        Name of the calibration method to call on the MMM.
-    params : dict or None
-        Keyword arguments to pass to the method.
-    """
+    """Schema for a single calibration step."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -189,32 +141,7 @@ class CalibrationStep(BaseModel):
 
 
 class MMMYamlConfig(BaseModel):
-    """Schema for the top-level MMM YAML configuration.
-
-    Mirrors the ``validate_or_raise`` pattern from
-    :class:`pymc_marketing.data.idata.schema.MMMIdataSchema`.
-
-    Parameters
-    ----------
-    model : BuildSpec
-        MMM class and constructor arguments (required).
-    data : DataConfig or None
-        Paths to covariate and target data files.
-    effects : list of BuildSpec or None
-        Additive effects to append to the model.
-    original_scale_vars : list of str or None
-        Variables to add at original scale.
-    calibration : list of CalibrationStep or None
-        Calibration steps to apply after model build.
-    idata_path : str or None
-        Path to pre-existing InferenceData (NetCDF).
-
-    Examples
-    --------
-    >>> cfg = MMMYamlConfig.from_yaml_file("config.yml")  # doctest: +SKIP
-    >>> cfg.model.class_  # doctest: +SKIP
-    'pymc_marketing.mmm.multidimensional.MMM'
-    """
+    """Schema for the top-level MMM YAML configuration."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -246,9 +173,6 @@ class MMMYamlConfig(BaseModel):
     def from_yaml_file(cls, path: str | Path) -> MMMYamlConfig:
         """Load and validate a YAML configuration file.
 
-        Analogous to
-        :meth:`pymc_marketing.data.idata.schema.MMMIdataSchema.from_model_config`.
-
         Parameters
         ----------
         path : str or Path
@@ -274,9 +198,6 @@ class MMMYamlConfig(BaseModel):
     @classmethod
     def validate_or_raise(cls, raw: dict[str, Any]) -> MMMYamlConfig:
         """Validate a raw config dict, re-raising as :class:`ValueError`.
-
-        Mirrors
-        :meth:`pymc_marketing.data.idata.schema.MMMIdataSchema.validate_or_raise`.
 
         Parameters
         ----------

--- a/pymc_marketing/mmm/builders/schema.py
+++ b/pymc_marketing/mmm/builders/schema.py
@@ -147,7 +147,14 @@ class CalibrationStep(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def _parse_single_method(cls, data: Any) -> dict[str, Any]:
-        if not isinstance(data, dict) or len(data) != 1:
+        if not isinstance(data, dict):
+            raise ValueError(
+                "Each calibration step must map exactly one method name "
+                "to its parameters."
+            )
+        if "method_name" in data:
+            return data
+        if len(data) != 1:
             raise ValueError(
                 "Each calibration step must map exactly one method name "
                 "to its parameters."

--- a/pymc_marketing/mmm/builders/schema.py
+++ b/pymc_marketing/mmm/builders/schema.py
@@ -71,6 +71,19 @@ def _valid_field_keys(cls: type[BaseModel]) -> set[str]:
     return keys
 
 
+def _check_for_unknown_keys(cls: type[BaseModel], data: Any, *, label: str) -> Any:
+    """Raise ``ValueError`` for any keys in *data* not declared on *cls*."""
+    if isinstance(data, dict):
+        valid_keys = _valid_field_keys(cls)
+        for key in set(data.keys()) - valid_keys:
+            hint = suggest_typo_fix(key, valid_keys)
+            msg = f"Unknown {label} key '{key}'."
+            if hint:
+                msg += f" Did you mean '{hint}'?"
+            raise ValueError(msg)
+    return data
+
+
 class BuildSpec(BaseModel):
     """Schema for an object build specification."""
 
@@ -93,15 +106,7 @@ class BuildSpec(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def _check_unknown_keys(cls, data: Any) -> Any:
-        if isinstance(data, dict):
-            valid_keys = _valid_field_keys(cls)
-            for key in set(data.keys()) - valid_keys:
-                hint = suggest_typo_fix(key, valid_keys)
-                msg = f"Unknown key '{key}' in build spec."
-                if hint:
-                    msg += f" Did you mean '{hint}'?"
-                raise ValueError(msg)
-        return data
+        return _check_for_unknown_keys(cls, data, label="build spec")
 
 
 class DataConfig(BaseModel):
@@ -159,15 +164,7 @@ class MMMYamlConfig(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def _check_unknown_keys(cls, data: Any) -> Any:
-        if isinstance(data, dict):
-            valid_keys = _valid_field_keys(cls)
-            for key in set(data.keys()) - valid_keys:
-                hint = suggest_typo_fix(key, valid_keys)
-                msg = f"Unknown config key '{key}'."
-                if hint:
-                    msg += f" Did you mean '{hint}'?"
-                raise ValueError(msg)
-        return data
+        return _check_for_unknown_keys(cls, data, label="config")
 
     @classmethod
     def from_yaml_file(cls, path: str | Path) -> MMMYamlConfig:

--- a/pymc_marketing/mmm/builders/schema.py
+++ b/pymc_marketing/mmm/builders/schema.py
@@ -1,0 +1,281 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Pydantic schemas for validating MMM YAML configuration files.
+
+Mirrors the ``validate_or_raise`` / factory-classmethod patterns from
+:mod:`pymc_marketing.data.idata.schema`.
+"""
+
+from __future__ import annotations
+
+import difflib
+from pathlib import Path
+from typing import Any
+
+import yaml  # type: ignore
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+
+def suggest_typo_fix(
+    key: str, valid_keys: set[str], *, cutoff: float = 0.6
+) -> str | None:
+    """Return the closest match for *key* from *valid_keys*, or ``None``.
+
+    Parameters
+    ----------
+    key : str
+        The unknown key that was provided.
+    valid_keys : set of str
+        The set of valid key names.
+    cutoff : float, default 0.6
+        Minimum similarity ratio for ``difflib.get_close_matches``.
+
+    Returns
+    -------
+    str or None
+        The closest matching key, or ``None`` if no close match is found.
+    """
+    matches = difflib.get_close_matches(key, valid_keys, n=1, cutoff=cutoff)
+    return matches[0] if matches else None
+
+
+_BUILD_SPEC_KEYS = {"class", "class_", "kwargs", "args"}
+
+
+class BuildSpec(BaseModel):
+    """Schema for an object build specification.
+
+    Parameters
+    ----------
+    class_ : str
+        Fully-qualified Python class name (aliased from ``class`` in YAML).
+    kwargs : dict, default {}
+        Keyword arguments for the class constructor.  Intentionally
+        ``dict[str, Any]`` because values are heterogeneous (plain values,
+        nested build specs, priors, etc.).
+    args : list, default []
+        Positional arguments for the class constructor.
+
+    Examples
+    --------
+    >>> spec = BuildSpec.model_validate(
+    ...     {"class": "pymc_marketing.mmm.GeometricAdstock", "kwargs": {"l_max": 12}}
+    ... )
+    >>> spec.class_
+    'pymc_marketing.mmm.GeometricAdstock'
+    """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    class_: str = Field(
+        ...,
+        alias="class",
+        description="Fully-qualified Python class name.",
+    )
+    kwargs: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Constructor keyword arguments.",
+    )
+    args: list[Any] = Field(
+        default_factory=list,
+        description="Constructor positional arguments.",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _check_unknown_keys(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            for key in set(data.keys()) - _BUILD_SPEC_KEYS:
+                hint = suggest_typo_fix(key, _BUILD_SPEC_KEYS)
+                msg = f"Unknown key '{key}' in build spec."
+                if hint:
+                    msg += f" Did you mean '{hint}'?"
+                raise ValueError(msg)
+        return data
+
+
+class DataConfig(BaseModel):
+    """Schema for data path configuration.
+
+    Parameters
+    ----------
+    X_path : str or None
+        Path to the covariate data file.
+    y_path : str or None
+        Path to the target data file.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    X_path: str | None = Field(None, description="Path to covariate data file.")
+    y_path: str | None = Field(None, description="Path to target data file.")
+
+
+class CalibrationStep(BaseModel):
+    """Schema for a single calibration step.
+
+    In YAML this is written as a single-key mapping, e.g.::
+
+        - add_lift_test_measurements:
+            df_lift_test: ...
+
+    The ``model_validator`` restructures this into ``method_name`` /
+    ``params`` fields.
+
+    Parameters
+    ----------
+    method_name : str
+        Name of the calibration method to call on the MMM.
+    params : dict or None
+        Keyword arguments to pass to the method.
+    """
+
+    method_name: str = Field(..., description="Calibration method name.")
+    params: dict[str, Any] | None = Field(None, description="Method keyword arguments.")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _parse_single_method(cls, data: Any) -> dict[str, Any]:
+        if not isinstance(data, dict) or len(data) != 1:
+            raise ValueError(
+                "Each calibration step must map exactly one method name "
+                "to its parameters."
+            )
+        name, params = next(iter(data.items()))
+        return {"method_name": name, "params": params}
+
+
+_TOP_LEVEL_KEYS = {
+    "model",
+    "data",
+    "effects",
+    "original_scale_vars",
+    "calibration",
+    "idata_path",
+}
+
+
+class MMMYamlConfig(BaseModel):
+    """Schema for the top-level MMM YAML configuration.
+
+    Mirrors the ``validate_or_raise`` pattern from
+    :class:`pymc_marketing.data.idata.schema.MMMIdataSchema`.
+
+    Parameters
+    ----------
+    model : BuildSpec
+        MMM class and constructor arguments (required).
+    data : DataConfig or None
+        Paths to covariate and target data files.
+    effects : list of BuildSpec or None
+        Additive effects to append to the model.
+    original_scale_vars : list of str or None
+        Variables to add at original scale.
+    calibration : list of CalibrationStep or None
+        Calibration steps to apply after model build.
+    idata_path : str or None
+        Path to pre-existing InferenceData (NetCDF).
+
+    Examples
+    --------
+    >>> cfg = MMMYamlConfig.from_yaml_file("config.yml")  # doctest: +SKIP
+    >>> cfg.model.class_  # doctest: +SKIP
+    'pymc_marketing.mmm.multidimensional.MMM'
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    model: BuildSpec = Field(..., description="MMM class and constructor arguments.")
+    data: DataConfig | None = Field(None, description="Data file paths.")
+    effects: list[BuildSpec] | None = Field(None, description="Additive effects.")
+    original_scale_vars: list[str] | None = Field(
+        None, description="Original-scale variables."
+    )
+    calibration: list[CalibrationStep] | None = Field(
+        None, description="Calibration steps."
+    )
+    idata_path: str | None = Field(None, description="Path to InferenceData file.")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _check_unknown_keys(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            for key in set(data.keys()) - _TOP_LEVEL_KEYS:
+                hint = suggest_typo_fix(key, _TOP_LEVEL_KEYS)
+                msg = f"Unknown config key '{key}'."
+                if hint:
+                    msg += f" Did you mean '{hint}'?"
+                raise ValueError(msg)
+        return data
+
+    @classmethod
+    def from_yaml_file(cls, path: str | Path) -> MMMYamlConfig:
+        """Load and validate a YAML configuration file.
+
+        Analogous to
+        :meth:`pymc_marketing.data.idata.schema.MMMIdataSchema.from_model_config`.
+
+        Parameters
+        ----------
+        path : str or Path
+            Path to the YAML configuration file.
+
+        Returns
+        -------
+        MMMYamlConfig
+            Validated configuration object.
+
+        Raises
+        ------
+        pydantic.ValidationError
+            If the YAML structure is invalid.
+        FileNotFoundError
+            If *path* does not exist.
+        yaml.YAMLError
+            If the file is not valid YAML.
+        """
+        raw = yaml.safe_load(Path(path).read_text())
+        return cls.model_validate(raw)
+
+    @classmethod
+    def validate_or_raise(cls, raw: dict[str, Any]) -> MMMYamlConfig:
+        """Validate a raw config dict, re-raising as :class:`ValueError`.
+
+        Mirrors
+        :meth:`pymc_marketing.data.idata.schema.MMMIdataSchema.validate_or_raise`.
+
+        Parameters
+        ----------
+        raw : dict
+            Raw parsed YAML dictionary.
+
+        Returns
+        -------
+        MMMYamlConfig
+            Validated configuration object.
+
+        Raises
+        ------
+        ValueError
+            If validation fails, with detailed error messages including
+            field locations.
+        """
+        try:
+            return cls.model_validate(raw)
+        except ValidationError as exc:
+            error_msg = "YAML configuration validation failed:\n" + "\n".join(
+                f"  - {e['msg']} (at {' -> '.join(str(x) for x in e['loc'])})"
+                for e in exc.errors()
+            )
+            raise ValueError(error_msg) from exc

--- a/pymc_marketing/mmm/builders/schema.py
+++ b/pymc_marketing/mmm/builders/schema.py
@@ -50,7 +50,29 @@ def suggest_typo_fix(
     return matches[0] if matches else None
 
 
-_BUILD_SPEC_KEYS = {"class", "class_", "kwargs", "args"}
+def _valid_field_keys(cls: type[BaseModel]) -> set[str]:
+    """Derive all accepted input keys from a Pydantic model's field definitions.
+
+    Collects both the Python field name and the alias (if any) for every
+    field declared on *cls*, so that YAML keys using either form are
+    recognised as valid.
+
+    Parameters
+    ----------
+    cls : type of BaseModel
+        The Pydantic model class to inspect.
+
+    Returns
+    -------
+    set of str
+        Union of field names and their aliases.
+    """
+    keys: set[str] = set()
+    for name, field_info in cls.model_fields.items():
+        keys.add(name)
+        if field_info.alias:
+            keys.add(field_info.alias)
+    return keys
 
 
 class BuildSpec(BaseModel):
@@ -96,8 +118,9 @@ class BuildSpec(BaseModel):
     @classmethod
     def _check_unknown_keys(cls, data: Any) -> Any:
         if isinstance(data, dict):
-            for key in set(data.keys()) - _BUILD_SPEC_KEYS:
-                hint = suggest_typo_fix(key, _BUILD_SPEC_KEYS)
+            valid_keys = _valid_field_keys(cls)
+            for key in set(data.keys()) - valid_keys:
+                hint = suggest_typo_fix(key, valid_keys)
                 msg = f"Unknown key '{key}' in build spec."
                 if hint:
                     msg += f" Did you mean '{hint}'?"
@@ -165,16 +188,6 @@ class CalibrationStep(BaseModel):
         return {"method_name": name, "params": params}
 
 
-_TOP_LEVEL_KEYS = {
-    "model",
-    "data",
-    "effects",
-    "original_scale_vars",
-    "calibration",
-    "idata_path",
-}
-
-
 class MMMYamlConfig(BaseModel):
     """Schema for the top-level MMM YAML configuration.
 
@@ -220,8 +233,9 @@ class MMMYamlConfig(BaseModel):
     @classmethod
     def _check_unknown_keys(cls, data: Any) -> Any:
         if isinstance(data, dict):
-            for key in set(data.keys()) - _TOP_LEVEL_KEYS:
-                hint = suggest_typo_fix(key, _TOP_LEVEL_KEYS)
+            valid_keys = _valid_field_keys(cls)
+            for key in set(data.keys()) - valid_keys:
+                hint = suggest_typo_fix(key, valid_keys)
                 msg = f"Unknown config key '{key}'."
                 if hint:
                     msg += f" Did you mean '{hint}'?"

--- a/pymc_marketing/mmm/builders/schema.py
+++ b/pymc_marketing/mmm/builders/schema.py
@@ -141,6 +141,8 @@ class CalibrationStep(BaseModel):
         Keyword arguments to pass to the method.
     """
 
+    model_config = ConfigDict(extra="forbid")
+
     method_name: str = Field(..., description="Calibration method name.")
     params: dict[str, Any] | None = Field(None, description="Method keyword arguments.")
 

--- a/pymc_marketing/mmm/builders/schema.py
+++ b/pymc_marketing/mmm/builders/schema.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Any
 
 import yaml  # type: ignore
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 def suggest_typo_fix(
@@ -194,36 +194,3 @@ class MMMYamlConfig(BaseModel):
         """
         raw = yaml.safe_load(Path(path).read_text())
         return cls.model_validate(raw)
-
-    @classmethod
-    def validate_or_raise(cls, raw: dict[str, Any]) -> MMMYamlConfig:
-        """Validate a raw config dict, re-raising as :class:`ValueError`.
-
-        Parameters
-        ----------
-        raw : dict
-            Raw parsed YAML dictionary.
-
-        Returns
-        -------
-        MMMYamlConfig
-            Validated configuration object.
-
-        Raises
-        ------
-        ValueError
-            If validation fails, with detailed error messages including
-            field locations.
-        """
-        try:
-            return cls.model_validate(raw)
-        except ValidationError as exc:
-            parts: list[str] = []
-            for e in exc.errors():
-                loc = " -> ".join(str(x) for x in e["loc"])
-                line = f"  - {e['msg']}"
-                if loc:
-                    line += f" (at {loc})"
-                parts.append(line)
-            error_msg = "YAML configuration validation failed:\n" + "\n".join(parts)
-            raise ValueError(error_msg) from exc

--- a/pymc_marketing/mmm/builders/yaml.py
+++ b/pymc_marketing/mmm/builders/yaml.py
@@ -17,27 +17,14 @@ from __future__ import annotations
 
 import os
 import warnings
-from collections.abc import Mapping
 from pathlib import Path
-from typing import Any
 
 import pandas as pd
-import yaml  # type: ignore
 
-from pymc_marketing.mmm.builders.factories import KNOWN_SPEC_KEYS, build, resolve
+from pymc_marketing.mmm.builders.factories import build, resolve
+from pymc_marketing.mmm.builders.schema import CalibrationStep, MMMYamlConfig
 from pymc_marketing.mmm.multidimensional import MMM
 from pymc_marketing.utils import from_netcdf
-
-KNOWN_TOP_LEVEL_KEYS = frozenset(
-    {
-        "model",
-        "data",
-        "effects",
-        "original_scale_vars",
-        "calibration",
-        "idata_path",
-    }
-)
 
 
 def _load_df(path: str | Path) -> pd.DataFrame:
@@ -54,72 +41,32 @@ def _load_df(path: str | Path) -> pd.DataFrame:
     raise ValueError(f"Unrecognised tabular format: {path}")
 
 
-def _validate_config_structure(cfg: Mapping[str, Any]) -> None:
-    """Detect common YAML mis-indentation that silently drops config sections."""
-    model_spec = cfg.get("model")
-    if model_spec is None:
-        raise ValueError("YAML config must contain a top-level 'model' key.")
-
-    if not isinstance(model_spec, Mapping):
-        raise TypeError(f"'model' must be a mapping, got {type(model_spec).__name__}.")
-
-    misplaced = set(model_spec.keys()) - KNOWN_SPEC_KEYS
-    candidates = misplaced & KNOWN_TOP_LEVEL_KEYS
-    if candidates:
-        raise ValueError(
-            f"Found {candidates} nested under 'model', but "
-            f"{'it' if len(candidates) == 1 else 'they'} "
-            f"should be at the top level of the YAML file. "
-            f"Check the indentation of your YAML configuration."
-        )
-
-
 def _apply_and_validate_calibration_steps(
-    model: MMM, cfg: Mapping[str, Any], base_dir: Path
+    model: MMM,
+    steps: list[CalibrationStep] | None,
+    base_dir: Path,
 ) -> None:
-    calibration_specs = cfg.get("calibration") or []
-    if not calibration_specs:
-        return
+    for step in steps or []:
+        if not hasattr(model, step.method_name):
+            raise AttributeError(f"MMM has no calibration method '{step.method_name}'.")
 
-    if not isinstance(calibration_specs, list):
-        raise TypeError("`calibration` section must be a list of steps.")
-
-    for step in calibration_specs:
-        if not isinstance(step, Mapping):
-            raise TypeError(
-                "Each calibration step must be a mapping of method to parameters."
-            )
-        if len(step) != 1:
-            raise ValueError(
-                "Calibration steps must map a single method to its parameters."
-            )
-
-        method_name, raw_params = next(iter(step.items()))
-
-        if not hasattr(model, method_name):
-            raise AttributeError(f"MMM has no calibration method '{method_name}'.")
-
-        method = getattr(model, method_name)
+        method = getattr(model, step.method_name)
         if not callable(method):
-            raise TypeError(f"Attribute '{method_name}' is not callable on MMM.")
-
-        if raw_params is not None and not isinstance(raw_params, Mapping):
-            raise TypeError(
-                f"Calibration parameters for '{method_name}' must be a mapping, got {type(raw_params).__name__}."
-            )
+            raise TypeError(f"Attribute '{step.method_name}' is not callable on MMM.")
 
         if (
-            method_name == "add_lift_test_measurements"
-            and raw_params
-            and "dist" in raw_params
+            step.method_name == "add_lift_test_measurements"
+            and step.params
+            and "dist" in step.params
         ):
             raise ValueError(
-                "`dist` parameter for 'add_lift_test_measurements' is not supported via YAML configuration yet."
+                "`dist` parameter for 'add_lift_test_measurements' is not "
+                "supported via YAML configuration yet."
             )
 
         resolved_kwargs = (
-            {key: resolve(value) for key, value in raw_params.items()}
-            if raw_params is not None
+            {key: resolve(value) for key, value in step.params.items()}
+            if step.params is not None
             else {}
         )
 
@@ -127,7 +74,8 @@ def _apply_and_validate_calibration_steps(
             method(**resolved_kwargs)
         except Exception as err:  # pragma: no cover - re-raise with context
             raise RuntimeError(
-                f"Failed to apply calibration step '{method_name}' from YAML configuration: \n {err}"
+                f"Failed to apply calibration step '{step.method_name}' "
+                f"from YAML configuration: \n {err}"
             ) from err
 
 
@@ -168,32 +116,28 @@ def build_mmm_from_yaml(
     model : MMM
     """
     config_path = Path(config_path)
-    cfg: Mapping[str, Any] = yaml.safe_load(config_path.read_text())
+    cfg = MMMYamlConfig.from_yaml_file(config_path)
 
-    _validate_config_structure(cfg)
-
-    # 1 ─────────────────────────────────── shell (no effects yet)
-    # Merge model_kwargs into cfg["model"]["kwargs"], with model_kwargs taking precedence
-    model_config = {**cfg["model"].get("kwargs", {}), **(model_kwargs or {})}
-    cfg["model"]["kwargs"] = model_config
+    # 1 -- build MMM shell (no effects yet)
+    model_spec = cfg.model.model_dump(by_alias=True)
+    model_spec["kwargs"] = {**model_spec.get("kwargs", {}), **(model_kwargs or {})}
 
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=DeprecationWarning)
-        model = build(cfg["model"])
+        model = build(model_spec)
 
-    # 2 ──────────────────────────────── resolve covariates / target
-    data_cfg: Mapping[str, Any] = cfg.get("data") or {}
+    # 2 -- resolve covariates / target
+    data_cfg = cfg.data
     if X is None:
-        if "X_path" not in data_cfg:
+        if data_cfg is None or data_cfg.X_path is None:
             raise ValueError("X not provided and no `data.X_path` found in YAML.")
-        X = _load_df(data_cfg["X_path"])
+        X = _load_df(data_cfg.X_path)
     if y is None:
-        if "y_path" not in data_cfg:
+        if data_cfg is None or data_cfg.y_path is None:
             raise ValueError("y not provided and no `data.y_path` found in YAML.")
-        y = _load_df(data_cfg["y_path"])
+        y = _load_df(data_cfg.y_path)
 
-    # Convert date column after loading data
-    date_column = model_config.get("date_column")
+    date_column = model_spec["kwargs"].get("date_column")
     if date_column:
         date_col_in_X = date_column in X.columns
 
@@ -202,28 +146,29 @@ def build_mmm_from_yaml(
 
         if not date_col_in_X:
             raise ValueError(
-                f"Date column '{date_column}' specified in config not found in either X or y data."
+                f"Date column '{date_column}' specified in config not found "
+                f"in either X or y data."
             )
 
-    # 3 ───────────────────────────────────── effects (preserve order)
-    for eff_spec in cfg.get("effects") or []:
-        effect = build(eff_spec)
+    # 3 -- effects (preserve order)
+    for eff_spec in cfg.effects or []:
+        effect = build(eff_spec.model_dump(by_alias=True))
         model.mu_effects.append(effect)
 
-    # 4 ───────────────────────────────────────────── build PyMC graph
-    model.build_model(X, y)  # this **must** precede any idata loading
+    # 4 -- build PyMC graph (must precede idata loading)
+    model.build_model(X, y)
 
-    # 5 ───────────────────────── add original scale contribution variables
-    original_scale_vars = cfg.get("original_scale_vars") or []
+    # 5 -- add original scale contribution variables
+    original_scale_vars = cfg.original_scale_vars or []
     if original_scale_vars:
         model.add_original_scale_contribution_variable(var=original_scale_vars)
 
-    # 6 ──────────────────────────────────────────── apply calibration steps (if any)
-    _apply_and_validate_calibration_steps(model, cfg, config_path.parent)
+    # 6 -- apply calibration steps (if any)
+    _apply_and_validate_calibration_steps(model, cfg.calibration, config_path.parent)
 
-    # 7 ──────────────────────────────────────────── attach inference data
-    if (idata_fp := cfg.get("idata_path")) is not None:
-        idata_path = Path(idata_fp)
+    # 7 -- attach inference data
+    if cfg.idata_path is not None:
+        idata_path = Path(cfg.idata_path)
         if os.path.exists(idata_path):
             model.idata = from_netcdf(idata_path)
 

--- a/pymc_marketing/mmm/builders/yaml.py
+++ b/pymc_marketing/mmm/builders/yaml.py
@@ -44,7 +44,6 @@ def _load_df(path: str | Path) -> pd.DataFrame:
 def _apply_and_validate_calibration_steps(
     model: MMM,
     steps: list[CalibrationStep] | None,
-    base_dir: Path,
 ) -> None:
     for step in steps or []:
         if not hasattr(model, step.method_name):
@@ -164,7 +163,7 @@ def build_mmm_from_yaml(
         model.add_original_scale_contribution_variable(var=original_scale_vars)
 
     # 6 -- apply calibration steps (if any)
-    _apply_and_validate_calibration_steps(model, cfg.calibration, config_path.parent)
+    _apply_and_validate_calibration_steps(model, cfg.calibration)
 
     # 7 -- attach inference data
     if cfg.idata_path is not None:

--- a/tests/mmm/builders/config_files/wrong_adstock_class.yml
+++ b/tests/mmm/builders/config_files/wrong_adstock_class.yml
@@ -17,9 +17,8 @@ model:
       class: pymc_marketing.mmm.MichaelisMentenSaturation
       kwargs: {}
 
-# ----------------------------------------------------------------------
-sampler_config:
-  tune: 1000
-  draws: 200
-  chains: 8
-  random_seed: 42
+    sampler_config:
+      tune: 1000
+      draws: 200
+      chains: 8
+      random_seed: 42

--- a/tests/mmm/builders/config_files/wrong_distribution.yml
+++ b/tests/mmm/builders/config_files/wrong_distribution.yml
@@ -23,9 +23,8 @@ model:
         dist: "InvalidDistribution"
         kwargs: {}
 
-# ----------------------------------------------------------------------
-sampler_config:
-  tune: 1000
-  draws: 200
-  chains: 8
-  random_seed: 42
+    sampler_config:
+      tune: 1000
+      draws: 200
+      chains: 8
+      random_seed: 42

--- a/tests/mmm/builders/config_files/wrong_parameter_type.yml
+++ b/tests/mmm/builders/config_files/wrong_parameter_type.yml
@@ -24,9 +24,8 @@ model:
         kwargs:
           sigma: "wrong_value_type"  # String instead of number
 
-# ----------------------------------------------------------------------
-sampler_config:
-  tune: 1000
-  draws: 200
-  chains: 8
-  random_seed: 42
+    sampler_config:
+      tune: 1000
+      draws: 200
+      chains: 8
+      random_seed: 42

--- a/tests/mmm/builders/config_files/wrong_saturation_params.yml
+++ b/tests/mmm/builders/config_files/wrong_saturation_params.yml
@@ -20,9 +20,8 @@ model:
           alpha: "not_a_number"  # String instead of number
           lambda: -5.0  # Negative value for parameter that should be positive
 
-# ----------------------------------------------------------------------
-sampler_config:
-  tune: 1000
-  draws: 200
-  chains: 8
-  random_seed: 42
+    sampler_config:
+      tune: 1000
+      draws: 200
+      chains: 8
+      random_seed: 42

--- a/tests/mmm/builders/test_schema.py
+++ b/tests/mmm/builders/test_schema.py
@@ -147,6 +147,12 @@ class TestCalibrationStep:
         with pytest.raises(ValidationError, match="exactly one method"):
             CalibrationStep.model_validate("not-a-dict")
 
+    def test_extra_keys_alongside_method_name_raises(self):
+        with pytest.raises(ValidationError):
+            CalibrationStep.model_validate(
+                {"method_name": "foo", "params": {"k": 1}, "extra": "bad"}
+            )
+
     def test_direct_construction(self):
         step = CalibrationStep(method_name="foo", params={"k": 1})
         assert step.method_name == "foo"

--- a/tests/mmm/builders/test_schema.py
+++ b/tests/mmm/builders/test_schema.py
@@ -1,0 +1,307 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""
+Unit tests for the Pydantic YAML configuration schema models.
+
+These tests validate the schema models in isolation (no model building).
+"""
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from pymc_marketing.mmm.builders.schema import (
+    BuildSpec,
+    CalibrationStep,
+    DataConfig,
+    MMMYamlConfig,
+    suggest_typo_fix,
+)
+
+# ---------------------------------------------------------------------------
+# suggest_typo_fix
+# ---------------------------------------------------------------------------
+
+
+class TestSuggestTypoFix:
+    def test_close_match(self):
+        assert suggest_typo_fix("modle", {"model", "data"}) == "model"
+
+    def test_no_match(self):
+        assert suggest_typo_fix("zzz", {"model", "data"}) is None
+
+    def test_close_match_kwargs(self):
+        assert suggest_typo_fix("kwarg", {"class", "kwargs", "args"}) == "kwargs"
+
+    def test_close_match_effects(self):
+        valid = {"model", "data", "effects", "original_scale_vars"}
+        assert suggest_typo_fix("efects", valid) == "effects"
+
+
+# ---------------------------------------------------------------------------
+# BuildSpec
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSpec:
+    def test_valid_minimal(self):
+        spec = BuildSpec.model_validate({"class": "foo.Bar"})
+        assert spec.class_ == "foo.Bar"
+        assert spec.kwargs == {}
+        assert spec.args == []
+
+    def test_valid_full(self):
+        spec = BuildSpec.model_validate(
+            {"class": "foo.Bar", "kwargs": {"x": 1}, "args": [2]}
+        )
+        assert spec.class_ == "foo.Bar"
+        assert spec.kwargs == {"x": 1}
+        assert spec.args == [2]
+
+    def test_missing_class_raises(self):
+        with pytest.raises(ValidationError):
+            BuildSpec.model_validate({"kwargs": {"x": 1}})
+
+    def test_non_string_class_raises(self):
+        with pytest.raises(ValidationError):
+            BuildSpec.model_validate({"class": 123})
+
+    def test_unknown_key_with_suggestion(self):
+        with pytest.raises(ValidationError, match="Did you mean 'kwargs'"):
+            BuildSpec.model_validate({"class": "foo.Bar", "kwarg": {}})
+
+    def test_unknown_key_without_suggestion(self):
+        with pytest.raises(ValidationError, match="Unknown key 'zzz'"):
+            BuildSpec.model_validate({"class": "foo.Bar", "zzz": {}})
+
+    def test_model_dump_round_trip(self):
+        original = {"class": "foo.Bar", "kwargs": {"x": 1}}
+        spec = BuildSpec.model_validate(original)
+        dumped = spec.model_dump(by_alias=True)
+        assert dumped["class"] == "foo.Bar"
+        assert dumped["kwargs"] == {"x": 1}
+        assert dumped["args"] == []
+
+    def test_nested_build_specs_in_kwargs_pass_through(self):
+        """Nested build specs inside kwargs are not recursively validated."""
+        raw = {
+            "class": "foo.Bar",
+            "kwargs": {
+                "nested": {
+                    "class": "baz.Qux",
+                    "kwargs": {"y": 2},
+                }
+            },
+        }
+        spec = BuildSpec.model_validate(raw)
+        assert spec.kwargs["nested"]["class"] == "baz.Qux"
+
+    def test_populate_by_name(self):
+        """class_ can be set by Python name (not just alias)."""
+        spec = BuildSpec(class_="foo.Bar")
+        assert spec.class_ == "foo.Bar"
+
+
+# ---------------------------------------------------------------------------
+# DataConfig
+# ---------------------------------------------------------------------------
+
+
+class TestDataConfig:
+    def test_valid(self):
+        cfg = DataConfig.model_validate(
+            {"X_path": "data/X.csv", "y_path": "data/y.csv"}
+        )
+        assert cfg.X_path == "data/X.csv"
+        assert cfg.y_path == "data/y.csv"
+
+    def test_empty(self):
+        cfg = DataConfig.model_validate({})
+        assert cfg.X_path is None
+        assert cfg.y_path is None
+
+    def test_unknown_key_raises(self):
+        with pytest.raises(ValidationError):
+            DataConfig.model_validate({"X_path": "a.csv", "z_path": "b.csv"})
+
+
+# ---------------------------------------------------------------------------
+# CalibrationStep
+# ---------------------------------------------------------------------------
+
+
+class TestCalibrationStep:
+    def test_valid_with_params(self):
+        step = CalibrationStep.model_validate(
+            {"add_lift_test_measurements": {"df": "some_value"}}
+        )
+        assert step.method_name == "add_lift_test_measurements"
+        assert step.params == {"df": "some_value"}
+
+    def test_valid_with_none_params(self):
+        step = CalibrationStep.model_validate({"some_method": None})
+        assert step.method_name == "some_method"
+        assert step.params is None
+
+    def test_empty_dict_raises(self):
+        with pytest.raises(ValidationError, match="exactly one method"):
+            CalibrationStep.model_validate({})
+
+    def test_multi_key_dict_raises(self):
+        with pytest.raises(ValidationError, match="exactly one method"):
+            CalibrationStep.model_validate({"method_a": {}, "method_b": {}})
+
+    def test_non_dict_raises(self):
+        with pytest.raises(ValidationError, match="exactly one method"):
+            CalibrationStep.model_validate("not-a-dict")
+
+
+# ---------------------------------------------------------------------------
+# MMMYamlConfig
+# ---------------------------------------------------------------------------
+
+
+class TestMMMYamlConfig:
+    def test_minimal_valid(self):
+        cfg = MMMYamlConfig.model_validate({"model": {"class": "some.Class"}})
+        assert cfg.model.class_ == "some.Class"
+        assert cfg.data is None
+        assert cfg.effects is None
+        assert cfg.original_scale_vars is None
+        assert cfg.calibration is None
+        assert cfg.idata_path is None
+
+    def test_full_valid(self):
+        raw = {
+            "model": {"class": "some.Class", "kwargs": {"x": 1}},
+            "data": {"X_path": "data/X.csv", "y_path": "data/y.csv"},
+            "effects": [{"class": "some.Effect", "kwargs": {}}],
+            "original_scale_vars": ["channel_contribution"],
+            "calibration": [{"method_a": {"param": 1}}],
+            "idata_path": "data/idata.nc",
+        }
+        cfg = MMMYamlConfig.model_validate(raw)
+        assert cfg.model.class_ == "some.Class"
+        assert cfg.data is not None
+        assert cfg.data.X_path == "data/X.csv"
+        assert len(cfg.effects) == 1
+        assert cfg.original_scale_vars == ["channel_contribution"]
+        assert len(cfg.calibration) == 1
+        assert cfg.calibration[0].method_name == "method_a"
+        assert cfg.idata_path == "data/idata.nc"
+
+    def test_missing_model_raises(self):
+        with pytest.raises(ValidationError):
+            MMMYamlConfig.model_validate({"effects": []})
+
+    def test_typo_model(self):
+        with pytest.raises(ValidationError, match="Did you mean 'model'"):
+            MMMYamlConfig.model_validate({"modle": {"class": "some.Class"}})
+
+    def test_typo_effects(self):
+        with pytest.raises(ValidationError, match="Did you mean 'effects'"):
+            MMMYamlConfig.model_validate(
+                {
+                    "model": {"class": "some.Class"},
+                    "efects": [],
+                }
+            )
+
+    def test_typo_calibration(self):
+        with pytest.raises(ValidationError, match="Did you mean 'calibration'"):
+            MMMYamlConfig.model_validate(
+                {
+                    "model": {"class": "some.Class"},
+                    "calibraton": [],
+                }
+            )
+
+    def test_unknown_key_no_suggestion(self):
+        with pytest.raises(ValidationError, match="Unknown config key 'zzz'"):
+            MMMYamlConfig.model_validate(
+                {
+                    "model": {"class": "some.Class"},
+                    "zzz": "value",
+                }
+            )
+
+    def test_original_scale_vars_none_accepted(self):
+        cfg = MMMYamlConfig.model_validate(
+            {
+                "model": {"class": "some.Class"},
+                "original_scale_vars": None,
+            }
+        )
+        assert cfg.original_scale_vars is None
+
+    def test_calibration_none_accepted(self):
+        cfg = MMMYamlConfig.model_validate(
+            {
+                "model": {"class": "some.Class"},
+                "calibration": None,
+            }
+        )
+        assert cfg.calibration is None
+
+
+# ---------------------------------------------------------------------------
+# MMMYamlConfig.from_yaml_file
+# ---------------------------------------------------------------------------
+
+
+class TestFromYamlFile:
+    def test_valid_file(self, tmp_path):
+        config = {
+            "model": {
+                "class": "pymc_marketing.mmm.multidimensional.MMM",
+                "kwargs": {"date_column": "date"},
+            }
+        }
+        path = tmp_path / "config.yml"
+        path.write_text(yaml.dump(config))
+
+        cfg = MMMYamlConfig.from_yaml_file(path)
+        assert cfg.model.class_ == "pymc_marketing.mmm.multidimensional.MMM"
+
+    def test_invalid_file_raises_validation_error(self, tmp_path):
+        config = {"modle": {"class": "some.Class"}}
+        path = tmp_path / "bad.yml"
+        path.write_text(yaml.dump(config))
+
+        with pytest.raises(ValidationError, match="Did you mean 'model'"):
+            MMMYamlConfig.from_yaml_file(path)
+
+    def test_missing_file_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            MMMYamlConfig.from_yaml_file(tmp_path / "nonexistent.yml")
+
+
+# ---------------------------------------------------------------------------
+# MMMYamlConfig.validate_or_raise
+# ---------------------------------------------------------------------------
+
+
+class TestValidateOrRaise:
+    def test_valid_dict(self):
+        raw = {"model": {"class": "some.Class"}}
+        cfg = MMMYamlConfig.validate_or_raise(raw)
+        assert cfg.model.class_ == "some.Class"
+
+    def test_invalid_dict_raises_value_error(self):
+        with pytest.raises(ValueError, match="YAML configuration validation failed"):
+            MMMYamlConfig.validate_or_raise({"modle": {"class": "some.Class"}})
+
+    def test_error_message_contains_location(self):
+        with pytest.raises(ValueError, match="at "):
+            MMMYamlConfig.validate_or_raise({})

--- a/tests/mmm/builders/test_schema.py
+++ b/tests/mmm/builders/test_schema.py
@@ -289,23 +289,3 @@ class TestFromYamlFile:
     def test_missing_file_raises(self, tmp_path):
         with pytest.raises(FileNotFoundError):
             MMMYamlConfig.from_yaml_file(tmp_path / "nonexistent.yml")
-
-
-class TestValidateOrRaise:
-    def test_valid_dict(self):
-        raw = {"model": {"class": "some.Class"}}
-        cfg = MMMYamlConfig.validate_or_raise(raw)
-        assert cfg.model.class_ == "some.Class"
-
-    def test_invalid_dict_raises_value_error(self):
-        with pytest.raises(ValueError, match="YAML configuration validation failed"):
-            MMMYamlConfig.validate_or_raise({"modle": {"class": "some.Class"}})
-
-    def test_error_message_contains_location_for_field_errors(self):
-        with pytest.raises(ValueError, match=r"\(at model\)"):
-            MMMYamlConfig.validate_or_raise({})
-
-    def test_empty_loc_omits_parenthetical(self):
-        with pytest.raises(ValueError, match=r"Did you mean 'model'\?$") as exc_info:
-            MMMYamlConfig.validate_or_raise({"modle": {"class": "some.Class"}})
-        assert "(at )" not in str(exc_info.value)

--- a/tests/mmm/builders/test_schema.py
+++ b/tests/mmm/builders/test_schema.py
@@ -73,7 +73,7 @@ class TestBuildSpec:
             BuildSpec.model_validate({"class": "foo.Bar", "kwarg": {}})
 
     def test_unknown_key_without_suggestion(self):
-        with pytest.raises(ValidationError, match="Unknown key 'zzz'"):
+        with pytest.raises(ValidationError, match="Unknown build spec key 'zzz'"):
             BuildSpec.model_validate({"class": "foo.Bar", "zzz": {}})
 
     def test_model_dump_round_trip(self):

--- a/tests/mmm/builders/test_schema.py
+++ b/tests/mmm/builders/test_schema.py
@@ -166,6 +166,20 @@ class TestCalibrationStep:
         with pytest.raises(ValidationError, match="exactly one method"):
             CalibrationStep.model_validate("not-a-dict")
 
+    def test_direct_construction(self):
+        step = CalibrationStep(method_name="foo", params={"k": 1})
+        assert step.method_name == "foo"
+        assert step.params == {"k": 1}
+
+    def test_model_dump_round_trip(self):
+        step = CalibrationStep.model_validate(
+            {"add_lift_test_measurements": {"df": "some_value"}}
+        )
+        dumped = step.model_dump()
+        restored = CalibrationStep.model_validate(dumped)
+        assert restored.method_name == step.method_name
+        assert restored.params == step.params
+
 
 # ---------------------------------------------------------------------------
 # MMMYamlConfig
@@ -253,6 +267,19 @@ class TestMMMYamlConfig:
             }
         )
         assert cfg.calibration is None
+
+    def test_model_dump_round_trip_with_calibration(self):
+        raw = {
+            "model": {"class": "some.Class", "kwargs": {"x": 1}},
+            "calibration": [{"method_a": {"param": 1}}],
+        }
+        cfg = MMMYamlConfig.model_validate(raw)
+        dumped = cfg.model_dump(by_alias=True)
+        restored = MMMYamlConfig.model_validate(dumped)
+        assert restored.model.class_ == cfg.model.class_
+        assert len(restored.calibration) == 1
+        assert restored.calibration[0].method_name == "method_a"
+        assert restored.calibration[0].params == {"param": 1}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/mmm/builders/test_schema.py
+++ b/tests/mmm/builders/test_schema.py
@@ -29,10 +29,6 @@ from pymc_marketing.mmm.builders.schema import (
     suggest_typo_fix,
 )
 
-# ---------------------------------------------------------------------------
-# suggest_typo_fix
-# ---------------------------------------------------------------------------
-
 
 class TestSuggestTypoFix:
     def test_close_match(self):
@@ -47,11 +43,6 @@ class TestSuggestTypoFix:
     def test_close_match_effects(self):
         valid = {"model", "data", "effects", "original_scale_vars"}
         assert suggest_typo_fix("efects", valid) == "effects"
-
-
-# ---------------------------------------------------------------------------
-# BuildSpec
-# ---------------------------------------------------------------------------
 
 
 class TestBuildSpec:
@@ -113,11 +104,6 @@ class TestBuildSpec:
         assert spec.class_ == "foo.Bar"
 
 
-# ---------------------------------------------------------------------------
-# DataConfig
-# ---------------------------------------------------------------------------
-
-
 class TestDataConfig:
     def test_valid(self):
         cfg = DataConfig.model_validate(
@@ -134,11 +120,6 @@ class TestDataConfig:
     def test_unknown_key_raises(self):
         with pytest.raises(ValidationError):
             DataConfig.model_validate({"X_path": "a.csv", "z_path": "b.csv"})
-
-
-# ---------------------------------------------------------------------------
-# CalibrationStep
-# ---------------------------------------------------------------------------
 
 
 class TestCalibrationStep:
@@ -179,11 +160,6 @@ class TestCalibrationStep:
         restored = CalibrationStep.model_validate(dumped)
         assert restored.method_name == step.method_name
         assert restored.params == step.params
-
-
-# ---------------------------------------------------------------------------
-# MMMYamlConfig
-# ---------------------------------------------------------------------------
 
 
 class TestMMMYamlConfig:
@@ -282,11 +258,6 @@ class TestMMMYamlConfig:
         assert restored.calibration[0].params == {"param": 1}
 
 
-# ---------------------------------------------------------------------------
-# MMMYamlConfig.from_yaml_file
-# ---------------------------------------------------------------------------
-
-
 class TestFromYamlFile:
     def test_valid_file(self, tmp_path):
         config = {
@@ -314,11 +285,6 @@ class TestFromYamlFile:
             MMMYamlConfig.from_yaml_file(tmp_path / "nonexistent.yml")
 
 
-# ---------------------------------------------------------------------------
-# MMMYamlConfig.validate_or_raise
-# ---------------------------------------------------------------------------
-
-
 class TestValidateOrRaise:
     def test_valid_dict(self):
         raw = {"model": {"class": "some.Class"}}
@@ -329,6 +295,11 @@ class TestValidateOrRaise:
         with pytest.raises(ValueError, match="YAML configuration validation failed"):
             MMMYamlConfig.validate_or_raise({"modle": {"class": "some.Class"}})
 
-    def test_error_message_contains_location(self):
-        with pytest.raises(ValueError, match="at "):
+    def test_error_message_contains_location_for_field_errors(self):
+        with pytest.raises(ValueError, match=r"\(at model\)"):
             MMMYamlConfig.validate_or_raise({})
+
+    def test_empty_loc_omits_parenthetical(self):
+        with pytest.raises(ValueError, match=r"Did you mean 'model'\?$") as exc_info:
+            MMMYamlConfig.validate_or_raise({"modle": {"class": "some.Class"}})
+        assert "(at )" not in str(exc_info.value)

--- a/tests/mmm/builders/test_yaml.py
+++ b/tests/mmm/builders/test_yaml.py
@@ -221,7 +221,7 @@ def failing_mmm(dummy_mmm):
     return failing
 
 
-def test_apply_and_validate_calibration_steps_success(dummy_mmm, tmp_path):
+def test_apply_and_validate_calibration_steps_success(dummy_mmm):
     steps = [
         CalibrationStep.model_validate(
             {
@@ -235,27 +235,27 @@ def test_apply_and_validate_calibration_steps_success(dummy_mmm, tmp_path):
         )
     ]
 
-    _apply_and_validate_calibration_steps(dummy_mmm, steps, tmp_path)
+    _apply_and_validate_calibration_steps(dummy_mmm, steps)
 
     assert isinstance(dummy_mmm.called_with["df"], pd.DataFrame)
 
 
-def test_apply_calibration_missing_method(dummy_mmm, tmp_path):
+def test_apply_calibration_missing_method(dummy_mmm):
     steps = [CalibrationStep.model_validate({"missing": {}})]
 
     with pytest.raises(AttributeError, match="has no calibration method 'missing'"):
-        _apply_and_validate_calibration_steps(dummy_mmm, steps, tmp_path)
+        _apply_and_validate_calibration_steps(dummy_mmm, steps)
 
 
-def test_apply_calibration_not_callable(dummy_mmm, tmp_path):
+def test_apply_calibration_not_callable(dummy_mmm):
     dummy_mmm.not_callable = 123  # type: ignore[attr-defined]
     steps = [CalibrationStep.model_validate({"not_callable": {}})]
 
     with pytest.raises(TypeError, match="not callable"):
-        _apply_and_validate_calibration_steps(dummy_mmm, steps, tmp_path)
+        _apply_and_validate_calibration_steps(dummy_mmm, steps)
 
 
-def test_apply_calibration_dist_disallowed(dummy_mmm, tmp_path):
+def test_apply_calibration_dist_disallowed(dummy_mmm):
     steps = [
         CalibrationStep.model_validate(
             {"add_lift_test_measurements": {"dist": "Gamma"}}
@@ -263,16 +263,16 @@ def test_apply_calibration_dist_disallowed(dummy_mmm, tmp_path):
     ]
 
     with pytest.raises(ValueError, match="`dist` parameter"):
-        _apply_and_validate_calibration_steps(dummy_mmm, steps, tmp_path)
+        _apply_and_validate_calibration_steps(dummy_mmm, steps)
 
 
-def test_apply_calibration_propagates_failure(failing_mmm, tmp_path):
+def test_apply_calibration_propagates_failure(failing_mmm):
     steps = [CalibrationStep.model_validate({"failing": {}})]
 
     with pytest.raises(
         RuntimeError, match="Failed to apply calibration step 'failing'"
     ):
-        _apply_and_validate_calibration_steps(failing_mmm, steps, tmp_path)
+        _apply_and_validate_calibration_steps(failing_mmm, steps)
 
 
 def test_special_prior_in_yaml(tmp_path, mock_pymc_sample):
@@ -516,9 +516,9 @@ def test_original_scale_vars_none_is_harmless(tmp_path):
     assert "channel_contribution_original_scale" not in det_names
 
 
-def test_calibration_none_is_harmless(dummy_mmm, tmp_path):
+def test_calibration_none_is_harmless(dummy_mmm):
     """calibration: None should not crash."""
-    _apply_and_validate_calibration_steps(dummy_mmm, None, tmp_path)
+    _apply_and_validate_calibration_steps(dummy_mmm, None)
     assert dummy_mmm.called_with is None
 
 

--- a/tests/mmm/builders/test_yaml.py
+++ b/tests/mmm/builders/test_yaml.py
@@ -43,6 +43,43 @@ def y_data():
     return pd.read_csv("data/processed/y.csv")
 
 
+@pytest.fixture
+def _minimal_model_config():
+    """Reusable minimal MMM config dict (no data/idata sections)."""
+    return {
+        "model": {
+            "class": "pymc_marketing.mmm.multidimensional.MMM",
+            "kwargs": {
+                "date_column": "date",
+                "channel_columns": ["channel_1", "channel_2"],
+                "target_column": "y",
+                "adstock": {
+                    "class": "pymc_marketing.mmm.GeometricAdstock",
+                    "kwargs": {"l_max": 4},
+                },
+                "saturation": {
+                    "class": "pymc_marketing.mmm.LogisticSaturation",
+                    "kwargs": {},
+                },
+            },
+        }
+    }
+
+
+@pytest.fixture
+def _sample_data():
+    """Small X / y pair for lightweight integration tests."""
+    X = pd.DataFrame(
+        {
+            "date": pd.date_range("2023-01-01", periods=52, freq="W"),
+            "channel_1": range(52),
+            "channel_2": range(100, 152),
+        }
+    )
+    y = pd.Series(range(52), name="y")
+    return X, y
+
+
 def get_yaml_files():
     """Get all YAML files from the data/config_files directory."""
     config_dir = Path("data/config_files")
@@ -313,9 +350,73 @@ def test_special_prior_in_yaml(tmp_path, mock_pymc_sample):
     assert "posterior" in model.idata
 
 
-# ---------------------------------------------------------------------------
-# Tests for config structure validation (MMMYamlConfig)
-# ---------------------------------------------------------------------------
+def test_build_mmm_loads_data_from_yaml_paths(
+    tmp_path, _minimal_model_config, _sample_data
+):
+    """X and y loaded from CSV paths declared in ``data`` section."""
+    X, y = _sample_data
+    X.to_csv(tmp_path / "X.csv", index=False)
+    y.to_csv(tmp_path / "y.csv", index=False)
+
+    config = _minimal_model_config
+    config["data"] = {
+        "X_path": str(tmp_path / "X.csv"),
+        "y_path": str(tmp_path / "y.csv"),
+    }
+
+    config_path = tmp_path / "config.yml"
+    config_path.write_text(yaml.dump(config))
+
+    model = build_mmm_from_yaml(config_path)
+
+    assert model is not None
+    assert hasattr(model, "model")
+
+
+def test_build_mmm_raises_when_X_missing_and_no_data_path(
+    tmp_path, _minimal_model_config
+):
+    """ValueError when X is not passed and YAML has no ``data.X_path``."""
+    config_path = tmp_path / "config.yml"
+    config_path.write_text(yaml.dump(_minimal_model_config))
+
+    with pytest.raises(ValueError, match="X not provided"):
+        build_mmm_from_yaml(config_path)
+
+
+def test_build_mmm_raises_when_y_missing_and_no_data_path(
+    tmp_path, _minimal_model_config, _sample_data
+):
+    """ValueError when y is not passed and YAML has no ``data.y_path``."""
+    X, _ = _sample_data
+
+    config_path = tmp_path / "config.yml"
+    config_path.write_text(yaml.dump(_minimal_model_config))
+
+    with pytest.raises(ValueError, match="y not provided"):
+        build_mmm_from_yaml(config_path, X=X)
+
+
+def test_build_mmm_loads_idata_from_path(tmp_path, _minimal_model_config, _sample_data):
+    """idata_path in YAML causes InferenceData to be loaded into model."""
+    import arviz as az
+
+    X, y = _sample_data
+
+    idata = az.from_dict(posterior={"intercept": [1.0, 2.0, 3.0]})
+    idata_file = tmp_path / "idata.nc"
+    idata.to_netcdf(str(idata_file))
+
+    config = _minimal_model_config
+    config["idata_path"] = str(idata_file)
+
+    config_path = tmp_path / "config.yml"
+    config_path.write_text(yaml.dump(config))
+
+    model = build_mmm_from_yaml(config_path, X=X, y=y)
+
+    assert model.idata is not None
+    assert "posterior" in model.idata
 
 
 class TestValidateConfigStructure:

--- a/tests/mmm/builders/test_yaml.py
+++ b/tests/mmm/builders/test_yaml.py
@@ -21,10 +21,11 @@ import pandas as pd
 import pytest
 import xarray as xr
 import yaml
+from pydantic import ValidationError
 
+from pymc_marketing.mmm.builders.schema import CalibrationStep, MMMYamlConfig
 from pymc_marketing.mmm.builders.yaml import (
     _apply_and_validate_calibration_steps,
-    _validate_config_structure,
     build_mmm_from_yaml,
 )
 from pymc_marketing.model_config import ModelConfigError
@@ -71,44 +72,33 @@ def get_yaml_files():
 @pytest.mark.parametrize("config_path", get_yaml_files())
 def test_build_mmm_from_yaml(config_path, X_data, y_data, model_kwargs):
     """Test that build_mmm_from_yaml can create models from all config files."""
-    # Load YAML to check if effects are defined
     with open(config_path) as file:
         config = yaml.safe_load(file)
 
-    # Build model from YAML
     model = build_mmm_from_yaml(
-        config_path=config_path, X=X_data, y=y_data.squeeze(), model_kwargs=model_kwargs
+        config_path=config_path,
+        X=X_data,
+        y=y_data.squeeze(),
+        model_kwargs=model_kwargs,
     )
 
-    # Check that model was created successfully
     assert model is not None
-
-    # Check that model has the expected structure
     assert hasattr(model, "model")
 
-    # Only check for mu_effects if effects are defined in the YAML
     if config.get("effects"):
         assert hasattr(model, "mu_effects")
         assert len(model.mu_effects) > 0
 
-    # Test that prior predictive sampling works using the model's method
     prior_predictive = model.sample_prior_predictive(X=X_data, y=y_data, samples=10)
-
-    # Verify we have a prior predictive result
     assert prior_predictive is not None
-
-    # Verify that the result is an xarray dataset
     assert isinstance(prior_predictive, xr.Dataset)
 
     if model_kwargs:
-        # assert that model_kwargs are reflected in the model
         for key, value in model_kwargs.items():
             attr = getattr(model, key, None)
             if isinstance(value, dict) and "class" in value and "kwargs" in value:
-                # Check class name
                 expected_class_name = value["class"].split(".")[-1]
                 assert attr.__class__.__name__ == expected_class_name
-                # Check only the specified kwargs
                 for k, v in value["kwargs"].items():
                     assert hasattr(attr, k), f"{key} missing attribute {k}"
                     assert getattr(attr, k) == v, f"{key}.{k}={getattr(attr, k)} != {v}"
@@ -120,11 +110,9 @@ def test_wrong_adstock_class():
     """Test that a model with a wrong adstock class fails appropriately."""
     wrong_config_path = Path("tests/mmm/builders/config_files/wrong_adstock_class.yml")
 
-    # Should fail with AttributeError for the non-existent adstock class
     with pytest.raises(AttributeError, match=r".*NonExistentAdstock.*"):
         build_mmm_from_yaml(wrong_config_path)
 
-    # Verify the config file has the expected wrong class
     cfg = yaml.safe_load(wrong_config_path.read_text())
     adstock_config = cfg["model"]["kwargs"]["adstock"]
     assert adstock_config["class"] == "pymc_marketing.mmm.NonExistentAdstock"
@@ -136,11 +124,9 @@ def test_wrong_saturation_params():
         "tests/mmm/builders/config_files/wrong_saturation_params.yml"
     )
 
-    # Should eventually fail with a ModelConfigError or TypeError
     with pytest.raises((TypeError, ModelConfigError, ValueError)):
         build_mmm_from_yaml(wrong_config_path)
 
-    # Verify the config file has the expected wrong parameters
     cfg = yaml.safe_load(wrong_config_path.read_text())
     saturation_config = cfg["model"]["kwargs"]["saturation"]["kwargs"]["priors"]
     assert saturation_config["alpha"] == "not_a_number"
@@ -151,11 +137,9 @@ def test_wrong_distribution():
     """Test that a model with an invalid distribution fails appropriately."""
     wrong_config_path = Path("tests/mmm/builders/config_files/wrong_distribution.yml")
 
-    # Should fail with ModelConfigError when parsing distributions
     with pytest.raises(ModelConfigError):
         build_mmm_from_yaml(wrong_config_path)
 
-    # Verify the config file has the expected wrong distribution
     cfg = yaml.safe_load(wrong_config_path.read_text())
     model_config = cfg["model"]["kwargs"]["model_config"]
     assert model_config["intercept"]["dist"] == "InvalidDistribution"
@@ -165,11 +149,9 @@ def test_wrong_parameter_type():
     """Test that a model with a wrong parameter type fails appropriately."""
     wrong_config_path = Path("tests/mmm/builders/config_files/wrong_parameter_type.yml")
 
-    # Should fail with ModelConfigError when parsing distributions
     with pytest.raises(ModelConfigError):
         build_mmm_from_yaml(wrong_config_path)
 
-    # Verify the config file has the expected wrong parameter type
     cfg = yaml.safe_load(wrong_config_path.read_text())
     model_config = cfg["model"]["kwargs"]["model_config"]
     assert model_config["likelihood"]["kwargs"]["sigma"] == "wrong_value_type"
@@ -203,8 +185,8 @@ def failing_mmm(dummy_mmm):
 
 
 def test_apply_and_validate_calibration_steps_success(dummy_mmm, tmp_path):
-    cfg = {
-        "calibration": [
+    steps = [
+        CalibrationStep.model_validate(
             {
                 "good": {
                     "df": {
@@ -213,76 +195,51 @@ def test_apply_and_validate_calibration_steps_success(dummy_mmm, tmp_path):
                     }
                 }
             }
-        ]
-    }
+        )
+    ]
 
-    _apply_and_validate_calibration_steps(dummy_mmm, cfg, tmp_path)
+    _apply_and_validate_calibration_steps(dummy_mmm, steps, tmp_path)
 
     assert isinstance(dummy_mmm.called_with["df"], pd.DataFrame)
 
 
-def test_apply_calibration_non_list(dummy_mmm, tmp_path):
-    cfg = {"calibration": "not-a-list"}
-
-    with pytest.raises(TypeError, match="must be a list"):
-        _apply_and_validate_calibration_steps(dummy_mmm, cfg, tmp_path)
-
-
-def test_apply_calibration_step_not_mapping(dummy_mmm, tmp_path):
-    cfg = {"calibration": ["not-mapping"]}
-
-    with pytest.raises(TypeError, match="must be a mapping"):
-        _apply_and_validate_calibration_steps(dummy_mmm, cfg, tmp_path)
-
-
-def test_apply_calibration_step_multiple_methods(dummy_mmm, tmp_path):
-    cfg = {"calibration": [{"good": {}, "other": {}}]}
-
-    with pytest.raises(ValueError, match="single method"):
-        _apply_and_validate_calibration_steps(dummy_mmm, cfg, tmp_path)
-
-
 def test_apply_calibration_missing_method(dummy_mmm, tmp_path):
-    cfg = {"calibration": [{"missing": {}}]}
+    steps = [CalibrationStep.model_validate({"missing": {}})]
 
     with pytest.raises(AttributeError, match="has no calibration method 'missing'"):
-        _apply_and_validate_calibration_steps(dummy_mmm, cfg, tmp_path)
+        _apply_and_validate_calibration_steps(dummy_mmm, steps, tmp_path)
 
 
 def test_apply_calibration_not_callable(dummy_mmm, tmp_path):
     dummy_mmm.not_callable = 123  # type: ignore[attr-defined]
-    cfg = {"calibration": [{"not_callable": {}}]}
+    steps = [CalibrationStep.model_validate({"not_callable": {}})]
 
     with pytest.raises(TypeError, match="not callable"):
-        _apply_and_validate_calibration_steps(dummy_mmm, cfg, tmp_path)
-
-
-def test_apply_calibration_params_not_mapping(dummy_mmm, tmp_path):
-    cfg = {"calibration": [{"good": "invalid"}]}
-
-    with pytest.raises(TypeError, match="must be a mapping"):
-        _apply_and_validate_calibration_steps(dummy_mmm, cfg, tmp_path)
+        _apply_and_validate_calibration_steps(dummy_mmm, steps, tmp_path)
 
 
 def test_apply_calibration_dist_disallowed(dummy_mmm, tmp_path):
-    cfg = {"calibration": [{"add_lift_test_measurements": {"dist": "Gamma"}}]}
+    steps = [
+        CalibrationStep.model_validate(
+            {"add_lift_test_measurements": {"dist": "Gamma"}}
+        )
+    ]
 
     with pytest.raises(ValueError, match="`dist` parameter"):
-        _apply_and_validate_calibration_steps(dummy_mmm, cfg, tmp_path)
+        _apply_and_validate_calibration_steps(dummy_mmm, steps, tmp_path)
 
 
 def test_apply_calibration_propagates_failure(failing_mmm, tmp_path):
-    cfg = {"calibration": [{"failing": {}}]}
+    steps = [CalibrationStep.model_validate({"failing": {}})]
 
     with pytest.raises(
         RuntimeError, match="Failed to apply calibration step 'failing'"
     ):
-        _apply_and_validate_calibration_steps(failing_mmm, cfg, tmp_path)
+        _apply_and_validate_calibration_steps(failing_mmm, steps, tmp_path)
 
 
 def test_special_prior_in_yaml(tmp_path, mock_pymc_sample):
     """Test that SpecialPrior (LogNormalPrior) works in YAML config."""
-    # Create test data
     X = pd.DataFrame(
         {
             "date": pd.date_range("2023-01-01", periods=100),
@@ -292,7 +249,6 @@ def test_special_prior_in_yaml(tmp_path, mock_pymc_sample):
     )
     y = pd.Series(range(100), name="y")
 
-    # Create YAML config with LogNormalPrior
     config = {
         "model": {
             "class": "pymc_marketing.mmm.multidimensional.MMM",
@@ -332,64 +288,56 @@ def test_special_prior_in_yaml(tmp_path, mock_pymc_sample):
         }
     }
 
-    # Write to temp file
     config_path = tmp_path / "test_config.yml"
     with open(config_path, "w") as f:
         yaml.dump(config, f)
 
-    # Build model from YAML
     model = build_mmm_from_yaml(config_path, X=X, y=y)
 
-    # Check that model was created successfully
     assert model is not None
     assert hasattr(model, "saturation")
 
-    # Check that the prior was deserialized correctly
     assert "lam" in model.saturation.priors
     lam_prior = model.saturation.priors["lam"]
 
-    # Check it has the special_prior attribute and correct values
     assert hasattr(lam_prior, "to_dict")
     lam_dict = lam_prior.to_dict()
     assert lam_dict.get("special_prior") == "LogNormalPrior"
-    # Parameters are stored in kwargs subdictionary
     assert lam_dict.get("kwargs", {}).get("mean") == 1.0
     assert lam_dict.get("kwargs", {}).get("std") == 0.5
     assert lam_dict.get("dims") == ("channel",)
 
-    # Fit the model to ensure SpecialPrior works end-to-end
     model.fit(X=X, y=y)
 
-    # Check that the model has inference data after fitting
     assert model.idata is not None
     assert "posterior" in model.idata
 
 
 # ---------------------------------------------------------------------------
-# Tests for config structure validation (_validate_config_structure)
+# Tests for config structure validation (MMMYamlConfig)
 # ---------------------------------------------------------------------------
 
 
 class TestValidateConfigStructure:
-    """Tests for _validate_config_structure detecting mis-indented YAML keys."""
+    """Tests for MMMYamlConfig detecting mis-indented/invalid YAML keys."""
 
     def test_valid_config(self):
         """No error for a well-formed config."""
         cfg = {
             "model": {"class": "some.Class", "kwargs": {}},
             "original_scale_vars": ["channel_contribution"],
-            "calibration": [],
-            "effects": [],
+            "calibration": [{"method_a": {"param": 1}}],
+            "effects": [{"class": "some.Effect", "kwargs": {}}],
         }
-        _validate_config_structure(cfg)
+        MMMYamlConfig.model_validate(cfg)
 
     def test_missing_model_key(self):
-        with pytest.raises(ValueError, match="must contain a top-level 'model' key"):
-            _validate_config_structure({"effects": []})
+        with pytest.raises(ValidationError):
+            MMMYamlConfig.model_validate({"effects": []})
 
     def test_model_not_a_mapping(self):
-        with pytest.raises(TypeError, match="'model' must be a mapping"):
-            _validate_config_structure({"model": "not-a-dict"})
+        with pytest.raises(ValidationError):
+            MMMYamlConfig.model_validate({"model": "not-a-dict"})
 
     @pytest.mark.parametrize(
         "misplaced_key",
@@ -409,8 +357,8 @@ class TestValidateConfigStructure:
                 misplaced_key: "value",
             }
         }
-        with pytest.raises(ValueError, match="nested under 'model'"):
-            _validate_config_structure(cfg)
+        with pytest.raises(ValidationError):
+            MMMYamlConfig.model_validate(cfg)
 
 
 @pytest.mark.parametrize(
@@ -422,8 +370,8 @@ class TestValidateConfigStructure:
     ],
 )
 def test_build_mmm_rejects_nested_keys(config_path, X_data, y_data):
-    """YAML files with mis-indented top-level keys should raise ValueError."""
-    with pytest.raises(ValueError, match="nested under 'model'"):
+    """YAML files with mis-indented top-level keys should raise ValidationError."""
+    with pytest.raises(ValidationError):
         build_mmm_from_yaml(config_path, X=X_data, y=y_data.squeeze())
 
 
@@ -468,9 +416,8 @@ def test_original_scale_vars_none_is_harmless(tmp_path):
 
 
 def test_calibration_none_is_harmless(dummy_mmm, tmp_path):
-    """calibration: (None in YAML) should not crash."""
-    cfg = {"calibration": None}
-    _apply_and_validate_calibration_steps(dummy_mmm, cfg, tmp_path)
+    """calibration: None should not crash."""
+    _apply_and_validate_calibration_steps(dummy_mmm, None, tmp_path)
     assert dummy_mmm.called_with is None
 
 


### PR DESCRIPTION
Followup of https://github.com/pymc-labs/pymc-marketing/pull/2409, see https://github.com/pymc-labs/pymc-marketing/pull/2409#issuecomment-4074688793

@carlosagostini @isofer 

## Summary

Refactors the YAML configuration validation in `pymc_marketing/mmm/builders/` to use **Pydantic v2**, replacing the manual validation boilerplate introduced in #2409. This follows the reviewer recommendation to leverage Pydantic for schema validation.

### What changed

- **New `pymc_marketing/mmm/builders/schema.py`** — Pydantic v2 models (`BuildSpec`, `DataConfig`, `CalibrationStep`, `MMMYamlConfig`) with:
  - `extra="forbid"` to catch unknown keys at parse time
  - Typo hints via `difflib.get_close_matches` ("Did you mean …?")
  - `from_yaml_file` and `validate_or_raise` classmethods (patterned after `idata/schema.py`)
- **Refactored `pymc_marketing/mmm/builders/yaml.py`** — removed manual validation (`_validate_config_structure`, `KNOWN_TOP_LEVEL_KEYS`), replaced with `MMMYamlConfig.from_yaml_file()`, switched from dict access to attribute access, simplified `_apply_and_validate_calibration_steps` to work with `CalibrationStep` objects.
- **Updated `pymc_marketing/mmm/builders/__init__.py`** — exports `MMMYamlConfig` as public API.
- **`factories.py` unchanged** — preserves backward compatibility for direct `build()` callers.
- **Fixed 4 test YAML fixtures** — moved misplaced `sampler_config` under `model.kwargs` in `wrong_adstock_class.yml`, `wrong_distribution.yml`, `wrong_saturation_params.yml`, `wrong_parameter_type.yml`.
- **Updated `tests/mmm/builders/test_yaml.py`** — adapted to use Pydantic `ValidationError` instead of manual `ValueError`/`TypeError`.
- **New `tests/mmm/builders/test_schema.py`** — 36 unit tests covering all Pydantic models, typo suggestions, round-trip `model_dump`, `from_yaml_file`, and `validate_or_raise`.

### Design decisions

- **Two-layer validation**: Pydantic handles schema validation at YAML load time; runtime checks (e.g., `hasattr(model, step.method_name)`) remain in Python code at model build time.
- **`BuildSpec.kwargs` stays `dict[str, Any]`**: the recursive, heterogeneous nature of kwargs makes deep Pydantic typing impractical without over-constraining the schema.
- **`suggest_typo_fix` lives in `schema.py`**: YAGNI — no separate utils module for a single small function.

## Test plan

- [x] All 36 new schema unit tests pass (`test_schema.py`)
- [x] All 48 existing builder tests pass (`test_yaml.py`)
- [x] All 4 factory tests pass (`test_factories.py`)
- [x] Pre-commit hooks pass (ruff check, ruff format, mypy, license headers)
- [x] No regressions in integration tests for all YAML config files

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2418.org.readthedocs.build/en/2418/

<!-- readthedocs-preview pymc-marketing end -->