### PR TITLE
feat(bass): plotting methods for BassModel

### DIFF
--- a/pymc_marketing/bass/__init__.py
+++ b/pymc_marketing/bass/__init__.py
@@ -52,10 +52,20 @@ Generate synthetic data from the prior, then fit the model:
 
 from pymc_marketing.bass.data import to_bass_dataset
 from pymc_marketing.bass.model import BassModel, BassPriors, create_bass_model
+from pymc_marketing.bass.plotting import (
+    plot_adoption_curve,
+    plot_cumulative,
+    plot_decomposition,
+    plot_peak,
+)
 
 __all__ = [
     "BassModel",
     "BassPriors",
     "create_bass_model",
+    "plot_adoption_curve",
+    "plot_cumulative",
+    "plot_decomposition",
+    "plot_peak",
     "to_bass_dataset",
 ]

--- a/pymc_marketing/bass/model.py
+++ b/pymc_marketing/bass/model.py
@@ -726,7 +726,11 @@ class BassModel(ModelBuilder):
 
         with self.model:
             idata = pm.sample(var_names=var_names, **sampler_kwargs)
-            idata.posterior = pm.compute_deterministics(
+            # Assign to the DataTree node, not the ``posterior`` property.
+            # Under arviz>=1.2 InferenceData subclasses xarray.DataTree, so
+            # ``idata.posterior = ...`` sets a shadowing instance attribute and
+            # leaves the actual group unchanged, dropping the deterministics.
+            idata["posterior"] = pm.compute_deterministics(
                 idata.posterior, merge_dataset=True
             )
 

--- a/pymc_marketing/bass/model.py
+++ b/pymc_marketing/bass/model.py
@@ -137,11 +137,14 @@ Create a basic Bass model for multiple products:
 from typing import Any, TypedDict, cast
 
 import arviz as az
+import matplotlib.pyplot as plt
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 import pymc as pm
 import pytensor.tensor as pt
 import xarray as xr
+from matplotlib.axes import Axes
 from numpy.typing import (
     ArrayLike,  # noqa: F401  # resolves pt.TensorLike's ForwardRef('ArrayLike') for sphinx_autodoc_typehints (#1197)
 )
@@ -149,6 +152,7 @@ from pymc.model import Model
 from pymc.util import RandomState
 from pymc_extras.prior import Censored, Prior, VariableFactory, create_dim_handler
 
+from pymc_marketing.bass import plotting
 from pymc_marketing.bass.data import to_bass_dataset
 from pymc_marketing.model_builder import ModelBuilder, create_sample_kwargs
 from pymc_marketing.version import __version__
@@ -740,6 +744,63 @@ class BassModel(ModelBuilder):
         self.idata["fit_data"] = xr.DataTree(ds)
         self.set_idata_attrs(self.idata)
         return self.idata
+
+    def plot_adoption_curve(
+        self, **kwargs: Any
+    ) -> tuple[plt.Figure, npt.NDArray[Axes]]:
+        """Plot the posterior adoption curve with the observed data.
+
+        See :func:`pymc_marketing.bass.plotting.plot_adoption_curve` for
+        the parameters.
+
+        Returns
+        -------
+        tuple[Figure, ndarray of Axes]
+            Figure and the axes.
+        """
+        return plotting.plot_adoption_curve(self, **kwargs)
+
+    def plot_cumulative(self, **kwargs: Any) -> tuple[plt.Figure, npt.NDArray[Axes]]:
+        """Plot the cumulative adoption S-curve with the observed data.
+
+        See :func:`pymc_marketing.bass.plotting.plot_cumulative` for
+        the parameters.
+
+        Returns
+        -------
+        tuple[Figure, ndarray of Axes]
+            Figure and the axes.
+        """
+        return plotting.plot_cumulative(self, **kwargs)
+
+    def plot_decomposition(self, **kwargs: Any) -> tuple[plt.Figure, npt.NDArray[Axes]]:
+        """Plot the adoption decomposition into innovators and imitators.
+
+        Per-period innovators and imitators go on the left y-axis and
+        cumulative adoption on a twin right y-axis.
+
+        See :func:`pymc_marketing.bass.plotting.plot_decomposition` for
+        the parameters.
+
+        Returns
+        -------
+        tuple[Figure, ndarray of Axes]
+            Figure and the primary (left) axes.
+        """
+        return plotting.plot_decomposition(self, **kwargs)
+
+    def plot_peak(self, **kwargs: Any) -> tuple[plt.Figure, npt.NDArray[Axes]]:
+        """Plot the posterior distribution of the peak adoption time.
+
+        See :func:`pymc_marketing.bass.plotting.plot_peak` for
+        the parameters.
+
+        Returns
+        -------
+        tuple[Figure, ndarray of Axes]
+            Figure and the axes.
+        """
+        return plotting.plot_peak(self, **kwargs)
 
     def build_from_idata(self, idata: xr.DataTree) -> None:
         """Rebuild the model from a ``DataTree`` object.

--- a/pymc_marketing/bass/plotting.py
+++ b/pymc_marketing/bass/plotting.py
@@ -1,0 +1,350 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Plotting functions for the Bass diffusion model.
+
+Each function takes a fitted :class:`~pymc_marketing.bass.model.BassModel`
+and returns a ``(Figure, ndarray of Axes)`` tuple, following the convention
+of :func:`pymc_marketing.plot.plot_curve`. Multi-product models plot one
+subplot per product; pass ``product`` to select a single one.
+
+The functions are also exposed as ``plot_*`` methods on
+:class:`~pymc_marketing.bass.model.BassModel`.
+"""
+
+from typing import TYPE_CHECKING, Any
+
+import arviz as az
+import matplotlib.pyplot as plt
+import numpy as np
+import numpy.typing as npt
+import xarray as xr
+from matplotlib.axes import Axes
+from matplotlib.lines import Line2D
+
+from pymc_marketing.plot import plot_curve
+
+if TYPE_CHECKING:
+    from pymc_marketing.bass.model import BassModel
+
+__all__ = [
+    "plot_adoption_curve",
+    "plot_cumulative",
+    "plot_decomposition",
+    "plot_peak",
+]
+
+
+def _select_product(da: xr.DataArray, product: str | None) -> xr.DataArray:
+    if product is None:
+        return da
+    if "product" not in da.dims:
+        raise ValueError(
+            "The model has no 'product' dimension. "
+            "Remove the product argument for single-product models."
+        )
+    return da.sel(product=product)
+
+
+def _get_observed(model: "BassModel", product: str | None) -> xr.DataArray | None:
+    idata = model.idata
+    if idata is None or "fit_data" not in idata or "observed" not in idata.fit_data:
+        return None
+    return _select_product(idata.fit_data["observed"], product)
+
+
+def _overlay_observed(
+    observed: xr.DataArray,
+    axes: npt.NDArray[Axes],
+    **plot_kwargs: Any,
+) -> None:
+    """Plot observed data on each axes, one product per axes."""
+    plot_kwargs = {"color": "black", **plot_kwargs}
+    t = observed.coords["T"].values
+    if "product" in observed.dims:
+        for ax, product in zip(
+            axes.flat, observed.coords["product"].values, strict=False
+        ):
+            ax.plot(t, observed.sel(product=product).values, **plot_kwargs)
+    else:
+        for ax in axes.flat:
+            ax.plot(t, observed.values, **plot_kwargs)
+
+
+def plot_adoption_curve(
+    model: "BassModel",
+    product: str | None = None,
+    n_samples: int = 10,
+    hdi_probs: float | list[float] | None = None,
+    random_seed: np.random.Generator | None = None,
+    subplot_kwargs: dict | None = None,
+    axes: npt.NDArray[Axes] | None = None,
+) -> tuple[plt.Figure, npt.NDArray[Axes]]:
+    """Plot the posterior adoption curve with the observed data.
+
+    Shows posterior samples and HDI of the ``adopters`` deterministic
+    (new adopters per period) over time, with the observed counts in black.
+
+    Parameters
+    ----------
+    model : BassModel
+        A fitted Bass model.
+    product : str, optional
+        Plot a single product of a multi-product model. Default plots
+        one subplot per product.
+    n_samples : int, optional
+        Number of posterior sample curves to draw. Default is 10.
+    hdi_probs : float or list of float, optional
+        HDI probabilities. Defaults to the ArviZ default (0.94).
+    random_seed : np.random.Generator, optional
+        Random number generator for sample selection.
+    subplot_kwargs : dict, optional
+        Additional kwargs for the subplot creation, e.g. ``figsize``.
+    axes : ndarray of Axes, optional
+        Existing axes to plot on.
+
+    Returns
+    -------
+    tuple[Figure, ndarray of Axes]
+        Figure and the axes.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        import numpy as np
+        from pymc_marketing.bass import BassModel
+
+        model = BassModel()
+        model.fit(data=adoption_counts)
+
+        fig, axes = model.plot_adoption_curve()
+    """
+    posterior = model.posterior
+    curve = _select_product(posterior["adopters"], product)
+
+    fig, axes = plot_curve(
+        curve,
+        {"T"},
+        n_samples=n_samples,
+        hdi_probs=hdi_probs,
+        random_seed=random_seed,
+        subplot_kwargs=subplot_kwargs,
+        axes=axes,
+    )
+
+    observed = _get_observed(model, product)
+    if observed is not None:
+        _overlay_observed(observed, axes)
+
+    for ax in axes.flat:
+        ax.set_xlabel("T")
+        ax.set_ylabel("New adopters")
+
+    return fig, axes
+
+
+def plot_cumulative(
+    model: "BassModel",
+    product: str | None = None,
+    n_samples: int = 10,
+    hdi_probs: float | list[float] | None = None,
+    random_seed: np.random.Generator | None = None,
+    subplot_kwargs: dict | None = None,
+    axes: npt.NDArray[Axes] | None = None,
+) -> tuple[plt.Figure, npt.NDArray[Axes]]:
+    """Plot the cumulative adoption S-curve with the observed data.
+
+    Shows posterior samples and HDI of the cumulative sum of the
+    ``adopters`` deterministic over time, with the observed cumulative
+    counts in black.
+
+    Parameters
+    ----------
+    model : BassModel
+        A fitted Bass model.
+    product : str, optional
+        Plot a single product of a multi-product model. Default plots
+        one subplot per product.
+    n_samples : int, optional
+        Number of posterior sample curves to draw. Default is 10.
+    hdi_probs : float or list of float, optional
+        HDI probabilities. Defaults to the ArviZ default (0.94).
+    random_seed : np.random.Generator, optional
+        Random number generator for sample selection.
+    subplot_kwargs : dict, optional
+        Additional kwargs for the subplot creation, e.g. ``figsize``.
+    axes : ndarray of Axes, optional
+        Existing axes to plot on.
+
+    Returns
+    -------
+    tuple[Figure, ndarray of Axes]
+        Figure and the axes.
+    """
+    posterior = model.posterior
+    curve = _select_product(posterior["adopters"], product).cumsum(dim="T")
+
+    fig, axes = plot_curve(
+        curve,
+        {"T"},
+        n_samples=n_samples,
+        hdi_probs=hdi_probs,
+        random_seed=random_seed,
+        subplot_kwargs=subplot_kwargs,
+        axes=axes,
+    )
+
+    observed = _get_observed(model, product)
+    if observed is not None:
+        _overlay_observed(observed.cumsum(dim="T"), axes)
+
+    for ax in axes.flat:
+        ax.set_xlabel("T")
+        ax.set_ylabel("Cumulative adopters")
+
+    return fig, axes
+
+
+def plot_decomposition(
+    model: "BassModel",
+    product: str | None = None,
+    n_samples: int = 10,
+    hdi_probs: float | list[float] | None = None,
+    random_seed: np.random.Generator | None = None,
+    subplot_kwargs: dict | None = None,
+    axes: npt.NDArray[Axes] | None = None,
+) -> tuple[plt.Figure, npt.NDArray[Axes]]:
+    """Plot the adoption decomposition into innovators and imitators.
+
+    Innovators and imitators (new adopters per period) are drawn on the
+    left y-axis. Cumulative adoption and the observed cumulative counts
+    are drawn on a twin right y-axis, since they are on a much larger
+    scale and would otherwise dwarf the per-period curves.
+
+    Parameters
+    ----------
+    model : BassModel
+        A fitted Bass model.
+    product : str, optional
+        Plot a single product of a multi-product model. Default plots
+        one subplot per product.
+    n_samples : int, optional
+        Number of posterior sample curves to draw. Default is 10.
+    hdi_probs : float or list of float, optional
+        HDI probabilities. Defaults to the ArviZ default (0.94).
+    random_seed : np.random.Generator, optional
+        Random number generator for sample selection.
+    subplot_kwargs : dict, optional
+        Additional kwargs for the subplot creation, e.g. ``figsize``.
+    axes : ndarray of Axes, optional
+        Existing axes to plot on.
+
+    Returns
+    -------
+    tuple[Figure, ndarray of Axes]
+        Figure and the primary (left) axes. The twin (right) axes are
+        accessible through ``fig.axes``.
+    """
+    posterior = model.posterior
+    innovators = _select_product(posterior["innovators"], product)
+    imitators = _select_product(posterior["imitators"], product)
+    cumulative = _select_product(posterior["adopters"], product).cumsum(dim="T")
+
+    n_axes = innovators.coords["product"].size if "product" in innovators.dims else 1
+    fig, axes = plot_curve(
+        innovators,
+        {"T"},
+        n_samples=n_samples,
+        hdi_probs=hdi_probs,
+        random_seed=random_seed,
+        subplot_kwargs=subplot_kwargs,
+        axes=axes,
+        colors=n_axes * ["C1"],
+        legend=False,
+    )
+    plot_curve(
+        imitators,
+        {"T"},
+        n_samples=n_samples,
+        hdi_probs=hdi_probs,
+        random_seed=random_seed,
+        axes=axes,
+        colors=n_axes * ["C2"],
+        legend=False,
+    )
+
+    twin_axes = np.array([ax.twinx() for ax in axes.flat]).reshape(axes.shape)
+    plot_curve(
+        cumulative,
+        {"T"},
+        n_samples=n_samples,
+        hdi_probs=hdi_probs,
+        random_seed=random_seed,
+        axes=twin_axes,
+        colors=n_axes * ["C0"],
+        legend=False,
+    )
+
+    observed = _get_observed(model, product)
+    if observed is not None:
+        _overlay_observed(observed.cumsum(dim="T"), twin_axes, linestyle="--")
+
+    for ax, twin_ax in zip(axes.flat, twin_axes.flat, strict=True):
+        ax.set_xlabel("T")
+        ax.set_ylabel("New adopters per period")
+        twin_ax.set_ylabel("Cumulative adopters")
+
+    handles = [
+        Line2D([], [], color="C1", label="innovators"),
+        Line2D([], [], color="C2", label="imitators"),
+        Line2D([], [], color="C0", label="cumulative adoption"),
+    ]
+    if observed is not None:
+        handles.append(
+            Line2D([], [], color="black", linestyle="--", label="observed cumulative")
+        )
+    axes.flat[0].legend(handles=handles, loc="upper left")
+
+    return fig, axes
+
+
+def plot_peak(
+    model: "BassModel",
+    product: str | None = None,
+    **plot_posterior_kwargs: Any,
+) -> tuple[plt.Figure, npt.NDArray[Axes]]:
+    """Plot the posterior distribution of the peak adoption time.
+
+    Parameters
+    ----------
+    model : BassModel
+        A fitted Bass model.
+    product : str, optional
+        Plot a single product of a multi-product model. Default plots
+        one subplot per product.
+    **plot_posterior_kwargs
+        Additional kwargs forwarded to :func:`arviz.plot_posterior`.
+
+    Returns
+    -------
+    tuple[Figure, ndarray of Axes]
+        Figure and the axes.
+    """
+    posterior = model.posterior
+    peak = _select_product(posterior["peak"], product)
+
+    axes = np.atleast_1d(az.plot_posterior(peak, **plot_posterior_kwargs))
+    fig = axes.flat[0].get_figure()
+
+    return fig, axes

--- a/pymc_marketing/bass/plotting.py
+++ b/pymc_marketing/bass/plotting.py
@@ -24,7 +24,7 @@ The functions are also exposed as ``plot_*`` methods on
 
 from typing import TYPE_CHECKING, Any
 
-import arviz as az
+import arviz_plots as azp
 import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
@@ -322,7 +322,7 @@ def plot_decomposition(
 def plot_peak(
     model: "BassModel",
     product: str | None = None,
-    **plot_posterior_kwargs: Any,
+    **plot_dist_kwargs: Any,
 ) -> tuple[plt.Figure, npt.NDArray[Axes]]:
     """Plot the posterior distribution of the peak adoption time.
 
@@ -333,8 +333,8 @@ def plot_peak(
     product : str, optional
         Plot a single product of a multi-product model. Default plots
         one subplot per product.
-    **plot_posterior_kwargs
-        Additional kwargs forwarded to :func:`arviz.plot_posterior`.
+    **plot_dist_kwargs
+        Additional kwargs forwarded to :func:`arviz_plots.plot_dist`.
 
     Returns
     -------
@@ -344,7 +344,13 @@ def plot_peak(
     posterior = model.posterior
     peak = _select_product(posterior["peak"], product)
 
-    axes = np.atleast_1d(az.plot_posterior(peak, **plot_posterior_kwargs))
-    fig = axes.flat[0].get_figure()
+    # One facet column per product for a multi-product model; plot_dist
+    # otherwise overlays them on a single axis.
+    if "product" in peak.dims:
+        plot_dist_kwargs.setdefault("cols", ["product"])
+
+    pc = azp.plot_dist(peak.to_dataset(), **plot_dist_kwargs)
+    fig = pc.viz["figure"].values.item()
+    axes = np.atleast_1d(pc.viz["plot"].values)
 
     return fig, axes

--- a/pymc_marketing/bass/plotting.py
+++ b/pymc_marketing/bass/plotting.py
@@ -314,7 +314,7 @@ def plot_decomposition(
         handles.append(
             Line2D([], [], color="black", linestyle="--", label="observed cumulative")
         )
-    axes.flat[0].legend(handles=handles, loc="upper left")
+    fig.legend(handles=handles, loc="center left", bbox_to_anchor=(1.0, 0.5))
 
     return fig, axes
 

--- a/pymc_marketing/bass/plotting.py
+++ b/pymc_marketing/bass/plotting.py
@@ -15,8 +15,9 @@
 
 Each function takes a fitted :class:`~pymc_marketing.bass.model.BassModel`
 and returns a ``(Figure, ndarray of Axes)`` tuple, following the convention
-of :func:`pymc_marketing.plot.plot_curve`. Multi-product models plot one
-subplot per product; pass ``product`` to select a single one.
+of :func:`pymc_marketing.plot.plot_curve`. Multi-series models plot one
+subplot per coordinate of the faceting dimension (inferred from the data,
+or set with ``dim``); pass ``coord`` to select a single one.
 
 The functions are also exposed as ``plot_*`` methods on
 :class:`~pymc_marketing.bass.model.BassModel`.
@@ -45,37 +46,51 @@ __all__ = [
 ]
 
 
-def _select_product(da: xr.DataArray, product: str | None) -> xr.DataArray:
-    if product is None:
+def _facet_dim(da: xr.DataArray, dim: str | None) -> str | None:
+    """Return the dimension the plots facet over.
+
+    ``dim`` if given, otherwise the single non-time, non-sample
+    dimension of ``da`` (the same one :func:`plot_curve` facets over), or
+    ``None`` for a single-series model.
+    """
+    if dim is not None:
+        return dim
+    extra = [d for d in da.dims if d not in ("chain", "draw", "T")]
+    return extra[0] if extra else None
+
+
+def _select(da: xr.DataArray, dim: str | None, coord: str | None) -> xr.DataArray:
+    if coord is None:
         return da
-    if "product" not in da.dims:
+    if dim is None or dim not in da.dims:
         raise ValueError(
-            "The model has no 'product' dimension. "
-            "Remove the product argument for single-product models."
+            "The model has no faceting dimension. "
+            "Remove the coord argument for single-series models."
         )
-    return da.sel(product=product)
+    return da.sel({dim: coord})
 
 
-def _get_observed(model: "BassModel", product: str | None) -> xr.DataArray | None:
+def _get_observed(
+    model: "BassModel", dim: str | None, coord: str | None
+) -> xr.DataArray | None:
     idata = model.idata
     if idata is None or "fit_data" not in idata or "observed" not in idata.fit_data:
         return None
-    return _select_product(idata.fit_data["observed"], product)
+    return _select(idata.fit_data["observed"], dim, coord)
 
 
 def _overlay_observed(
     observed: xr.DataArray,
     axes: npt.NDArray[Axes],
+    dim: str | None,
     **plot_kwargs: Any,
 ) -> None:
-    """Plot observed data on each axes, one product per axes."""
+    """Plot observed data on each axes, one coordinate per axes."""
     plot_kwargs = {"color": "black", **plot_kwargs}
     t = observed.coords["T"].values
-    if "product" in observed.dims:
-        for ax, product in zip(
-            axes.flat, observed.coords["product"].values, strict=False
-        ):
-            ax.plot(t, observed.sel(product=product).values, **plot_kwargs)
+    if dim is not None and dim in observed.dims:
+        for ax, coord in zip(axes.flat, observed.coords[dim].values, strict=False):
+            ax.plot(t, observed.sel({dim: coord}).values, **plot_kwargs)
     else:
         for ax in axes.flat:
             ax.plot(t, observed.values, **plot_kwargs)
@@ -83,7 +98,8 @@ def _overlay_observed(
 
 def plot_adoption_curve(
     model: "BassModel",
-    product: str | None = None,
+    dim: str | None = None,
+    coord: str | None = None,
     n_samples: int = 10,
     hdi_probs: float | list[float] | None = None,
     random_seed: np.random.Generator | None = None,
@@ -99,9 +115,12 @@ def plot_adoption_curve(
     ----------
     model : BassModel
         A fitted Bass model.
-    product : str, optional
-        Plot a single product of a multi-product model. Default plots
-        one subplot per product.
+    dim : str, optional
+        Dimension to facet over. Inferred from the fitted data when not
+        given (the non-time, non-sample dimension).
+    coord : str, optional
+        Plot a single coordinate along ``dim``. Default plots one
+        subplot per coordinate.
     n_samples : int, optional
         Number of posterior sample curves to draw. Default is 10.
     hdi_probs : float or list of float, optional
@@ -131,7 +150,8 @@ def plot_adoption_curve(
         fig, axes = model.plot_adoption_curve()
     """
     posterior = model.posterior
-    curve = _select_product(posterior["adopters"], product)
+    dim = _facet_dim(posterior["adopters"], dim)
+    curve = _select(posterior["adopters"], dim, coord)
 
     fig, axes = plot_curve(
         curve,
@@ -143,9 +163,9 @@ def plot_adoption_curve(
         axes=axes,
     )
 
-    observed = _get_observed(model, product)
+    observed = _get_observed(model, dim, coord)
     if observed is not None:
-        _overlay_observed(observed, axes)
+        _overlay_observed(observed, axes, dim)
 
     for ax in axes.flat:
         ax.set_xlabel("T")
@@ -156,7 +176,8 @@ def plot_adoption_curve(
 
 def plot_cumulative(
     model: "BassModel",
-    product: str | None = None,
+    dim: str | None = None,
+    coord: str | None = None,
     n_samples: int = 10,
     hdi_probs: float | list[float] | None = None,
     random_seed: np.random.Generator | None = None,
@@ -173,9 +194,12 @@ def plot_cumulative(
     ----------
     model : BassModel
         A fitted Bass model.
-    product : str, optional
-        Plot a single product of a multi-product model. Default plots
-        one subplot per product.
+    dim : str, optional
+        Dimension to facet over. Inferred from the fitted data when not
+        given (the non-time, non-sample dimension).
+    coord : str, optional
+        Plot a single coordinate along ``dim``. Default plots one
+        subplot per coordinate.
     n_samples : int, optional
         Number of posterior sample curves to draw. Default is 10.
     hdi_probs : float or list of float, optional
@@ -193,7 +217,8 @@ def plot_cumulative(
         Figure and the axes.
     """
     posterior = model.posterior
-    curve = _select_product(posterior["adopters"], product).cumsum(dim="T")
+    dim = _facet_dim(posterior["adopters"], dim)
+    curve = _select(posterior["adopters"], dim, coord).cumsum(dim="T")
 
     fig, axes = plot_curve(
         curve,
@@ -205,9 +230,9 @@ def plot_cumulative(
         axes=axes,
     )
 
-    observed = _get_observed(model, product)
+    observed = _get_observed(model, dim, coord)
     if observed is not None:
-        _overlay_observed(observed.cumsum(dim="T"), axes)
+        _overlay_observed(observed.cumsum(dim="T"), axes, dim)
 
     for ax in axes.flat:
         ax.set_xlabel("T")
@@ -218,7 +243,8 @@ def plot_cumulative(
 
 def plot_decomposition(
     model: "BassModel",
-    product: str | None = None,
+    dim: str | None = None,
+    coord: str | None = None,
     n_samples: int = 10,
     hdi_probs: float | list[float] | None = None,
     random_seed: np.random.Generator | None = None,
@@ -236,9 +262,12 @@ def plot_decomposition(
     ----------
     model : BassModel
         A fitted Bass model.
-    product : str, optional
-        Plot a single product of a multi-product model. Default plots
-        one subplot per product.
+    dim : str, optional
+        Dimension to facet over. Inferred from the fitted data when not
+        given (the non-time, non-sample dimension).
+    coord : str, optional
+        Plot a single coordinate along ``dim``. Default plots one
+        subplot per coordinate.
     n_samples : int, optional
         Number of posterior sample curves to draw. Default is 10.
     hdi_probs : float or list of float, optional
@@ -257,11 +286,12 @@ def plot_decomposition(
         accessible through ``fig.axes``.
     """
     posterior = model.posterior
-    innovators = _select_product(posterior["innovators"], product)
-    imitators = _select_product(posterior["imitators"], product)
-    cumulative = _select_product(posterior["adopters"], product).cumsum(dim="T")
+    dim = _facet_dim(posterior["innovators"], dim)
+    innovators = _select(posterior["innovators"], dim, coord)
+    imitators = _select(posterior["imitators"], dim, coord)
+    cumulative = _select(posterior["adopters"], dim, coord).cumsum(dim="T")
 
-    n_axes = innovators.coords["product"].size if "product" in innovators.dims else 1
+    n_axes = innovators.coords[dim].size if dim in innovators.dims else 1
     fig, axes = plot_curve(
         innovators,
         {"T"},
@@ -296,9 +326,9 @@ def plot_decomposition(
         legend=False,
     )
 
-    observed = _get_observed(model, product)
+    observed = _get_observed(model, dim, coord)
     if observed is not None:
-        _overlay_observed(observed.cumsum(dim="T"), twin_axes, linestyle="--")
+        _overlay_observed(observed.cumsum(dim="T"), twin_axes, dim, linestyle="--")
 
     for ax, twin_ax in zip(axes.flat, twin_axes.flat, strict=True):
         ax.set_xlabel("T")
@@ -326,7 +356,8 @@ def plot_decomposition(
 
 def plot_peak(
     model: "BassModel",
-    product: str | None = None,
+    dim: str | None = None,
+    coord: str | None = None,
     **plot_dist_kwargs: Any,
 ) -> tuple[plt.Figure, npt.NDArray[Axes]]:
     """Plot the posterior distribution of the peak adoption time.
@@ -335,9 +366,12 @@ def plot_peak(
     ----------
     model : BassModel
         A fitted Bass model.
-    product : str, optional
-        Plot a single product of a multi-product model. Default plots
-        one subplot per product.
+    dim : str, optional
+        Dimension to facet over. Inferred from the fitted data when not
+        given (the non-time, non-sample dimension).
+    coord : str, optional
+        Plot a single coordinate along ``dim``. Default plots one
+        subplot per coordinate.
     **plot_dist_kwargs
         Additional kwargs forwarded to :func:`arviz_plots.plot_dist`.
 
@@ -347,12 +381,13 @@ def plot_peak(
         Figure and the axes.
     """
     posterior = model.posterior
-    peak = _select_product(posterior["peak"], product)
+    dim = _facet_dim(posterior["peak"], dim)
+    peak = _select(posterior["peak"], dim, coord)
 
-    # One facet column per product for a multi-product model; plot_dist
+    # One facet column per coordinate for a multi-series model; plot_dist
     # otherwise overlays them on a single axis.
-    if "product" in peak.dims:
-        plot_dist_kwargs.setdefault("cols", ["product"])
+    if dim in peak.dims:
+        plot_dist_kwargs.setdefault("cols", [dim])
 
     pc = azp.plot_dist(peak.to_dataset(), **plot_dist_kwargs)
     fig = pc.viz["figure"].values.item()

--- a/pymc_marketing/bass/plotting.py
+++ b/pymc_marketing/bass/plotting.py
@@ -314,7 +314,12 @@ def plot_decomposition(
         handles.append(
             Line2D([], [], color="black", linestyle="--", label="observed cumulative")
         )
-    fig.legend(handles=handles, loc="center left", bbox_to_anchor=(1.0, 0.5))
+    fig.legend(
+        handles=handles,
+        loc="upper center",
+        bbox_to_anchor=(0.5, -0.03),
+        ncol=len(handles),
+    )
 
     return fig, axes
 

--- a/tests/bass/test_model.py
+++ b/tests/bass/test_model.py
@@ -755,8 +755,13 @@ class TestBassModelClass:
         assert "/fit_data" in idata.groups
 
     def test_fit_deterministics(self, fitted_model: BassModel):
+        # Read through the public ``posterior`` accessor (the DataTree node),
+        # which is what the plotting methods use. Asserting against
+        # ``idata.posterior`` would pass even with the deterministics missing
+        # from the node, since under arviz>=1.2 a stray ``idata.posterior =``
+        # assignment leaves a shadowing attribute behind.
         for var in ["adopters", "innovators", "imitators", "peak"]:
-            assert var in fitted_model.idata.posterior, f"Missing deterministic: {var}"
+            assert var in fitted_model.posterior, f"Missing deterministic: {var}"
 
     def test_fit_with_dataframe(self, mock_pymc_sample):
         df = pd.DataFrame(

--- a/tests/bass/test_plotting.py
+++ b/tests/bass/test_plotting.py
@@ -1,0 +1,137 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+import xarray as xr
+from pymc_extras.prior import Prior
+
+from pymc_marketing.bass import BassModel
+
+PLOT_METHODS = [
+    "plot_adoption_curve",
+    "plot_cumulative",
+    "plot_decomposition",
+    "plot_peak",
+]
+
+
+@pytest.fixture(autouse=True)
+def close_figures():
+    yield
+    plt.close("all")
+
+
+@pytest.fixture(scope="module")
+def single_product_model(mock_pymc_sample) -> BassModel:
+    y = np.random.default_rng(42).poisson(lam=100, size=20)
+    model = BassModel()
+    model.fit(data=y, draws=20, tune=5, chains=1, random_seed=42)
+    return model
+
+
+@pytest.fixture(scope="module")
+def multi_product_model(mock_pymc_sample) -> BassModel:
+    products = ["A", "B", "C"]
+    counts = np.random.default_rng(42).poisson(lam=100, size=(20, len(products)))
+    ds = xr.Dataset(
+        {"observed": (("T", "product"), counts)},
+        coords={"T": np.arange(20), "product": products},
+    )
+    model = BassModel(
+        model_config={
+            "m": Prior("Normal", mu=1000, sigma=200, dims="product"),
+            "p": Prior("Beta", alpha=1.5, beta=20, dims="product"),
+            "q": Prior("Beta", alpha=2, beta=5, dims="product"),
+            "likelihood": Prior("Poisson"),
+        },
+    )
+    model.fit(data=ds, draws=20, tune=5, chains=1, random_seed=42)
+    return model
+
+
+@pytest.mark.parametrize("method", PLOT_METHODS)
+def test_single_product(single_product_model: BassModel, method: str) -> None:
+    fig, axes = getattr(single_product_model, method)()
+
+    assert isinstance(fig, plt.Figure)
+    assert isinstance(axes, np.ndarray)
+    assert axes.size == 1
+
+
+@pytest.mark.parametrize("method", PLOT_METHODS)
+def test_multi_product_grid(multi_product_model: BassModel, method: str) -> None:
+    fig, axes = getattr(multi_product_model, method)()
+
+    assert isinstance(fig, plt.Figure)
+    assert axes.size == 3
+
+
+@pytest.mark.parametrize("method", PLOT_METHODS)
+def test_multi_product_selection(multi_product_model: BassModel, method: str) -> None:
+    fig, axes = getattr(multi_product_model, method)(product="B")
+
+    assert isinstance(fig, plt.Figure)
+    assert axes.size == 1
+
+
+@pytest.mark.parametrize("n_products", [1, 3], ids=["single", "multi"])
+def test_decomposition_twin_axes(
+    single_product_model: BassModel,
+    multi_product_model: BassModel,
+    n_products: int,
+) -> None:
+    model = single_product_model if n_products == 1 else multi_product_model
+    fig, axes = model.plot_decomposition()
+
+    # One twin (right) axis per primary (left) axis
+    assert axes.size == n_products
+    assert len(fig.axes) == 2 * n_products
+
+
+def test_observed_data_overlaid(single_product_model: BassModel) -> None:
+    _, axes = single_product_model.plot_adoption_curve()
+
+    observed = single_product_model.idata.fit_data["observed"].values
+    overlay = [line for line in axes.flat[0].get_lines() if line.get_color() == "black"]
+    assert len(overlay) == 1
+    np.testing.assert_array_equal(overlay[0].get_ydata(), observed)
+
+
+def test_observed_data_aligned_per_product(multi_product_model: BassModel) -> None:
+    _, axes = multi_product_model.plot_adoption_curve()
+
+    observed = multi_product_model.idata.fit_data["observed"]
+    products = observed.coords["product"].values
+    for ax, product in zip(axes.flat, products, strict=True):
+        overlay = [line for line in ax.get_lines() if line.get_color() == "black"]
+        assert len(overlay) == 1
+        np.testing.assert_array_equal(
+            overlay[0].get_ydata(), observed.sel(product=product).values
+        )
+
+
+@pytest.mark.parametrize("method", PLOT_METHODS)
+def test_unfitted_model_raises(method: str) -> None:
+    model = BassModel()
+    with pytest.raises(RuntimeError, match="hasn't been fit"):
+        getattr(model, method)()
+
+
+@pytest.mark.parametrize("method", PLOT_METHODS)
+def test_product_on_single_product_raises(
+    single_product_model: BassModel, method: str
+) -> None:
+    with pytest.raises(ValueError, match="no 'product' dimension"):
+        getattr(single_product_model, method)(product="A")

--- a/tests/bass/test_plotting.py
+++ b/tests/bass/test_plotting.py
@@ -61,6 +61,27 @@ def multi_product_model(mock_pymc_sample) -> BassModel:
     return model
 
 
+@pytest.fixture(scope="module")
+def region_model(mock_pymc_sample) -> BassModel:
+    """Multi-series model whose faceting dimension is named "region"."""
+    regions = ["north", "south", "east"]
+    counts = np.random.default_rng(42).poisson(lam=100, size=(20, len(regions)))
+    ds = xr.Dataset(
+        {"observed": (("T", "region"), counts)},
+        coords={"T": np.arange(20), "region": regions},
+    )
+    model = BassModel(
+        model_config={
+            "m": Prior("Normal", mu=1000, sigma=200, dims="region"),
+            "p": Prior("Beta", alpha=1.5, beta=20, dims="region"),
+            "q": Prior("Beta", alpha=2, beta=5),
+            "likelihood": Prior("Poisson"),
+        },
+    )
+    model.fit(data=ds, draws=20, tune=5, chains=1, random_seed=42)
+    return model
+
+
 @pytest.mark.parametrize("method", PLOT_METHODS)
 def test_single_product(single_product_model: BassModel, method: str) -> None:
     fig, axes = getattr(single_product_model, method)()
@@ -80,10 +101,31 @@ def test_multi_product_grid(multi_product_model: BassModel, method: str) -> None
 
 @pytest.mark.parametrize("method", PLOT_METHODS)
 def test_multi_product_selection(multi_product_model: BassModel, method: str) -> None:
-    fig, axes = getattr(multi_product_model, method)(product="B")
+    fig, axes = getattr(multi_product_model, method)(coord="B")
 
     assert isinstance(fig, plt.Figure)
     assert axes.size == 1
+
+
+@pytest.mark.parametrize("method", PLOT_METHODS)
+def test_custom_facet_dim(region_model: BassModel, method: str) -> None:
+    # A model whose series dimension is "region", not "product": the dim is
+    # inferred, no need to name it.
+    _, axes = getattr(region_model, method)()
+    assert axes.size == 3
+
+    # and a single coordinate along the inferred dimension can be selected.
+    _, axes_one = getattr(region_model, method)(coord="south")
+    assert axes_one.size == 1
+
+
+def test_custom_dim_observed_overlay(region_model: BassModel) -> None:
+    # Each subplot overlays only its own coordinate's observed data, not all
+    # of them (regression guard: the faceting dim must match plot_curve's).
+    _, axes = region_model.plot_adoption_curve()
+    for ax in axes.flat:
+        black = [ln for ln in ax.get_lines() if ln.get_color() == "black"]
+        assert len(black) == 1
 
 
 @pytest.mark.parametrize("n_products", [1, 3], ids=["single", "multi"])
@@ -133,5 +175,5 @@ def test_unfitted_model_raises(method: str) -> None:
 def test_product_on_single_product_raises(
     single_product_model: BassModel, method: str
 ) -> None:
-    with pytest.raises(ValueError, match="no 'product' dimension"):
-        getattr(single_product_model, method)(product="A")
+    with pytest.raises(ValueError, match="no faceting dimension"):
+        getattr(single_product_model, method)(coord="A")


### PR DESCRIPTION
Closes #2589
Related to #1706

Retargeted to `v1.0.0`.

Adds four plotting methods to `BassModel`, built on `pymc_marketing.plot.plot_curve`:

- `plot_adoption_curve`: posterior new adopters per period with HDI, observed counts overlaid.
- `plot_cumulative`: cumulative adoption S-curve with HDI, observed cumulative overlaid.
- `plot_decomposition`: innovators and imitators per period on the left y-axis, cumulative adoption on a twin right y-axis (the dual-axes design from #1706).
- `plot_peak`: posterior of the peak adoption time.

All live in `pymc_marketing.bass.plotting` and are exposed as `plot_*` methods on `BassModel`. Each returns `(fig, axes)`, so `mlflow.log_figure` works with the autolog workflow in #2624.

v1 adaptations:

- `plot_peak` uses `arviz_plots.plot_dist` (arviz 1.2 removed `arviz.plot_posterior`), faceting by product for multi-product models.
- Fixes a v1 regression in `BassModel.fit`: under arviz 1.2 `InferenceData` subclasses `xarray.DataTree`, so `idata.posterior = compute_deterministics(...)` set a shadowing attribute and dropped the deterministics (`adopters`, `innovators`, `imitators`, `peak`) from the fitted posterior. The plots need those, so `fit` now writes to the `idata["posterior"]` node.
