### PR TITLE
Docs: revamp MMM modeling docs and references

### DIFF
--- a/.cursor/skills/mmm-modeling/SKILL.md
+++ b/.cursor/skills/mmm-modeling/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: mmm-modeling
+name: pymc-marketing-mmm
 description: >
   Media Mix Modeling with PyMC-Marketing. Use when building MMMs, specifying adstock/saturation
   transformations, setting priors, fitting multidimensional (geo-level) models, computing channel
@@ -27,6 +27,10 @@ import pandas as pd
 from pymc_extras.prior import Prior
 
 from pymc_marketing.mmm import GeometricAdstock, LogisticSaturation
+
+# Always import MMM from multidimensional (the newer unified class).
+# `from pymc_marketing.mmm import MMM` resolves to the legacy class with
+# a different constructor (no dims, no target_column, no cost_per_unit).
 from pymc_marketing.mmm.multidimensional import MMM
 
 # Load data
@@ -46,13 +50,13 @@ mmm = MMM(
 
 # Build and fit on FULL dataset
 mmm.build_model(X, y)
-mmm.fit(X=X, y=y, nuts_sampler="nutpie", target_accept=0.9, random_seed=42)
+mmm.fit(X=X, y=y, target_accept=0.9, random_seed=42)
 mmm.sample_posterior_predictive(X=X, random_seed=42)
 ```
 
 ## Model Specification
 
-The `MMM` class is the central entry point:
+The `MMM` class is the central entry point. **Reserved dim names** (`date`, `channel`, `control`, `fourier_mode`) cannot be used as custom dims:
 
 ```python
 mmm = MMM(
@@ -69,22 +73,92 @@ mmm = MMM(
     yearly_seasonality=5,
     time_varying_intercept=False,
     time_varying_media=False,
+    adstock_first=True,                   # adstock before saturation (default)
+    cost_per_unit=None,                   # pd.DataFrame to convert monetary to model units
 )
 ```
 
-Priors are customized via `model_config` using `pymc_extras.prior.Prior`:
+### Adstock Transformations
+
+All adstock classes share the interface `(l_max, normalize=True, mode=ConvMode.After, priors=None)`:
+
+| Class | Key Params | Use Case |
+|-------|-----------|----------|
+| `GeometricAdstock` | `alpha` (decay rate) | Default choice -- exponential decay |
+| `DelayedAdstock` | `alpha` (decay), `theta` (peak delay) | Channels with delayed peak effect |
+| `WeibullPDFAdstock` | `lam`, `k` | Flexible shape via Weibull PDF |
+| `WeibullCDFAdstock` | `lam`, `k` | Flexible shape via Weibull CDF |
+| `BinomialAdstock` | `alpha` | Binomial-based decay |
+| `NoAdstock` | (none) | Bypass adstock entirely |
+
+### Saturation Transformations
+
+| Class | Key Params | Use Case |
+|-------|-----------|----------|
+| `LogisticSaturation` | `lam`, `beta` | Default -- S-shaped diminishing returns |
+| `HillSaturation` | `slope`, `kappa`, `beta` | Generalized Hill function |
+| `MichaelisMentenSaturation` | `alpha`, `lam` | Enzyme kinetics-inspired curve |
+| `TanhSaturation` | `b`, `c` | Hyperbolic tangent |
+| `TanhSaturationBaselined` | `x0`, `gain`, `r`, `beta` | Tanh with offset |
+| `HillSaturationSigmoid` | `sigma`, `beta`, `lam` | Sigmoid Hill variant |
+| `InverseScaledLogisticSaturation` | `lam`, `beta` | Inverse-scaled logistic |
+| `RootSaturation` | `alpha`, `beta` | Power-law transformation |
+| `NoSaturation` | `beta` | Scaling only, no saturation |
+
+All are imported from `pymc_marketing.mmm` and accept custom `priors` dicts.
+
+### Priors
+
+**Best practice**: set adstock and saturation priors directly on the transformation objects via their `priors` argument. This keeps transformation-specific priors co-located with the component and is the recommended approach:
+
+```python
+adstock = GeometricAdstock(
+    l_max=6,
+    priors={"alpha": Prior("Beta", alpha=2, beta=5, dims="channel")},
+)
+saturation = LogisticSaturation(
+    priors={
+        "lam": Prior("Gamma", alpha=3, beta=1, dims="channel"),
+        "beta": Prior("HalfNormal", sigma=spend_shares, dims="channel"),
+    },
+)
+```
+
+Use `model_config` for non-component priors (intercept, controls, seasonality, likelihood):
 
 ```python
 model_config = {
     "intercept": Prior("Normal", mu=0.2, sigma=0.05),
-    "saturation_beta": Prior("HalfNormal", sigma=spend_shares, dims="channel"),
     "gamma_control": Prior("Normal", mu=0, sigma=1, dims="control"),
     "gamma_fourier": Prior("Laplace", mu=0, b=1, dims="fourier_mode"),
     "likelihood": Prior("TruncatedNormal", lower=0, sigma=Prior("HalfNormal", sigma=1)),
 }
 ```
 
-See [references/model_specification.md](references/model_specification.md) for full constructor reference, hierarchical prior patterns (partial/full/no pooling), and prior predictive checks.
+See [references/model_specification.md](references/model_specification.md) for full constructor reference (including `dag`/`treatment_nodes`/`outcome_node` for causal graph integration), hierarchical prior patterns (partial/full/no pooling), adstock/saturation default priors, and prior predictive checks.
+
+## Prior Predictive Checks
+
+Sample from the prior predictive distribution **after** `build_model` and **before** `fit` to verify that priors produce plausible target ranges:
+
+```python
+mmm.build_model(X, y)
+
+# Returns an xr.Dataset (az.extract output), not InferenceData
+prior_samples = mmm.sample_prior_predictive(X=X, random_seed=42)
+prior_samples["y"]  # access from returned Dataset
+
+# Or equivalently, access from idata (populated via extend_idata=True default)
+mmm.idata.prior_predictive["y"]
+```
+
+**Common pitfall**: The prior predictive variable is always `"y"` because `MMM.output_var = "y"` is hardcoded as a class attribute (the PyMC likelihood variable name). It does **not** follow `target_column`. Using the target column name (e.g., `mmm.idata.prior_predictive["revenue"]`) will raise a `KeyError`.
+
+Plot with the built-in method:
+
+```python
+mmm.plot.prior_predictive(var="y", hdi_prob=0.85)
+```
 
 ## Data Preparation
 
@@ -100,7 +174,7 @@ Always fit on the full dataset, then run diagnostics:
 
 ```python
 mmm.fit(X=X, y=y, target_accept=0.9, chains=6, draws=800,
-        tune=1_500, nuts_sampler="nutpie", random_seed=rng)
+        tune=1_500, random_seed=rng)
 mmm.sample_posterior_predictive(X=X, random_seed=rng)
 
 # Divergences (must be 0)
@@ -119,13 +193,48 @@ Use `TimeSliceCrossValidator` to assess model stability **before** the final fit
 from pymc_marketing.mmm.time_slice_cross_validation import TimeSliceCrossValidator
 
 cv = TimeSliceCrossValidator(n_init=163, forecast_horizon=12, date_column="date", step_size=1)
-results = cv.run(X, y, sampler_config={...}, yaml_path=...)
-cv.plot.param_stability(results, parameter=["adstock_alpha"], dims={...})
-cv.plot.cv_predictions(results)
-cv.plot.cv_crps(results)
+results = cv.run(
+    X, y, sampler_config={...},
+    yaml_path=...,                        # or pass mmm=mmm_instance directly
+    df_lift_test=None,                    # optional lift test for each fold
+    original_scale_vars=None,             # variables to rescale
+    return_models=False,                  # True to get fitted models per fold
+)
+mmm.plot.cv_predictions(results)
+mmm.plot.param_stability(results, parameter=["adstock_alpha"], dims={...})
+mmm.plot.cv_crps(results)
 ```
 
 See [references/model_fit.md](references/model_fit.md) for the full diagnostics checklist, time-slice CV workflow, and common fit issues.
+
+## Model Variables and Original Scale
+
+`build_model` creates variables on the **scaled** space. The key model variables are:
+
+| Variable | Present when |
+|----------|-------------|
+| `channel_contribution` | Always |
+| `intercept_contribution` | Always |
+| `control_contribution` | `control_columns` set |
+| `yearly_seasonality_contribution` | `yearly_seasonality` set |
+| `baseline_channel_contribution` | `time_varying_media=True` |
+| `y` | Always (predicted target) |
+
+`total_media_contribution_original_scale` is created automatically. All other `*_original_scale` variants require an explicit call to `add_original_scale_contribution_variable` **after** `build_model` and **before** `sample_posterior_predictive` or `sample_prior_predictive`:
+
+```python
+mmm.build_model(X, y)
+
+mmm.add_original_scale_contribution_variable(
+    var=["channel_contribution", "control_contribution",
+         "intercept_contribution", "yearly_seasonality_contribution", "y"]
+)
+
+mmm.fit(X=X, y=y, target_accept=0.9, random_seed=rng)
+mmm.sample_posterior_predictive(X=X, random_seed=rng)
+```
+
+This multiplies each variable by `target_scale` and registers it as `{var}_original_scale` (e.g. `channel_contribution_original_scale`). Without this call, plotting and analysis methods that reference `*_original_scale` names will fail.
 
 ## Media Analysis
 
@@ -153,7 +262,7 @@ mmm.plot.saturation_scatterplot(original_scale=True)
 # Sensitivity analysis
 sweeps = np.linspace(0, 1.5, 16)
 mmm.sensitivity.run_sweep(
-    sweep_values=sweeps, var_input="channel_data",
+    var_input="channel_data", sweep_values=sweeps,
     var_names="channel_contribution_original_scale", extend_idata=True,
 )
 mmm.plot.sensitivity_analysis(hue_dim="channel", x_sweep_axis="relative")
@@ -163,7 +272,9 @@ See [references/media_deep_dive.md](references/media_deep_dive.md) for ROAS comp
 
 ## Time-Varying Parameters
 
-The `MMM` class supports GP-based time-varying intercept and time-varying media multiplier via Hilbert Space Gaussian Processes (HSGP):
+The `MMM` class supports GP-based time-varying intercept and time-varying media multiplier via Hilbert Space Gaussian Processes (HSGP).
+
+**Option A** -- `bool` + `HSGPKwargs` in `model_config` (simple):
 
 ```python
 from pymc_marketing.hsgp_kwargs import HSGPKwargs
@@ -173,9 +284,23 @@ mmm = MMM(
     time_varying_intercept=True,
     time_varying_media=True,
     model_config={
-        "intercept_tvp_config": HSGPKwargs(m=500, L=188, eta_lam=5.0, ls_mu=5.0, ls_sigma=10.0),
+        "intercept_tvp_config": HSGPKwargs(
+            m=500, L=188, eta_lam=5.0, ls_mu=5.0, ls_sigma=10.0,
+        ),
         "media_tvp_config": HSGPKwargs(ls_mu=11.0, ls_sigma=5.0),
     },
+)
+```
+
+**Option B** -- pass an `HSGPBase` instance directly (full control over dims and priors):
+
+```python
+from pymc_marketing.mmm.hsgp import HSGPBase
+
+mmm = MMM(
+    ...,
+    time_varying_intercept=HSGPBase(m=500, ...),
+    time_varying_media=HSGPBase(m=200, ...),
 )
 ```
 
@@ -212,18 +337,27 @@ optimizable_model = MultiDimensionalBudgetOptimizerWrapper(
 )
 
 allocation, result = optimizable_model.optimize_budget(
-    budget=budget_per_period, budget_bounds=budget_bounds_xr,
+    budget=budget_per_period,
+    budget_bounds=budget_bounds_xr,
+    budgets_to_optimize=None,             # xr.DataArray mask to fix certain channels
+    budget_distribution_over_period=None,  # temporal distribution (flighting)
+    cost_per_unit=None,                   # convert monetary to model units
+    constraints=(),                       # custom Constraint objects
     minimize_kwargs={"method": "SLSQP", "options": {"ftol": 1e-4, "maxiter": 10_000}},
 )
 
 response = optimizable_model.sample_response_distribution(
     allocation_strategy=allocation,
-    include_last_observations=True, include_carryover=True,
+    additional_var_names=["channel_contribution_original_scale"],
+    include_last_observations=False, include_carryover=True,
+    noise_level=0.05,
 )
 optimizable_model.plot.budget_allocation(samples=response)
 ```
 
-See [references/budget_optimization.md](references/budget_optimization.md) for budget bounds setup, custom constraints, budget sweeps, and channel fixing.
+For impression-based models, use `mmm.set_cost_per_unit(cost_df)` after fitting or pass `cost_per_unit` to the constructor to convert monetary budgets to model units.
+
+See [references/budget_optimization.md](references/budget_optimization.md) for budget bounds setup, custom constraints, budget sweeps, channel fixing, and temporal distribution.
 
 ## Lift Test Calibration
 
@@ -233,13 +367,30 @@ Lift tests resolve causal identification when channels are correlated:
 # After build_model, before fit
 mmm.build_model(X, y)
 mmm.add_lift_test_measurements(df_lift_test)
-mmm.fit(X=X, y=y, nuts_sampler="nutpie", ...)
+mmm.fit(X=X, y=y, ...)
 ```
 
 The lift test DataFrame requires columns: `channel`, `x`, `delta_x`, `delta_y`, `sigma` (plus `geo` for geo-level).
 When `time_varying_media=True`, include `date` so each lift measurement maps to the correct `media_temporal_latent_multiplier` time coordinate.
 
-See [references/liftest_calibration.md](references/liftest_calibration.md) for data format, calibrated vs uncalibrated comparison, geo-level patterns, and sigma estimation.
+## Cost-Per-Target Calibration
+
+When you have cost-efficiency benchmarks instead of full lift tests, use CPT calibration. It adds an observed Normal likelihood constraining `mean(spend) / mean(contribution)` toward a target CPT:
+
+```python
+calibration_data = pd.DataFrame({
+    "channel": ["tv", "social"],
+    "cost_per_target": [25.0, 12.0],
+    "sigma": [5.0, 3.0],
+    # include one column per model dim, e.g. "geo"
+})
+
+mmm.build_model(X, y)
+mmm.add_cost_per_target_calibration(data=X, calibration_data=calibration_data)
+mmm.fit(X=X, y=y, ...)
+```
+
+See [references/liftest_calibration.md](references/liftest_calibration.md) for lift test data format, CPT calibration details, calibrated vs uncalibrated comparison, geo-level patterns, and sigma estimation.
 
 ## Saving, Loading, and YAML Specification
 
@@ -251,10 +402,10 @@ loaded_mmm = MMM.load("mmm_model.nc")
 # Build model from a YAML specification
 from pymc_marketing.mmm.builders.yaml import build_mmm_from_yaml
 
-mmm = build_mmm_from_yaml("model_spec.yaml", X=X, y=y)
+mmm = build_mmm_from_yaml(config_path="model_spec.yaml", X=X, y=y)
 ```
 
-The YAML builder (`build_mmm_from_yaml`) enables declarative model specification -- useful for reproducible experiments, `TimeSliceCrossValidator` integration (via `yaml_path`), and MLflow tracking.
+The YAML builder (`build_mmm_from_yaml`) enables declarative model specification -- useful for reproducible experiments, `TimeSliceCrossValidator` integration (via its `yaml_path` parameter), and MLflow tracking.
 
 ## Incremental Analysis and Summary
 
@@ -268,7 +419,7 @@ cac = mmm.incrementality.spend_over_contribution(frequency="quarterly")
 marginal_roas = mmm.incrementality.marginal_contribution_over_spend(frequency="all_time")
 ```
 
-See [references/media_deep_dive.md](references/media_deep_dive.md#incremental-analysis-mmmincementality) for details.
+See [references/media_deep_dive.md](references/media_deep_dive.md#incremental-analysis-mmmincrementality) for details.
 
 ### `mmm.summary`
 
@@ -287,23 +438,50 @@ mmm.summary.change_over_time()           # percentage change between periods
 
 ### `mmm.data`
 
-Validated access to `idata` with convenience methods:
+Validated access to `idata` via `MMMIDataWrapper` with convenience methods:
 
 ```python
 mmm.data.get_target()                    # observed target values
-mmm.data.get_contributions(original_scale=True)
-mmm.data.filter_dates("2024-01-01", "2024-12-31")
+mmm.data.get_channel_contributions(original_scale=True)
+mmm.data.get_contributions(original_scale=True, include_baseline=True)
+mmm.data.get_channel_spend()             # channel spend in monetary units
+mmm.data.get_target_scale()              # scaling factor used during fit
+mmm.data.validate_or_raise()             # validate idata structure
+
+# Chained filtering and aggregation
+monthly = mmm.data.filter_dates("2024-01-01", "2024-12-31").aggregate_time("monthly")
 ```
+
+## Event Effects
+
+Add holiday or campaign effects before building the model via the `MuEffect` system:
+
+```python
+from pymc_marketing.mmm.events import EventEffect
+
+df_events = pd.DataFrame({
+    "name": ["black_friday", "christmas"],
+    "start_date": ["2024-11-29", "2024-12-25"],
+    "end_date": ["2024-11-29", "2024-12-25"],
+})
+
+mmm.add_events(df_events, prefix="holiday", effect=EventEffect(dims=("holiday",)))
+mmm.build_model(X, y)
+```
+
+Events are registered as `EventAdditiveEffect` instances in the model's `mu_effects` list. The `LinearTrendEffect` and `FourierEffect` also use this system. See [references/custom_model.md](references/custom_model.md) for advanced additive effects.
 
 ## Plotting Methods Quick Reference
 
-All visualization methods are accessed via the `mmm.plot` namespace. See [references/plot.md](references/plot.md) for the complete API with exact signatures.
+All visualization methods are accessed via the `mmm.plot` namespace (matplotlib). For interactive Plotly plots, use `mmm.plot_interactive` (requires `pip install pymc-marketing[plotly]`).
+
+See [references/plot.md](references/plot.md) for the complete API with exact signatures.
 
 | Method | Description |
 |--------|-------------|
 | `prior_predictive(var=..., hdi_prob=0.85)` | Prior predictive HDI bands |
 | `posterior_predictive(var=..., hdi_prob=0.85)` | Posterior predictive HDI bands |
-| `residuals_over_time(hdi_prob=...)` | Residuals with HDI bands |
+| `residuals_over_time(hdi_prob=[0.94])` | Residuals with HDI bands (`hdi_prob` is `list[float]`) |
 | `residuals_posterior_distribution(aggregation=...)` | Residual distribution |
 | `contributions_over_time(var=..., combine_dims=..., hdi_prob=...)` | Contributions over time with HDI |
 | `waterfall_components_decomposition(split_by=...)` | Mean component decomposition (waterfall) |
@@ -314,8 +492,8 @@ All visualization methods are accessed via the `mmm.plot` namespace. See [refere
 | `saturation_scatterplot(original_scale=...)` | Observed spend vs. saturated effect |
 | `saturation_curves(curve, original_scale=...)` | Smooth posterior saturation curves |
 | `sensitivity_analysis(hue_dim=..., x_sweep_axis=...)` | Counterfactual response under spend scaling |
-| `uplift_curve(hue_dim=...)` | Precomputed uplift curves |
-| `marginal_curve(hue_dim=...)` | Precomputed marginal effects |
+| `uplift_curve(hdi_prob=..., aggregation=...)` | Precomputed uplift curves |
+| `marginal_curve(hdi_prob=..., aggregation=...)` | Precomputed marginal effects |
 | `budget_allocation(samples=...)` | Optimal allocation summary |
 | `allocated_contribution_by_channel_over_time(samples=...)` | Contributions under optimal allocation |
 | `cv_predictions(results)` | Posterior predictive across CV folds |
@@ -329,11 +507,15 @@ EDA & Data Prep
     ↓
 Model Specification (priors, adstock, saturation, dims)
     ↓
+[Optional] Add Events (mmm.add_events, before build_model)
+    ↓
 Build Model (mmm.build_model)
     ↓
 Prior Predictive Checks
     ↓
-[Optional] Add Lift Test / Cost-Per-Target Calibration
+[Optional] Time-Slice Cross-Validation (stability assessment, before final fit)
+    ↓
+[Optional] Add Lift Test / Cost-Per-Target Calibration (after build, before fit)
     ↓
 Fit on FULL Dataset (mmm.fit)
     ↓
@@ -342,8 +524,6 @@ Diagnostics (divergences, R-hat, ESS, trace plots)
 Posterior Predictive Checks
     ↓
 Media Deep Dive (contributions, ROAS, saturation, sensitivity)
-    ↓
-[Optional] Time-Slice Cross-Validation (stability assessment)
     ↓
 Budget Optimization
 ```

--- a/.cursor/skills/mmm-modeling/references/liftest_calibration.md
+++ b/.cursor/skills/mmm-modeling/references/liftest_calibration.md
@@ -219,7 +219,7 @@ This gives larger geos tighter uncertainty (smaller sigma) and smaller geos wide
 
 ## Cost-Per-Target Calibration
 
-An alternative to lift test calibration is `add_cost_per_target_calibration`, which constrains the model's cost-per-target (CPT) estimates via `pm.Potential` penalties:
+An alternative to lift test calibration is `add_cost_per_target_calibration`, which constrains the model's cost-per-target (CPT) ratio via an **observed Normal likelihood**:
 
 ```python
 import pandas as pd
@@ -227,7 +227,7 @@ import pandas as pd
 calibration_data = pd.DataFrame({
     "channel": ["tv", "social"],
     "cost_per_target": [25.0, 12.0],   # desired CPT
-    "sigma": [5.0, 3.0],               # tolerance (larger = weaker penalty)
+    "sigma": [5.0, 3.0],               # tolerance (larger = weaker constraint)
 })
 
 mmm.build_model(X, y)
@@ -238,9 +238,30 @@ mmm.add_cost_per_target_calibration(
 mmm.fit(X=X, y=y, nuts_sampler="nutpie", target_accept=0.9, random_seed=rng)
 ```
 
-The method adds a quadratic penalty: `penalty = -|cpt_mean - target|^2 / (2 * sigma^2)`, pulling the model's CPT toward the calibration target. This is useful when you have cost-efficiency benchmarks but not full lift test data.
+Internally, for each calibration row the method computes `mean(spend) / mean(contribution)` over the date dimension and adds:
+
+```
+Normal(mu=cpt_mean, sigma=sigma, observed=cost_per_target)
+```
+
+This constrains the model's CPT ratio toward the calibration target within the specified uncertainty. Useful when you have cost-efficiency benchmarks but not full lift test data.
+
+**Prerequisite**: `channel_contribution_original_scale` must exist in the model graph. Call `add_original_scale_contribution_variable` before `add_cost_per_target_calibration` if it is not already present.
 
 The `calibration_data` DataFrame requires columns: `channel`, `cost_per_target`, `sigma`, plus one column per model dimension (e.g., `geo`).
+
+### Geo-Level CPT Calibration
+
+For multidimensional models, include dimension columns:
+
+```python
+calibration_data = pd.DataFrame({
+    "channel": ["tv", "tv", "social"],
+    "geo": ["US", "UK", "US"],
+    "cost_per_target": [25.0, 30.0, 12.0],
+    "sigma": [5.0, 6.0, 3.0],
+})
+```
 
 ## Practical Guidelines
 

--- a/.cursor/skills/mmm-modeling/references/model_specification.md
+++ b/.cursor/skills/mmm-modeling/references/model_specification.md
@@ -31,8 +31,14 @@ mmm = MMM(
     adstock_first=True,                     # adstock before saturation
     time_varying_intercept=False,           # bool or HSGPBase
     time_varying_media=False,               # bool or HSGPBase
+    cost_per_unit=None,                     # pd.DataFrame for monetary→model unit conversion
+    dag=None,                               # causal graph string (DOT format)
+    treatment_nodes=None,                   # list[str] of treatment nodes in the DAG
+    outcome_node=None,                      # outcome node name in the DAG
 )
 ```
+
+**Reserved dim names**: `date`, `channel`, `control`, `fourier_mode` are used internally and cannot be passed as custom `dims`.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
@@ -49,8 +55,16 @@ mmm = MMM(
 | `time_varying_intercept` | `bool \| HSGPBase` | Gaussian process intercept |
 | `time_varying_media` | `bool \| HSGPBase` | Gaussian process media effects |
 | `adstock_first` | `bool` | Apply adstock before saturation (default `True`) |
+| `cost_per_unit` | `pd.DataFrame \| None` | Maps monetary spend to model units (impressions, clicks). Also settable post-fit via `mmm.set_cost_per_unit()` |
+| `dag` | `str \| None` | Causal DAG in DOT format for `CausalGraphModel` integration |
+| `treatment_nodes` | `list[str] \| None` | Treatment nodes in the causal DAG |
+| `outcome_node` | `str \| None` | Outcome node in the causal DAG |
 
 ## Adstock Transformations
+
+All adstock classes share the constructor `(l_max, normalize=True, mode=ConvMode.After, priors=None, prefix=None)`. The `mode` parameter controls alignment: `After` (default, causal), `Before`, or `Overlap`.
+
+**Best practice**: set adstock priors directly via the `priors` argument on the transformation object rather than through `model_config`. This keeps transformation-specific priors co-located with the component they belong to. Use `model_config` only for non-component parameters (intercept, controls, seasonality, likelihood).
 
 ### GeometricAdstock
 
@@ -89,7 +103,32 @@ adstock = GeometricAdstock(
 
 **Rule of thumb for `l_max`**: Set to the maximum plausible carryover duration. For weekly data, `l_max=6` (6 weeks) is typical. For daily data, use `l_max=14` or higher. Too large wastes computation; too small truncates real effects.
 
+### DelayedAdstock
+
+Adds a `theta` parameter for peak delay on top of geometric decay. Useful when the effect peaks days/weeks after exposure:
+
+```python
+from pymc_marketing.mmm import DelayedAdstock
+
+adstock = DelayedAdstock(l_max=10)
+```
+
+Default priors: `alpha ~ Beta(1, 3)`, `theta ~ HalfNormal(sigma=1)`.
+
+### Other Adstock Types
+
+| Class | Lookup | Default Priors | Notes |
+|-------|--------|----------------|-------|
+| `BinomialAdstock` | `"binomial"` | `alpha ~ Beta(1, 3)` | Binomial-based decay |
+| `WeibullPDFAdstock` | `"weibull_pdf"` | `lam ~ Gamma(mu=2, sigma=1)`, `k ~ Gamma(mu=3, sigma=1)` | Flexible shape via Weibull PDF |
+| `WeibullCDFAdstock` | `"weibull_cdf"` | `lam ~ Gamma(mu=2, sigma=2.5)`, `k ~ Gamma(mu=2, sigma=2.5)` | Flexible shape via Weibull CDF |
+| `NoAdstock` | `"no_adstock"` | (none) | Bypasses adstock entirely |
+
+All are imported from `pymc_marketing.mmm` and use the `adstock_from_dict()` factory for deserialization.
+
 ## Saturation Transformations
+
+**Best practice**: set saturation priors directly via the `priors` argument on the transformation object. The `beta` parameter on saturation classes controls the maximum reachable effect per channel -- setting it proportional to spend shares is a common, effective pattern.
 
 ### LogisticSaturation
 
@@ -177,18 +216,14 @@ The `dims` argument determines broadcasting across model dimensions and controls
 
 ## Model Config Dictionary
 
-The `model_config` dictionary maps parameter names to `Prior` objects:
+The `model_config` dictionary is for **non-component** priors (intercept, controls, seasonality, likelihood). Adstock and saturation priors should be set directly on the transformation objects via their `priors` argument (see above).
 
 ```python
-import numpy as np
 from pymc_extras.prior import Prior
 
 model_config = {
     # Intercept
     "intercept": Prior("Normal", mu=0.2, sigma=0.05),
-
-    # Channel saturation effect (informed by spend shares)
-    "saturation_beta": Prior("HalfNormal", sigma=spend_shares, dims="channel"),
 
     # Control variable coefficients
     "gamma_control": Prior("Normal", mu=0, sigma=1, dims="control"),
@@ -204,10 +239,11 @@ model_config = {
 | Config Key | Description | Default | Typical Custom Prior |
 |------------|-------------|---------|----------------------|
 | `intercept` | Baseline response | `Normal(mu=0, sigma=2, dims=self.dims)` | `Normal(mu=0.2, sigma=0.05)` |
-| `saturation_beta` | Per-channel media effect | (from saturation class) | `HalfNormal(sigma=spend_shares, dims="channel")` |
 | `gamma_control` | Control coefficients | `Normal(mu=0, sigma=2, dims=(*dims, "control"))` | `Normal(0, 1, dims="control")` |
 | `gamma_fourier` | Seasonality coefficients | `Laplace(mu=0, b=1, dims=(*dims, "fourier_mode"))` | `Laplace(0, 1)` |
 | `likelihood` | Observation noise | `Normal(sigma=HalfNormal(sigma=2))` | `TruncatedNormal(lower=0, sigma=HalfNormal(1))` |
+
+Note: `saturation_beta` can still be set via `model_config` for backward compatibility, but placing it on the saturation object via `priors={"beta": ...}` is preferred.
 
 ## Multidimensional / Hierarchical Models
 


### PR DESCRIPTION
Rename skill to `pymc-marketing-mmm` and modernize MMM docs and examples. Switch examples to the multidimensional MMM import, remove deprecated nuts_sampler usage, and update YAML builder call (config_path).

Add comprehensive documentation for adstock and saturation transforms, priors best-practices (prefer priors on transformation objects), prior-predictive checks, original-scale contribution variables, event effects, CPT (cost-per-target) calibration (observed Normal likelihood) and geo-level CPT examples, and improved guidance for time-varying parameters (HSGP options). Clarify reserved dimension names and introduce new constructor params (cost_per_unit, dag, treatment_nodes, outcome_node).

Update plotting, CV, and budget-optimization examples (new params and return shapes), adjust convenience data/api method names, and refine various doc links and examples across references/liftest_calibration.md and references/model_specification.md to reflect API changes and best practices.

<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2453.org.readthedocs.build/en/2453/

<!-- readthedocs-preview pymc-marketing end -->