### PR TITLE
fix(model_builder): update model data on repeated fit (#2605)

### DIFF
--- a/pymc_marketing/model_builder.py
+++ b/pymc_marketing/model_builder.py
@@ -1054,6 +1054,11 @@ class RegressionModelBuilder(ModelBuilder):
 
         if not hasattr(self, "model"):
             self.build_model(X, y)
+        else:
+            # Refresh data on the existing model so repeated fits (or a fit
+            # after build_model) sample from the new X, y instead of the
+            # values baked in when the model was first built.
+            self._data_setter(X, y)
 
         sampler_kwargs = create_sample_kwargs(
             self.sampler_config,
@@ -1195,6 +1200,11 @@ class RegressionModelBuilder(ModelBuilder):
 
         if not hasattr(self, "model"):
             self.build_model(X, y)
+        else:
+            # Refresh data on the existing model so repeated fits (or a fit
+            # after build_model) sample from the new X, y instead of the
+            # values baked in when the model was first built.
+            self._data_setter(X, y)
 
         # Prepare kwargs for pymc.fit
         _fit_kwargs: dict[str, Any] = {}

--- a/tests/test_model_builder.py
+++ b/tests/test_model_builder.py
@@ -842,6 +842,61 @@ def test_second_fit(toy_X, toy_y, mock_pymc_sample):
     assert id_before != id_after
 
 
+def test_second_fit_uses_new_data(toy_X, toy_y, mock_pymc_sample):
+    """A second fit with new data must update the model, not ignore it (issue #2605)."""
+    model = RegressionModelBuilderTest()
+    model.fit(X=toy_X, y=toy_y, chains=1, draws=100, tune=100)
+
+    new_X = pd.DataFrame({"input": toy_X["input"].to_numpy() + 1})
+    new_y = toy_y + 2
+    model.fit(X=new_X, y=new_y, chains=1, draws=100, tune=100)
+
+    # The PyMC data containers used for sampling now hold the new data ...
+    np.testing.assert_allclose(model.model["x"].get_value(), new_X["input"])
+    np.testing.assert_allclose(model.model["y_data"].get_value(), new_y)
+    # ... and the stored fit_data agrees with the model.
+    xr.testing.assert_allclose(
+        model.idata.fit_data["input"], new_X["input"].to_xarray()
+    )
+    xr.testing.assert_allclose(
+        model.idata.fit_data[model.output_var],
+        new_y.rename(model.output_var).to_xarray(),
+    )
+
+
+def test_fit_after_build_model_uses_new_data(toy_X, toy_y, mock_pymc_sample):
+    """fit after an explicit build_model must use fit's data (issue #2605)."""
+    model = RegressionModelBuilderTest()
+    model.build_model(X=toy_X, y=toy_y)
+
+    new_X = pd.DataFrame({"input": toy_X["input"].to_numpy() + 1})
+    new_y = toy_y + 2
+    model.fit(X=new_X, y=new_y, chains=1, draws=100, tune=100)
+
+    np.testing.assert_allclose(model.model["x"].get_value(), new_X["input"])
+    np.testing.assert_allclose(model.model["y_data"].get_value(), new_y)
+
+
+def test_approximate_fit_after_build_model_uses_new_data(toy_X, toy_y):
+    """approximate_fit must also refresh data on an existing model (issue #2605)."""
+    model = RegressionModelBuilderTest(sampler_config={"draws": 20, "chains": 1})
+    model.build_model(X=toy_X, y=toy_y)
+
+    new_X = pd.DataFrame({"input": toy_X["input"].to_numpy() + 1})
+    new_y = toy_y + 2
+    model.approximate_fit(
+        new_X,
+        new_y,
+        progressbar=False,
+        random_seed=42,
+        fit_kwargs={"n": 200, "method": "advi"},
+        sample_kwargs={"draws": 20},
+    )
+
+    np.testing.assert_allclose(model.model["x"].get_value(), new_X["input"])
+    np.testing.assert_allclose(model.model["y_data"].get_value(), new_y)
+
+
 class InsufficientModel(RegressionModelBuilder):
     def __init__(
         self, model_config=None, sampler_config=None, new_parameter=None


### PR DESCRIPTION
## Description

Fixes #2605

```python
if not hasattr(self, "model"):
    self.build_model(X, y)

So a second fit, or a fit after an explicit build_model, silently ignored the new X, y and sampled from the data baked in when the model was first built. fit_data, meanwhile, was recorded from the new X, y — so the stored data and the data actually sampled disagreed.

This PR refreshes the existing model's data via the existing _data_setter mechanism (the same one sample_posterior_predictive uses) before sampling, in both fit and approximate_fit:
    self.build_model(X, y)
else:
    self._data_setter(X, y)
```

Added regression tests (test_second_fit_uses_new_data, test_fit_after_build_model_uses_new_data, test_approximate_fit_after_build_model_uses_new_data) that assert both the PyMC data containers and stored fit_data use the new inputs. They fail on main (100% mismatched elements) and pass with this change.

Scope notes: Fixes the base class and subclasses with a real _data_setter (e.g. BassModel). MMM and mv_its implement _data_setter as a deliberate no-op (MMM stores scaled data and re-derives scaling in build_model), so they are not changed here — but they aren't regressed either, and the documented build_model → add_lift_test_measurements → fit workflow is preserved. A real MMM refit path can be a follow-up. Overlaps with #2686 (which changes fit only); this PR also covers approximate_fit and adds broader tests.

Related Issue

- [x] Closes #2605
- [ ] Related to #

Checklist

- [x] Checked that the pre-commit linting/style checks pass. Feel free to comment pre-commit.ci autofix to auto-fix.
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using numpydoc format.
- [x] If you are a pro: each commit corresponds to a relevant logical change

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2742.org.readthedocs.build/en/2742/

<!-- readthedocs-preview pymc-marketing end -->