### PR TITLE
feat(mlflow): attach active run id to idata.attrs in autolog

### DIFF
--- a/pymc_marketing/mlflow.py
+++ b/pymc_marketing/mlflow.py
@@ -31,6 +31,7 @@ are patched:
     - :func:`log_arviz_summary`: Log table of summary statistics about estimated parameters
     - :func:`log_metadata`: Log the metadata of the data used in the model.
     - :func:`log_error`: Log the traceback and exception if an error occurs during sampling.
+    - Stamp the active MLflow run id on ``idata.attrs["mlflow_run_id"]``.
 
 - `pymc.find_MAP`:
 
@@ -40,11 +41,13 @@ are patched:
 
     - All parameters, metrics, and artifacts from `pymc.sample`
     - :func:`log_mmm_configuration`: Log the configuration of the MMM model.
+    - Stamp the active MLflow run id on ``idata.attrs["mlflow_run_id"]``.
 
 - `CLVModel.fit`:
 
     - Information dependent on fit method used (MCMC or MAP)
     - Model type and fit method
+    - Stamp the active MLflow run id on ``idata.attrs["mlflow_run_id"]``.
 
 Examples
 --------

--- a/pymc_marketing/mlflow.py
+++ b/pymc_marketing/mlflow.py
@@ -344,6 +344,22 @@ def _force_load_idata_groups(idata: az.InferenceData) -> None:
                 group_data.load()
 
 
+def _attach_run_id(idata: az.InferenceData) -> None:
+    """Stamp the active MLflow run id onto ``idata.attrs``.
+
+    No-op when no MLflow run is active.
+
+    Parameters
+    ----------
+    idata : az.InferenceData
+        The InferenceData object to stamp.
+    """
+    run = mlflow.active_run()
+    if run is None:
+        return
+    idata.attrs["mlflow_run_id"] = run.info.run_id
+
+
 def log_arviz_summary(
     idata: az.InferenceData,
     path: str | Path,
@@ -1214,6 +1230,7 @@ def autolog(
                 log_model_derived_info(model)
 
             idata = sample(*args, **kwargs)
+            _attach_run_id(idata)
 
             # Align with the default values in pymc.sample
             tune = kwargs.get("tune", 1000)
@@ -1259,6 +1276,7 @@ def autolog(
             log_mmm_configuration(self)
 
             idata = fit(self, *args, **kwargs)
+            _attach_run_id(idata)
 
             log_inference_data(idata, save_file="idata.nc")
 
@@ -1280,6 +1298,7 @@ def autolog(
             mlflow.log_params(
                 idata.attrs,
             )
+            _attach_run_id(idata)
             log_inference_data(idata, save_file="idata.nc")
 
             return idata

--- a/tests/test_mlflow.py
+++ b/tests/test_mlflow.py
@@ -214,6 +214,31 @@ def test_log_data_no_data(no_input_model) -> None:
     basic_logging_checks(run_data)
 
 
+def test_run_id_attached_to_idata(model_with_likelihood, tmp_path) -> None:
+    mlflow.set_experiment("pymc-marketing-test-suite-run-id-attr")
+    with mlflow.start_run() as run:
+        idata = pm.sample(
+            model=model_with_likelihood,
+            chains=1,
+            draws=25,
+            tune=10,
+        )
+
+    assert idata.attrs["mlflow_run_id"] == run.info.run_id
+
+    save_path = tmp_path / "idata.nc"
+    idata.to_netcdf(str(save_path))
+    reloaded = az.from_netcdf(str(save_path))
+    assert reloaded.attrs["mlflow_run_id"] == run.info.run_id
+
+
+def test_attach_run_id_no_active_run_is_noop() -> None:
+    assert mlflow.active_run() is None
+    idata = az.InferenceData()
+    pmm_mlflow._attach_run_id(idata)
+    assert "mlflow_run_id" not in idata.attrs
+
+
 def test_multi_likelihood_type(multi_likelihood_model) -> None:
     mlflow.set_experiment("pymc-marketing-test-suite-multi-likelihood")
     with mlflow.start_run() as run:


### PR DESCRIPTION
Closes #1684.

When `autolog` is enabled, stamp `mlflow.active_run().info.run_id` onto `idata.attrs["mlflow_run_id"]` in the three patched paths (`pm.sample`, `MMM.fit`, `CLVModel.fit`). The attribute round-trips through `to_netcdf`, so a saved idata carries a back-pointer to the run that produced it. No-op when no MLflow run is active.

## Test plan
Two new tests in `tests/test_mlflow.py`. `test_run_id_attached_to_idata` samples inside `mlflow.start_run()`, asserts the run id is on `idata.attrs`, and confirms it survives a netcdf round-trip. `test_attach_run_id_no_active_run_is_noop` calls the helper with no active run and asserts no attr is set.

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2574.org.readthedocs.build/en/2574/

<!-- readthedocs-preview pymc-marketing end -->