### PR TITLE
docs: add Bass Diffusion Model to home and getting started pages

### DIFF
--- a/docs/source/getting_started/index.md
+++ b/docs/source/getting_started/index.md
@@ -14,11 +14,5 @@ installation/index
 quickstart/clv/index
 quickstart/mmm/index
 quickstart/customer_choice/index
-:::
-
-:::{toctree}
-:caption: Bass Diffusion
-:maxdepth: 1
-
 ../notebooks/bass/bass_example
 :::

--- a/docs/source/getting_started/index.md
+++ b/docs/source/getting_started/index.md
@@ -15,3 +15,10 @@ quickstart/clv/index
 quickstart/mmm/index
 quickstart/customer_choice/index
 :::
+
+:::{toctree}
+:caption: Bass Diffusion
+:maxdepth: 1
+
+../notebooks/bass/bass_example
+:::

--- a/docs/source/getting_started/index.md
+++ b/docs/source/getting_started/index.md
@@ -14,5 +14,5 @@ installation/index
 quickstart/clv/index
 quickstart/mmm/index
 quickstart/customer_choice/index
-../notebooks/bass/bass_example
+Bass Diffusion Model Quickstart <../notebooks/bass/bass_example>
 :::

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -196,6 +196,12 @@ Analyze the impact of new product launches and understand customer choice behavi
 
 See our example notebooks for [saturated markets](https://www.pymc-marketing.io/en/stable/notebooks/customer_choice/mv_its_saturated.html) and [unsaturated markets](https://www.pymc-marketing.io/en/stable/notebooks/customer_choice/mv_its_unsaturated.html) to learn more about customer choice modeling with PyMC-Marketing.
 
+## Bass Diffusion Model
+
+Forecast the adoption of new products with the **Bass Diffusion Model**. The model captures how innovators and imitators drive cumulative adoption over time, which is useful for product launch forecasts, demand planning, and growth analysis.
+
+See the [Bass Diffusion Model example notebook](https://www.pymc-marketing.io/en/stable/notebooks/bass/bass_example.html) for a worked example.
+
 ---
 
 ## Resources


### PR DESCRIPTION
## Description

Mentions the Bass Diffusion Model on two pages where it was previously invisible:

- Home page: short section parallel to the existing MMM, CLV, and Customer Choice Analysis sections, linking to the example notebook.
- Getting Started: appends `../notebooks/bass/bass_example` to the existing Quickstart toctree so the Bass notebook surfaces alongside the CLV / MMM / Customer Choice quickstarts.

## Related Issue

- [x] Closes #1850

## Checklist

- [x] Checked that the pre-commit linting/style checks pass
- [ ] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation
- [x] If you are a pro: each commit corresponds to a relevant logical change

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2573.org.readthedocs.build/en/2573/

<!-- readthedocs-preview pymc-marketing end -->