### PR TITLE
fix(mmm): correct return type on sample_posterior_predictive and sample_response_distribution

### DIFF
--- a/pymc_marketing/mmm/mmm.py
+++ b/pymc_marketing/mmm/mmm.py
@@ -2531,7 +2531,7 @@ class MMM(RegressionModelBuilder):
         include_last_observations: bool = False,  # type: ignore
         clone_model: bool = True,  # type: ignore
         **sample_posterior_predictive_kwargs,  # type: ignore
-    ) -> xr.DataArray:
+    ) -> xr.Dataset:
         """Sample from the model's posterior predictive distribution.
 
         Parameters
@@ -2552,7 +2552,7 @@ class MMM(RegressionModelBuilder):
 
         Returns
         -------
-        xr.DataArray
+        xr.Dataset
             Posterior predictive samples.
         """
         # Update model data with xarray
@@ -3966,7 +3966,7 @@ class BudgetOptimizerWrapper(OptimizerCompatibleModelWrapper):
         include_last_observations: bool = False,
         include_carryover: bool = True,
         budget_distribution_over_period: xr.DataArray | None = None,
-    ) -> az.InferenceData:
+    ) -> xr.Dataset:
         """Generate synthetic dataset and sample posterior predictive based on allocation.
 
         Parameters
@@ -3993,7 +3993,7 @@ class BudgetOptimizerWrapper(OptimizerCompatibleModelWrapper):
 
         Returns
         -------
-        az.InferenceData
+        xr.Dataset
             The posterior predictive samples based on the synthetic dataset.
         """
         data = create_zero_dataset(


### PR DESCRIPTION
Closes #2582.

Two methods in `pymc_marketing/mmm/mmm.py` advertised the wrong return type:

- `MMM.sample_posterior_predictive` was annotated `-> xr.DataArray`. It returns `az.extract(post_pred, "posterior_predictive", combined=combined)` with no `var_names` filter, which is an `xr.Dataset`.
- `BudgetOptimizerWrapper.sample_response_distribution` was annotated `-> az.InferenceData`. Its return chain is `sample_posterior_predictive(...).merge(constant_data).merge(_dataset)`, which is also an `xr.Dataset`.

Updates both annotations and the matching "Returns" sections in the docstrings. No behavior change.

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2591.org.readthedocs.build/en/2591/

<!-- readthedocs-preview pymc-marketing end -->