### PR TITLE
fix: preserve metadata attrs on sample_prior/sample_posterior_predictive return values

### DIFF
--- a/pymc_marketing/model_builder.py
+++ b/pymc_marketing/model_builder.py
@@ -1286,10 +1286,9 @@ class RegressionModelBuilder(ModelBuilder):
             else:
                 self.idata = prior_pred
 
-        result = az.extract(prior_pred, "prior_predictive", combined=combined)
-        if isinstance(result, xr.DataArray):
-            result = result.to_dataset()
-
+        result = az.extract(
+            prior_pred, "prior_predictive", combined=combined, keep_dataset=True
+        )
         return result
 
     def sample_posterior_predictive(
@@ -1335,9 +1334,9 @@ class RegressionModelBuilder(ModelBuilder):
             else "posterior_predictive"
         )
 
-        result = az.extract(post_pred, variable_name, combined=combined)
-        if isinstance(result, xr.DataArray):
-            result = result.to_dataset()
+        result = az.extract(
+            post_pred, variable_name, combined=combined, keep_dataset=True
+        )
         return result
 
     def predict_proba(

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -763,6 +763,28 @@ def test_sample_prior_predictive_has_pymc_marketing_version(
     )
 
 
+@pytest.mark.parametrize("combined", [True, False])
+def test_sample_prior_predictive_returns_dataset_with_attrs(toy_X, combined):
+    model = RegressionModelBuilderTest()
+    result = model.sample_prior_predictive(toy_X, combined=combined)
+    assert isinstance(result, xr.Dataset)
+    assert "pymc_marketing_version" in result.attrs
+    assert "inference_library" in result.attrs
+    assert "inference_library_version" in result.attrs
+
+
+@pytest.mark.parametrize("combined", [True, False])
+def test_sample_posterior_predictive_returns_dataset_with_attrs(
+    fitted_regression_model_instance, toy_X, combined
+):
+    result = fitted_regression_model_instance.sample_posterior_predictive(
+        toy_X, combined=combined, extend_idata=False
+    )
+    assert isinstance(result, xr.Dataset)
+    assert "inference_library" in result.attrs
+    assert "inference_library_version" in result.attrs
+
+
 def test_fit_after_prior_keeps_prior(
     model_with_prior_predictive,
     toy_X,


### PR DESCRIPTION
Pass `keep_dataset=True` to `az.extract` in both `sample_prior_predictive` and `sample_posterior_predictive` to prevent xarray's `Dataset.__getitem__` from stripping group-level attrs when converting single-variable groups to DataArrays.

This restores metadata (`created_at`, `inference_library`, `pymc_marketing_version`, etc.) on the returned Dataset, which was lost after the PyMC 6 / DataTree migration.

**Root cause:** `az.extract` converts single-variable datasets to DataArrays via `data[var_name]` (xarray's `__getitem__`), which does not propagate dataset-level attrs to the returned DataArray. `keep_dataset=True` skips this conversion.

**Added tests:** parametrized by `combined=True/False` for both methods, verifying result is a Dataset with metadata attrs.

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2675.org.readthedocs.build/en/2675/

<!-- readthedocs-preview pymc-marketing end -->