### PR TITLE
feat(mmm): add ControlEffect MuEffect to handle control variables via protocol

### DIFF
--- a/pymc_marketing/mmm/additive_effect.py
+++ b/pymc_marketing/mmm/additive_effect.py
@@ -84,8 +84,8 @@ Example of a custom additive effect
 
 How it works
 ------------
-- Mu effects follow a simple protocol: ``create_data(mmm)``, ``create_effect(mmm)``,
-  and ``set_data(mmm, model, X)``.
+- Mu effects follow a simple protocol: ``create_data(mmm, X=None)``,
+  ``create_effect(mmm)``, and ``set_data(mmm, model, X)``.
 - During ``MMM.build_model(...)``, each effect’s ``create_data`` is called first to
   introduce any needed ``pmd.Data``. Then ``create_effect`` must return a tensor with
   dims ("date", *mmm.dims) that is added additively to the model mean.
@@ -114,7 +114,8 @@ import pymc as pm
 import pymc.dims as pmd
 import pytensor.xtensor as ptx
 import xarray as xr
-from pydantic import Field, InstanceOf
+from pydantic import Field, InstanceOf, field_validator
+from pymc_extras.prior import Prior
 from pytensor.xtensor.type import XTensorVariable
 
 from pymc_marketing.mmm.events import EventEffect, days_from_reference
@@ -231,15 +232,25 @@ class MuEffect(SerializableBaseModel, ABC):
     """
 
     @abstractmethod
-    def create_data(self, mmm: Model) -> None:
-        """Create the required data in the model."""
+    def create_data(self, mmm: Model, X: xr.Dataset | None = None) -> None:
+        """Create the required data in the model.
+
+        Parameters
+        ----------
+        mmm : Model
+            The MMM model instance.
+        X : xr.Dataset, optional
+            The xarray dataset containing training data. Effects that need
+            external data (e.g. control variables) use this parameter.
+            Effects that derive data purely from model coordinates may ignore it.
+        """
 
     @abstractmethod
     def create_effect(self, mmm: Model) -> XTensorVariable:
         """Create the additive effect in the model."""
 
     @abstractmethod
-    def set_data(self, mmm: Model, model: pm.Model, X: xr.Dataset) -> None:
+    def set_data(self, mmm: Model, model: pm.Model, X: xr.Dataset | None) -> None:
         """Set the data for new predictions."""
 
 
@@ -271,13 +282,15 @@ class FourierEffect(MuEffect):
             fourier = deserialize(fourier_data)
         return cls(fourier=fourier, date_dim_name=work.get("date_dim_name", "date"))
 
-    def create_data(self, mmm: Model) -> None:
+    def create_data(self, mmm: Model, X: xr.Dataset | None = None) -> None:
         """Create the required data in the model.
 
         Parameters
         ----------
         mmm : MMM
             The MMM model instance
+        X : xr.Dataset, optional
+            Not used by this effect. Dates are derived from model coordinates.
         """
         model = mmm.model
 
@@ -491,13 +504,15 @@ class LinearTrendEffect(MuEffect):
             date_dim_name=work.get("date_dim_name", "date"),
         )
 
-    def create_data(self, mmm: Model) -> None:
+    def create_data(self, mmm: Model, X: xr.Dataset | None = None) -> None:
         """Create the required data in the model.
 
         Parameters
         ----------
         mmm : MMM
             The MMM model instance.
+        X : xr.Dataset, optional
+            Not used by this effect. Time index is derived from model coordinates.
         """
         model: pm.Model = mmm.model
 
@@ -621,13 +636,15 @@ class EventAdditiveEffect(MuEffect):
         """The end dates of the events."""
         return pd.to_datetime(self.df_events["end_date"])
 
-    def create_data(self, mmm: Model) -> None:
+    def create_data(self, mmm: Model, X: xr.Dataset | None = None) -> None:
         """Create the required data in the model.
 
         Parameters
         ----------
         mmm : MMM
             The MMM model instance.
+        X : xr.Dataset, optional
+            Not used by this effect. Event data is carried in :attr:`df_events`.
 
         """
         model: pm.Model = mmm.model
@@ -705,6 +722,185 @@ class EventAdditiveEffect(MuEffect):
         pm.set_data(new_data=new_data, model=model)
 
 
+class ControlEffect(MuEffect):
+    """Additive effect for control variables in the MMM.
+
+    Encapsulates the control column logic so that control variables are handled
+    through the :class:`MuEffect` protocol rather than as inline code inside
+    ``build_model``.
+
+    Parameters
+    ----------
+    prior : Prior, optional
+        The prior distribution for the ``gamma_control`` coefficients.
+        If ``"control"`` is absent from the prior's ``dims`` it is
+        automatically added so each control column receives its own
+        independent coefficient. Defaults to
+        ``Normal(mu=0, sigma=2, dims="control")``.
+    date_dim_name : str, optional
+        The name of the date dimension in the model. Default is ``"date"``.
+
+    Examples
+    --------
+    Standalone usage (the MMM wires this automatically when ``control_columns``
+    is provided, but you can also construct it explicitly):
+
+    .. code-block:: python
+
+        from pymc_extras.prior import Prior
+        from pymc_marketing.mmm.additive_effect import ControlEffect
+
+        effect = ControlEffect(
+            prior=Prior("Normal", mu=0, sigma=1, dims="control"),
+        )
+
+    """
+
+    prior: InstanceOf[Prior] = Field(
+        default_factory=lambda: Prior("Normal", mu=0, sigma=2, dims="control"),
+        description="Prior for the gamma_control coefficients (one per control column).",
+    )
+    date_dim_name: str = Field(default="date")
+
+    @field_validator("prior", mode="after")
+    @classmethod
+    def _ensure_control_dim(cls, prior: Prior) -> Prior:
+        """Ensure ``"control"`` is the default dim when none are specified.
+
+        Mirrors the behaviour of ``Transformation.with_default_prior_dims``:
+        dims are only set when ``prior.dims is None``; an explicitly supplied
+        ``dims`` value is left untouched.
+        """
+        dims = prior.dims
+        if dims is None:
+            new = prior.deepcopy()
+            new.dims = "control"
+            return new
+        return prior
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a dict. ``__type__`` is injected by the registry wrapper."""
+        return {
+            "prior": self.prior.to_dict(),
+            "date_dim_name": self.date_dim_name,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ControlEffect":
+        """Reconstruct from a dict."""
+        from pymc_marketing.serialization import serialization
+
+        work = {k: v for k, v in data.items() if k != "__type__"}
+        prior_data = work["prior"]
+        if "__type__" in prior_data:
+            prior = serialization.deserialize(prior_data)
+        else:
+            from pymc_extras.deserialize import deserialize
+
+            prior = deserialize(prior_data)
+        return cls(prior=prior, date_dim_name=work.get("date_dim_name", "date"))
+
+    def create_data(self, mmm: Model, X: xr.Dataset | None = None) -> None:
+        """Register control data in the PyMC model.
+
+        Parameters
+        ----------
+        mmm : Model
+            The MMM model instance.
+        X : xr.Dataset, optional
+            The xarray dataset containing training data. Must include a
+            ``"_control"`` variable and a ``"control"`` coordinate when
+            control columns are present. If ``None`` or ``"_control"`` is
+            absent, this method does nothing.
+        """
+        if X is None or "_control" not in X:
+            return
+
+        model: pm.Model = mmm.model
+
+        control_values = X["_control"].transpose(
+            self.date_dim_name, *mmm.dims, "control"
+        )
+        if "control" not in model.coords:
+            model.add_coord("control", X.coords["control"].values)
+        if "control_data" not in model.named_vars:
+            pmd.Data(
+                "control_data",
+                control_values,
+                dims=(self.date_dim_name, *mmm.dims, "control"),
+            )
+
+    def create_effect(self, mmm: Model) -> XTensorVariable:
+        """Create the control contribution deterministic in the model.
+
+        Parameters
+        ----------
+        mmm : Model
+            The MMM model instance.
+
+        Returns
+        -------
+        XTensorVariable
+            The summed control contribution with dims
+            ``(self.date_dim_name, *mmm.dims)``.
+
+        Raises
+        ------
+        RuntimeError
+            If ``create_data`` was not called before this method (i.e.
+            ``control_data`` is not registered in the model).
+        """
+        model: pm.Model = mmm.model
+
+        if "control_data" not in model.named_vars:
+            raise RuntimeError(
+                "ControlEffect.create_effect() called before create_data(). "
+                "Call create_data(mmm, X) first to register control_data in the model."
+            )
+
+        control_data_ = model["control_data"]
+        gamma_control = self.prior.create_variable("gamma_control", xdist=True)
+
+        control_contribution = pmd.Deterministic(
+            "control_contribution",
+            control_data_ * gamma_control,
+        )
+
+        return control_contribution.sum(dim="control")
+
+    def set_data(self, mmm: Model, model: pm.Model, X: xr.Dataset | None) -> None:
+        """Update control data for new predictions.
+
+        Parameters
+        ----------
+        mmm : Model
+            The MMM model instance.
+        model : pm.Model
+            The cloned PyMC model used for prediction.
+        X : xr.Dataset or None
+            The dataset for prediction. Must contain ``"_control"`` if the
+            model was trained with control columns. If ``None`` or
+            ``"_control"`` is absent, this method does nothing.
+        """
+        if X is None or "_control" not in X:
+            return
+
+        control_values = X["_control"].transpose(
+            self.date_dim_name, *mmm.dims, "control"
+        )
+
+        # Preserve the original dtype to avoid PyMC shared-variable type errors.
+        if "control_data" in model.named_vars:
+            original_dtype = model.named_vars["control_data"].type.dtype
+            control_values = control_values.astype(original_dtype)
+
+        pm.set_data(
+            {"control_data": control_values},
+            coords={"control": X.coords["control"].values},
+            model=model,
+        )
+
+
 def _deserialize_event_additive_effect(
     data: dict[str, Any],
     context: Any,
@@ -755,3 +951,15 @@ def _register_event_additive_effect() -> None:
 
 
 _register_event_additive_effect()
+
+
+def _register_control_effect() -> None:
+    from pymc_marketing.serialization import serialization
+
+    serialization.register(
+        f"{ControlEffect.__module__}.{ControlEffect.__qualname__}",
+        ControlEffect,
+    )
+
+
+_register_control_effect()

--- a/pymc_marketing/mmm/multidimensional.py
+++ b/pymc_marketing/mmm/multidimensional.py
@@ -202,6 +202,7 @@ from pymc_marketing.data.idata.utils import subsample_draws
 from pymc_marketing.hsgp_kwargs import HSGPKwargs
 from pymc_marketing.mmm import SoftPlusHSGP
 from pymc_marketing.mmm.additive_effect import (
+    ControlEffect,
     EventAdditiveEffect,
     MuEffect,
     safe_to_datetime,
@@ -585,6 +586,14 @@ class MMM(RegressionModelBuilder):
             )
 
         self.mu_effects: list[MuEffect] = []
+
+        # Insert ControlEffect at position 0 when control_columns are present so
+        # control variables are handled via the MuEffect protocol rather than
+        # inline build_model code.
+        if self.control_columns:
+            self.mu_effects.insert(
+                0, ControlEffect(prior=self.model_config["gamma_control"])
+            )
 
     def add_mu_effect(
         self: Self,
@@ -2135,7 +2144,7 @@ class MMM(RegressionModelBuilder):
             self.target_data_scaled = target_data_scaled
 
             for mu_effect in self.mu_effects:
-                mu_effect.create_data(self)
+                mu_effect.create_data(self, self.xarray_dataset)
 
             if self.time_varying_intercept or self.time_varying_media:
                 time_index = pmd.Data("time_index", self._time_index)
@@ -2215,20 +2224,6 @@ class MMM(RegressionModelBuilder):
 
             # Add other contributions and likelihood
             mu_var = intercept + channel_contribution.sum(dim="channel")
-
-            if self.control_columns is not None and len(self.control_columns) > 0:
-                gamma_control = self.model_config["gamma_control"].create_variable(
-                    name="gamma_control", xdist=True
-                )
-
-                control_data_ = pmd.Data("control_data", self.xarray_dataset._control)
-
-                control_contribution = pmd.Deterministic(
-                    "control_contribution",
-                    control_data_ * gamma_control,
-                )
-
-                mu_var += control_contribution.sum(dim="control")
 
             if self.yearly_seasonality is not None:
                 dayofyear = pmd.Data(
@@ -2423,15 +2418,6 @@ class MMM(RegressionModelBuilder):
         coords = self.model.coords.copy()
         coords["date"] = dataset_xarray["date"].to_numpy()
 
-        if "_control" in dataset_xarray:
-            control_values = dataset_xarray["_control"].transpose(
-                "date", *self.dims, "control"
-            )
-            if "control_data" in model.named_vars:
-                original_dtype = model.named_vars["control_data"].type.dtype
-                control_values = control_values.astype(original_dtype)
-            data["control_data"] = control_values
-            coords["control"] = dataset_xarray["control"].to_numpy()
         if self.yearly_seasonality is not None:
             data["dayofyear"] = dataset_xarray["date"].dt.dayofyear.to_numpy()
 
@@ -3389,6 +3375,18 @@ class MMM(RegressionModelBuilder):
                 serialization.deserialize(effect_data, context=ctx)
                 for effect_data in mu_effects_data
             ]
+
+            # Backward compatibility: models saved before ControlEffect was
+            # introduced stored the control logic inline in build_model, so
+            # the serialized mu_effects list contains no ControlEffect.
+            # Re-inject one when control_columns are present but none exists.
+            has_control_effect = any(
+                isinstance(e, ControlEffect) for e in self.mu_effects
+            )
+            if self.control_columns and not has_control_effect:
+                self.mu_effects.insert(
+                    0, ControlEffect(prior=self.model_config["gamma_control"])
+                )
 
         dataset = idata.fit_data.to_dataframe()
 

--- a/tests/mmm/test_additive_effect.py
+++ b/tests/mmm/test_additive_effect.py
@@ -20,6 +20,7 @@ import xarray as xr
 from pymc_extras.prior import Prior
 
 from pymc_marketing.mmm.additive_effect import (
+    ControlEffect,
     FourierEffect,
     LinearTrendEffect,
 )
@@ -472,8 +473,262 @@ class TestEventAdditiveEffectRoundtrips:
         "pymc_marketing.mmm.additive_effect.FourierEffect",
         "pymc_marketing.mmm.additive_effect.LinearTrendEffect",
         "pymc_marketing.mmm.additive_effect.EventAdditiveEffect",
+        "pymc_marketing.mmm.additive_effect.ControlEffect",
     ],
     ids=lambda s: s.rsplit(".", 1)[-1],
 )
 def test_additive_effect_type_registered(type_key):
     assert type_key in serialization._registry, f"{type_key} not registered"
+
+
+# ---------------------------------------------------------------------------
+# ControlEffect tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="function")
+def control_dates() -> pd.DatetimeIndex:
+    return pd.date_range("2025-01-01", periods=10, freq="W-MON", name="date")
+
+
+@pytest.fixture(scope="function")
+def control_xarray(control_dates) -> xr.Dataset:
+    """Minimal xarray Dataset mimicking what MMM._set_xarray_data produces."""
+    n_dates = len(control_dates)
+    control_cols = ["price_index", "promo"]
+    rng = np.random.default_rng(0)
+    data = rng.standard_normal((n_dates, len(control_cols)))
+    control_da = xr.DataArray(
+        data,
+        dims=["date", "control"],
+        coords={"date": control_dates, "control": control_cols},
+        name="_control",
+    )
+    return xr.Dataset({"_control": control_da})
+
+
+@pytest.fixture(scope="function")
+def control_model(control_dates) -> pm.Model:
+    return pm.Model(coords={"date": control_dates})
+
+
+@pytest.fixture(scope="function")
+def mock_mmm_control(control_model):
+    class MMM:
+        pass
+
+    mmm = MMM()
+    mmm.dims = ()
+    mmm.model = control_model
+    return mmm
+
+
+def _make_panel_xarray(dates, geos, control_cols, seed=0):
+    """Build a panel _control DataArray with dims (date, geo, control)."""
+    rng = np.random.default_rng(seed)
+    data = rng.standard_normal((len(dates), len(geos), len(control_cols)))
+    return xr.Dataset(
+        {
+            "_control": xr.DataArray(
+                data,
+                dims=["date", "geo", "control"],
+                coords={"date": dates, "geo": geos, "control": control_cols},
+            )
+        }
+    )
+
+
+class TestControlEffect:
+    def test_create_data_registers_shared_variable(
+        self, mock_mmm_control, control_xarray, control_model
+    ):
+        effect = ControlEffect()
+        with control_model:
+            effect.create_data(mock_mmm_control, X=control_xarray)
+
+        assert "control_data" in control_model.named_vars
+        assert "control" in control_model.coords
+
+    def test_create_data_with_no_X_does_nothing(self, mock_mmm_control, control_model):
+        effect = ControlEffect()
+        with control_model:
+            effect.create_data(mock_mmm_control, X=None)
+
+        assert "control_data" not in control_model.named_vars
+
+    def test_create_data_with_missing_control_key_does_nothing(
+        self, mock_mmm_control, control_dates, control_model
+    ):
+        effect = ControlEffect()
+        X_no_control = xr.Dataset({"other": xr.DataArray([1, 2], dims=["date"])})
+        with control_model:
+            effect.create_data(mock_mmm_control, X=X_no_control)
+
+        assert "control_data" not in control_model.named_vars
+
+    def test_create_data_idempotent_coord(
+        self, mock_mmm_control, control_xarray, control_model
+    ):
+        """Calling create_data twice must not raise due to duplicate coord."""
+        effect = ControlEffect()
+        with control_model:
+            effect.create_data(mock_mmm_control, X=control_xarray)
+            # Second call should not raise even though "control" coord exists
+            effect.create_data(mock_mmm_control, X=control_xarray)
+
+    def test_create_effect_produces_deterministic(
+        self, mock_mmm_control, control_xarray, control_model
+    ):
+        effect = ControlEffect()
+        with control_model:
+            effect.create_data(mock_mmm_control, X=control_xarray)
+            result = effect.create_effect(mock_mmm_control)
+
+        assert "control_contribution" in control_model.named_vars
+        # Result should have summed over "control" dim — only date dim remains
+        assert "control" not in result.type.dims
+
+    def test_create_effect_raises_without_create_data(
+        self, mock_mmm_control, control_model
+    ):
+        """create_effect must raise clearly when create_data was not called first."""
+        effect = ControlEffect()
+        with control_model:
+            with pytest.raises(RuntimeError, match="create_data"):
+                effect.create_effect(mock_mmm_control)
+
+    def test_set_data_updates_shared_variable(
+        self, mock_mmm_control, control_xarray, control_model
+    ):
+        effect = ControlEffect()
+        with control_model:
+            effect.create_data(mock_mmm_control, X=control_xarray)
+            effect.create_effect(mock_mmm_control)
+
+        # New dataset with same structure but different values
+        n_dates = len(control_xarray.coords["date"])
+        rng = np.random.default_rng(42)
+        new_data = rng.standard_normal((n_dates, 2))
+        new_control_da = xr.DataArray(
+            new_data,
+            dims=["date", "control"],
+            coords={
+                "date": control_xarray.coords["date"],
+                "control": control_xarray.coords["control"],
+            },
+            name="_control",
+        )
+        new_X = xr.Dataset({"_control": new_control_da})
+
+        # Should not raise
+        effect.set_data(mock_mmm_control, control_model, new_X)
+
+    def test_set_data_with_none_does_nothing(
+        self, mock_mmm_control, control_xarray, control_model
+    ):
+        effect = ControlEffect()
+        with control_model:
+            effect.create_data(mock_mmm_control, X=control_xarray)
+            effect.create_effect(mock_mmm_control)
+
+        # Should not raise
+        effect.set_data(mock_mmm_control, control_model, None)
+
+    def test_set_data_with_no_control_key_does_nothing(
+        self, mock_mmm_control, control_xarray, control_model
+    ):
+        effect = ControlEffect()
+        with control_model:
+            effect.create_data(mock_mmm_control, X=control_xarray)
+            effect.create_effect(mock_mmm_control)
+
+        X_no_control = xr.Dataset()
+        # Should not raise
+        effect.set_data(mock_mmm_control, control_model, X_no_control)
+
+    def test_to_dict_round_trip(self):
+        prior = Prior("Normal", mu=0, sigma=1, dims="control")
+        effect = ControlEffect(prior=prior, date_dim_name="time")
+
+        data = serialization.serialize(effect)
+        restored = serialization.deserialize(data)
+
+        assert type(restored) is ControlEffect
+        assert restored.date_dim_name == "time"
+        assert restored.prior._distribution == "Normal"
+
+    def test_default_prior(self):
+        effect = ControlEffect()
+        assert effect.prior._distribution == "Normal"
+        assert effect.prior.parameters["mu"] == 0
+        assert effect.prior.parameters["sigma"] == 2
+        assert "control" in (effect.prior.dims or ())
+
+    @pytest.mark.parametrize(
+        "input_prior,expected_dims",
+        [
+            (Prior("Normal"), ("control",)),
+            (Prior("Normal", dims="control"), ("control",)),
+            (Prior("Normal", mu=0, sigma=1), ("control",)),
+            (Prior("Normal", dims="geo"), ("geo",)),
+        ],
+        ids=["no-dims", "already-control", "kwargs-no-dims", "explicit-other-dim"],
+    )
+    def test_prior_validator_ensures_control_dim(self, input_prior, expected_dims):
+        """Prior with dims=None is defaulted to 'control'; explicit dims are untouched."""
+        effect = ControlEffect(prior=input_prior)
+        assert effect.prior.dims == expected_dims
+
+    @pytest.mark.parametrize(
+        "dims,extra_coords",
+        [
+            ((), {}),
+            (("geo",), {"geo": ["A", "B"]}),
+        ],
+        ids=["scalar", "panel-geo"],
+    )
+    def test_create_effect_multidimensional(self, control_dates, dims, extra_coords):
+        """ControlEffect must produce correct dims for both scalar and panel MMMs."""
+        control_cols = ["price_index", "promo"]
+        geos = extra_coords.get("geo", [])
+
+        coords = {"date": control_dates, **extra_coords}
+        model = pm.Model(coords=coords)
+
+        class MockMMM:
+            pass
+
+        mmm = MockMMM()
+        mmm.dims = dims
+        mmm.model = model
+
+        if dims:
+            X = _make_panel_xarray(control_dates, geos, control_cols)
+            prior = Prior("Normal", mu=0, sigma=2, dims=(*dims, "control"))
+        else:
+            rng = np.random.default_rng(0)
+            data = rng.standard_normal((len(control_dates), len(control_cols)))
+            X = xr.Dataset(
+                {
+                    "_control": xr.DataArray(
+                        data,
+                        dims=["date", "control"],
+                        coords={"date": control_dates, "control": control_cols},
+                    )
+                }
+            )
+            prior = Prior("Normal", mu=0, sigma=2, dims="control")
+
+        effect = ControlEffect(prior=prior)
+
+        with model:
+            effect.create_data(mmm, X=X)
+            result = effect.create_effect(mmm)
+
+        assert "control_contribution" in model.named_vars
+        assert "control" not in result.type.dims
+        # date dim should be present
+        assert "date" in result.type.dims
+        # geo dim should be present for panel models
+        for dim in dims:
+            assert dim in result.type.dims


### PR DESCRIPTION
## Context

This is exploratory work on how to allow MuEffects to consume additional external data (e.g. control columns from the training `X` DataFrame). Previously, control-variable logic lived as inline code inside `build_model` and `_set_xarray_data`. This PR routes it through the `MuEffect` protocol instead, using `ControlEffect` as the first concrete example.

The key design question being explored: **how should MuEffects that need external data (beyond model coordinates) receive it?** The solution here is to pass an optional `X: xr.Dataset | None` to `create_data`, which effects that don't need external data simply ignore.

## Changes

### `MuEffect` ABC
- `create_data(mmm, X=None)` — optional `X` so effects that need external data can consume it; existing effects ignore it safely
- `set_data(mmm, model, X: xr.Dataset | None)` — type annotation corrected

### `ControlEffect(MuEffect)`
- Registers `control_data` as a `pmd.Data` shared variable
- Creates `gamma_control` from a configurable `Prior`
- Returns `control_contribution` Deterministic with `"control"` dim summed out
- `field_validator` mirrors `Transformation.with_default_prior_dims`: `dims=None` defaults to `"control"`; explicit dims are untouched
- Fully serializable; registered in the serialization registry

### `MMM`
- `__init__`: auto-inserts `ControlEffect(prior=model_config["gamma_control"])` at position 0 of `mu_effects` when `control_columns` are present
- `build_model`: inline control block removed; delegated to `mu_effects`
- `_set_xarray_data`: hardcoded control `pm.set_data` block removed
- `build_from_idata`: backward-compat guard re-injects `ControlEffect` for models saved before this change

## What's not in scope
- Other MuEffects receiving `X` (only `ControlEffect` uses it today)
- Public API changes (`control_columns` param unchanged)
- Panel/multidimensional dims are handled transparently via `mmm.dims`

## Testing
- 17 `TestControlEffect` unit tests covering create/effect/set_data, idempotency, serialization round-trip, prior validator, and scalar + panel-geo multidimensional cases
- All existing tests pass

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2568.org.readthedocs.build/en/2568/

<!-- readthedocs-preview pymc-marketing end -->