### PR TITLE
Fix flaky test_log_model_graph_no_graphviz polluted by MLflow infra logs

### DIFF
--- a/pymc_marketing/mlflow.py
+++ b/pymc_marketing/mlflow.py
@@ -184,6 +184,8 @@ from pymc_marketing.mmm import MMM
 from pymc_marketing.mmm.evaluation import compute_summary_metrics
 from pymc_marketing.version import __version__
 
+logger = logging.getLogger(__name__)
+
 # MLflow 3.0.0+ deprecated artifact_path in favor of name
 _MLFLOW_SUPPORTS_NAME_PARAM = version.parse(mlflow.__version__) >= version.parse(
     "3.0.0"
@@ -450,7 +452,7 @@ def log_model_graph(model: Model, path: str | Path) -> None:
             "Unable to render the model graph. Please install the graphviz package. "
             f"{e}"
         )
-        logging.info(msg)
+        logger.info(msg)
 
         return None
 
@@ -458,7 +460,7 @@ def log_model_graph(model: Model, path: str | Path) -> None:
         saved_path = graph.render(path)
     except Exception as e:
         msg = f"Unable to render the model graph. {e}"
-        logging.info(msg)
+        logger.info(msg)
         return None
     else:
         _log_and_remove_artifact(saved_path)

--- a/tests/test_mlflow.py
+++ b/tests/test_mlflow.py
@@ -281,10 +281,20 @@ def test_log_model_graph_no_graphviz(
         side_effect=side_effect,
     )
     with mlflow.start_run() as run:
-        with caplog.at_level(logging.INFO):
+        with caplog.at_level(logging.INFO, logger="pymc_marketing.mlflow"):
             log_model_graph(model_with_likelihood, "model_graph")
 
-    assert caplog.messages == [
+    # Only inspect records emitted by pymc-marketing itself. caplog's handler is
+    # attached to the root logger, so it also captures unrelated INFO logs from
+    # third-party libraries (e.g. MLflow's "Creating initial MLflow database
+    # tables..." emitted on first backend-store creation), which would otherwise
+    # make this assertion order-dependent and flaky.
+    messages = [
+        record.message
+        for record in caplog.records
+        if record.name == "pymc_marketing.mlflow"
+    ]
+    assert messages == [
         expected_info_message,
     ]
 


### PR DESCRIPTION
## Problem

CI was failing across PRs (e.g. https://github.com/pymc-labs/pymc-marketing/actions/runs/28073259746) on:

```
tests/test_mlflow.py::test_log_model_graph_no_graphviz[no_graphviz]
assert caplog.messages == [expected_info_message]
At index 0 diff: 'Creating initial MLflow database tables...'
              != 'Unable to render the model graph. Please install the graphviz package. ...'
```

## Root cause

`test_log_model_graph_no_graphviz` captures log output with `caplog.at_level(logging.INFO)` and then asserts **strict equality** on `caplog.messages`:

```python
with caplog.at_level(logging.INFO):
    log_model_graph(model_with_likelihood, "model_graph")
assert caplog.messages == [expected_info_message]
```

`caplog`'s capture handler is attached to the **root** logger, so it records INFO logs from *every* logger, not just our code. The source under test logged via the root logger too (`logging.info(...)` in `pymc_marketing/mlflow.py`).

The first time any test in a worker creates an MLflow run against a fresh SQLite backend store, MLflow emits an INFO record on `mlflow.store.db.utils`:

```
Creating initial MLflow database tables...
```

When this test happens to be the first to touch the MLflow DB (which depends on test ordering / `pytest-xdist` sharding), that infra message lands in `caplog` ahead of our expected message and the strict-equality assertion fails. This is why it failed **non-deterministically across unrelated PRs**, and consistently in test shard 1. The `[render_error]` parametrization passed because by then the DB already existed, so no extra log was emitted — confirming the ordering dependency.

## Fix (not a workaround)

Two complementary changes that make the test deterministic *and* improve the library:

1. **`pymc_marketing/mlflow.py`** — log through a module-level logger (`logger = logging.getLogger(__name__)`) instead of the root logger. Logging to the root logger from a library is an anti-pattern: it gives callers no way to configure or silence our logs independently. Now our records carry the name `pymc_marketing.mlflow`.

2. **`tests/test_mlflow.py`** — scope the capture to our logger and filter `caplog.records` by logger name before asserting, so the test only inspects messages emitted by our own code:

   ```python
   with caplog.at_level(logging.INFO, logger="pymc_marketing.mlflow"):
       log_model_graph(model_with_likelihood, "model_graph")

   messages = [
       record.message
       for record in caplog.records
       if record.name == "pymc_marketing.mlflow"
   ]
   assert messages == [expected_info_message]
   ```

The assertion is **not weakened** — it still verifies that exactly one message is emitted and that its content matches. It is simply no longer sensitive to unrelated third-party log noise or test execution order.

## Verification

Reproduced the exact failure (`At index 0 diff: 'Creating initial MLflow database tables...'`) in an isolated `caplog` test that mixes an `mlflow.store.db.utils` INFO record with the source message: the old strict-equality style fails, the new name-filtered style passes. `ruff check` passes on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2644.org.readthedocs.build/en/2644/

<!-- readthedocs-preview pymc-marketing end -->