### PR TITLE
Warn on unused model_config keys

### DIFF
--- a/pymc_marketing/model_builder.py
+++ b/pymc_marketing/model_builder.py
@@ -603,6 +603,8 @@ class ModelBuilder(ABC, ModelIO):
         model_config : Dictionary, optional
             dictionary of parameters that initialise model configuration.
             Class-default defined by the user default_model_config method.
+            A ``UserWarning`` is raised for any key not present in
+            ``default_model_config``, since such keys are ignored by the model.
         sampler_config : Dictionary, optional
             dictionary of parameters that initialise sampler configuration.
             Class-default defined by the user default_sampler_config method.
@@ -625,9 +627,22 @@ class ModelBuilder(ABC, ModelIO):
         self.sampler_config = (
             self.default_sampler_config | sampler_config
         )  # Parameters for fit sampling
+        default_model_config = self.default_model_config
         self.model_config = (
-            self.default_model_config | model_config
+            default_model_config | model_config
         )  # parameters for priors etc.
+
+        # Warn about model_config keys that the model does not use, so that
+        # typos (e.g. "alphaa" instead of "alpha") don't silently get ignored.
+        unused_model_config_keys = set(model_config) - set(default_model_config)
+        if unused_model_config_keys:
+            warnings.warn(
+                "The following model_config keys are not used by the model "
+                f"and will be ignored: {sorted(unused_model_config_keys)}. "
+                f"Valid keys are: {sorted(default_model_config)}.",
+                UserWarning,
+                stacklevel=2,
+            )
 
         self.model: pm.Model
         self.idata: xr.DataTree | None = None  # idata is generated during fitting

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -296,6 +296,18 @@ def test_model_configuration(model_class, expected_type, test_config):
     assert nondefault.sampler_config == default.sampler_config | {"draws": 42}
 
 
+def test_model_config_warns_on_unused_keys():
+    """Unknown model_config keys should warn so typos are not silently ignored."""
+    with pytest.warns(UserWarning, match="not used by the model"):
+        ModelBuilderTest(model_config={"mu_loc": 5, "typo_key": 1})
+
+
+def test_model_config_no_warning_for_valid_keys(recwarn):
+    """No unused-key warning is raised when every key is a valid default key."""
+    ModelBuilderTest(model_config={"mu_loc": 5})
+    assert not [w for w in recwarn if "not used by the model" in str(w.message)]
+
+
 @pytest.mark.parametrize(
     "test_case,model_class,method,expected_error,args",
     [


### PR DESCRIPTION
Closes #1256.

## Problem

`ModelBuilder.__init__` merges user config with `self.default_model_config | model_config`. Any key the user passes that is **not** part of `default_model_config` is silently merged in and then ignored by the model. A typo like `model_config={"alphaa": ...}` (instead of `"alpha"`) leaves the user wondering why their model didn't change.

## Change

After the merge, warn about keys that the model does not use:

```python
unused_model_config_keys = set(model_config) - set(default_model_config)
if unused_model_config_keys:
    warnings.warn(
        "The following model_config keys are not used by the model "
        f"and will be ignored: {sorted(unused_model_config_keys)}. "
        f"Valid keys are: {sorted(default_model_config)}.",
        UserWarning,
        stacklevel=2,
    )
```

- Chose a **`UserWarning`** rather than raising, to stay backward compatible (existing code passing extra keys keeps working). Happy to switch to raising a `ModelConfigError` if you'd prefer stricter behavior.
- `default_model_config` is cached in a local so the property isn't evaluated twice.
- Updated the `model_config` docstring to mention the warning.

## Tests

Added to `tests/test_model_builder.py`:
- `test_model_config_warns_on_unused_keys` — unknown key triggers the warning.
- `test_model_config_no_warning_for_valid_keys` — valid-only config stays silent.

This assumes `default_model_config` enumerates every key a model uses (per its docstring). If some model intentionally accepts keys outside it, the warning is harmless (no break) and we can refine the check.

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2632.org.readthedocs.build/en/2632/

<!-- readthedocs-preview pymc-marketing end -->