### PR TITLE
Use tmp_path for CLV save-load tests

### DIFF
--- a/tests/clv/models/test_basic.py
+++ b/tests/clv/models/test_basic.py
@@ -11,8 +11,6 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-import os
-
 import numpy as np
 import pandas as pd
 import pymc as pm
@@ -214,21 +212,21 @@ class TestCLVModel:
         ):
             model.fit(fit_method="mcmc")
 
-    def test_load(self, mocker):
+    def test_load(self, mocker, tmp_path):
         model = CLVModelTest()
+        save_path = tmp_path / "test_model"
 
         mocker.patch("pymc.sample", mock_sample)
 
         model.fit(tune=0, chains=2, draws=5)
-        model.save("test_model")
-        model2 = model.load("test_model")
+        model.save(save_path)
+        model2 = model.load(save_path)
 
         assert model2.fit_result is not None
 
         # TODO: Add this to the model_builder.py load method?
         model2.build_model()
         assert model2.model is not None
-        os.remove("test_model")
 
     def test_load_from_idata_without_fit_data_warns(self, mocker):
         mocker.patch("pymc.sample", mock_sample)
@@ -263,25 +261,25 @@ class TestCLVModel:
         assert isinstance(serializable_config, dict)
         assert serializable_config == model.model_config
 
-    def test_fail_id_after_load(self, mocker, monkeypatch):
+    def test_fail_id_after_load(self, mocker, monkeypatch, tmp_path):
         # This is the new behavior for the property
         def mock_property(self):
             return "for sure not correct id"
 
         # Now create an instance of MyClass
         mock_basic = CLVModelTest()
+        save_path = tmp_path / "test_model"
         mocker.patch("pymc.sample", mock_sample)
         mock_basic.fit(tune=0, chains=2, draws=5)
-        mock_basic.save("test_model")
+        mock_basic.save(save_path)
 
         # Apply the monkeypatch for the property
         monkeypatch.setattr(CLVModelTest, "id", property(mock_property))
         with pytest.raises(
             DifferentModelError,
-            match=r"The file 'test_model'",
+            match=r"The file '.*test_model'",
         ):
-            CLVModelTest.load("test_model")
-        os.remove("test_model")
+            CLVModelTest.load(save_path)
 
     def test_thin_fit_result(self):
         data = pd.DataFrame(dict(y=[-3, -2, -1]))
@@ -309,7 +307,7 @@ class TestCLVModel:
             "x": Prior("StudentT", mu=0, sigma=5, nu=15),
         }
 
-    def test_backwards_compatibility_with_old_config(self):
+    def test_backwards_compatibility_with_old_config(self, tmp_path):
         model = CLVModelTest()
         model.build_model()
 
@@ -317,15 +315,13 @@ class TestCLVModel:
         set_model_fit(model, old_posterior)
         assert "alpha_prior" in model.idata.posterior
 
-        save_path = "test_model"
+        save_path = tmp_path / "test_model"
         model.save(save_path)
 
         loaded_model = CLVModelTest.load(save_path)
 
         assert "alpha" in loaded_model.idata.posterior
         assert "alpha_prior" not in loaded_model.idata.posterior
-
-        os.remove("test_model")
 
     def test_deprecation_warning_on_old_config(self):
         old_model_config = {

--- a/tests/clv/models/test_beta_geo.py
+++ b/tests/clv/models/test_beta_geo.py
@@ -11,8 +11,6 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-import os
-
 import arviz as az
 import numpy as np
 import pandas as pd
@@ -665,11 +663,12 @@ class TestBetaGeoModel:
             rtol=rtol,
         )
 
-    def test_save_load(self):
-        self.model.save("test_model")
+    def test_save_load(self, tmp_path):
+        save_path = tmp_path / "test_model"
+        self.model.save(save_path)
         # Testing the valid case.
 
-        model2 = BetaGeoModel.load("test_model")
+        model2 = BetaGeoModel.load(save_path)
 
         # Check if the loaded model is indeed an instance of the class
         assert isinstance(self.model, BetaGeoModel)
@@ -678,7 +677,6 @@ class TestBetaGeoModel:
         assert self.model.model_config == model2.model_config
         assert self.model.sampler_config == model2.sampler_config
         assert self.model.idata == model2.idata
-        os.remove("test_model")
 
 
 class TestBetaGeoModelWithCovariates:

--- a/tests/clv/models/test_beta_geo_beta_binom.py
+++ b/tests/clv/models/test_beta_geo_beta_binom.py
@@ -11,8 +11,6 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-import os
-
 import arviz as az
 import numpy as np
 import pandas as pd
@@ -550,11 +548,12 @@ class TestBetaGeoBetaBinomModel:
             rtol=rtol,
         )
 
-    def test_save_load(self):
-        self.model.save("test_model")
+    def test_save_load(self, tmp_path):
+        save_path = tmp_path / "test_model"
+        self.model.save(save_path)
         # Testing the valid case.
 
-        model2 = BetaGeoBetaBinomModel.load("test_model")
+        model2 = BetaGeoBetaBinomModel.load(save_path)
 
         # Check if the loaded model is indeed an instance of the class
         assert isinstance(self.model, BetaGeoBetaBinomModel)
@@ -563,4 +562,3 @@ class TestBetaGeoBetaBinomModel:
         assert self.model.model_config == model2.model_config
         assert self.model.sampler_config == model2.sampler_config
         assert self.model.idata == model2.idata
-        os.remove("test_model")

--- a/tests/clv/models/test_gamma_gamma.py
+++ b/tests/clv/models/test_gamma_gamma.py
@@ -11,7 +11,6 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-import os
 from unittest.mock import patch
 
 import numpy as np
@@ -303,20 +302,21 @@ class TestGammaGammaModel(BaseTestGammaGammaModel):
             "\nlikelihood~Potential(f(q,p,v))"
         )
 
-    def test_save_load(self, mocker):
+    def test_save_load(self, mocker, tmp_path):
         model = GammaGammaModel(
             data=self.data,
         )
+        save_path = tmp_path / "test_model"
         model.model_config = {
             param: Prior("HalfNormal") for param in model.model_config
         }
 
         mocker.patch("pymc_marketing.clv.models.basic.CLVModel._fit_MAP", mock_fit_MAP)
         model.fit(method="map", maxeval=1)
-        model.save("test_model")
+        model.save(save_path)
         # Testing the valid case.
 
-        model2 = GammaGammaModel.load("test_model")
+        model2 = GammaGammaModel.load(save_path)
 
         # Check if the loaded model is indeed an instance of the class
         assert isinstance(model, GammaGammaModel)
@@ -325,7 +325,6 @@ class TestGammaGammaModel(BaseTestGammaGammaModel):
         assert model.model_config == model2.model_config
         assert model.sampler_config == model2.sampler_config
         assert model.idata == model2.idata
-        os.remove("test_model")
 
 
 class TestGammaGammaModelIndividual(BaseTestGammaGammaModel):
@@ -472,19 +471,20 @@ class TestGammaGammaModelIndividual(BaseTestGammaGammaModel):
             "\nspend~Gamma(p,f(nu))"
         )
 
-    def test_save_load(self, mocker):
+    def test_save_load(self, mocker, tmp_path):
         model = GammaGammaModelIndividual(
             data=self.individual_data,
         )
+        save_path = tmp_path / "test_model"
         model.model_config = {
             param: Prior("HalfNormal") for param in model.model_config
         }
         mocker.patch("pymc_marketing.clv.models.basic.CLVModel._fit_MAP", mock_fit_MAP)
         model.fit(method="map", maxeval=1)
-        model.save("test_model")
+        model.save(save_path)
         # Testing the valid case.
 
-        model2 = GammaGammaModelIndividual.load("test_model")
+        model2 = GammaGammaModelIndividual.load(save_path)
 
         # Check if the loaded model is indeed an instance of the class
         assert isinstance(model, GammaGammaModelIndividual)
@@ -493,4 +493,3 @@ class TestGammaGammaModelIndividual(BaseTestGammaGammaModel):
         assert model.model_config == model2.model_config
         assert model.sampler_config == model2.sampler_config
         assert model.idata == model2.idata
-        os.remove("test_model")

--- a/tests/clv/models/test_modified_beta_geo.py
+++ b/tests/clv/models/test_modified_beta_geo.py
@@ -11,8 +11,6 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-import os
-
 import arviz as az
 import numpy as np
 import pandas as pd
@@ -469,11 +467,12 @@ class TestModifiedBetaGeoModel:
             rtol=rtol,
         )
 
-    def test_save_load(self):
-        self.model.save("test_model")
+    def test_save_load(self, tmp_path):
+        save_path = tmp_path / "test_model"
+        self.model.save(save_path)
         # Testing the valid case.
 
-        model2 = ModifiedBetaGeoModel.load("test_model")
+        model2 = ModifiedBetaGeoModel.load(save_path)
 
         # Check if the loaded model is indeed an instance of the class
         assert isinstance(self.model, ModifiedBetaGeoModel)
@@ -482,7 +481,6 @@ class TestModifiedBetaGeoModel:
         assert self.model.model_config == model2.model_config
         assert self.model.sampler_config == model2.sampler_config
         assert self.model.idata == model2.idata
-        os.remove("test_model")
 
 
 class TestModifiedBetaGeoModelWithCovariates:

--- a/tests/clv/models/test_pareto_nbd.py
+++ b/tests/clv/models/test_pareto_nbd.py
@@ -11,8 +11,6 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-import os
-
 import arviz as az
 import numpy as np
 import pandas as pd
@@ -452,11 +450,12 @@ class TestParetoNBDModel:
         np.testing.assert_allclose(customer_freq.mean(), ref_freq.mean(), rtol=0.5)
         np.testing.assert_allclose(customer_freq.std(), ref_freq.std(), rtol=0.5)
 
-    def test_save_load_pareto_nbd(self):
-        self.model.save("test_model")
+    def test_save_load_pareto_nbd(self, tmp_path):
+        save_path = tmp_path / "test_model"
+        self.model.save(save_path)
         # Testing the valid case.
 
-        loaded_model = ParetoNBDModel.load("test_model")
+        loaded_model = ParetoNBDModel.load(save_path)
 
         # Check if the loaded model is indeed an instance of the class
         assert isinstance(loaded_model, ParetoNBDModel)
@@ -469,7 +468,6 @@ class TestParetoNBDModel:
         assert self.model.model_config == loaded_model.model_config
         assert self.model.sampler_config == loaded_model.sampler_config
         assert self.model.idata == loaded_model.idata
-        os.remove("test_model")
 
     def test_fit_exception(self):
         with pytest.warns(

--- a/tests/clv/models/test_shifted_beta_geo.py
+++ b/tests/clv/models/test_shifted_beta_geo.py
@@ -11,8 +11,6 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-import os
-
 import arviz as az
 import numpy as np
 import pandas as pd
@@ -546,16 +544,16 @@ class TestShiftedBetaGeoModel:
         assert len(idata.posterior.draw) == 10
         assert model.idata is idata
 
-    def test_save_load(self):
+    def test_save_load(self, tmp_path):
         model = ShiftedBetaGeoModel()
+        save_path = tmp_path / "test_model"
         model.build_model(data=self.data)
         model.fit(method="map")
-        model.save("test_model")
-        model2 = ShiftedBetaGeoModel.load("test_model")
+        model.save(save_path)
+        model2 = ShiftedBetaGeoModel.load(save_path)
         assert model.model_config == model2.model_config
         assert model.sampler_config == model2.sampler_config
         assert model.idata == model2.idata
-        os.remove("test_model")
 
     def test_requires_cohort_dims_on_alpha_beta_missing_raises(self):
         config_missing_dims = {
@@ -1388,15 +1386,16 @@ class TestShiftedBetaGeoModelIndividual:
             rtol=0.05,
         )
 
-    def test_save_load(self, data):
+    def test_save_load(self, data, tmp_path):
         model = ShiftedBetaGeoModelIndividual(
             data=data,
         )
+        save_path = tmp_path / "test_model"
         model.build_model()
         model.fit(method="map", maxeval=1)
-        model.save("test_model")
+        model.save(save_path)
         # Testing the valid case.
-        model2 = ShiftedBetaGeoModelIndividual.load("test_model")
+        model2 = ShiftedBetaGeoModelIndividual.load(save_path)
         # Check if the loaded model is indeed an instance of the class
         assert isinstance(model, ShiftedBetaGeoModelIndividual)
         # Check if the loaded data matches with the model data
@@ -1404,4 +1403,3 @@ class TestShiftedBetaGeoModelIndividual:
         assert model.model_config == model2.model_config
         assert model.sampler_config == model2.sampler_config
         assert model.idata == model2.idata
-        os.remove("test_model")


### PR DESCRIPTION
﻿Closes #2615

## Summary
- Use pytest `tmp_path` for CLV model save/load tests instead of writing `test_model` in the repository working directory.
- Remove the now-unneeded manual `os.remove("test_model")` cleanup and unused `os` imports.

## Impact
- Keeps save/load tests isolated from one another and from local repository state.
- Lets pytest handle temporary file cleanup after each test.

## Validation
- Installed core package dependencies with `python -m pip install -e . pytest-mock pytest-cov`.
- Command: `PYTENSOR_FLAGS=cxx= python -m pytest -o addopts="" --basetemp .pytest-tmp tests/clv/models/test_basic.py::TestCLVModel::test_load tests/clv/models/test_basic.py::TestCLVModel::test_fail_id_after_load tests/clv/models/test_basic.py::TestCLVModel::test_backwards_compatibility_with_old_config tests/clv/models/test_beta_geo.py::TestBetaGeoModel::test_save_load tests/clv/models/test_beta_geo_beta_binom.py::TestBetaGeoBetaBinomModel::test_save_load tests/clv/models/test_gamma_gamma.py::TestGammaGammaModel::test_save_load tests/clv/models/test_gamma_gamma.py::TestGammaGammaModelIndividual::test_save_load tests/clv/models/test_modified_beta_geo.py::TestModifiedBetaGeoModel::test_save_load tests/clv/models/test_pareto_nbd.py::TestParetoNBDModel::test_save_load_pareto_nbd tests/clv/models/test_shifted_beta_geo.py::TestShiftedBetaGeoModel::test_save_load tests/clv/models/test_shifted_beta_geo.py::TestShiftedBetaGeoModelIndividual::test_save_load`
- Result: 11 passed, 10 warnings.


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2617.org.readthedocs.build/en/2617/

<!-- readthedocs-preview pymc-marketing end -->