### PR TITLE
DIAG (do not merge): probe matplotlib OOM in notebook CI

### DIFF
--- a/scripts/run_notebooks/injected.py
+++ b/scripts/run_notebooks/injected.py
@@ -6,6 +6,40 @@ import numpy as np
 import pymc as pm
 import pymc.testing
 
+# --- TEMPORARY DIAGNOSTIC (remove before merge) -------------------------------
+# Capture oversized matplotlib Agg allocations behind the intermittent
+# ``MemoryError: std::bad_alloc`` in notebook CI. We print the requested
+# width/height/dpi (and a stack) *before* the C++ buffer is allocated, so the
+# real figure dimensions are visible even when the allocation then fails.
+try:  # pragma: no cover - diagnostic only
+    import sys as _sys
+    import traceback as _tb
+
+    import matplotlib.backends.backend_agg as _bagg
+
+    _orig_renderer_init = _bagg.RendererAgg.__init__
+
+    def _diag_renderer_init(self, width, height, dpi):
+        try:
+            if float(width) * float(height) > 2e7:
+                print(
+                    f"[DIAG-OOM] RendererAgg width={width!r} height={height!r} "
+                    f"dpi={dpi!r} px={float(width) * float(height):.3e}",
+                    file=_sys.stderr,
+                    flush=True,
+                )
+                _tb.print_stack(file=_sys.stderr)
+                _sys.stderr.flush()
+        except Exception as _diag_err:  # never let the probe break rendering
+            print(f"[DIAG-OOM] probe error: {_diag_err!r}", file=_sys.stderr)
+        return _orig_renderer_init(self, width, height, dpi)
+
+    _bagg.RendererAgg.__init__ = _diag_renderer_init
+    print("[DIAG-OOM] RendererAgg probe installed", file=_sys.stderr, flush=True)
+except Exception as _diag_install_err:  # pragma: no cover
+    print(f"[DIAG-OOM] probe install failed: {_diag_install_err!r}")
+# --- END TEMPORARY DIAGNOSTIC -------------------------------------------------
+
 
 def mock_diverging(size):
     return np.zeros(size, dtype=int)


### PR DESCRIPTION
Temporary diagnostic to capture the actual matplotlib `RendererAgg` allocation dimensions behind the intermittent `MemoryError: std::bad_alloc` in the `mmm --start-idx 10` notebook split (seen on #2665). Not for merge — will be reverted once the real figure dimensions are captured from a CI run.

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2671.org.readthedocs.build/en/2671/

<!-- readthedocs-preview pymc-marketing end -->