### PR TITLE
Fix mypy errors blocking pre-commit on main

### DIFF
--- a/pymc_marketing/customer_choice/synthetic_data.py
+++ b/pymc_marketing/customer_choice/synthetic_data.py
@@ -306,11 +306,12 @@ def generate_blp_panel(
     nu = halton_draws(n_dgp_draws, n_random, seed=halton_seed)
     nu_alpha = nu[:, 0]
     nu_beta_idx = np.where(sigma_beta > 0)[0]
-    nu_beta_cols = {k: nu[:, 1 + i] for i, k in enumerate(nu_beta_idx)}
+    nu_beta_cols = {int(k): nu[:, 1 + i] for i, k in enumerate(nu_beta_idx)}
 
     delta = alpha_r[:, None, None] * price + np.einsum("rk,rtjk->rtj", beta_r, x) + xi
     mu_dev = sigma_alpha * nu_alpha[None, None, None, :] * price[..., None]
-    for k in nu_beta_idx:
+    for k_idx in nu_beta_idx:
+        k = int(k_idx)
         mu_dev = mu_dev + (
             sigma_beta[k] * nu_beta_cols[k][None, None, None, :] * x[..., k, None]
         )

--- a/pymc_marketing/mmm/hsgp.py
+++ b/pymc_marketing/mmm/hsgp.py
@@ -179,8 +179,8 @@ def approx_hsgp_hyperparams(
             "Unsupported covariance function. Supported options are 'expquad', 'matern52', and 'matern32'."
         )
 
-    c = max(a1 * (lengthscale_max / S), 1.2)
-    m = int(a2 * c / (lengthscale_min / S))
+    c = max(float(a1 * (lengthscale_max / S)), 1.2)
+    m = int(a2 * c / float(lengthscale_min / S))
 
     return m, c
 

--- a/pymc_marketing/mmm/lift_test.py
+++ b/pymc_marketing/mmm/lift_test.py
@@ -34,7 +34,7 @@ from pytensor.xtensor.type import XTensorVariable
 
 from pymc_marketing.mmm.components.saturation import SaturationTransformation
 
-Index = Sequence[int]
+Index = Sequence[int] | npt.NDArray
 Indices = dict[str, Index]
 Values = npt.NDArray[np.int_] | npt.NDArray | npt.NDArray[np.str_]
 


### PR DESCRIPTION
## Summary

Fixes the 6 `mypy` failures currently breaking pre-commit on `main` (see [pre-commit.ci run](https://results.pre-commit.ci/run/github/467144767/1782810614.5N6TOoywQbmfLoVpActaiw)).

## Changes

- **`customer_choice/synthetic_data.py`** — The loop variable `k` was first bound to `int` via an earlier `range()` loop, so mypy inferred it as `int`. Reassigning it from `np.where(...)[0]` (a `signedinteger` array) caused an assignment/index mismatch. Cast the index to `int` explicitly and key `nu_beta_cols` by `int`.
- **`mmm/hsgp.py`** — `max(...)` over a numpy scalar and a float produced a `SupportsDunderLT | SupportsDunderGT` union, breaking the downstream `*` operator and the declared `tuple[int, float]` return. Coerce the scalar operands to `float` before `max()`/`int()`.
- **`mmm/lift_test.py`** — Widen the `Index` alias from `Sequence[int]` to `Sequence[int] | npt.NDArray` so the `np.argmax(...)` result assigned into `indices[col]` type-checks.

## Verification

Ran `mypy --ignore-missing-imports` (matching the pre-commit hook config) against the three files — all 6 reported errors are resolved with no new errors at the affected lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2667.org.readthedocs.build/en/2667/

<!-- readthedocs-preview pymc-marketing end -->