### PR TITLE
feat(plot): add n_samples=0 support and list hdi_prob in plot_hdi

### DIFF
--- a/pymc_marketing/plot.py
+++ b/pymc_marketing/plot.py
@@ -456,7 +456,7 @@ def _plot_across_coord(
 def plot_hdi(
     curve: xr.DataArray,
     non_grid_names: str | set[str],
-    hdi_prob: float | None = None,
+    hdi_prob: Sequence[float | None] | float | None = None,
     hdi_kwargs: dict | None = None,
     subplot_kwargs: dict[str, Any] | None = None,
     plot_kwargs: dict[str, Any] | None = None,
@@ -475,10 +475,17 @@ def plot_hdi(
     non_grid_names : str | set[str]
         The names to exclude from the grid. chain and draw are
         excluded automatically
-    n : int, optional
-        Number of samples to plot
-    rng : np.random.Generator, optional
-        Random number generator
+    hdi_prob : float | list[float], optional
+        HDI probabilities. Defaults to None which uses arviz default for
+        stats.ci_prob which is 94%
+    hdi_kwargs : dict, optional
+        Kwargs for the arviz.hdi function
+    same_axes : bool
+        All of the plots in the same axis
+    colors : Iterable[str], optional
+        Colors for the plots
+    legend : bool, optional
+        If to include a legend. Defaults to True if same_axes
     axes : npt.NDArray[plt.Axes], optional
         Axes to plot on
     subplot_kwargs : dict, optional
@@ -492,37 +499,47 @@ def plot_hdi(
         Figure and the axes
 
     """
+    if isinstance(hdi_prob, list) and not hdi_prob:
+        hdi_prob = [None]
+    elif isinstance(hdi_prob, (float, int)) or hdi_prob is None:
+        hdi_prob = [hdi_prob]
+
     hdi_kwargs = hdi_kwargs or {}
-    hdi_kwargs = {**dict(prob=hdi_prob), **hdi_kwargs}
-    get_plot_data = _create_get_hdi_plot_data(hdi_kwargs)
-    make_selection = _make_hdi_selection
-    plot_selection = _plot_hdi_selection
 
-    if isinstance(non_grid_names, str):
-        non_grid_names = {non_grid_names}
+    for ihdi_prob in hdi_prob:
+        current_hdi_kwargs = {**hdi_kwargs, **dict(prob=ihdi_prob)}
 
-    if "sample" in curve.dims:
-        curve = _unstack_sample(curve)
+        if "sample" in curve.dims:
+            curve = _unstack_sample(curve)
 
-    plot_kwargs = plot_kwargs or {}
-    plot_kwargs = {**{"alpha": 0.25}, **plot_kwargs}
+        get_plot_data = _create_get_hdi_plot_data(current_hdi_kwargs)
+        make_selection = _make_hdi_selection
+        plot_selection = _plot_hdi_selection
 
-    return _plot_across_coord(
-        curve=curve,
-        non_grid_names=non_grid_names,
-        get_plot_data=get_plot_data,
-        make_selection=make_selection,
-        plot_selection=plot_selection,
-        subplot_kwargs=subplot_kwargs,
-        same_axes=same_axes,
-        axes=axes,
-        colors=colors,
-        legend=legend,
-        plot_kwargs=plot_kwargs,
-        patch=True,
-        line=False,
-        sel_to_string=sel_to_string,
-    )
+        if isinstance(non_grid_names, str):
+            non_grid_names = {non_grid_names}
+
+        plot_kwargs = plot_kwargs or {}
+        plot_kwargs = {**{"alpha": 0.25}, **plot_kwargs}
+
+        fig, axes = _plot_across_coord(
+            curve=curve,
+            non_grid_names=non_grid_names,
+            get_plot_data=get_plot_data,
+            make_selection=make_selection,
+            plot_selection=plot_selection,
+            subplot_kwargs=subplot_kwargs,
+            same_axes=same_axes,
+            axes=axes,
+            colors=colors,
+            legend=legend,
+            plot_kwargs=plot_kwargs,
+            patch=True,
+            line=False,
+            sel_to_string=sel_to_string,
+        )
+
+    return fig, cast(npt.NDArray[Axes], axes)
 
 
 def plot_samples(
@@ -632,7 +649,7 @@ def plot_curve(
         The names to exclude from the grid. HDI and samples both
         have defaults of hdi and chain, draw, respectively
     n_samples : int, optional
-        Number of samples
+        Number of samples to plot
     hdi_probs : float | list[float], optional
         HDI probabilities. Defaults to None which uses arviz default for
         stats.ci_prob which is 94%
@@ -750,42 +767,48 @@ def plot_curve(
         hdi_probs = [hdi_probs]  # type: ignore
 
     hdi_kwargs = hdi_kwargs or {}
-    sample_kwargs = sample_kwargs or {}
-
-    sample_kwargs = {**dict(n=n_samples, rng=random_seed), **sample_kwargs}
-
-    if "subplot_kwargs" not in sample_kwargs:
-        sample_kwargs["subplot_kwargs"] = subplot_kwargs
-
-    if "axes" not in sample_kwargs:
-        sample_kwargs["axes"] = axes
 
     if same_axes:
-        sample_kwargs["same_axes"] = True
-        sample_kwargs["legend"] = False
         hdi_kwargs["same_axes"] = True
         hdi_kwargs["legend"] = legend if isinstance(legend, bool) else True
 
     if colors is not None:
-        sample_kwargs["colors"] = colors
         hdi_kwargs["colors"] = colors
 
     if sel_to_string is not None:
-        sample_kwargs["sel_to_string"] = sel_to_string
         hdi_kwargs["sel_to_string"] = sel_to_string
 
-    fig, axes = plot_samples(
+    if n_samples > 0:
+        sample_kwargs = sample_kwargs or {}
+
+        sample_kwargs = {**dict(n=n_samples, rng=random_seed), **sample_kwargs}
+        if "subplot_kwargs" not in sample_kwargs:
+            sample_kwargs["subplot_kwargs"] = subplot_kwargs
+
+        if "axes" not in sample_kwargs:
+            sample_kwargs["axes"] = axes
+
+        if same_axes:
+            sample_kwargs["same_axes"] = True
+            sample_kwargs["legend"] = False
+        if colors is not None:
+            sample_kwargs["colors"] = colors
+
+        if sel_to_string is not None:
+            sample_kwargs["sel_to_string"] = sel_to_string
+
+        fig, axes = plot_samples(curve, non_grid_names=non_grid_names, **sample_kwargs)
+
+    elif n_samples == 0:
+        if "subplot_kwargs" not in hdi_kwargs:
+            hdi_kwargs["subplot_kwargs"] = subplot_kwargs
+
+    fig, axes = plot_hdi(
         curve,
+        hdi_prob=hdi_probs,
         non_grid_names=non_grid_names,
-        **sample_kwargs,
+        axes=axes,
+        **hdi_kwargs,
     )
-    for hdi_prob in hdi_probs:
-        fig, axes = plot_hdi(
-            curve,
-            hdi_prob=hdi_prob,
-            non_grid_names=non_grid_names,
-            axes=axes,
-            **hdi_kwargs,
-        )
 
     return fig, axes

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -226,6 +226,40 @@ def test_plot_curve_combined_sample_n_samples(mock_curve_combined) -> None:
     plt.close(fig)
 
 
+def test_plot_curve_n_samples_zero(mock_curve) -> None:
+    fig, axes = plot_curve(mock_curve, non_grid_names={"day"}, n_samples=0)
+
+    assert axes.size == mock_curve.sizes["geo"]
+    assert isinstance(fig, plt.Figure)
+    plt.close(fig)
+
+
+def test_plot_curve_n_samples_zero_multi_hdi(mock_curve) -> None:
+    fig, axes = plot_curve(
+        mock_curve, non_grid_names={"day"}, n_samples=0, hdi_probs=[0.5, 0.8, 0.95]
+    )
+
+    assert axes.size == mock_curve.sizes["geo"]
+    assert isinstance(fig, plt.Figure)
+    plt.close(fig)
+
+
+def test_plot_hdi_multiple_hdi_probs(mock_curve) -> None:
+    fig, axes = plot_hdi(mock_curve, non_grid_names={"day"}, hdi_prob=[0.5, 0.8, 0.95])
+
+    assert axes.size == mock_curve.sizes["geo"]
+    assert isinstance(fig, plt.Figure)
+    plt.close(fig)
+
+
+def test_plot_hdi_empty_hdi_prob_list(mock_curve) -> None:
+    fig, axes = plot_hdi(mock_curve, non_grid_names={"day"}, hdi_prob=[])
+
+    assert axes.size == mock_curve.sizes["geo"]
+    assert isinstance(fig, plt.Figure)
+    plt.close(fig)
+
+
 @pytest.fixture
 def mock_curve_with_scalars() -> xr.DataArray:
     coords = {


### PR DESCRIPTION
Picks up and completes #2257 by @pkaf.

## Changes
1. **Allow `n_samples=0` in `plot_curve()`** — when 0, skips individual sample lines and only plots HDI bands
2. **Allow `hdi_prob` to accept a list in `plot_hdi()`** — e.g. `[0.5, 0.8, 0.95]` for multiple HDI intervals
3. **Added 4 tests** covering both new features

## What was done
- Rebased pkaf's original work from the fork onto `v1.0.0`
- Squashed 12 messy commits into one clean commit
- Added tests that were requested in review but never completed
- Resolved a merge conflict with `_unstack_sample` added since the original PR

Closes #2225

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2650.org.readthedocs.build/en/2650/

<!-- readthedocs-preview pymc-marketing end -->