### PR TITLE
feat(mlflow): autolog support for BassModel

### DIFF
--- a/pymc_marketing/mlflow.py
+++ b/pymc_marketing/mlflow.py
@@ -164,6 +164,8 @@ Autologging for a PyMC-Marketing Bass model:
 
     import mlflow
 
+    from pymc_extras.prior import Prior
+
     from pymc_marketing.bass import BassModel
 
     import pymc_marketing.mlflow
@@ -174,7 +176,12 @@ Autologging for a PyMC-Marketing Bass model:
 
     adoption = np.array([10, 25, 50, 80, 100, 90, 60, 35, 20, 10])
 
-    model = BassModel()
+    # Positive prior on the market size m keeps the Poisson rate valid
+    model_config = {
+        "m": Prior("Normal", mu=500, sigma=100),
+    }
+
+    model = BassModel(model_config=model_config)
 
     with mlflow.start_run():
         idata = model.fit(data=adoption)
@@ -1056,8 +1063,9 @@ def log_mmm_configuration(mmm: MMM) -> None:
 def log_bass_configuration(model: BassModel) -> None:
     """Log the configuration of the Bass model to MLflow.
 
-    Logs the model type, version, and the prior configuration
-    (``m``, ``p``, ``q``, ``likelihood``) for reproducibility.
+    Logs the model's idata attributes: id, model type, version,
+    sampler config, and the prior configuration
+    (``m``, ``p``, ``q``, ``likelihood``).
     """
     attrs = model.create_idata_attrs()
     mlflow.log_params(attrs)
@@ -1277,6 +1285,8 @@ def autolog(
 
         import mlflow
 
+        from pymc_extras.prior import Prior
+
         from pymc_marketing.bass import BassModel
 
         import pymc_marketing.mlflow
@@ -1287,7 +1297,12 @@ def autolog(
 
         adoption = np.array([10, 25, 50, 80, 100, 90, 60, 35, 20, 10])
 
-        model = BassModel()
+        # Positive prior on the market size m keeps the Poisson rate valid
+        model_config = {
+            "m": Prior("Normal", mu=500, sigma=100),
+        }
+
+        model = BassModel(model_config=model_config)
 
         with mlflow.start_run():
             idata = model.fit(data=adoption)

--- a/pymc_marketing/mlflow.py
+++ b/pymc_marketing/mlflow.py
@@ -485,6 +485,10 @@ def log_model_graph(model: Model, path: str | Path) -> None:
         logging.info(msg)
 
         return None
+    except Exception as e:
+        msg = f"Unable to render the model graph. {e}"
+        logging.info(msg)
+        return None
 
     try:
         saved_path = graph.render(path)

--- a/pymc_marketing/mlflow.py
+++ b/pymc_marketing/mlflow.py
@@ -49,6 +49,12 @@ are patched:
     - Model type and fit method
     - Stamp the active MLflow run id on ``idata.attrs["mlflow_run_id"]``.
 
+- `BassModel.fit`:
+
+    - All parameters, metrics, and artifacts from `pymc.sample`
+    - :func:`log_bass_configuration`: Log the configuration of the Bass model.
+    - Stamp the active MLflow run id on ``idata.attrs["mlflow_run_id"]``.
+
 Examples
 --------
 Autologging for a PyMC model:
@@ -150,6 +156,29 @@ Autologging for a PyMC-Marketing CLV model:
     with mlflow.start_run():
         model.fit()
 
+Autologging for a PyMC-Marketing Bass model:
+
+.. code-block:: python
+
+    import numpy as np
+
+    import mlflow
+
+    from pymc_marketing.bass import BassModel
+
+    import pymc_marketing.mlflow
+
+    pymc_marketing.mlflow.autolog(log_bass=True)
+
+    mlflow.set_experiment("Bass Experiment")
+
+    adoption = np.array([10, 25, 50, 80, 100, 90, 60, 35, 20, 10])
+
+    model = BassModel()
+
+    with mlflow.start_run():
+        idata = model.fit(data=adoption)
+
 """
 
 import logging
@@ -179,6 +208,7 @@ except ImportError:  # pragma: no cover
 from mlflow.utils.autologging_utils import autologging_integration
 from packaging import version
 
+from pymc_marketing.bass import BassModel
 from pymc_marketing.clv.models.basic import CLVModel
 from pymc_marketing.mmm import MMM
 from pymc_marketing.mmm.evaluation import compute_summary_metrics
@@ -1019,6 +1049,16 @@ def log_mmm_configuration(mmm: MMM) -> None:
     mlflow.log_param("saturation_name", saturation_name)
 
 
+def log_bass_configuration(model: BassModel) -> None:
+    """Log the configuration of the Bass model to MLflow.
+
+    Logs the model type, version, and the prior configuration
+    (``m``, ``p``, ``q``, ``likelihood``) for reproducibility.
+    """
+    attrs = model.create_idata_attrs()
+    mlflow.log_params(attrs)
+
+
 def log_error(func: Callable, file_name: str):
     """Log arbitrary caught error and traceback to MLflow.
 
@@ -1081,6 +1121,7 @@ def autolog(
     arviz_summary_kwargs: dict | None = None,
     log_mmm: bool = True,
     log_clv: bool = True,
+    log_bass: bool = True,
     disable: bool = False,
     silent: bool = False,
 ) -> None:
@@ -1112,6 +1153,8 @@ def autolog(
         Whether to log PyMC-Marketing MMM models. Default is True.
     log_clv : bool, optional
         Whether to log PyMC-Marketing CLV models. Default is True.
+    log_bass : bool, optional
+        Whether to log PyMC-Marketing Bass models. Default is True.
     disable : bool, optional
         Whether to disable autologging. Default is False.
     silent : bool, optional
@@ -1222,6 +1265,29 @@ def autolog(
         with mlflow.start_run():
             model.fit(fit_method="map")
 
+    Autologging for a PyMC-Marketing Bass model:
+
+    .. code-block:: python
+
+        import numpy as np
+
+        import mlflow
+
+        from pymc_marketing.bass import BassModel
+
+        import pymc_marketing.mlflow
+
+        pymc_marketing.mlflow.autolog(log_bass=True)
+
+        mlflow.set_experiment("Bass Experiment")
+
+        adoption = np.array([10, 25, 50, 80, 100, 90, 60, 35, 20, 10])
+
+        model = BassModel()
+
+        with mlflow.start_run():
+            idata = model.fit(data=adoption)
+
     """
     arviz_summary_kwargs = arviz_summary_kwargs or {}
 
@@ -1315,3 +1381,20 @@ def autolog(
 
     if log_clv:
         CLVModel.fit = patch_clv_fit(CLVModel.fit)
+
+    def patch_bass_fit(fit: Callable) -> Callable:
+        @wraps(fit)
+        def new_fit(self, *args, **kwargs):
+            log_bass_configuration(self)
+
+            idata = fit(self, *args, **kwargs)
+            _attach_run_id(idata)
+
+            log_inference_data(idata, save_file="idata.nc")
+
+            return idata
+
+        return new_fit
+
+    if log_bass:
+        BassModel.fit = patch_bass_fit(BassModel.fit)  # type: ignore[method-assign]

--- a/tests/test_mlflow.py
+++ b/tests/test_mlflow.py
@@ -790,6 +790,9 @@ def test_autolog_bass(bass_data) -> None:
         "draws": 2,
         "chains": 1,
         "tune": 1,
+        # Force the pymc sampler so sampling_time / time_per_draw metrics are
+        # populated; the pymc6 default sampler (nutpie) does not log them.
+        "nuts_sampler": "pymc",
     }
     # Positive prior on m keeps the Poisson rate valid when the model graph
     # is rendered (it draws from the prior to evaluate shapes), so

--- a/tests/test_mlflow.py
+++ b/tests/test_mlflow.py
@@ -268,8 +268,13 @@ def test_multi_likelihood_type(multi_likelihood_model) -> None:
             Exception("Unknown error occurred"),
             "Unable to render the model graph. Unknown error occurred",
         ),
+        (
+            "pymc.model_to_graphviz",
+            ValueError("lam < 0 or lam contains NaNs"),
+            "Unable to render the model graph. lam < 0 or lam contains NaNs",
+        ),
     ],
-    ids=["no_graphviz", "render_error"],
+    ids=["no_graphviz", "render_error", "graph_creation_error"],
 )
 def test_log_model_graph_no_graphviz(
     caplog,

--- a/tests/test_mlflow.py
+++ b/tests/test_mlflow.py
@@ -24,8 +24,10 @@ import pytest
 import xarray as xr
 from mlflow.client import MlflowClient
 from pymc.exceptions import SamplingError
+from pymc_extras.prior import Prior
 
 import pymc_marketing.mlflow as pmm_mlflow
+from pymc_marketing.bass import BassModel
 from pymc_marketing.clv import BetaGeoModel
 from pymc_marketing.mlflow import (
     autolog,
@@ -57,6 +59,8 @@ def setup_module():
         pm.sample = pm.sample.__wrapped__
     while hasattr(MMM.fit, "__wrapped__"):
         MMM.fit = MMM.fit.__wrapped__
+    while hasattr(BassModel.fit, "__wrapped__"):
+        BassModel.fit = BassModel.fit.__wrapped__
 
 
 @pytest.fixture(scope="module")
@@ -765,6 +769,64 @@ def test_clv_fit_map(model_cls, clv_data) -> None:
         "coords.json",
         "model_repr.txt",
         "model_graph.pdf",
+        "idata.nc",
+    }
+
+
+@pytest.fixture
+def bass_data() -> np.ndarray:
+    return np.random.default_rng(42).poisson(lam=100, size=20)
+
+
+def test_autolog_bass(bass_data) -> None:
+    mlflow.set_experiment("pymc-marketing-test-suite-bass")
+
+    sampler_config = {
+        "draws": 2,
+        "chains": 1,
+        "tune": 1,
+    }
+    # Positive prior on m keeps the Poisson rate valid when the model graph
+    # is rendered (it draws from the prior to evaluate shapes), so
+    # model_graph.pdf is logged deterministically
+    model_config = {
+        "m": Prior("Normal", mu=100, sigma=10),
+    }
+
+    model = BassModel(model_config=model_config, sampler_config=sampler_config)
+    with mlflow.start_run() as run:
+        idata = model.fit(data=bass_data, random_seed=42)
+
+    assert mlflow.active_run() is None
+    assert idata.attrs["mlflow_run_id"] == run.info.run_id
+
+    run_id = run.info.run_id
+    inputs, params, metrics, tags, artifacts = get_run_data(run_id)
+
+    assert isinstance(inputs, list)
+
+    assert params["model_type"] == "BassModel"
+    assert params["version"] == __version__
+
+    model_config_logged = json.loads(params["model_config"])
+    assert set(model_config_logged.keys()) == {"m", "p", "q", "likelihood"}
+
+    sampler_config_logged = json.loads(params["sampler_config"])
+    assert sampler_config_logged["draws"] == 2
+
+    assert set(metrics.keys()) == {
+        "total_divergences",
+        "sampling_time",
+        "time_per_draw",
+    }
+
+    assert tags == {}
+
+    assert set(artifacts) == {
+        "coords.json",
+        "model_repr.txt",
+        "model_graph.pdf",
+        "summary.html",
         "idata.nc",
     }
 


### PR DESCRIPTION
Closes #2588

Retargeted to `v1.0.0`.

Adds Bass model support to `pymc_marketing.mlflow.autolog`, following the MMM and CLV patterns:

- `log_bass` flag (default `True`) patches `BassModel.fit` to log the model configuration, stamp the run id on the idata, and store the `idata.nc` artifact.
- `log_bass_configuration` logs model type, version, sampler config, and the prior configuration (`m`, `p`, `q`, `likelihood`).
- `log_model_graph` treats graph creation as best-effort: if `pm.model_to_graphviz` fails (for example the default `m ~ Normal(0, 10)` prior can make the Poisson rate negative), it logs a message and continues instead of aborting the run.

v1 adaptation: the autolog test forces `nuts_sampler="pymc"` so the `sampling_time` / `time_per_draw` metrics are populated, since the pymc6 default sampler (nutpie) does not log them. This matches the MMM and CLV autolog tests on `v1.0.0`.
