### PR TITLE
fix: register xr.DataArray deserializer in SpecialPrior to fix save/load round-trip

### DIFF
--- a/pymc_marketing/special_priors.py
+++ b/pymc_marketing/special_priors.py
@@ -42,6 +42,26 @@ from pytensor.xtensor.type import XTensorVariable, as_xtensor
 from pymc_marketing.serialization import serialization
 
 
+def _is_xarray_dataarray_dict(data: Any) -> bool:
+    """Return True for dicts produced by ``xr.DataArray.to_dict()``."""
+    if not isinstance(data, dict):
+        return False
+    required = {"dims", "attrs", "data", "coords"}
+    return (
+        required.issubset(data.keys())
+        and "data_vars" not in data
+        and "dist" not in data
+        and "special_prior" not in data
+        and "lookup_name" not in data
+    )
+
+
+register_deserialization(
+    is_type=_is_xarray_dataarray_dict,
+    deserialize=xr.DataArray.from_dict,
+)
+
+
 class SpecialPrior(ABC):
     """A base class for specialized priors."""
 
@@ -137,6 +157,9 @@ class SpecialPrior(ABC):
 
                 if isinstance(value, np.ndarray):
                     return value.tolist()
+
+                if isinstance(value, xr.DataArray):
+                    return value.to_dict()
 
                 if hasattr(value, "to_dict"):
                     return value.to_dict()

--- a/tests/test_special_priors.py
+++ b/tests/test_special_priors.py
@@ -17,6 +17,7 @@ import pandas as pd
 import pymc as pm
 import pytest
 import xarray as xr
+from pymc_extras.deserialize import deserialize
 from pymc_extras.prior import Prior
 from pytensor import function
 
@@ -876,3 +877,59 @@ def test_mmm_with_special_prior_save_load_round_trip(tmp_path, mock_pymc_sample)
     # Verify prior parameters match
     assert mmm_loaded.saturation.priors["lam"] == mmm.saturation.priors["lam"]
     assert mmm_loaded.saturation.priors["beta"] == mmm.saturation.priors["beta"]
+
+
+def test_xarray_dataarray_deserializer_registered():
+    da = xr.DataArray([1.0, 2.0], dims=["channel"], coords={"channel": ["a", "b"]})
+    result = deserialize(da.to_dict())
+    assert isinstance(result, xr.DataArray)
+    xr.testing.assert_equal(result, da)
+
+
+def test_lognormal_prior_roundtrip_with_dataarray_params():
+    coords = {"country": ["ES", "IT"], "channel": ["search", "social"]}
+    mean = xr.DataArray(
+        [[1.0, 2.0], [3.0, 4.0]], dims=["country", "channel"], coords=coords
+    )
+    std = xr.DataArray(
+        [[0.5, 0.5], [0.5, 0.5]], dims=["country", "channel"], coords=coords
+    )
+    prior = LogNormalPrior(mean=mean, std=std, dims=("country", "channel"))
+    restored = LogNormalPrior.from_dict(prior.to_dict())
+    assert isinstance(restored.parameters["mean"], xr.DataArray)
+    assert isinstance(restored.parameters["std"], xr.DataArray)
+    xr.testing.assert_equal(restored.parameters["mean"], mean)
+    xr.testing.assert_equal(restored.parameters["std"], std)
+    assert restored.dims == prior.dims
+
+
+def test_lognormal_prior_roundtrip_non_centered():
+    coords = {"country": ["ES", "IT"], "channel": ["search", "social"]}
+    mean = xr.DataArray(
+        [[1.0, 2.0], [3.0, 4.0]], dims=["country", "channel"], coords=coords
+    )
+    std = xr.DataArray(
+        [[0.5, 0.5], [0.5, 0.5]], dims=["country", "channel"], coords=coords
+    )
+    prior = LogNormalPrior(
+        mean=mean, std=std, dims=("country", "channel"), centered=False
+    )
+    restored = LogNormalPrior.from_dict(prior.to_dict())
+    assert not restored.centered
+    xr.testing.assert_equal(restored.parameters["mean"], mean)
+    xr.testing.assert_equal(restored.parameters["std"], std)
+
+
+def test_lognormal_prior_roundtrip_via_deserialize():
+    coords = {"country": ["ES", "IT"], "channel": ["search", "social"]}
+    mean = xr.DataArray(
+        [[1.0, 2.0], [3.0, 4.0]], dims=["country", "channel"], coords=coords
+    )
+    std = xr.DataArray(
+        [[0.5, 0.5], [0.5, 0.5]], dims=["country", "channel"], coords=coords
+    )
+    prior = LogNormalPrior(mean=mean, std=std, dims=("country", "channel"))
+    restored = deserialize(prior.to_dict())
+    assert isinstance(restored, LogNormalPrior)
+    xr.testing.assert_equal(restored.parameters["mean"], mean)
+    xr.testing.assert_equal(restored.parameters["std"], std)


### PR DESCRIPTION
## Summary

Fixes a bug where `MMM.load()` raises `DeserializableError` on any model saved with `xr.DataArray` values in `SpecialPrior` parameters (e.g. `LogNormalPrior(mean=xr.DataArray(...), dims=(...))`).

## Root Cause

`SpecialPrior.to_dict()` serialises `xr.DataArray` parameter values via `xr.DataArray.to_dict()`, producing a dict with keys `{dims, attrs, data, coords, name}`.

`SpecialPrior.from_dict()` dispatches any dict-valued kwarg to `pymc_extras.deserialize()`, but no deserializer for the `xr.DataArray.to_dict()\ format was registered → `DeserializableError`.

This affects any `SpecialPrior` whose parameters are `xr.DataArray` values — i.e. any multidimensional model where priors carry explicit dimension coordinates.

## Fix

Two changes to `pymc_marketing/special_priors.py`:

1. Register `_is_xarray_dataarray_dict` / `xr.DataArray.from_dict` via `register_deserialization()`. The type-guard checks for `{dims, attrs, data, coords} ⊆ keys` and explicitly excludes `data_vars`, `dist`, `special_prior`, `lookup_name` to avoid false positives with other registered types.

2. Add an explicit `isinstance(value, xr.DataArray)` branch in `to_dict()`'s `handle_value()` before the generic `hasattr(value, "to_dict")` check, making intent explicit.

## Tests

Four new tests in `tests/test_special_priors.py`:

- `test_xarray_dataarray_deserializer_registered` — verifies `deserialize(da.to_dict())` returns an `xr.DataArray`
- `test_lognormal_prior_roundtrip_with_dataarray_params` — full `to_dict()` / `from_dict()` round-trip with coords preserved
- `test_lognormal_prior_roundtrip_non_centered` — same for the non-centered variant
- `test_lognormal_prior_roundtrip_via_deserialize` — round-trip via the top-level `deserialize()` call

All 52 tests in `tests/test_special_priors.py` pass.