### PR TITLE
fix(clv): normalize dates before period bounds

### DIFF
--- a/pymc_marketing/clv/utils.py
+++ b/pymc_marketing/clv/utils.py
@@ -202,24 +202,28 @@ def _find_first_transactions(
     """
     select_columns = [customer_id_col, datetime_col]
 
+    if monetary_value_col:
+        select_columns.append(monetary_value_col)
+
+    transactions = transactions[select_columns].copy()
+    transactions[datetime_col] = pandas.to_datetime(
+        transactions[datetime_col], format=datetime_format
+    )
+
     if observation_period_end is None:
         observation_period_end = transactions[datetime_col].max()
 
     if isinstance(observation_period_end, pandas.Period):
         observation_period_end = observation_period_end.to_timestamp()
     if isinstance(observation_period_end, str):
-        observation_period_end = pandas.to_datetime(observation_period_end)
-
-    if monetary_value_col:
-        select_columns.append(monetary_value_col)
+        observation_period_end = pandas.to_datetime(
+            observation_period_end, format=datetime_format
+        )
 
     if sort_transactions:
-        transactions = transactions[select_columns].sort_values(select_columns).copy()
+        transactions = transactions.sort_values(select_columns)
 
     # convert date column into a DateTimeIndex for time-wise grouping and truncating
-    transactions[datetime_col] = pandas.to_datetime(
-        transactions[datetime_col], format=datetime_format
-    )
     transactions = (
         transactions.set_index(datetime_col).to_period(time_unit).to_timestamp()
     )
@@ -334,7 +338,8 @@ def rfm_summary(
     """
     if observation_period_end is None:
         observation_period_end_ts = (
-            pandas.to_datetime(transactions[datetime_col].max(), format=datetime_format)
+            pandas.to_datetime(transactions[datetime_col], format=datetime_format)
+            .max()
             .to_period(time_unit)
             .to_timestamp()
         )
@@ -487,9 +492,6 @@ def rfm_train_test_split(
         and *monetary_value* if specified
 
     """
-    if test_period_end is None:
-        test_period_end = transactions[datetime_col].max()
-
     transaction_cols = [customer_id_col, datetime_col]
     if monetary_value_col:
         transaction_cols.append(monetary_value_col)
@@ -498,6 +500,9 @@ def rfm_train_test_split(
     transactions[datetime_col] = pandas.to_datetime(
         transactions[datetime_col], format=datetime_format
     )
+    if test_period_end is None:
+        test_period_end = transactions[datetime_col].max()
+
     test_period_end = pandas.to_datetime(test_period_end, format=datetime_format)
     train_period_end = pandas.to_datetime(train_period_end, format=datetime_format)
 

--- a/tests/clv/test_utils.py
+++ b/tests/clv/test_utils.py
@@ -537,6 +537,44 @@ class TestRFM:
         )
         assert_frame_equal(actual, expected)
 
+    def test_rfm_summary_string_dates_match_preconverted_datetimes(self):
+        transactions = pd.DataFrame(
+            {
+                "id": [1, 1, 1],
+                "date": ["11/01/2025", "12/20/2025", "01/15/2026"],
+                "spend": [50.0, 60.0, 70.0],
+            }
+        )
+
+        actual = rfm_summary(
+            transactions,
+            "id",
+            "date",
+            "spend",
+            datetime_format="%m/%d/%Y",
+        )
+        preconverted = rfm_summary(
+            transactions.assign(
+                date=pd.to_datetime(transactions["date"], format="%m/%d/%Y")
+            ),
+            "id",
+            "date",
+            "spend",
+        )
+        expected = pd.DataFrame(
+            [[1, 2.0, 75.0, 75.0, 65.0]],
+            columns=[
+                "customer_id",
+                "frequency",
+                "recency",
+                "T",
+                "monetary_value",
+            ],
+        )
+
+        assert_frame_equal(actual, expected)
+        assert_frame_equal(actual, preconverted)
+
     def test_rfm_summary_non_daily_frequency(
         self,
         transaction_data,
@@ -697,6 +735,49 @@ class TestRFM:
 
         with pytest.raises(KeyError):
             actual.loc[6]
+
+    def test_rfm_train_test_split_string_dates_match_preconverted_datetimes(self):
+        transactions = pd.DataFrame(
+            {
+                "id": [1, 1, 1],
+                "date": ["11/01/2025", "12/20/2025", "01/15/2026"],
+                "spend": [50.0, 60.0, 70.0],
+            }
+        )
+
+        actual = rfm_train_test_split(
+            transactions,
+            "id",
+            "date",
+            train_period_end="12/31/2025",
+            datetime_format="%m/%d/%Y",
+            monetary_value_col="spend",
+        )
+        preconverted = rfm_train_test_split(
+            transactions.assign(
+                date=pd.to_datetime(transactions["date"], format="%m/%d/%Y")
+            ),
+            "id",
+            "date",
+            train_period_end=datetime(2025, 12, 31),
+            monetary_value_col="spend",
+        )
+        expected = pd.DataFrame(
+            [[1, 1.0, 49.0, 60.0, 60.0, 1, 70.0, 15.0]],
+            columns=[
+                "customer_id",
+                "frequency",
+                "recency",
+                "T",
+                "monetary_value",
+                "test_frequency",
+                "test_monetary_value",
+                "test_T",
+            ],
+        )
+
+        assert_frame_equal(actual, expected)
+        assert_frame_equal(actual, preconverted)
 
     @pytest.mark.parametrize("train_end", ("2014-02-07", "2015-02-08"))
     def test_rfm_train_test_split_throws_better_error_if_test_period_end_is_too_early(


### PR DESCRIPTION
## Description

Parse transaction date columns before deriving default observation/test period bounds, sorting transactions, or filtering periods. This prevents non-ISO string dates from being compared lexicographically and makes `datetime_format` inputs deterministic with pre-converted datetime columns.

Regression tests cover both reported paths:

- `rfm_summary` includes the January 2026 transaction and returns the same summary as pre-converted datetimes.
- `rfm_train_test_split` keeps the January 2026 transaction in the test period instead of raising `ValueError`.

## Related Issue

- [x] Closes #2744
- [ ] Related to #

## Checklist

- [x] Checked that the pre-commit linting/style checks pass.
- [x] Included tests that prove the fix is effective.
- [x] Documentation is unchanged because this bug fix preserves the public API and documented `datetime_format` semantics.
- [x] The commit is one relevant logical change and includes DCO sign-off.

## Validation

- `.venv/bin/pytest --no-cov tests/clv/test_utils.py` (`61 passed`)
- `.venv/bin/pre-commit run --files pymc_marketing/clv/utils.py tests/clv/test_utils.py`


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2745.org.readthedocs.build/en/2745/

<!-- readthedocs-preview pymc-marketing end -->