### PR TITLE
fix(deps): upper bound matplotlib <3.11

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   # Base dependencies
   - python=3.12
   - arviz>=0.13.0,<1.0.0
-  - matplotlib>=3.5.1
+  - matplotlib>=3.5.1,<3.11
   - narwhals
   - numpy>=1.17
   - scipy>=1.15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 dependencies = [
     "arviz>=0.13.0,<1.0.0",
     "arviz-plots[matplotlib]>=1.0.0,<2.0",
-    "matplotlib>=3.5.1",
+    "matplotlib>=3.5.1,<3.11",
     "narwhals",
     "numpy>=2.0",
     "pandas",


### PR DESCRIPTION
## Related Issue
- [x] Closes #2625

## Description
Pins `matplotlib<3.11` in `pyproject.toml` and `environment.yml`, same pattern as the pymc-extras upper bound in #2623.

matplotlib 3.11.0 stopped auto-importing the deprecated `matplotlib.style.core` shim, and the released `arviz_plots` 1.1.0 accesses it at import time, so every CI job fails with `AttributeError` before any test runs. See #2625 for details. The pin can be dropped once the arviz devs publish an arviz-plots release that includes arviz-devs/arviz-plots#466.

## Checklist
- [x] Checked that the pre-commit linting/style checks pass
- [x] Included tests that prove the fix is effective or that the new feature works (no test applies; the CI run on this PR is the verification)
- [x] Added necessary documentation (docstrings and/or example notebooks) using numpydoc format (not applicable)


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2626.org.readthedocs.build/en/2626/

<!-- readthedocs-preview pymc-marketing end -->