### PR TITLE
fix(plot): support combined sample dim in plot_curve

### DIFF
--- a/pymc_marketing/plot.py
+++ b/pymc_marketing/plot.py
@@ -85,7 +85,7 @@ def drop_scalar_coords(curve: xr.DataArray) -> xr.DataArray:
     return curve.reset_coords(scalar_coords_to_drop, drop=True)
 
 
-def unstack_sample(curve: xr.DataArray) -> xr.DataArray:
+def _unstack_sample(curve: xr.DataArray) -> xr.DataArray:
     """Unstack a ``(chain, draw)`` ``sample`` MultiIndex back into chain/draw.
 
     ``arviz.extract(..., combined=True)`` returns a DataArray whose ``chain``
@@ -500,7 +500,7 @@ def plot_hdi(
         non_grid_names = {non_grid_names}
 
     if "sample" in curve.dims:
-        curve = unstack_sample(curve)
+        curve = _unstack_sample(curve)
 
     plot_kwargs = plot_kwargs or {}
     plot_kwargs = {**{"alpha": 0.25}, **plot_kwargs}
@@ -570,7 +570,7 @@ def plot_samples(
         non_grid_names = {non_grid_names}
 
     if "sample" in curve.dims:
-        curve = unstack_sample(curve)
+        curve = _unstack_sample(curve)
     n_chains = curve.sizes["chain"]
     n_draws = curve.sizes["draw"]
     make_selection = _create_make_sample_selection(
@@ -740,7 +740,7 @@ def plot_curve(
 
     """
     if "sample" in curve.dims:
-        curve = unstack_sample(curve)
+        curve = _unstack_sample(curve)
     curve = drop_scalar_coords(curve)
 
     hdi_probs = hdi_probs or None

--- a/pymc_marketing/plot.py
+++ b/pymc_marketing/plot.py
@@ -86,17 +86,17 @@ def drop_scalar_coords(curve: xr.DataArray) -> xr.DataArray:
 
 
 def unstack_sample(curve: xr.DataArray) -> xr.DataArray:
-    """Unstack ``sample`` back into ``chain`` / ``draw`` when combined.
+    """Unstack a ``(chain, draw)`` ``sample`` MultiIndex back into chain/draw.
 
     ``arviz.extract(..., combined=True)`` returns a DataArray whose ``chain``
     and ``draw`` dims have been stacked into a single ``sample`` MultiIndex.
     The plotting helpers in this module index ``chain`` and ``draw`` directly,
-    so a combined input is silently unstacked here. Inputs without a ``sample``
-    MultiIndex are returned unchanged.
+    so a combined input must be unstacked first. Assumes ``sample`` is a dim
+    of ``curve``. Returns ``curve`` unchanged if ``sample`` is not a
+    ``pd.MultiIndex`` with ``chain`` and ``draw`` levels. Pure: ``curve`` is
+    not mutated.
 
     """
-    if "sample" not in curve.dims:
-        return curve
     index = curve.indexes.get("sample")
     if isinstance(index, pd.MultiIndex) and {"chain", "draw"} <= set(index.names):
         # chain/draw must lead so make_sample_selection's `.loc[idx, :]` resolves
@@ -499,7 +499,8 @@ def plot_hdi(
     if isinstance(non_grid_names, str):
         non_grid_names = {non_grid_names}
 
-    curve = unstack_sample(curve)
+    if "sample" in curve.dims:
+        curve = unstack_sample(curve)
 
     plot_kwargs = plot_kwargs or {}
     plot_kwargs = {**{"alpha": 0.25}, **plot_kwargs}
@@ -568,7 +569,8 @@ def plot_samples(
     if isinstance(non_grid_names, str):
         non_grid_names = {non_grid_names}
 
-    curve = unstack_sample(curve)
+    if "sample" in curve.dims:
+        curve = unstack_sample(curve)
     n_chains = curve.sizes["chain"]
     n_draws = curve.sizes["draw"]
     make_selection = _create_make_sample_selection(
@@ -737,7 +739,8 @@ def plot_curve(
         plt.show()
 
     """
-    curve = unstack_sample(curve)
+    if "sample" in curve.dims:
+        curve = unstack_sample(curve)
     curve = drop_scalar_coords(curve)
 
     hdi_probs = hdi_probs or None

--- a/pymc_marketing/plot.py
+++ b/pymc_marketing/plot.py
@@ -93,8 +93,8 @@ def unstack_sample(curve: xr.DataArray) -> xr.DataArray:
     The plotting helpers in this module index ``chain`` and ``draw`` directly,
     so a combined input must be unstacked first. Assumes ``sample`` is a dim
     of ``curve``. Returns ``curve`` unchanged if ``sample`` is not a
-    ``pd.MultiIndex`` with ``chain`` and ``draw`` levels. Pure: ``curve`` is
-    not mutated.
+    ``pd.MultiIndex`` with ``chain`` and ``draw`` levels. Does not modify
+    ``curve``.
 
     """
     index = curve.indexes.get("sample")

--- a/pymc_marketing/plot.py
+++ b/pymc_marketing/plot.py
@@ -85,6 +85,25 @@ def drop_scalar_coords(curve: xr.DataArray) -> xr.DataArray:
     return curve.reset_coords(scalar_coords_to_drop, drop=True)
 
 
+def unstack_sample(curve: xr.DataArray) -> xr.DataArray:
+    """Unstack ``sample`` back into ``chain`` / ``draw`` when combined.
+
+    ``arviz.extract(..., combined=True)`` returns a DataArray whose ``chain``
+    and ``draw`` dims have been stacked into a single ``sample`` MultiIndex.
+    The plotting helpers in this module index ``chain`` and ``draw`` directly,
+    so a combined input is silently unstacked here. Inputs without a ``sample``
+    MultiIndex are returned unchanged.
+
+    """
+    if "sample" not in curve.dims:
+        return curve
+    index = curve.indexes.get("sample")
+    if isinstance(index, pd.MultiIndex) and {"chain", "draw"} <= set(index.names):
+        # chain/draw must lead so make_sample_selection's `.loc[idx, :]` resolves
+        return curve.unstack("sample").transpose("chain", "draw", ...)
+    return curve
+
+
 def get_total_coord_size(coords: Coords) -> int:
     """Get the total size of the coordinates.
 
@@ -480,6 +499,8 @@ def plot_hdi(
     if isinstance(non_grid_names, str):
         non_grid_names = {non_grid_names}
 
+    curve = unstack_sample(curve)
+
     plot_kwargs = plot_kwargs or {}
     plot_kwargs = {**{"alpha": 0.25}, **plot_kwargs}
 
@@ -547,6 +568,7 @@ def plot_samples(
     if isinstance(non_grid_names, str):
         non_grid_names = {non_grid_names}
 
+    curve = unstack_sample(curve)
     n_chains = curve.sizes["chain"]
     n_draws = curve.sizes["draw"]
     make_selection = _create_make_sample_selection(
@@ -715,6 +737,7 @@ def plot_curve(
         plt.show()
 
     """
+    curve = unstack_sample(curve)
     curve = drop_scalar_coords(curve)
 
     hdi_probs = hdi_probs or None

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -193,6 +193,39 @@ def test_plot_curve_exposed_parameters(mock_curve, kwargs) -> None:
     plt.close(fig)
 
 
+@pytest.fixture(scope="module")
+def mock_curve_combined(mock_curve) -> xr.DataArray:
+    return mock_curve.stack(sample=("chain", "draw"))
+
+
+@pytest.mark.parametrize(
+    "plot_func", [plot_curve, plot_samples, plot_hdi], ids=lambda f: f.__name__
+)
+@pytest.mark.parametrize(
+    "same_axes", [True, False], ids=["same_axes", "different_axes"]
+)
+def test_plot_functions_combined_sample(
+    mock_curve_combined, plot_func, same_axes: bool
+) -> None:
+    fig, axes = plot_func(
+        mock_curve_combined, non_grid_names={"day"}, same_axes=same_axes
+    )
+
+    assert axes.size == (1 if same_axes else mock_curve_combined.sizes["geo"])
+    assert isinstance(fig, plt.Figure)
+    plt.close(fig)
+
+
+def test_plot_curve_combined_sample_n_samples(mock_curve_combined) -> None:
+    fig, axes = plot_curve(
+        mock_curve_combined, non_grid_names={"day"}, n_samples=3, hdi_probs=[0.5, 0.9]
+    )
+
+    assert axes.size == mock_curve_combined.sizes["geo"]
+    assert isinstance(fig, plt.Figure)
+    plt.close(fig)
+
+
 @pytest.fixture
 def mock_curve_with_scalars() -> xr.DataArray:
     coords = {


### PR DESCRIPTION
## Summary

`plot_curve` / `plot_samples` raised `KeyError: 'chain'` when given a DataArray whose `chain` / `draw` dims had been stacked into a single `sample` MultiIndex (the shape `arviz.extract(..., combined=True)` returns).

Fix: at the top of `plot_curve`, `plot_samples`, and `plot_hdi`, detect a `sample` MultiIndex with `chain` / `draw` levels and unstack it (transposing chain/draw to lead, which `_create_make_sample_selection` relies on). Inputs without a `sample` MultiIndex are returned unchanged, so this is backwards-compatible.

Closes #1270

## Test plan

- [x] New regression test `test_plot_functions_combined_sample` covers `plot_curve` / `plot_samples` / `plot_hdi` × `same_axes` ∈ {True, False}
- [x] New `test_plot_curve_combined_sample_n_samples` exercises `n_samples` and `hdi_probs` on combined input
- [x] All existing `tests/test_plot.py` tests pass (34/34)
- [x] `tests/mmm/test_fourier.py`, `tests/mmm/test_hsgp.py` pass
- [x] `pre-commit` clean (ruff, mypy)

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2587.org.readthedocs.build/en/2587/

<!-- readthedocs-preview pymc-marketing end -->