### PR TITLE
Add merge_group trigger to CI workflows for merge queue support

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,7 @@ on:
     branches: [main, v1.0.0]
   push:
     branches: [main, v1.0.0]
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -4,6 +4,7 @@ on:
     branches: [main, v1.0.0]
   push:
     branches: [main, v1.0.0]
+  merge_group:
   release:
     types: [published]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, v1.0.0]
   push:
     branches: [main, v1.0.0]
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/test_notebook.yml
+++ b/.github/workflows/test_notebook.yml
@@ -23,6 +23,16 @@ on:
      - "docs/source/notebooks/**.ipynb"
      - "!docs/source/notebooks/mmm/**.ipynb"
      - "!docs/source/notebooks/*/dev/**.ipynb"
+  merge_group:
+    paths:
+     - "pyproject.toml"
+     - "tests/**.py"
+     - "pymc_marketing/**"
+     - ".github/workflows/test_notebook.yml"
+     - "scripts/run_notebooks/**.py"
+     - "docs/source/notebooks/**.ipynb"
+     - "!docs/source/notebooks/mmm/**.ipynb"
+     - "!docs/source/notebooks/*/dev/**.ipynb"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Adds `merge_group:` trigger to CI workflows required for enabling GitHub Merge Queue on `main` and `v1.0.0`.

Closes #2566.

### Changes

| Workflow | Change |
|---|---|
| `test.yml` | Added `merge_group:` trigger. Path filtering via `dorny/paths-filter` preserved. |
| `pypi.yml` | Added `merge_group:` trigger. Path filtering preserved. Upload/publish jobs gated on `release` only. |
| `docs.yml` | Added `merge_group:` trigger. Path filtering preserved. |
| `test_notebook.yml` | Added `merge_group:` trigger with same `paths:` filter as `pull_request`/`push`. |

### What this enables

Once merged, branch protection can be updated:
1. **Enable** "Require merge queue" on `main` and `v1.0.0` (squash, concurrency 1, timeout 60m)
2. **Disable** "Require branches to be up to date" (`strict`) — the queue handles rebase + re-test

Eliminates the manual "Update branch" → wait-for-CI → "Merge" bottleneck.

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2676.org.readthedocs.build/en/2676/

<!-- readthedocs-preview pymc-marketing end -->