### PR TITLE
Bump version to 0.19.3

### DIFF
--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -8,6 +8,7 @@
   :toctree: generated/
 
   bass
+  bidder
   causal_utils
   clv
   customer_choice
@@ -26,5 +27,7 @@
   serialization
   serialization_migration
   special_priors
+  types
+  user_priors
   utils
 ```

--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -8,7 +8,6 @@
   :toctree: generated/
 
   bass
-  bidder
   causal_utils
   clv
   customer_choice
@@ -27,7 +26,5 @@
   serialization
   serialization_migration
   special_priors
-  types
-  user_priors
   utils
 ```

--- a/pymc_marketing/version.py
+++ b/pymc_marketing/version.py
@@ -13,4 +13,4 @@
 #   limitations under the License.
 """Version of the package."""
 
-__version__ = "0.19.2"
+__version__ = "0.19.3"


### PR DESCRIPTION
Bump version to 0.19.3

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2499.org.readthedocs.build/en/2499/

<!-- readthedocs-preview pymc-marketing end -->