### PR TITLE
Address review feedback on the pymc6 / DataTree migration

### DIFF
--- a/pymc_marketing/mlflow.py
+++ b/pymc_marketing/mlflow.py
@@ -332,19 +332,21 @@ def _log_and_remove_artifact(path: str | Path) -> None:
 
 
 def _force_load_idata_groups(idata: xr.DataTree) -> None:
-    """Force load all groups into memory since ArviZ does lazy loading.
+    """Force load all groups into memory since the store is read lazily.
+
+    netCDF/Zarr-backed ``DataTree`` objects load their groups lazily, so we
+    materialize every group in the tree before logging to MLflow.
 
     Parameters
     ----------
     idata : xr.DataTree
         The DataTree object to force load.
     """
-    for group in idata.groups:
-        # Convert each group to an in-memory dataset
-        if hasattr(idata, group):
-            group_data = getattr(idata, group)
-            if hasattr(group_data, "load"):
-                group_data.load()
+    # ``DataTree.groups`` yields ``/``-prefixed paths (e.g. ``"/posterior"``),
+    # which are not attribute names, so iterate the nodes directly and load
+    # each group's dataset in place.
+    for node in idata.subtree:
+        node.dataset.load()
 
 
 def _attach_run_id(idata: xr.DataTree) -> None:
@@ -561,10 +563,10 @@ def log_sample_diagnostics(
 
     """
     if "posterior" not in idata:
-        raise KeyError("InferenceData object does not contain the group posterior.")
+        raise KeyError("DataTree object does not contain the group posterior.")
 
     if "sample_stats" not in idata:
-        raise KeyError("InferenceData object does not contain the group sample_stats.")
+        raise KeyError("DataTree object does not contain the group sample_stats.")
 
     posterior = idata["posterior"]
     sample_stats = idata["sample_stats"]
@@ -606,14 +608,14 @@ def log_inference_data(
     idata: xr.DataTree,
     save_file: str | Path = "idata.nc",
 ) -> None:
-    """Log the InferenceData to MLflow.
+    """Log the DataTree to MLflow.
 
     Parameters
     ----------
     idata : xr.DataTree
         The DataTree object returned by the sampling method.
     save_file : str | Path
-        The path to save the InferenceData object as a netCDF file.
+        The path to save the DataTree object as a netCDF file.
 
     """
     idata.to_netcdf(str(save_file))
@@ -1103,7 +1105,7 @@ def autolog(
         None, the error will not be logged. Default is "sample-error.txt".
     summary_var_names : list[str], optional
         The names of the variables to include in the ArviZ summary. Default is
-        all the variables in the InferenceData object.
+        all the variables in the DataTree object.
     arviz_summary_kwargs : dict, optional
         Additional keyword arguments to pass to `az.summary`.
     log_mmm : bool, optional

--- a/pymc_marketing/model_builder.py
+++ b/pymc_marketing/model_builder.py
@@ -50,21 +50,21 @@ except ImportError:
 
 
 def create_idata_accessor(value: str, message: str):
-    """Create a property accessor for an InferenceData object.
+    """Create a property accessor for a group of the model's DataTree.
 
-    Underlying object must have an InferenceData object attribute named 'idata'.
+    Underlying object must have a ``xr.DataTree`` attribute named 'idata'.
 
     Parameters
     ----------
     value : str
-        The value to access in the InferenceData object.
+        The group to access in the DataTree.
     message : str
-        The error message to raise if the value is not found in the InferenceData object.
+        The error message to raise if the group is not found in the DataTree.
 
     Returns
     -------
     property
-        The property accessor for the InferenceData object.
+        The property accessor for the DataTree group.
 
     """
 
@@ -76,7 +76,7 @@ def create_idata_accessor(value: str, message: str):
 
     return property(
         accessor,
-        doc=f"Access the '{value}' attribute of the InferenceData object.",
+        doc=f"Access the '{value}' group of the DataTree.",
     )
 
 
@@ -800,6 +800,10 @@ class ModelBuilder(ABC, ModelIO):
             if "/posterior" in res.groups:
                 self.idata["/posterior"] = res["/posterior"].to_dataset()
             else:
+                # ``res`` has no explicit posterior group (e.g. a flat DataTree
+                # built from a bare Dataset): flatten every group's variables
+                # into a single posterior Dataset, keeping the first occurrence
+                # of each variable name.
                 posterior_flat = xr.Dataset()
                 for g in res.groups:
                     if g == "/":

--- a/pymc_marketing/pytensor_utils.py
+++ b/pymc_marketing/pytensor_utils.py
@@ -36,11 +36,6 @@ from pytensor.xtensor import xtensor_constant
 from pytensor.xtensor.vectorization import vectorize_graph
 
 
-def _as_symbolic(name: str):
-    var = Variable(name)
-    return var
-
-
 def _prefix_model(f2, prefix: str, exclude_vars: set | None = None):
     """Prefix variable and dimension names in a FunctionGraph.
 

--- a/pymc_marketing/serialization.py
+++ b/pymc_marketing/serialization.py
@@ -56,8 +56,8 @@ class DeserializationContext:
 
     Attributes
     ----------
-    idata : InferenceData or None
-        The InferenceData object being loaded from, used by deserializers
+    idata : xr.DataTree or None
+        The DataTree object being loaded from, used by deserializers
         that need to read supplementary data groups (e.g., EventAdditiveEffect
         reads df_events from a named idata group).
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,8 +211,11 @@ ignore_missing_imports = true
 [tool.mypy-scipy]
 ignore_missing_imports = true
 
+# Temporary: pin pymc-extras to a specific commit until a release containing
+# the pymc>=6 / DataTree changes is published on PyPI. Pinning the commit keeps
+# the build reproducible (an unpinned branch would resolve to a moving target).
 [tool.uv.sources]
-pymc-extras = { git = "https://github.com/pymc-devs/pymc-extras.git" }
+pymc-extras = { git = "https://github.com/pymc-devs/pymc-extras.git", rev = "ee8cc37df25f177ae7aea8a76587fb26da261a80" }
 
 [dependency-groups]
 dev = [

--- a/tests/test_mlflow.py
+++ b/tests/test_mlflow.py
@@ -658,9 +658,33 @@ def mock_idata() -> xr.DataTree:
 def test_log_sample_diagnostics_missing_group(mock_idata, selected_group: str) -> None:
     idata = xr.DataTree.from_dict({f"/{selected_group}": mock_idata[selected_group]})
     missing_group = "sample_stats" if selected_group == "posterior" else "posterior"
-    match = rf"InferenceData object does not contain the group {missing_group}."
+    match = rf"DataTree object does not contain the group {missing_group}."
     with pytest.raises(KeyError, match=match):
         log_sample_diagnostics(idata)
+
+
+def test_force_load_idata_groups_visits_every_group(mock_idata, monkeypatch) -> None:
+    """Regression test: ``_force_load_idata_groups`` must load every group.
+
+    ``DataTree.groups`` yields ``/``-prefixed paths (e.g. ``"/posterior"``),
+    so the previous ``hasattr(idata, group)`` guard was always ``False`` and
+    the function silently loaded nothing. Spy on ``Dataset.load`` to assert
+    each group's dataset is actually materialized.
+    """
+    loaded_vars: list[set[str]] = []
+    original_load = xr.Dataset.load
+
+    def spy_load(self, *args, **kwargs):
+        loaded_vars.append(set(self.data_vars))
+        return original_load(self, *args, **kwargs)
+
+    monkeypatch.setattr(xr.Dataset, "load", spy_load)
+
+    pmm_mlflow._force_load_idata_groups(mock_idata)
+
+    all_loaded = set().union(*loaded_vars) if loaded_vars else set()
+    assert {"mu", "sigma"} <= all_loaded
+    assert {"diverging", "energy"} <= all_loaded
 
 
 @pytest.fixture

--- a/uv.lock
+++ b/uv.lock
@@ -3959,7 +3959,7 @@ wheels = [
 [[package]]
 name = "pymc-extras"
 version = "0.12.2.dev1+gee8cc37df"
-source = { git = "https://github.com/pymc-devs/pymc-extras.git#ee8cc37df25f177ae7aea8a76587fb26da261a80" }
+source = { git = "https://github.com/pymc-devs/pymc-extras.git?rev=ee8cc37df25f177ae7aea8a76587fb26da261a80#ee8cc37df25f177ae7aea8a76587fb26da261a80" }
 dependencies = [
     { name = "arviz" },
     { name = "better-optimize" },
@@ -4137,7 +4137,7 @@ requires-dist = [
     { name = "pymc", specifier = ">=6.0.0" },
     { name = "pymc-bart", marker = "extra == 'pie'", specifier = ">=0.12.0" },
     { name = "pymc-bart", marker = "extra == 'test'", specifier = ">=0.12.0" },
-    { name = "pymc-extras", git = "https://github.com/pymc-devs/pymc-extras.git" },
+    { name = "pymc-extras", git = "https://github.com/pymc-devs/pymc-extras.git?rev=ee8cc37df25f177ae7aea8a76587fb26da261a80" },
     { name = "pyprojroot" },
     { name = "pyprojroot", marker = "extra == 'test'" },
     { name = "pytensor", specifier = ">=3.0.0" },


### PR DESCRIPTION
Follow-up to the review of #2616, addressing the concrete issues raised. Scoped to library source + tests; no notebook changes.

## Bug fixes (with tests)

**1. `mlflow._force_load_idata_groups` was a silent no-op.**
```python
for group in idata.groups:        # DataTree.groups -> "/posterior", "/sample_stats", ...
    if hasattr(idata, group):     # hasattr(idata, "/posterior") -> always False
        ...
```
`DataTree.groups` yields `/`-prefixed paths, so the guard never passed and no group was ever materialized — lazy (netCDF/Zarr-backed) idata was not force-loaded before MLflow logging. Replaced with iteration over `idata.subtree`, loading each group's dataset in place. Verified the data is genuinely materialized (the backing file can be deleted afterwards and values still read), and added `test_force_load_idata_groups_visits_every_group`.

**2. `pytensor_utils._as_symbolic` was dead and broken.** Never called (the old `as_symbolic` usage was replaced inline by `StringConstant(dim.type, ...)`), and `Variable(name)` mis-constructs a `Variable` (first positional arg is `type`). Removed.

## Reproducibility

**3. `pymc-extras` was pinned to a moving git branch.** `[tool.uv.sources]` pointed at `pymc-extras.git` with no rev, so it resolved to whatever HEAD happened to be. Pinned to the exact commit already in `uv.lock` (`ee8cc37`) so the build is reproducible. The lock change is just the `?rev=` annotation of the same commit — no resolution change. Left a comment noting this is temporary until a pymc-extras release with the pymc>=6/DataTree changes lands on PyPI.

## Docstring / message cleanup

**4. Remaining `InferenceData` references** where the object is now concretely a `DataTree`: the two user-facing `KeyError` messages in `log_sample_diagnostics`, `log_inference_data` / `autolog` docstrings, `create_idata_accessor` docstrings, and the `DeserializationContext.idata` docstring. (Deliberately left alone: the `InferenceDataGroupSchema` class name, and prose referring to the arviz *concept* — renaming those is out of scope for this migration.) Updated the corresponding test assertion for the new message text.

**5. `model_builder.fit_result` setter** — added a comment explaining the flatten-into-posterior branch (when `res` has no explicit posterior group).

## Deliberately NOT changed (need author input)

- **ADVI convergence callback** removed from `clv/models/basic.py::_fit_approx` (`CheckParametersConvergence`). This is a behavior change, not part of the API migration, and @williambdean's own inline "Need to look into this" is on this file — flagging rather than guessing. Was it intentional (e.g. callback API changed under pymc 6) or an accidental drop?
- **`fit()` idiom drift** between `bass/model.py` (keeps `.copy()` before `.update()`) and `model_builder.py` (mutates in place); and `fit_data` assignment via `xr.DataTree(ds)` vs raw Dataset. All functionally correct — left for a consistency pass if desired rather than risk altering `fit()` semantics on a green branch.
- **`residuals_posterior_distribution` rendering** (`az.plot_dist` → `sns.kdeplot` + quantile `axvline`s) — a necessary consequence of the arviz API change; visual semantics differ slightly, worth an eyeball but not a bug.
- **`@OriolAbril`'s `.dataset` (view) / `.children` style suggestions** — left as-is to avoid introducing view-aliasing subtleties / behavior changes for nested trees; happy to apply if you'd prefer.

## Testing

Ran `tests/test_mlflow.py` for the touched paths — the new force-load test and the updated `test_log_sample_diagnostics_missing_group` pass. `ruff check` / `ruff format --check` clean on all changed files. (Couldn't run the full suite locally — optional samplers and graphviz aren't installed in the sandbox — but confirmed the unrelated failures are identical with and without these changes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2645.org.readthedocs.build/en/2645/

<!-- readthedocs-preview pymc-marketing end -->