### PR TITLE
fix: work around RuntimeError

### DIFF
--- a/pymc_marketing/paths.py
+++ b/pymc_marketing/paths.py
@@ -26,10 +26,6 @@ from os import PathLike
 
 from pyprojroot import here
 
-root = here()
-data_dir = root / "data"
-
-
 URL = "https://raw.githubusercontent.com/pymc-labs/pymc-marketing/{branch}/data"
 
 
@@ -86,5 +82,10 @@ def create_data_url(branch: str) -> URLPath:
     return URLPath(URL.format(branch=branch))
 
 
-if not data_dir.exists():
+try:
+    root = here()
+except RuntimeError:
+    root = None
     data_dir = create_data_url("main")
+else:
+    data_dir = root / "data"

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -11,8 +11,10 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+import importlib
 from os import fspath
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from pyprojroot import here
@@ -28,17 +30,33 @@ def test_root_path() -> None:
 
 
 def test_data_dir() -> None:
-    """Test that data directory path is correctly defined."""
+    """Test that data directory path is correctly defined when inside the repo."""
     expected_data_dir = here() / "data"
     assert paths.data_dir == expected_data_dir
-    # Note: We don't assert exists() here as the data dir might not exist in CI
     assert isinstance(paths.data_dir, Path)
 
 
 def test_paths_are_absolute() -> None:
-    """Test that all defined paths are absolute."""
+    """Test that root and data_dir are absolute paths when inside the repo."""
+    assert paths.root is not None
     assert paths.root.is_absolute()
+    assert isinstance(paths.data_dir, Path)
     assert paths.data_dir.is_absolute()
+
+
+@pytest.fixture()
+def no_project_root():
+    with patch("pyprojroot.here", side_effect=RuntimeError("Project root not found.")):
+        importlib.reload(paths)
+        yield
+    importlib.reload(paths)
+
+
+def test_data_dir_falls_back_to_url_when_no_project_root(no_project_root) -> None:
+    """Test that data_dir falls back to a URL when pyprojroot cannot find the project root."""
+    assert paths.root is None
+    assert isinstance(paths.data_dir, paths.URLPath)
+    assert "main" in paths.data_dir.url
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

The README example should work now.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2421.org.readthedocs.build/en/2421/

<!-- readthedocs-preview pymc-marketing end -->