### PR TITLE
fix: pin pymc-extras<0.11.0 and matplotlib<3.11 on v1.0.0 branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 dependencies = [
     "arviz>=0.13.0,<1.0.0",
     "arviz-plots[matplotlib]>=1.0.0,<2.0",
-    "matplotlib>=3.5.1",
+    "matplotlib>=3.5.1,<3.11",
     "narwhals",
     "numpy>=2.0",
     "pandas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "xarray>=2024.1.0",
     "xarray-einstats>=0.5.1",
     "pyprojroot",
-    "pymc-extras>=0.9.2",
+    "pymc-extras>=0.9.2,<0.11.0",
     "preliz>=0.20.0",
     "pyyaml",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -4099,7 +4099,7 @@ requires-dist = [
     { name = "ipywidgets", marker = "extra == 'docs'" },
     { name = "jax", marker = "extra == 'test'" },
     { name = "labs-sphinx-theme", marker = "extra == 'docs'" },
-    { name = "matplotlib", specifier = ">=3.5.1" },
+    { name = "matplotlib", specifier = ">=3.5.1,<3.11" },
     { name = "mlflow", marker = "extra == 'docs'", specifier = ">=2.0.0" },
     { name = "mlflow", marker = "extra == 'test'", specifier = ">=2.0.0" },
     { name = "mypy", marker = "extra == 'lint'" },

--- a/uv.lock
+++ b/uv.lock
@@ -4137,7 +4137,7 @@ requires-dist = [
     { name = "pymc", specifier = ">=5.28.5,<6.0.0" },
     { name = "pymc-bart", marker = "extra == 'pie'" },
     { name = "pymc-bart", marker = "extra == 'test'" },
-    { name = "pymc-extras", specifier = ">=0.9.2" },
+    { name = "pymc-extras", specifier = ">=0.9.2,<0.11.0" },
     { name = "pyprojroot" },
     { name = "pyprojroot", marker = "extra == 'test'" },
     { name = "pytensor", specifier = ">=2.38.2,<3.0.0" },


### PR DESCRIPTION
## Summary
Backports two dependency pins to the `v1.0.0` branch so the "build source distribution" job (and any fresh install) works again. Both mirror fixes on `main`; lockfile metadata updated to match (resolved versions were already compatible, so only the requirement specifiers change).

- `pymc-extras>=0.9.2,<0.11.0` (from #2623, merged on `main`): pymc-extras 0.11.0+ requires `arviz>=1.1`, conflicting with our `arviz<1.0.0` pin — pip fails with `ResolutionImpossible`.
- `matplotlib>=3.5.1,<3.11` (from #2626, approved on `main`): matplotlib 3.11.0 removed the deprecated `matplotlib.style.core` shim that arviz-plots 1.1.0 accesses at import time, so importing `pymc_marketing` fails with `AttributeError`. Droppable once an arviz-plots release includes arviz-devs/arviz-plots#466.

These currently break every PR targeting `v1.0.0` (e.g. #2570).

## Test plan
- [x] `uv lock` resolves cleanly (only requirement specifiers change in the lockfile)
- [x] pre-commit clean
- [ ] "build source distribution" job green on this PR