### PR TITLE
Fix Serialization LogNormal from YAML

### DIFF
--- a/pymc_marketing/mmm/builders/factories.py
+++ b/pymc_marketing/mmm/builders/factories.py
@@ -110,11 +110,13 @@ def build(spec: Mapping[str, Any]) -> Any:
             # Handle priors and prior differently
             if isinstance(v, dict):
                 if k == "priors":
-                    # Create a dictionary of priors
                     priors_dict = {}
                     for prior_key, prior_value in v.items():
                         if isinstance(prior_value, dict):
-                            priors_dict[prior_key] = deserialize(prior_value)
+                            if "class" in prior_value:
+                                priors_dict[prior_key] = build(prior_value)
+                            else:
+                                priors_dict[prior_key] = deserialize(prior_value)
                         else:
                             priors_dict[prior_key] = prior_value
                     kwargs[k] = priors_dict
@@ -139,8 +141,11 @@ def resolve(value):
 
     This is a helper function for build.
     """
-    if isinstance(value, Mapping) and "class" in value:
-        return build(value)
+    if isinstance(value, Mapping):
+        if "class" in value:
+            return build(value)
+        if "distribution" in value or "special_prior" in value:
+            return deserialize(value)
 
     if (
         isinstance(value, list)

--- a/tests/mmm/builders/test_factories.py
+++ b/tests/mmm/builders/test_factories.py
@@ -16,8 +16,9 @@ import warnings
 import pytest
 from pymc_extras.prior import Prior
 
-from pymc_marketing.mmm.builders.factories import build, locate
+from pymc_marketing.mmm.builders.factories import build, locate, resolve
 from pymc_marketing.mmm.mmm import MMM
+from pymc_marketing.special_priors import LogNormalPrior
 
 
 @pytest.mark.parametrize(
@@ -61,3 +62,115 @@ def test_build_no_warning_for_clean_spec():
 
     warning_messages = [str(w.message) for w in caught]
     assert not any("Unknown keys" in msg for msg in warning_messages)
+
+
+class TestBuildClassKeyedPriorInPriors:
+    """Regression tests for GitHub issues #2071 and #2439.
+
+    When a prior inside ``priors`` uses the ``class:`` BuildSpec format
+    (e.g. LogNormalPrior), ``build()`` must route it through the factory
+    instead of ``pymc_extras.deserialize()``, which cannot handle
+    ``class``-keyed dicts.
+    """
+
+    def test_build_lognormal_prior_via_class_key_in_priors(self):
+        """LogNormalPrior specified with class: key inside priors dict."""
+        spec = {
+            "class": "pymc_marketing.mmm.LogisticSaturation",
+            "kwargs": {
+                "priors": {
+                    "lam": {
+                        "distribution": "Gamma",
+                        "mu": 0.5,
+                        "sigma": 1.5,
+                    },
+                    "beta": {
+                        "class": "pymc_marketing.special_priors.LogNormalPrior",
+                        "kwargs": {
+                            "mean": 1.0,
+                            "std": 0.5,
+                        },
+                    },
+                }
+            },
+        }
+        result = build(spec)
+        assert isinstance(result.priors["lam"], Prior)
+        assert isinstance(result.priors["beta"], LogNormalPrior)
+
+    def test_build_lognormal_prior_with_nested_distribution_params(self):
+        """LogNormalPrior with nested distribution-keyed Prior parameters."""
+        spec = {
+            "class": "pymc_marketing.special_priors.LogNormalPrior",
+            "kwargs": {
+                "mean": {
+                    "distribution": "Gamma",
+                    "mu": 0.25,
+                    "sigma": 1.0,
+                },
+                "std": {
+                    "distribution": "HalfNormal",
+                    "sigma": 1.0,
+                },
+            },
+        }
+        result = build(spec)
+        assert isinstance(result, LogNormalPrior)
+        assert isinstance(result.parameters["mean"], Prior)
+        assert isinstance(result.parameters["std"], Prior)
+
+    def test_build_lognormal_prior_with_dims_and_centered(self):
+        """LogNormalPrior with dims and centered=False inside kwargs."""
+        spec = {
+            "class": "pymc_marketing.special_priors.LogNormalPrior",
+            "kwargs": {
+                "mean": {
+                    "distribution": "Gamma",
+                    "mu": 0.25,
+                    "sigma": 1.0,
+                    "dims": "channel",
+                },
+                "std": {
+                    "distribution": "HalfNormal",
+                    "sigma": 1.0,
+                    "dims": "channel",
+                },
+                "centered": False,
+                "dims": ["geo", "channel"],
+            },
+        }
+        result = build(spec)
+        assert isinstance(result, LogNormalPrior)
+        assert result.centered is False
+        assert result.dims == ("geo", "channel")
+        assert isinstance(result.parameters["mean"], Prior)
+        assert isinstance(result.parameters["std"], Prior)
+
+
+class TestResolveDistributionDicts:
+    """resolve() must handle distribution-keyed and special_prior-keyed dicts."""
+
+    def test_resolve_distribution_dict(self):
+        data = {"distribution": "HalfNormal", "sigma": 1.0}
+        result = resolve(data)
+        assert isinstance(result, Prior)
+
+    def test_resolve_special_prior_dict(self):
+        data = {"special_prior": "LogNormalPrior", "mean": 1.0, "std": 0.5}
+        result = resolve(data)
+        assert isinstance(result, LogNormalPrior)
+
+    def test_resolve_plain_dict_unchanged(self):
+        data = {"some_key": "some_value", "number": 42}
+        result = resolve(data)
+        assert result == data
+
+    def test_resolve_class_dict_builds(self):
+        data = {
+            "class": "pymc_marketing.mmm.GeometricAdstock",
+            "kwargs": {"l_max": 4},
+        }
+        result = resolve(data)
+        from pymc_marketing.mmm.components.adstock import GeometricAdstock
+
+        assert isinstance(result, GeometricAdstock)

--- a/tests/mmm/builders/test_yaml.py
+++ b/tests/mmm/builders/test_yaml.py
@@ -350,6 +350,97 @@ def test_special_prior_in_yaml(tmp_path, mock_pymc_sample):
     assert "posterior" in model.idata
 
 
+def test_lognormal_prior_class_key_in_yaml(tmp_path, mock_pymc_sample):
+    """Regression test for #2071 / #2439: LogNormalPrior via class: key in priors."""
+    from pymc_extras.prior import Prior
+
+    from pymc_marketing.special_priors import LogNormalPrior
+
+    X = pd.DataFrame(
+        {
+            "date": pd.date_range("2023-01-01", periods=100),
+            "channel_1": range(100),
+            "channel_2": range(100, 200),
+        }
+    )
+    y = pd.Series(range(100), name="y")
+
+    config = {
+        "model": {
+            "class": "pymc_marketing.mmm.multidimensional.MMM",
+            "kwargs": {
+                "date_column": "date",
+                "channel_columns": ["channel_1", "channel_2"],
+                "target_column": "y",
+                "adstock": {
+                    "class": "pymc_marketing.mmm.GeometricAdstock",
+                    "kwargs": {"l_max": 4},
+                },
+                "saturation": {
+                    "class": "pymc_marketing.mmm.LogisticSaturation",
+                    "kwargs": {
+                        "priors": {
+                            "lam": {
+                                "distribution": "Gamma",
+                                "mu": 0.5,
+                                "sigma": 1.5,
+                                "dims": ["channel"],
+                            },
+                            "beta": {
+                                "class": "pymc_marketing.special_priors.LogNormalPrior",
+                                "kwargs": {
+                                    "mean": {
+                                        "distribution": "Gamma",
+                                        "mu": 0.25,
+                                        "sigma": 1.0,
+                                        "dims": ["channel"],
+                                    },
+                                    "std": {
+                                        "distribution": "HalfNormal",
+                                        "sigma": 1.0,
+                                        "dims": ["channel"],
+                                    },
+                                    "centered": False,
+                                    "dims": ["channel"],
+                                },
+                            },
+                        }
+                    },
+                },
+                "sampler_config": {
+                    "draws": 10,
+                    "tune": 10,
+                    "chains": 1,
+                    "random_seed": 42,
+                },
+            },
+        }
+    }
+
+    config_path = tmp_path / "test_config.yml"
+    with open(config_path, "w") as f:
+        yaml.dump(config, f)
+
+    model = build_mmm_from_yaml(config_path, X=X, y=y)
+
+    assert model is not None
+    assert hasattr(model, "saturation")
+
+    lam_prior = model.saturation.priors["lam"]
+    assert isinstance(lam_prior, Prior)
+
+    beta_prior = model.saturation.priors["beta"]
+    assert isinstance(beta_prior, LogNormalPrior)
+    assert beta_prior.centered is False
+    assert beta_prior.dims == ("channel",)
+    assert isinstance(beta_prior.parameters["mean"], Prior)
+    assert isinstance(beta_prior.parameters["std"], Prior)
+
+    model.fit(X=X, y=y)
+    assert model.idata is not None
+    assert "posterior" in model.idata
+
+
 def test_build_mmm_loads_data_from_yaml_paths(
     tmp_path, _minimal_model_config, _sample_data
 ):


### PR DESCRIPTION
## Summary

- Fix `DeserializableError` when using `LogNormalPrior` with the `class:` BuildSpec format in YAML configs passed to `build_mmm_from_yaml`
- Extend `resolve()` to handle `distribution`- and `special_prior`-keyed dicts so nested Prior parameters are properly deserialized

Closes https://github.com/pymc-labs/pymc-marketing/issues/2071
Closes https://github.com/pymc-labs/pymc-marketing/issues/2439

## Root Cause

In `pymc_marketing/mmm/builders/factories.py`, the `build()` function unconditionally routed all dict values inside `priors` through `pymc_extras.deserialize()`. That function only recognizes `distribution`-, `special_prior`-, or `dist`-keyed dicts. When a user specified a `LogNormalPrior` using the standard `class:` BuildSpec format in YAML, none of the registered deserializers matched, raising `DeserializableError`.

A secondary issue: even after routing `class`-keyed priors through `build()`, the `LogNormalPrior`'s own kwargs (`mean`, `std`) are `distribution`-keyed dicts that fell into the general `else` branch calling `resolve()`. Since `resolve()` only handled `class`-keyed dicts, these were passed as raw dicts to `LogNormalPrior.__init__` instead of as deserialized `Prior` objects.

## Changes Made

**`pymc_marketing/mmm/builders/factories.py`** (2 targeted changes):

1. **`build()` -- `priors` loop**: Added a `"class" in prior_value` check so `class`-keyed dicts (like `LogNormalPrior` specs) are routed through `build()` instead of `deserialize()`
2. **`resolve()`**: Extended to detect `distribution`-keyed and `special_prior`-keyed dicts and route them through `deserialize()`, so nested Prior parameters get properly deserialized anywhere in kwargs

**`tests/mmm/builders/test_factories.py`** (7 new tests):

- `TestBuildClassKeyedPriorInPriors` (3 tests): `LogNormalPrior` via `class:` key in `priors`, with nested `distribution` params, and with `dims`/`centered`
- `TestResolveDistributionDicts` (4 tests): `resolve()` handling `distribution`, `special_prior`, plain dicts, and `class` dicts

**`tests/mmm/builders/test_yaml.py`** (1 new test):

- `test_lognormal_prior_class_key_in_yaml`: Full integration test reproducing the exact YAML pattern from issue #2071 -- builds model, verifies prior types, nested `Prior` parameters, and runs fit

## Test Plan

- [x] New unit tests in `test_factories.py` confirm `build()` and `resolve()` handle all dict formats correctly
- [x] New integration test in `test_yaml.py` reproduces the exact YAML config from issue #2071 end-to-end
- [x] Existing `test_special_prior_in_yaml` (using `special_prior:` key format) still passes
- [x] Full builder test suite (101 tests) passes with no regressions
- [x] Pre-commit checks pass (ruff, mypy, formatting)

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2476.org.readthedocs.build/en/2476/

<!-- readthedocs-preview pymc-marketing end -->