### PR TITLE
feat(mmm): stamp version on optimize_budget and sample_response_distribution

### DIFF
--- a/pymc_marketing/mmm/budget_optimizer.py
+++ b/pymc_marketing/mmm/budget_optimizer.py
@@ -245,6 +245,7 @@ from pymc_marketing.mmm.constraints import (
 )
 from pymc_marketing.mmm.utility import UtilityFunctionType, average_response
 from pymc_marketing.pytensor_utils import merge_models
+from pymc_marketing.version import __version__
 
 # Delayed import inside methods to avoid circular dependency on pytensor_utils
 
@@ -1340,6 +1341,7 @@ class BudgetOptimizer(BaseModel):
             optimal_budgets = DataArray(
                 optimal_budgets, dims=self._budget_dims, coords=self._budget_coords
             )
+            optimal_budgets.attrs["pymc_marketing_version"] = __version__
 
             if callback:
                 return optimal_budgets, result, callback_info

--- a/pymc_marketing/mmm/mmm.py
+++ b/pymc_marketing/mmm/mmm.py
@@ -245,6 +245,7 @@ from pymc_marketing.model_builder import RegressionModelBuilder
 from pymc_marketing.model_config import parse_model_config
 from pymc_marketing.model_graph import deterministics_to_flat
 from pymc_marketing.serialization import DeserializationContext, serialization
+from pymc_marketing.version import __version__
 
 
 def _deserialize_cost_per_unit(json_str: str) -> pd.DataFrame:
@@ -4049,7 +4050,7 @@ class BudgetOptimizerWrapper(OptimizerCompatibleModelWrapper):
         if additional_var_names is not None:
             var_names.extend(additional_var_names)
 
-        return (
+        response = (
             self.sample_posterior_predictive(
                 X=data_with_noise,
                 extend_idata=False,
@@ -4060,3 +4061,5 @@ class BudgetOptimizerWrapper(OptimizerCompatibleModelWrapper):
             .merge(constant_data)
             .merge(_dataset)
         )
+        response.attrs["pymc_marketing_version"] = __version__
+        return response

--- a/tests/mmm/test_budget_optimizer_mmm.py
+++ b/tests/mmm/test_budget_optimizer_mmm.py
@@ -27,6 +27,7 @@ from pymc_marketing.mmm.mmm import (
     MMM,
     BudgetOptimizerWrapper,
 )
+from pymc_marketing.version import __version__
 
 
 @pytest.fixture(scope="module")
@@ -1454,6 +1455,7 @@ def test_sample_response_distribution_includes_total_allocation(
         )
         expected = allocation_strategy * optimizable_model.num_periods
         xr.testing.assert_allclose(result["total_allocation"], expected)
+        assert result.attrs.get("pymc_marketing_version") == __version__
 
 
 @compile_kwargs

--- a/tests/mmm/test_budget_optimizer_mmm.py
+++ b/tests/mmm/test_budget_optimizer_mmm.py
@@ -217,6 +217,7 @@ def test_budget_optimizer_no_mask(dummy_df, fitted_mmm, compile_kwargs):
     assert isinstance(optimal_budgets, xr.DataArray)
     assert optimal_budgets.shape == (2, 2)  # 2 channels, 2 geos
     assert result.success
+    assert optimal_budgets.attrs.get("pymc_marketing_version") == __version__
 
 
 @compile_kwargs


### PR DESCRIPTION
Closes #1776, closes #1775.

## Summary

Sets `attrs["pymc_marketing_version"]` on the optimizer outputs, matching the pattern already used in `ModelBuilder.fit` / `.sample_prior_predictive` and the customer_choice models:

- The `az.InferenceData` returned by `BudgetOptimizerWrapper.sample_response_distribution` (#1776).
- The `xr.DataArray` of optimal budgets returned by `BudgetOptimizer.allocate_budget`, which is what `MMM.optimize_budget` and `BudgetOptimizerWrapper.optimize_budget` return (#1775).

## Test plan

- [x] `pytest tests/mmm/test_budget_optimizer_mmm.py::test_sample_response_distribution_includes_total_allocation`
- [x] `pytest tests/mmm/test_budget_optimizer_mmm.py::test_budget_optimizer_no_mask`
- [x] `pre-commit run --files pymc_marketing/mmm/mmm.py pymc_marketing/mmm/budget_optimizer.py tests/mmm/test_budget_optimizer_mmm.py`
