### PR TITLE
Restore from_netcdf with deprecation warning

### DIFF
--- a/pymc_marketing/utils.py
+++ b/pymc_marketing/utils.py
@@ -13,6 +13,43 @@
 #   limitations under the License.
 """Utility functions for PyMC-Marketing."""
 
+import warnings
+from pathlib import Path
+
+import arviz as az
+
 from pymc_marketing.data.idata.utils import idata_from_zarr, idata_to_zarr
 
-__all__ = ["idata_from_zarr", "idata_to_zarr"]
+__all__ = ["from_netcdf", "idata_from_zarr", "idata_to_zarr"]
+
+
+def from_netcdf(filepath: str | Path) -> az.InferenceData:
+    """Load inference data from a netcdf file without ``fit_data`` group warnings.
+
+    .. deprecated::
+        ``from_netcdf`` will be removed in a future release.
+        Use ``arviz.from_netcdf`` directly instead.
+
+    Parameters
+    ----------
+    filepath : str or Path
+        The path to the netcdf file.
+
+    Returns
+    -------
+    az.InferenceData
+        The inference data.
+    """
+    warnings.warn(
+        "pymc_marketing.utils.from_netcdf is deprecated and will be removed "
+        "in a future release. Use arviz.from_netcdf directly instead.",
+        FutureWarning,
+        stacklevel=2,
+    )
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            category=UserWarning,
+            message=r"fit_data group is not defined in the InferenceData scheme",
+        )
+        return az.from_netcdf(filepath)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,46 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+import warnings
+
+import arviz as az
+import numpy as np
+import pytest
+
+from pymc_marketing.utils import from_netcdf
+
+
+class TestFromNetcdf:
+    def test_loads_inference_data(self, tmp_path):
+        filepath = tmp_path / "test.nc"
+        idata = az.from_dict(posterior={"x": np.random.randn(2, 100)})
+        idata.to_netcdf(str(filepath))
+
+        with pytest.warns(FutureWarning, match="deprecated"):
+            result = from_netcdf(filepath)
+
+        assert isinstance(result, az.InferenceData)
+        assert "posterior" in result.groups()
+
+    def test_emits_deprecation_warning(self, tmp_path):
+        filepath = tmp_path / "test.nc"
+        idata = az.from_dict(posterior={"x": np.random.randn(2, 100)})
+        idata.to_netcdf(str(filepath))
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            from_netcdf(filepath)
+
+        future_warnings = [x for x in w if issubclass(x.category, FutureWarning)]
+        assert len(future_warnings) == 1
+        assert "arviz.from_netcdf" in str(future_warnings[0].message)


### PR DESCRIPTION
## Summary

- PR #2512 removed `from_netcdf` from `pymc_marketing.utils` without a deprecation period, breaking external code that relies on this import (e.g. `from pymc_marketing.utils import from_netcdf`).
- This restores the function with a `FutureWarning` deprecation, guiding users to migrate to `arviz.from_netcdf` directly.
- Adds tests for the deprecation behavior.

## Context

The `from_netcdf` wrapper was a thin convenience around `arviz.from_netcdf()` that suppressed the `fit_data` group `UserWarning`. It was removed as a side effect of the Zarr IO refactor in #2512. While the internal codebase was updated to use `az.from_netcdf()` directly, external users were given no deprecation notice or migration path.

## Changes

- **`pymc_marketing/utils.py`**: Restored `from_netcdf` with a `FutureWarning` that tells users to switch to `arviz.from_netcdf`.
- **`tests/test_utils.py`**: New test file verifying the function still loads InferenceData and emits the deprecation warning.

## Test plan

- [x] `pre-commit` passes on all changed files
- [x] Function logic verified (deprecation warning emitted, InferenceData loaded correctly)
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2529.org.readthedocs.build/en/2529/

<!-- readthedocs-preview pymc-marketing end -->