### PR TITLE
Fix MaskedPrior with non-scalar Prior parameters

### DIFF
--- a/pymc_marketing/special_priors.py
+++ b/pymc_marketing/special_priors.py
@@ -634,6 +634,7 @@ class MaskedPrior:
         if isinstance(value, xr.DataArray):
             try:
                 broadcasted, _ = xr.broadcast(value, self.mask)
+                broadcasted = broadcasted.transpose(*self.mask.dims)
                 return broadcasted.values.ravel()[flat_mask]
             except Exception:
                 return value

--- a/pymc_marketing/special_priors.py
+++ b/pymc_marketing/special_priors.py
@@ -598,20 +598,66 @@ class MaskedPrior:
         # Depth-first remap of any nested VariableFactory with dims == parent dims
         # This keeps internal subset checks (_param_dims_work) satisfied.
         if hasattr(factory, "parameters"):
-            # Recurse on child parameters first
             for key, value in list(factory.parameters.items()):
                 if hasattr(value, "create_variable") and hasattr(value, "dims"):
                     factory.parameters[key] = self._remap_dims(value)  # type: ignore[arg-type]
 
-        # Now remap this object's dims if they exactly match the masked dims
         if hasattr(factory, "dims"):
             dims = factory.dims or ()
             if isinstance(dims, str):
                 dims = (dims,)
             if tuple(dims) == tuple(self.dims):
+                if hasattr(factory, "parameters"):
+                    flat_mask = self.mask.values.astype(bool).ravel()
+                    for key, value in list(factory.parameters.items()):
+                        if not (
+                            hasattr(value, "create_variable") and hasattr(value, "dims")
+                        ):
+                            factory.parameters[key] = self._subset_raw_parameter(
+                                value, flat_mask
+                            )
                 factory.dims = (self.active_dim,)
 
         return factory
+
+    def _subset_raw_parameter(self, value: Any, flat_mask: np.ndarray) -> Any:
+        """Subset a raw parameter to match the active entries of the mask.
+
+        Dispatches on parameter type so that dimension-name-aware
+        ``xr.DataArray`` values are broadcast correctly (by name),
+        while plain lists / numpy arrays use positional broadcasting
+        consistent with PyMC's rightmost-dim convention.
+        """
+        if value is None or np.isscalar(value):
+            return value
+
+        if isinstance(value, xr.DataArray):
+            try:
+                broadcasted, _ = xr.broadcast(value, self.mask)
+                return broadcasted.values.ravel()[flat_mask]
+            except Exception:
+                return value
+
+        if isinstance(value, TensorVariable):
+            if value.type.ndim == 0:
+                return value
+            try:
+                broadcasted = pt.broadcast_to(value, self.mask.shape)
+                return broadcasted.ravel()[flat_mask]
+            except Exception:
+                return value
+
+        try:
+            arr = np.asarray(value)
+        except (ValueError, TypeError):
+            return value
+        if arr.ndim == 0:
+            return value
+        try:
+            broadcasted = np.broadcast_to(arr, self.mask.shape)
+        except ValueError:
+            return value
+        return broadcasted.ravel()[flat_mask]
 
     def create_variable(
         self, name: str, xdist: bool = False

--- a/tests/test_special_priors.py
+++ b/tests/test_special_priors.py
@@ -188,6 +188,30 @@ def test_masked_prior_non_scalar_params_regression_2463(mu_value, param_id):
     assert np.isfinite(vals[0])  # Venezuela is active
 
 
+def test_subset_raw_parameter_dataarray_dim_order():
+    """Verify xr.DataArray params are subset in mask dim order, not broadcast dim order."""
+    coords = {"country": ["Venezuela", "Colombia"], "channel": ["TV", "Radio"]}
+    mask = xr.DataArray(
+        [[True, False], [True, True]],
+        dims=["country", "channel"],
+        coords=coords,
+    )
+    base = Prior("Normal", mu=0, sigma=1, dims=("country", "channel"))
+    mp = MaskedPrior(base, mask)
+    flat_mask = mask.values.astype(bool).ravel()
+
+    value = xr.DataArray([0, 1], dims="channel")
+    result = mp._subset_raw_parameter(value, flat_mask)
+    # Active positions in (country, channel) order: (Ven,TV), (Col,TV), (Col,Radio)
+    # TV=0, Radio=1 → expected [0, 0, 1]
+    np.testing.assert_array_equal(result, [0, 0, 1])
+
+    value_country = xr.DataArray([5, 10], dims="country")
+    result_country = mp._subset_raw_parameter(value_country, flat_mask)
+    # Venezuela=5, Colombia=10 → expected [5, 10, 10]
+    np.testing.assert_array_equal(result_country, [5, 10, 10])
+
+
 def test_masked_prior_dataarray_per_channel_2d_mask():
     """DataArray param along rightmost dim with a 2D mask (migration guide pattern)."""
     coords = {"country": ["Venezuela", "Colombia"], "channel": ["TV", "Radio"]}
@@ -198,8 +222,8 @@ def test_masked_prior_dataarray_per_channel_2d_mask():
     )
     prior = Prior(
         "Normal",
-        mu=xr.DataArray([0, 1], dims="channel"),
-        sigma=10,
+        mu=xr.DataArray([0, 100], dims="channel"),
+        sigma=0.001,
         dims=("country", "channel"),
     )
 
@@ -210,6 +234,9 @@ def test_masked_prior_dataarray_per_channel_2d_mask():
     vals = result.eval()
     assert vals.shape == (2, 2)
     assert vals[0, 1] == 0.0  # (Venezuela, Radio) masked out
+    assert abs(vals[0, 0] - 0) < 1  # (Ven, TV) ≈ mu_TV = 0
+    assert abs(vals[1, 0] - 0) < 1  # (Col, TV) ≈ mu_TV = 0
+    assert abs(vals[1, 1] - 100) < 1  # (Col, Radio) ≈ mu_Radio = 100
 
 
 def test_masked_prior_dataarray_non_rightmost_dim_2d_mask():

--- a/tests/test_special_priors.py
+++ b/tests/test_special_priors.py
@@ -163,6 +163,144 @@ def test_masked_prior_simple_1d():
     assert np.all(samples[..., 1] == 0)
 
 
+@pytest.mark.parametrize(
+    "mu_value, param_id",
+    [
+        ([0, 1], "list"),
+        (np.array([0, 1]), "numpy_array"),
+        (xr.DataArray([0, 1], dims="country"), "dataarray_1d"),
+    ],
+    ids=lambda x: x if isinstance(x, str) else None,
+)
+def test_masked_prior_non_scalar_params_regression_2463(mu_value, param_id):
+    """Regression test for #2463: MaskedPrior must work with non-scalar Prior params."""
+    coords = {"country": ["Venezuela", "Colombia"]}
+    mask = xr.DataArray([True, False], dims=["country"], coords=coords)
+    prior = Prior("Normal", mu=mu_value, sigma=10, dims=("country",))
+
+    with pm.Model(coords=coords):
+        mp = MaskedPrior(prior, mask)
+        result = mp.create_variable("test")
+
+    vals = result.eval()
+    assert vals.shape == (2,)
+    assert vals[1] == 0.0  # Colombia is masked out
+    assert np.isfinite(vals[0])  # Venezuela is active
+
+
+def test_masked_prior_dataarray_per_channel_2d_mask():
+    """DataArray param along rightmost dim with a 2D mask (migration guide pattern)."""
+    coords = {"country": ["Venezuela", "Colombia"], "channel": ["TV", "Radio"]}
+    mask = xr.DataArray(
+        [[True, False], [True, True]],
+        dims=["country", "channel"],
+        coords=coords,
+    )
+    prior = Prior(
+        "Normal",
+        mu=xr.DataArray([0, 1], dims="channel"),
+        sigma=10,
+        dims=("country", "channel"),
+    )
+
+    with pm.Model(coords=coords):
+        mp = MaskedPrior(prior, mask)
+        result = mp.create_variable("test")
+
+    vals = result.eval()
+    assert vals.shape == (2, 2)
+    assert vals[0, 1] == 0.0  # (Venezuela, Radio) masked out
+
+
+def test_masked_prior_dataarray_non_rightmost_dim_2d_mask():
+    """DataArray param along non-rightmost dim -- only xarray broadcasting gets this right."""
+    coords = {
+        "country": ["Venezuela", "Colombia"],
+        "channel": ["TV", "Radio", "Digital"],
+    }
+    mask = xr.DataArray(
+        [[True, False, True], [True, True, False]],
+        dims=["country", "channel"],
+        coords=coords,
+    )
+    prior = Prior(
+        "Normal",
+        mu=xr.DataArray([5, 10], dims="country"),
+        sigma=1,
+        dims=("country", "channel"),
+    )
+
+    with pm.Model(coords=coords):
+        mp = MaskedPrior(prior, mask)
+        result = mp.create_variable("test")
+
+    vals = result.eval()
+    assert vals.shape == (2, 3)
+    assert vals[0, 1] == 0.0  # (Venezuela, Radio) masked
+    assert vals[1, 2] == 0.0  # (Colombia, Digital) masked
+    active_mask = mask.values
+    assert np.all(np.isfinite(vals[active_mask]))
+
+
+def test_masked_prior_2d_mask_full_shape_list():
+    """Plain list matching full mask shape with 2D dims."""
+    coords = {"country": ["Venezuela", "Colombia"], "channel": ["TV", "Radio"]}
+    mask = xr.DataArray(
+        [[True, False], [True, True]],
+        dims=["country", "channel"],
+        coords=coords,
+    )
+    prior = Prior(
+        "Normal",
+        mu=[[0, 1], [2, 3]],
+        sigma=1,
+        dims=("country", "channel"),
+    )
+
+    with pm.Model(coords=coords):
+        mp = MaskedPrior(prior, mask)
+        result = mp.create_variable("test")
+
+    vals = result.eval()
+    assert vals.shape == (2, 2)
+    assert vals[0, 1] == 0.0
+
+
+def test_masked_prior_nested_prior_with_array_params():
+    """Nested Prior whose inner parameters are lists must be subset via recursion."""
+    coords = {"country": ["Venezuela", "Colombia"]}
+    mask = xr.DataArray([True, False], dims=["country"], coords=coords)
+    prior = Prior(
+        "Normal",
+        mu=Prior("Normal", mu=[0, 1], sigma=1, dims=("country",)),
+        sigma=1,
+        dims=("country",),
+    )
+
+    with pm.Model(coords=coords):
+        mp = MaskedPrior(prior, mask)
+        result = mp.create_variable("test")
+
+    vals = result.eval()
+    assert vals.shape == (2,)
+    assert vals[1] == 0.0
+
+
+def test_masked_prior_all_active_preserves_array_param():
+    """All-True mask with array params: no subsetting, full shape preserved."""
+    coords = {"country": ["Venezuela", "Colombia"]}
+    mask = xr.DataArray([True, True], dims=["country"], coords=coords)
+    prior = Prior("Normal", mu=[0, 1], sigma=10, dims=("country",))
+
+    with pm.Model(coords=coords):
+        mp = MaskedPrior(prior, mask)
+        result = mp.create_variable("test")
+
+    vals = result.eval()
+    assert vals.shape == (2,)
+    assert np.all(np.isfinite(vals))
+
+
 def test_masked_prior_with_logistic_saturation_prior_sampling():
     """Mask a saturation parameter and check zeros at masked positions in prior sampling."""
     coords = {


### PR DESCRIPTION
Closes [#2463](https://github.com/pymc-labs/pymc-marketing/issues/2463)

### Summary

- `MaskedPrior.create_variable` now works with non-scalar Prior parameters (lists, numpy arrays, `xr.DataArray`, PyTensor tensors), not just scalars and nested `Prior` objects.
- Added `_subset_raw_parameter` helper that dispatches on parameter type: `xr.DataArray` uses dimension-name-aware `xr.broadcast`, plain arrays use positional `np.broadcast_to`, and PyTensor tensors use `pt.broadcast_to`.
- Added 8 new tests covering the exact issue reproducer, DataArray parameters from the [dims migration guide](https://www.pymc-marketing.io/en/stable/notebooks/mmm/mmm_dims_migration_guide.html), 2D masks, nested Priors, and edge cases.

### Root cause

`_remap_dims` rewrites a Prior's `dims` from the original (e.g. `("country",)`) to `(active_dim,)` of length `n_active`, but only recurses into parameters that are `VariableFactory` instances (nested `Prior` objects). Raw parameters like `mu=[0, 1]` passed through unchanged with their original shape, causing a shape mismatch at sampling time:

```
ValueError: Output size (1,) is not compatible with broadcast dimensions of inputs (2,).
```

### Fix

When `_remap_dims` is about to remap a factory's dims, it now also subsets non-`VariableFactory` parameters via `_subset_raw_parameter`. This method dispatches on type:

| Parameter type | Broadcasting strategy |
|---|---|
| `None` / scalar | Pass through unchanged |
| `xr.DataArray` | `xr.broadcast` (dimension-name-aware) |
| `TensorVariable` | `pt.broadcast_to` (tensor ops) |
| Plain list / `np.ndarray` | `np.broadcast_to` (positional, rightmost-dim) |

The `xr.DataArray` path is critical for the new dims API where parameters like `mu=DataArray([5, 10], dims="country")` on a Prior with `dims=("country", "channel")` must broadcast by dimension **name**, not position.

### Test plan

| Test | Scenario |
|---|---|
| `test_masked_prior_non_scalar_params_regression_2463` (x3) | Exact issue reproducer: list, numpy array, DataArray 1D |
| `test_masked_prior_dataarray_per_channel_2d_mask` | DataArray along rightmost dim with 2D mask |
| `test_masked_prior_dataarray_non_rightmost_dim_2d_mask` | DataArray along non-rightmost dim (only xarray gets this right) |
| `test_masked_prior_2d_mask_full_shape_list` | Plain nested list matching full 2D mask shape |
| `test_masked_prior_nested_prior_with_array_params` | Inner Prior has list params, subset via recursion |
| `test_masked_prior_all_active_preserves_array_param` | All-True mask preserves full array without errors |

All 41 tests in `test_special_priors.py` pass. Pre-commit (ruff check, ruff format, mypy) clean.

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2464.org.readthedocs.build/en/2464/

<!-- readthedocs-preview pymc-marketing end -->