### PR TITLE
Retry notebook execution on transient out-of-memory failures

### DIFF
--- a/scripts/run_notebooks/runner.py
+++ b/scripts/run_notebooks/runner.py
@@ -66,7 +66,9 @@ def _patched_output(self, outs, msg, display_id, cell_index):
 nbclient.client.NotebookClient.output = _patched_output
 
 import argparse
+import gc
 import logging
+import time
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import TypedDict
@@ -164,17 +166,70 @@ def actual_run(notebook_path: Path, kernel_name: str = KERNEL_NAME) -> None:
     )
 
 
+# Number of attempts for each notebook before giving up. Only *transient*
+# (out-of-memory) failures are retried -- see ``_is_transient_error``.
+MAX_NOTEBOOK_ATTEMPTS = 3
+
+# Markers that identify a flaky out-of-memory failure rather than a genuine
+# code error. The hosted CI runner occasionally raises a transient
+# ``MemoryError: std::bad_alloc`` while a notebook renders a figure, even
+# though peak usage is well within the runner's limit -- a noisy-neighbour /
+# momentary-pressure artifact, not a defect in the notebook.
+_TRANSIENT_ERROR_MARKERS = (
+    "MemoryError",
+    "bad_alloc",
+    "Cannot allocate memory",
+    "Unable to allocate",
+    "OutOfMemory",
+)
+
+
+def _is_transient_error(error: Exception) -> bool:
+    """Return True if *error* looks like a flaky out-of-memory failure.
+
+    Genuine notebook code errors are deterministic and therefore keep
+    failing across retries until the attempts are exhausted, so a retry is
+    safe: it only rescues transient OOM blips and never hides a real bug.
+    ``papermill.PapermillExecutionError`` carries the kernel-side exception
+    name/value in ``ename``/``evalue``, so we inspect those too.
+    """
+    haystack = " ".join(
+        str(part)
+        for part in (
+            type(error).__name__,
+            error,
+            getattr(error, "ename", ""),
+            getattr(error, "evalue", ""),
+        )
+    )
+    return any(marker in haystack for marker in _TRANSIENT_ERROR_MARKERS)
+
+
 def run_notebook(
-    notebook_path: Path, mock: bool = True, kernel_name: str = KERNEL_NAME
+    notebook_path: Path,
+    mock: bool = True,
+    kernel_name: str = KERNEL_NAME,
+    max_attempts: int = MAX_NOTEBOOK_ATTEMPTS,
 ) -> None:
     logging.info(f"Running notebook: {notebook_path.name}")
     run = mock_run if mock else actual_run
 
-    try:
-        run(notebook_path, kernel_name=kernel_name)
-    except Exception as e:
-        logging.error(f"Error running notebook: {notebook_path.name}")
-        raise e
+    for attempt in range(1, max_attempts + 1):
+        try:
+            run(notebook_path, kernel_name=kernel_name)
+            return
+        except Exception as e:
+            if _is_transient_error(e) and attempt < max_attempts:
+                logging.warning(
+                    f"Transient (out-of-memory) failure running "
+                    f"{notebook_path.name} on attempt {attempt}/{max_attempts}; "
+                    f"retrying with a fresh kernel. Error: {type(e).__name__}: {e}"
+                )
+                gc.collect()
+                time.sleep(5)
+                continue
+            logging.error(f"Error running notebook: {notebook_path.name}")
+            raise e
 
 
 class RunParams(TypedDict):


### PR DESCRIPTION
## What

Makes the `Test Notebooks` workflow resilient to a flaky
`MemoryError: std::bad_alloc` that intermittently fails the
`mmm --start-idx 10` split at `mmm_evaluation.ipynb` (seen on #2665).

The runner now retries each notebook up to 3 times, **but only when the
failure looks transient** (a `MemoryError` / `bad_alloc` / "Cannot
allocate memory" signature — including the kernel-side `ename`/`evalue`
carried by `papermill.PapermillExecutionError`). Each retry runs in a
fresh kernel after `gc.collect()` and a short pause.

## Why this is the right fix (not a notebook bug)

The crash is matplotlib's `RendererAgg.__init__` raising `std::bad_alloc`
while rendering a figure in `mmm_evaluation.ipynb` cell `In [8]`
(`prior_vs_posterior(var_names=["adstock_alpha"])`). Investigation on a
dev environment matched to CI (arviz / arviz-plots 1.2.0, matplotlib
3.10.9):

- `mmm_evaluation.ipynb` runs fine **standalone** and **within the full
  `mmm --start-idx 10` batch**; peak memory across the whole batch is
  **~1.5 GB** on an 8 GB box — the CI runner (`ubuntu-latest`) has 16 GB.
- The figure is an ordinary **1000×400 px** plot. Rendering it **70+
  times** — including the faithful inline retina + `bbox_inches="tight"`
  + `suptitle(y=1.07)` path, with varied mocked-sampling RNG — never
  reproduces the failure; axis limits are always finite and the PNG is
  ~85 KB.
- The **same notebook passed on the base branch one day earlier** with
  the identical dependency set.

A `std::bad_alloc` on a ~1.6 MB allocation, on a 16 GB runner whose peak
usage is ~1.5 GB, is a transient hosted-runner OOM blip (noisy
neighbour / momentary memory pressure), not a defect in the notebook.

## Safety

Genuine notebook code errors are deterministic: they keep failing across
retries and still surface once the attempts are exhausted. The retry
only rescues flaky OOM blips and never hides a real regression.

## Validation

- Unit-tested the retry logic: a flaky OOM recovers on retry; a
  persistent OOM raises after `MAX_NOTEBOOK_ATTEMPTS`; a real
  `ValueError` fails fast in a single attempt (no masking).
- Confirmed `mmm_evaluation.ipynb` still runs end-to-end through the
  patched runner with no behavioural change.

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2670.org.readthedocs.build/en/2670/

<!-- readthedocs-preview pymc-marketing end -->