### PR TITLE
Fix MemoryError (std::bad_alloc) rendering RMSE plot in mmm_evaluation notebook

### DIFF
--- a/docs/source/notebooks/mmm/mmm_evaluation.ipynb
+++ b/docs/source/notebooks/mmm/mmm_evaluation.ipynb
@@ -558,7 +558,6 @@
     "ax.axvline(\n",
     "    proper_rmse_mean, color=\"C2\", linestyle=\"--\", label=\"Mean of metric distribution\"\n",
     ")\n",
-    "ax.set_xlim(0, 500)\n",
     "ax.set_xlabel(\"RMSE\")\n",
     "ax.set_ylabel(\"Density\")\n",
     "ax.legend()\n",


### PR DESCRIPTION
## Problem

The **Test Notebooks** job for `mmm --start-idx 10` is failing on `nb-migration-batch-2` (PR #2665) with `MemoryError: std::bad_alloc`:

https://github.com/pymc-labs/pymc-marketing/actions/runs/28450887711/job/84312594175

The crash happens while rendering the RMSE-distribution plot (`In [8]`) of `docs/source/notebooks/mmm/mmm_evaluation.ipynb`. Both the `cvm` and `numba` variants of that shard fail at the same cell.

## Root cause

Under CI the sampler is **mocked** (`pm.sample` → `pymc.testing.mock_sample`), so the posterior-predictive draws are not meaningful and the resulting RMSE distribution spans a huge range (up to ~6e6 in a local repro). The cell forced:

```python
ax.set_xlim(0, 500)
```

which compresses the data→display scale so that the KDE line (extending to ~6e6) maps to an enormous *physical* extent. The inline backend renders with `bbox_inches="tight"`, and `get_tightbbox` does **not** respect axes clipping, so it computes a ~21,640-inch-wide figure → a ~4.3M × 1.3k pixel Agg renderer → `std::bad_alloc`.

The axvlines are not the cause — instrumented runs show the KDE line alone triggers the blow-up once `set_xlim(0, 500)` is applied.

## Fix

Drop the hard-coded `ax.set_xlim(0, 500)` and let the axis autoscale. This matches the sibling **R-squared** cell, which has no `set_xlim` and was always safe.

For a real fit the RMSE distribution and both reference lines sit in a narrow range (`naive_rmse ≈ proper_rmse_mean ≈ 351`), so the rendered figure is visually equivalent. Under the mocked CI sampler the figure now renders at a sane size.

## Verification

Reproduced and verified locally with the exact CI runner:

```
uv run python scripts/run_notebooks/runner.py \
  --notebooks docs/source/notebooks/mmm/mmm_evaluation.ipynb
# before: MemoryError: std::bad_alloc at In [8]
# after:  "Notebooks run successfully!"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2669.org.readthedocs.build/en/2669/

<!-- readthedocs-preview pymc-marketing end -->