### PR TITLE
fix: cap jax below 0.10.0 due to breaking changes in new release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ test = [
     "nutpie>=0.16.7",
     "numpyro",
     "ipykernel",
-    "jax",
+    "jax<0.10.0",
     "graphviz>=0.20.1",
     "papermill",
     "polars>=1.0.0",


### PR DESCRIPTION
JAX 0.10.0 was just released and [tests are failing](https://github.com/pymc-labs/pymc-marketing/actions/runs/24513139797/job/71649587231?pr=2488).
pining to jax<0.10



<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2500.org.readthedocs.build/en/2500/

<!-- readthedocs-preview pymc-marketing end -->