### PR TITLE
feat(model_builder): warn on unused model_config keys

### DIFF
--- a/pymc_marketing/model_builder.py
+++ b/pymc_marketing/model_builder.py
@@ -603,6 +603,8 @@ class ModelBuilder(ABC, ModelIO):
         model_config : Dictionary, optional
             dictionary of parameters that initialise model configuration.
             Class-default defined by the user default_model_config method.
+            A ``UserWarning`` is raised for any key not present in
+            ``default_model_config``, since such keys are ignored by the model.
         sampler_config : Dictionary, optional
             dictionary of parameters that initialise sampler configuration.
             Class-default defined by the user default_sampler_config method.
@@ -625,9 +627,22 @@ class ModelBuilder(ABC, ModelIO):
         self.sampler_config = (
             self.default_sampler_config | sampler_config
         )  # Parameters for fit sampling
+        default_model_config = self.default_model_config
         self.model_config = (
-            self.default_model_config | model_config
+            default_model_config | model_config
         )  # parameters for priors etc.
+
+        # Warn about model_config keys that the model does not use, so that
+        # typos (e.g. "alphaa" instead of "alpha") don't silently get ignored.
+        unused_model_config_keys = set(model_config) - set(default_model_config)
+        if unused_model_config_keys:
+            warnings.warn(
+                "The following model_config keys are not used by the model "
+                f"and will be ignored: {sorted(unused_model_config_keys)}. "
+                f"Valid keys are: {sorted(default_model_config)}.",
+                UserWarning,
+                stacklevel=2,
+            )
 
         self.model: pm.Model
         self.idata: xr.DataTree | None = None  # idata is generated during fitting

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -296,6 +296,18 @@ def test_model_configuration(model_class, expected_type, test_config):
     assert nondefault.sampler_config == default.sampler_config | {"draws": 42}
 
 
+def test_model_config_warns_on_unused_keys():
+    """Unknown model_config keys should warn so typos are not silently ignored."""
+    with pytest.warns(UserWarning, match="not used by the model"):
+        ModelBuilderTest(model_config={"mu_loc": 5, "typo_key": 1})
+
+
+def test_model_config_no_warning_for_valid_keys(recwarn):
+    """No unused-key warning is raised when every key is a valid default key."""
+    ModelBuilderTest(model_config={"mu_loc": 5})
+    assert not [w for w in recwarn if "not used by the model" in str(w.message)]
+
+
 @pytest.mark.parametrize(
     "test_case,model_class,method,expected_error,args",
     [


### PR DESCRIPTION
Cherry-pick of #2632 onto v1.0.0.

Warns about model_config keys not in default_model_config (e.g., typos).
Emits a UserWarning listing the unused keys and the valid ones.

Closes #1256

Original PR: #2632
Co-authored-by: MECoban <cobanmehmetemin@gmail.com>

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2725.org.readthedocs.build/en/2725/

<!-- readthedocs-preview pymc-marketing end -->