### PR TITLE
feat(mmm): chainable mu effects

### DIFF
--- a/pymc_marketing/mmm/additive_effect.py
+++ b/pymc_marketing/mmm/additive_effect.py
@@ -77,7 +77,7 @@ Example of a custom additive effect
 
     # Build your MMM as usual (with channels, etc.), then add the effect before build/fit:
     # mmm = MMM(...)
-    # mmm.mu_effects.append(weekend_penalty)
+    # mmm.add_mu_effect(weekend_penalty)
     # mmm.build_model(X, y)
     # mmm.fit(X, y, ...)
     # At prediction time, the effect updates itself via set_data.

--- a/pymc_marketing/mmm/builders/yaml.py
+++ b/pymc_marketing/mmm/builders/yaml.py
@@ -152,7 +152,7 @@ def build_mmm_from_yaml(
     # 3 -- effects (preserve order)
     for eff_spec in cfg.effects or []:
         effect = build(eff_spec.model_dump(by_alias=True))
-        model.mu_effects.append(effect)
+        model.add_mu_effect(effect)
 
     # 4 -- build PyMC graph (must precede idata loading)
     model.build_model(X, y)

--- a/pymc_marketing/mmm/multidimensional.py
+++ b/pymc_marketing/mmm/multidimensional.py
@@ -182,7 +182,7 @@ import json
 import warnings
 from collections.abc import Callable, Sequence
 from copy import deepcopy
-from typing import Annotated, Any, cast
+from typing import Annotated, Any, Self, cast
 
 import arviz as az
 import numpy as np
@@ -586,6 +586,41 @@ class MMM(RegressionModelBuilder):
 
         self.mu_effects: list[MuEffect] = []
 
+    def add_mu_effect(
+        self: Self,
+        mu_effect: MuEffect,
+    ) -> Self:
+        """Include MuEffect in model.
+
+        Parameters
+        ----------
+        mu_effect : MuEffect
+            Any MuEffect Protocol to include in the model.
+
+        Returns
+        -------
+        The instance for chaining.
+
+        Examples
+        --------
+        Add LinearTrend to the MMM.
+
+        .. code-block:: python
+
+            from pymc_marketing.mmm import MMM, LinearTrend
+            from pymc_marketing.mmm.additive_effect import LinearTrendEffect
+
+            mmm = MMM(...).add_mu_effect(
+                LinearTrendEffect(
+                    trend=LinearTrend(n_changepoints=10),
+                    prefix="linear_trend",
+                )
+            )
+
+        """
+        self.mu_effects.append(mu_effect)
+        return self
+
     def __eq__(self, other: object) -> bool:
         """Compare two MMM instances for equivalence.
 
@@ -859,11 +894,11 @@ class MMM(RegressionModelBuilder):
     def _data_setter(self, X, y=None): ...
 
     def add_events(
-        self,
+        self: Self,
         df_events: pd.DataFrame,
         prefix: str,
         effect: EventEffect,
-    ) -> None:
+    ) -> Self:
         """Add event effects to the model.
 
         This must be called before building the model.
@@ -879,6 +914,10 @@ class MMM(RegressionModelBuilder):
             The prefix to use for the event effect and associated variables.
         effect : EventEffect
             The event effect to apply.
+
+        Returns
+        -------
+        The instance for chaining.
 
         Raises
         ------
@@ -897,6 +936,8 @@ class MMM(RegressionModelBuilder):
             effect=effect,
         )
         self.mu_effects.append(event_effect)
+
+        return self
 
     @property
     def _serializable_model_config(self) -> dict[str, Any]:

--- a/pymc_marketing/mmm/multidimensional.py
+++ b/pymc_marketing/mmm/multidimensional.py
@@ -1949,7 +1949,10 @@ class MMM(RegressionModelBuilder):
         if var not in self.model.named_vars:
             raise ValueError(f"Variable {var} is not in the model")
 
-    def add_original_scale_contribution_variable(self, var: list[str]) -> None:
+    def add_original_scale_contribution_variable(
+        self: Self,
+        var: list[str],
+    ) -> Self:
         """Add a pymc.dims.Deterministic variable to the model that multiplies by the scaler.
 
         Restricted to the model parameters. Only make it possible for "_contribution" variables.
@@ -1987,6 +1990,8 @@ class MMM(RegressionModelBuilder):
                         "date", ..., missing_dims="ignore"
                     ),
                 )
+
+        return self
 
     def fit(  # type: ignore[override]
         self,
@@ -2955,11 +2960,11 @@ class MMM(RegressionModelBuilder):
         return target_transform
 
     def add_lift_test_measurements(
-        self,
+        self: Self,
         df_lift_test: pd.DataFrame,
         dist: type[pmd.DimDistribution] = pmd.Gamma,
         name: str = "lift_measurements",
-    ) -> None:
+    ) -> Self:
         """Add lift tests to the model.
 
         The model for the difference of a channel's saturation curve is created
@@ -3099,12 +3104,14 @@ class MMM(RegressionModelBuilder):
             name=name,
         )
 
+        return self
+
     def add_cost_per_target_calibration(
-        self,
+        self: Self,
         data: pd.DataFrame,
         calibration_data: pd.DataFrame,
         name_prefix: str = "cpt_calibration",
-    ) -> None:
+    ) -> Self:
         """Calibrate cost-per-target using an observed Normal likelihood.
 
         This computes cost-per-target as
@@ -3167,7 +3174,7 @@ class MMM(RegressionModelBuilder):
                 UserWarning,
                 stacklevel=2,
             )
-            return
+            return self
 
         # Validate required columns in calibration_data
         if "channel" not in calibration_data.columns:
@@ -3219,6 +3226,8 @@ class MMM(RegressionModelBuilder):
             target_value=self.model["channel_contribution_original_scale"],
             name_prefix=name_prefix,
         )
+
+        return self
 
     def create_fit_data(
         self,

--- a/tests/mmm/test_multidimensional.py
+++ b/tests/mmm/test_multidimensional.py
@@ -236,24 +236,26 @@ def test_save_load_equality_with_all_effects(mock_pymc_sample):
     )
 
     # Create MMM with time-varying effects
-    mmm = MMM(
-        date_column="date",
-        channel_columns=["channel_1", "channel_2"],
-        target_column="target",
-        adstock=GeometricAdstock(l_max=8),
-        saturation=LogisticSaturation(),
-        time_varying_intercept=True,
-        time_varying_media=True,
-    )
-
-    # Add MuEffects
-    mmm.mu_effects.append(
-        FourierEffect(fourier=YearlyFourier(n_order=3, prefix="yearly"))
-    )
-    mmm.mu_effects.append(
-        LinearTrendEffect(
-            trend=LinearTrend(n_changepoints=5),
-            prefix="trend",
+    mmm = (
+        MMM(
+            date_column="date",
+            channel_columns=["channel_1", "channel_2"],
+            target_column="target",
+            adstock=GeometricAdstock(l_max=8),
+            saturation=LogisticSaturation(),
+            time_varying_intercept=True,
+            time_varying_media=True,
+        )
+        .add_mu_effect(
+            FourierEffect(
+                fourier=YearlyFourier(n_order=3, prefix="yearly"),
+            ),
+        )
+        .add_mu_effect(
+            LinearTrendEffect(
+                trend=LinearTrend(n_changepoints=5),
+                prefix="trend",
+            )
         )
     )
 
@@ -499,20 +501,22 @@ class TestSerializationIntegration:
         )
 
         X, y = minimal_fit_data
-        mmm = self._base_mmm()
-        mmm.mu_effects.append(
-            FourierEffect(fourier=YearlyFourier(n_order=3, prefix="yearly"))
+        mmm = (
+            self._base_mmm()
+            .add_mu_effect(
+                FourierEffect(fourier=YearlyFourier(n_order=3, prefix="yearly"))
+            )
+            .add_events(
+                df_events,
+                prefix="promos",
+                effect=EventEffect(
+                    basis=GaussianBasis(),
+                    effect_size=Prior("Normal"),
+                    dims=("promos",),
+                ),
+            )
+            .add_mu_effect(_TestCustomEffect(my_param=42.0))
         )
-        mmm.add_events(
-            df_events,
-            prefix="promos",
-            effect=EventEffect(
-                basis=GaussianBasis(),
-                effect_size=Prior("Normal"),
-                dims=("promos",),
-            ),
-        )
-        mmm.mu_effects.append(_TestCustomEffect(my_param=42.0))
         mmm.fit(X, y)
 
         fname = tmp_path / "mu_effects_model.nc"
@@ -3646,7 +3650,7 @@ def test_mmm_linear_trend_different_dimensions_original_scale(
 
     # Create the wrapper
     trend_effect = LinearTrendEffect(trend=trend, prefix="trend")
-    mmm.mu_effects.append(trend_effect)
+    mmm.add_mu_effect(trend_effect)
 
     mmm.build_model(X, y)
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

Allows for chaining with mu_effects:

```python
mmm = MMM(...).add_mu_effect(
  effect_1
).add_mu_effect(
  effect_2
).add_mu_effect(
  effect_3
).add_events(...)
```

Work toward : https://github.com/pymc-labs/pymc-marketing/issues/2471

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->