### PR TITLE
Freeze MMM model before sampling

### DIFF
--- a/pymc_marketing/mmm/mmm.py
+++ b/pymc_marketing/mmm/mmm.py
@@ -193,6 +193,7 @@ import pymc as pm
 import pymc.dims as pmd
 import xarray as xr
 from pydantic import ConfigDict, Field, InstanceOf, StrictBool, validate_call
+from pymc.model.transform.optimization import freeze_dims_and_data
 from pymc.util import RandomState
 from pymc_extras.prior import Prior
 from pytensor.xtensor import as_xtensor
@@ -2046,6 +2047,9 @@ class MMM(RegressionModelBuilder):
                 )
 
         return self
+
+    def _get_sampling_model(self) -> pm.Model:
+        return freeze_dims_and_data(self.model)
 
     def fit(  # type: ignore[override]
         self,

--- a/pymc_marketing/model_builder.py
+++ b/pymc_marketing/model_builder.py
@@ -956,6 +956,9 @@ class RegressionModelBuilder(ModelBuilder):
         """Perform transformation on the model after sampling."""
         pass
 
+    def _get_sampling_model(self) -> pm.Model:
+        return self.model
+
     def fit(  # type: ignore[override]
         self,
         X: pd.DataFrame | xr.Dataset | xr.DataArray,
@@ -1021,13 +1024,15 @@ class RegressionModelBuilder(ModelBuilder):
             **kwargs,
         )
 
+        sampling_model = self._get_sampling_model()
+
         # Sample without deterministics first
-        var_names = [var.name for var in self.model.free_RVs]
-        with self.model:
+        var_names = [var.name for var in sampling_model.free_RVs]
+        with sampling_model:
             idata = pm.sample(var_names=var_names, **sampler_kwargs)
 
         # Compute deterministics after sampling
-        with self.model:
+        with sampling_model:
             idata.posterior = pm.compute_deterministics(
                 idata.posterior, merge_dataset=True
             )

--- a/tests/mmm/test_mmm.py
+++ b/tests/mmm/test_mmm.py
@@ -912,7 +912,8 @@ class TestSerializationIntegration:
                 import pytensor.tensor as pt
                 from pytensor.xtensor.type import as_xtensor
 
-                return as_xtensor(pt.zeros(1), dims=["date"])
+                n_obs = mmm.model.dim_lengths["date"]
+                return as_xtensor(pt.zeros(n_obs), dims=["date"])
 
             def set_data(self, mmm, model, X):
                 pass


### PR DESCRIPTION
Together with https://github.com/pymc-devs/pytensor/pull/2175  I get a 1.5x speedup MCMC sampling in the demo MMM with default nutpie+numba. On CPU it's better than JAX

The PyTensor improvement part will only be seen when we update the dependency ofc.