### PR TITLE
fix(docs): convert Resources section from raw HTML to markdown heading

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -199,7 +199,7 @@ See our example notebooks for [saturated markets](https://www.pymc-marketing.io/
 
 ---
 
-<h1 style="text-align: center;">Resources</h1>
+## Resources
 
 ### Bolt's success story with PyMC-Marketing
 **Checkout the video below to see how Bolt leverages PyMC-Marketing to assess the impact of their marketing efforts.**


### PR DESCRIPTION
## Problem

The "Resources" section title on the main landing page was written as a raw HTML tag:

`html
<h1 style="text-align: center;">Resources</h1>
`

Sphinx/MyST does not parse raw HTML elements as document section boundaries. This caused all the subsections that follow (### Bolt's success story, ### Time-varying parameters in MMMs, ### Customer Lifetime Value Modeling in Marine Industry) to be treated as **children of the preceding ## Customer Choice Analysis section** in the sidebar navigation - making them appear incorrectly nested, as reported in #2535.

## Fix

Replace the HTML <h1> tag with a proper MyST/Markdown heading at the same level as the other major sections:

`markdown
## Resources
`

Sphinx now recognises "Resources" as a top-level section boundary, so the subsections beneath it appear under "Resources" in the sidebar - not under "Customer Choice Analysis".

## Testing

Build the docs locally (make html in docs/) and verify the sidebar shows:

- .
- Customer Choice Analysis
- **Resources**
  - Bolt's success story.
  - Time-varying parameters.
  - Customer Lifetime Value Modeling.

Fixes #2535

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2537.org.readthedocs.build/en/2537/

<!-- readthedocs-preview pymc-marketing end -->