### PR TITLE
Add v1.0.0 branch to CI triggers

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,9 +9,9 @@ name: Docs
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, v1.0.0]
   push:
-    branches: [main]
+    branches: [main, v1.0.0]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/install-conda-env.yml
+++ b/.github/workflows/install-conda-env.yml
@@ -6,7 +6,7 @@ on:
   schedule:
     - cron: '0 12 * * 1'
   pull_request:
-    branches: [main]
+    branches: [main, v1.0.0]
     paths:
       - ".github/workflows/install-conda-env.yml"
       - "environment.yml"

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,9 +1,9 @@
 name: PyPI
 on:
   pull_request:
-    branches: [main]
+    branches: [main, v1.0.0]
   push:
-    branches: [main]
+    branches: [main, v1.0.0]
   release:
     types: [published]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, v1.0.0]
   push:
-    branches: [main]
+    branches: [main, v1.0.0]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/test_notebook.yml
+++ b/.github/workflows/test_notebook.yml
@@ -2,7 +2,7 @@ name: Test Notebooks
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, v1.0.0]
     paths:
      - "pyproject.toml"
      - "tests/**.py"
@@ -13,7 +13,7 @@ on:
      - "!docs/source/notebooks/mmm/**.ipynb"
      - "!docs/source/notebooks/*/dev/**.ipynb"
   push:
-    branches: [main]
+    branches: [main, v1.0.0]
     paths:
      - "pyproject.toml"
      - "tests/**.py"

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,6 +11,7 @@ coverage:
        # advanced settings
         branches:
           - main
+          - v1.0.0
         if_ci_failed: error #success, failure, error, ignore
         informational: false
         only_pulls: false


### PR DESCRIPTION
Add `v1.0.0` alongside `main` in all CI workflow branch triggers so that PRs targeting the new `v1.0.0` branch get full CI/CD coverage.

**Files changed:**
- `.github/workflows/test.yml` — add v1.0.0 to push/pull_request triggers
- `.github/workflows/pypi.yml` — add v1.0.0 to push/pull_request triggers
- `.github/workflows/docs.yml` — add v1.0.0 to push/pull_request triggers
- `.github/workflows/test_notebook.yml` — add v1.0.0 to push/pull_request triggers
- `.github/workflows/install-conda-env.yml` — add v1.0.0 to pull_request trigger
- `codecov.yml` — add v1.0.0 to branch coverage tracking

After merge, `v1.0.0` will be set as the default branch for active development toward the v1.0.0 release. `main` will remain for bug-fix-only releases.