### PR TITLE
docs(mmm): clarify kappa description in hill_function

### DIFF
--- a/pymc_marketing/mmm/transformers.py
+++ b/pymc_marketing/mmm/transformers.py
@@ -1043,7 +1043,7 @@ def hill_function(
 
     where:
      - :math:`s` is the slope of the hill.
-     - :math:`\kappa` is the half-saturation point as :math:`f(\kappa) = 0.5` for any value of :math:`s` and :math:`\kappa`.
+     - :math:`\kappa` is the half-saturation point as :math:`f(\kappa) = 0.5` for any value of :math:`s`.
      - :math:`x` is the independent variable and must be non-negative.
 
     Hill function from Equation (5) in the paper [1]_.
@@ -1093,7 +1093,7 @@ def hill_function(
     slope : XTensorLike
         The slope of the hill. Must be non-positive.
     kappa : XTensorLike
-        The half-saturation point as :math:`f(\kappa) = 0.5` for any value of :math:`s` and :math:`\kappa`.
+        The half-saturation point as :math:`f(\kappa) = 0.5` for any value of :math:`s`.
 
     Returns
     -------
@@ -1104,7 +1104,7 @@ def hill_function(
     ----------
     .. [1] Jin, Yuxue, et al. “Bayesian methods for media mix modeling with carryover and shape effects.” (2017).
 
-    """  # noqa: E501
+    """
     x = as_xtensor(x)
     slope = as_xtensor(slope)
     kappa = as_xtensor(kappa)


### PR DESCRIPTION
Closes #1220.

The previous wording said `f(kappa) = 0.5` "for any value of `s` and `kappa`", but kappa being the half-saturation point makes "for any value of kappa" circular. The relevant invariant is that the property holds for any slope `s`. Updated the math description block and the `kappa` parameter description.

Side effect: the `# noqa: E501` on the closing `"""` is no longer needed (lines now fit), so ruff removed it.

## Test plan
- [x] `pre-commit run --files pymc_marketing/mmm/transformers.py` passes (ruff-check, ruff-format, mypy, validate-api-docs).
- Docs-only change, no behavior modified.

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2540.org.readthedocs.build/en/2540/

<!-- readthedocs-preview pymc-marketing end -->