### PR TITLE
Allow models to declare optional config keys that override unused-key warning

### DIFF
--- a/pymc_marketing/clv/models/beta_geo.py
+++ b/pymc_marketing/clv/models/beta_geo.py
@@ -150,6 +150,7 @@ class BetaGeoModel(CLVModel):
     """  # noqa: E501
 
     _model_type = "BG/NBD"  # Beta-Geometric Negative Binomial Distribution
+    _skipped_config_keys = {"a", "b"}
 
     def __init__(
         self,

--- a/pymc_marketing/clv/models/beta_geo_beta_binom.py
+++ b/pymc_marketing/clv/models/beta_geo_beta_binom.py
@@ -144,6 +144,7 @@ class BetaGeoBetaBinomModel(CLVModel):
     """
 
     _model_type = "BG/BB"  # Beta-Geometric, Beta-Binomial Distribution
+    _skipped_config_keys = {"alpha", "beta", "gamma", "delta"}
 
     def __init__(
         self,

--- a/pymc_marketing/clv/models/shifted_beta_geo.py
+++ b/pymc_marketing/clv/models/shifted_beta_geo.py
@@ -170,6 +170,7 @@ class ShiftedBetaGeoModel(CLVModel):
     """
 
     _model_type = "Shifted Beta-Geometric"
+    _skipped_config_keys = {"alpha", "beta"}
 
     def __init__(
         self,

--- a/pymc_marketing/model_builder.py
+++ b/pymc_marketing/model_builder.py
@@ -590,6 +590,7 @@ class ModelBuilder(ABC, ModelIO):
 
     _model_type = "BaseClass"
     version = "None"
+    _skipped_config_keys: set[str] = set()
 
     def __init__(
         self,
@@ -634,7 +635,9 @@ class ModelBuilder(ABC, ModelIO):
 
         # Warn about model_config keys that the model does not use, so that
         # typos (e.g. "alphaa" instead of "alpha") don't silently get ignored.
-        unused_model_config_keys = set(model_config) - set(default_model_config)
+        unused_model_config_keys = (
+            set(model_config) - set(default_model_config) - self._skipped_config_keys
+        )
         if unused_model_config_keys:
             warnings.warn(
                 "The following model_config keys are not used by the model "

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -308,6 +308,26 @@ def test_model_config_no_warning_for_valid_keys(recwarn):
     assert not [w for w in recwarn if "not used by the model" in str(w.message)]
 
 
+def test_model_config_no_warning_for_skipped_keys(recwarn):
+    """No unused-key warning for keys listed in _skipped_config_keys."""
+
+    class SkippedKeysModel(ModelBuilderTest):
+        _skipped_config_keys = {"extra_a", "extra_b"}
+
+    SkippedKeysModel(model_config={"extra_a": 1, "extra_b": 2})
+    assert not [w for w in recwarn if "not used by the model" in str(w.message)]
+
+
+def test_model_config_warns_on_non_skipped_keys():
+    """Keys not in defaults or _skipped_config_keys still warn."""
+
+    class SkippedKeysModel(ModelBuilderTest):
+        _skipped_config_keys = {"extra_a"}
+
+    with pytest.warns(UserWarning, match="not used by the model"):
+        SkippedKeysModel(model_config={"extra_a": 1, "typo_key": 2})
+
+
 @pytest.mark.parametrize(
     "test_case,model_class,method,expected_error,args",
     [


### PR DESCRIPTION
## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes https://github.com/pymc-labs/pymc-marketing/issues/2727
- [ ] Related to https://github.com/pymc-labs/pymc-marketing/pull/2723

## Context

Commit aaae9b66 added a `UserWarning` in `ModelBuilder.__init__` when user-supplied `model_config` keys are not present in `default_model_config`. This catches typos (e.g. `"alphaa"` instead of `"alpha"`).

However, several CLV models support **optional alternative parameterizations** — config keys that aren't in `default_model_config` but are explicitly checked and used in `build_model` (e.g. `if "a" in self.model_config`). The warning incorrectly tells users these keys "will be ignored" when they are in fact consumed.

**Affected models and their optional keys:**

| Model | Optional keys | Check location |
|---|---|---|
| `BetaGeoModel` | `a`, `b` | `beta_geo.py:269` |
| `ModifiedBetaGeoModel` | `a`, `b` | `modified_beta_geo.py:202` |
| `BetaGeoBetaBinomModel` | `alpha`, `beta`, `gamma`, `delta` | `beta_geo_beta_binom.py:216,232` |
| `ShiftedBetaGeoModel` | `alpha`, `beta` | `shifted_beta_geo.py:326,373` |

## Approach

Add a class attribute `_skipped_config_keys: set[str]` to `ModelBuilder` (defaulting to empty set). The warning logic subtracts this set before deciding what's unused. Each affected CLV model overrides it with its optional keys.

### Changes

**1. `pymc_marketing/model_builder.py`**

- Add `_skipped_config_keys: set[str] = set()` as a class attribute on `ModelBuilder` (near `_model_type` / `version`, around line 591).
- In `__init__` (line 637), change the unused-key computation from:
  ```python
  unused_model_config_keys = set(model_config) - set(default_model_config)
  ```
  to:
  ```python
  unused_model_config_keys = set(model_config) - set(default_model_config) - self._skipped_config_keys
  ```

**2. CLV model files** — add `_skipped_config_keys` override:

- `pymc_marketing/clv/models/beta_geo.py` — `BetaGeoModel`: `_skipped_config_keys = {"a", "b"}`
- `pymc_marketing/clv/models/modified_beta_geo.py` — `ModifiedBetaGeoModel`: inherits from `BetaGeoModel`, so gets it automatically. Verify no override needed.
- `pymc_marketing/clv/models/beta_geo_beta_binom.py` — `BetaGeoBetaBinomModel`: `_skipped_config_keys = {"alpha", "beta", "gamma", "delta"}`
- `pymc_marketing/clv/models/shifted_beta_geo.py` — `ShiftedBetaGeoModel`: `_skipped_config_keys = {"alpha", "beta"}`

**3. `tests/test_model_builder.py`**

- Add a test that a subclass with `_skipped_config_keys` does NOT warn when those keys are passed.
- Verify existing tests (`test_model_config_warns_on_unused_keys`, `test_model_config_no_warning_for_valid_keys`) still pass.

## Verification

1. `uv run pytest tests/test_model_builder.py -x -q` — existing + new tests pass.
2. `uv run pytest tests/clv/models/test_beta_geo.py tests/clv/models/test_shifted_beta_geo.py tests/clv/models/test_beta_geo_beta_binom.py -x -q -k "config"` — CLV model config tests pass without spurious warnings.
3. `uv run pre-commit run --files pymc_marketing/model_builder.py pymc_marketing/clv/models/beta_geo.py pymc_marketing/clv/models/modified_beta_geo.py pymc_marketing/clv/models/beta_geo_beta_binom.py pymc_marketing/clv/models/shifted_beta_geo.py tests/test_model_builder.py`

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2729.org.readthedocs.build/en/2729/

<!-- readthedocs-preview pymc-marketing end -->