### PR TITLE
Restore metric coordinate order after to_xarray

### DIFF
--- a/pymc_marketing/mmm/multidimensional.py
+++ b/pymc_marketing/mmm/multidimensional.py
@@ -1624,10 +1624,16 @@ class MMM(RegressionModelBuilder):
         # Convert to xarray, renaming date_column to "date" for internal consistency
         df_long = df_long.rename(columns={date_column: "date"})
         if valid_dims:
-            return df_long.set_index(
+            ds = df_long.set_index(
                 ["date", *valid_dims, metric_coordinate_name]
             ).to_xarray()
-        return df_long.set_index(["date", metric_coordinate_name]).to_xarray()
+        else:
+            ds = df_long.set_index(["date", metric_coordinate_name]).to_xarray()
+
+        # .to_xarray() alphabetically sorts coordinates; restore the
+        # user-provided ordering so downstream code (pm.set_data,
+        # coordinate comparisons, etc.) sees a consistent order.
+        return ds.reindex({metric_coordinate_name: valid_metrics})
 
     def _create_xarray_from_pandas(
         self,

--- a/tests/mmm/test_multidimensional.py
+++ b/tests/mmm/test_multidimensional.py
@@ -4064,6 +4064,55 @@ def test_calibration_coordinate_label_mismatch_error(multi_dim_data, mock_pymc_s
         )
 
 
+def test_cost_per_target_calibration_non_alphabetical_channels(
+    multi_dim_data, mock_pymc_sample
+):
+    """Regression test: add_cost_per_target_calibration should work when
+    channel_columns are not in alphabetical order.
+
+    _create_xarray_from_pandas alphabetically sorts the channel coordinate,
+    but the model coords preserve the user-provided order.  The calibration
+    method must reindex to match before comparing.
+    """
+    X, y = multi_dim_data
+
+    non_alpha_channels = ["channel_2", "channel_1", "channel_3"]
+
+    mmm = MMM(
+        date_column="date",
+        target_column="target",
+        channel_columns=non_alpha_channels,
+        dims=("country",),
+        adstock=GeometricAdstock(l_max=2),
+        saturation=LogisticSaturation(),
+    )
+
+    mmm.build_model(X, y)
+    mmm.add_original_scale_contribution_variable(var=["channel_contribution"])
+
+    spend_df = X.copy()
+
+    countries = mmm.model.coords["country"]
+    calibration_df = pd.DataFrame(
+        {
+            "country": [countries[0], countries[1]],
+            "channel": [non_alpha_channels[0], non_alpha_channels[1]],
+            "cost_per_target": [30.0, 45.0],
+            "sigma": [2.0, 3.0],
+        }
+    )
+
+    mmm.add_cost_per_target_calibration(
+        data=spend_df,
+        calibration_data=calibration_df,
+        name_prefix="cpt_calibration",
+    )
+
+    assert "channel_contribution_original_scale" in mmm.model.named_vars
+    obs_names = [rv.name for rv in mmm.model.observed_RVs]
+    assert "cpt_calibration" in obs_names
+
+
 class TestAddOriginalScaleContributionVariable:
     """Tests for add_original_scale_contribution_variable method."""
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->
to_xarray() alphabetically sorts coordinates which reorder user-provided metric/channel ordering and break downstream coordinate comparisons. Reindex the dataset to the original metric ordering after conversion so model coords remain consistent (used by pm.set_data and calibration routines).

Also add a regression test ensuring cost-per-target calibration works when channel_columns are not alphabetical by constructing a non-alphabetical channel order and verifying the calibration observable and contribution variable are created.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2445.org.readthedocs.build/en/2445/

<!-- readthedocs-preview pymc-marketing end -->