### PR TITLE
[HOT-FIX] NDArray.record() now requires an in_warmup keyword

### DIFF
--- a/pymc_marketing/clv/models/basic.py
+++ b/pymc_marketing/clv/models/basic.py
@@ -210,7 +210,10 @@ class CLVModel(ModelBuilder):
         # Convert map result to InferenceData
         map_strace = NDArray(model=model)
         map_strace.setup(draws=1, chain=0)
-        map_strace.record(map_res)
+        try:
+            map_strace.record(map_res, in_warmup=False)
+        except TypeError:
+            map_strace.record(map_res)
         map_strace.close()
         trace = MultiTrace([map_strace])
         return pm.to_inference_data(trace, model=model)


### PR DESCRIPTION
Fix from other PRs

```python
FAILED tests/clv/models/test_beta_geo.py::TestBetaGeoModel::test_model_convergence[map-0.2] - TypeError: NDArray.record() missing 1 required keyword-only argument: 'in_warmup'
FAILED tests/clv/models/test_modified_beta_geo.py::TestModifiedBetaGeoModel::test_model_convergence[map-0.15] - TypeError: NDArray.record() missing 1 required keyword-only argument: 'in_warmup'
FAILED tests/clv/models/test_shifted_beta_geo.py::TestShiftedBetaGeoModel::test_model_convergence[map-0.1] - TypeError: NDArray.record() missing 1 required keyword-only argument: 'in_warmup'
```

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2429.org.readthedocs.build/en/2429/

<!-- readthedocs-preview pymc-marketing end -->