### PR TITLE
refactor(pie): move PIE to top-level package

### DIFF
--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -20,6 +20,7 @@
   model_config
   model_graph
   paths
+  pie
   plot
   prior
   pytensor_utils

--- a/pymc_marketing/__init__.py
+++ b/pymc_marketing/__init__.py
@@ -27,7 +27,7 @@ import pymc_marketing.data.fivetran  # noqa: E402
 
 # Register SpecialPrior deserializers (LogNormalPrior, LaplacePrior, etc.)
 import pymc_marketing.special_priors  # noqa: E402, F401
-from pymc_marketing import bass, clv, customer_choice, mmm  # noqa: E402
+from pymc_marketing import bass, clv, customer_choice, mmm, pie  # noqa: E402
 from pymc_marketing.version import __version__  # noqa: E402
 
-__all__ = ["__version__", "bass", "clv", "customer_choice", "mmm"]
+__all__ = ["__version__", "bass", "clv", "customer_choice", "mmm", "pie"]

--- a/pymc_marketing/mmm/__init__.py
+++ b/pymc_marketing/mmm/__init__.py
@@ -61,7 +61,6 @@ from pymc_marketing.mmm.mmm import (
     MMM,
     BudgetOptimizerWrapper,
 )
-from pymc_marketing.mmm.pie import PIEModel
 from pymc_marketing.mmm.plotting import MMMPlotSuiteFacade
 from pymc_marketing.mmm.preprocessing import (
     preprocessing_method_X,
@@ -108,7 +107,6 @@ __all__ = [
     "MonthlyFourier",
     "NoAdstock",
     "NoSaturation",
-    "PIEModel",
     "PeriodicCovFunc",
     "RootSaturation",
     "SaturationTransformation",

--- a/pymc_marketing/pie/__init__.py
+++ b/pymc_marketing/pie/__init__.py
@@ -1,0 +1,42 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Predicted Incrementality by Experimentation (PIE).
+
+The recommended entry point is :class:`PIEModel`, which wraps the model in a
+:class:`~pymc_marketing.model_builder.RegressionModelBuilder` interface with
+standard ``.fit()``, ``.save()``, and ``.load()`` methods.
+
+Examples
+--------
+Fit on a corpus of past RCTs, then predict incrementality for new campaigns:
+
+.. code-block:: python
+
+    import pandas as pd
+    from pymc_marketing.pie import PIEModel
+
+    X = pd.DataFrame({...})
+    y = pd.Series([...])
+
+    model = PIEModel(
+        pre_determined_features=["objective", "vertical", "budget"],
+        post_determined_features=["exposure_rate"],
+    )
+    model.fit(X, y, random_seed=42)
+    predictions = model.predict(X_new)
+"""
+
+from pymc_marketing.pie.model import PIEModel
+
+__all__ = ["PIEModel"]

--- a/pymc_marketing/pie/model.py
+++ b/pymc_marketing/pie/model.py
@@ -43,6 +43,8 @@ far outside the corpus's feature support are extrapolation and unreliable)
 3. measured incrementality is a consistent estimate of the true causal effect
 (per-RCT measurement error is not yet modelled — see :class:`PIEModel`).
 
+For the full method, see [1]_.
+
 References
 ----------
 .. [1] Gordon, B. R., Moakler, R., & Zettelmeyer, F. (2026).
@@ -118,6 +120,7 @@ class PIEModel(RegressionModelBuilder):
         :py:meth:`default_model_config`; nested dicts (e.g. ``"bart"``) are
         replaced wholesale, so a partial ``"bart"`` override must restate
         every required key (``m``, ``alpha``, ``beta``). Keys:
+
         - ``"bart"``: dict with ``m`` (int), ``alpha`` (float), ``beta``
           (float), and optional ``response`` — ``"constant"`` (default,
           piecewise-constant leaves), ``"linear"``, or ``"mix"`` (the latter
@@ -136,7 +139,7 @@ class PIEModel(RegressionModelBuilder):
 
         import pandas as pd
 
-        from pymc_marketing.mmm import PIEModel
+        from pymc_marketing.pie import PIEModel
 
         # Corpus of past campaigns, each labelled with the incrementality
         # measured by its RCT.
@@ -160,7 +163,7 @@ class PIEModel(RegressionModelBuilder):
     Notes
     -----
     **This module is alpha — the API and defaults may change.** Tracked
-    deviations from the paper (Gordon, Moakler & Zettelmeyer 2026):
+    deviations from the paper [1]_:
 
     - The paper uses a random forest fit to 2,226 RCTs; this implementation
       uses Bayesian Additive Regression Trees (PyMC-BART) for native

--- a/tests/pie/__init__.py
+++ b/tests/pie/__init__.py
@@ -1,0 +1,13 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.

--- a/tests/pie/test_model.py
+++ b/tests/pie/test_model.py
@@ -11,8 +11,6 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-"""Tests for the PIE model."""
-
 import numpy as np
 import pandas as pd
 import pytest

--- a/tests/pie/test_model.py
+++ b/tests/pie/test_model.py
@@ -11,7 +11,7 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-"""Tests for pymc_marketing.mmm.pie."""
+"""Tests for the PIE model."""
 
 import numpy as np
 import pandas as pd
@@ -19,7 +19,7 @@ import pytest
 from pymc_extras.prior import Prior
 from scipy.stats import pearsonr
 
-from pymc_marketing.mmm.pie import PIEModel
+from pymc_marketing.pie import PIEModel
 
 EXPECTED_COLUMNS = [
     "campaign_id",
@@ -246,7 +246,7 @@ def test_negative_incrementality_is_allowed(default_model, small_corpus):
 
 def test_pymc_bart_missing_raises(small_corpus, monkeypatch):
     """build_model raises ImportError when pymc-bart is unavailable."""
-    import pymc_marketing.mmm.pie as pie_module
+    import pymc_marketing.pie.model as pie_module
 
     monkeypatch.setattr(pie_module, "pmb", None)
 


### PR DESCRIPTION
## Summary

Stacks on #2593 (`feat/pie-model`). Moves PIE out of the MMM module into a first-class `pymc_marketing.pie` package (same layout as `bass/`):

- `pymc_marketing/mmm/pie.py` → `pymc_marketing/pie/model.py` + `pie/__init__.py`
- `tests/mmm/test_pie.py` → `tests/pie/test_model.py`
- Removes `PIEModel` from `pymc_marketing.mmm`; registers `pie` in top-level `__init__.py`
- Adds `pie` to API docs autosummary

**Import change:** `from pymc_marketing.mmm import PIEModel` → `from pymc_marketing.pie import PIEModel`

Merge this PR into `feat/pie-model` before merging #2593 to `main`.

## Test plan

- [x] `pytest tests/pie/test_model.py -v` (31 passed, 1 skipped)
- [x] pre-commit on touched files
- [x] Sphinx build: no `mmm.pie` warnings; `pymc_marketing.pie` API pages generated


Made with [Cursor](https://cursor.com)

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2600.org.readthedocs.build/en/2600/

<!-- readthedocs-preview pymc-marketing end -->