### PR TITLE
ci: add git-ai workflow for authorship attribution

### DIFF
--- a/.github/workflows/git-ai.yaml
+++ b/.github/workflows/git-ai.yaml
@@ -1,0 +1,26 @@
+name: Git AI
+
+on:
+  pull_request:
+    types: [closed, synchronize]
+
+jobs:
+  git-ai:
+    if: github.event.pull_request.merged == true || github.event.action == 'synchronize'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Install git-ai
+        run: |
+          curl -fsSL https://usegitai.com/install.sh | bash
+          echo "$HOME/.git-ai/bin" >> $GITHUB_PATH
+      - name: Run git-ai
+        id: run-git-ai
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git-ai ci github run


### PR DESCRIPTION
Installs git-ai GitHub Actions workflow to automatically rewrite authorship logs for squash/rebase merged PRs, preserving AI contributor attribution in git notes.

This workflow:
- Triggers on pull request merge events
- Configures git-ai with GitHub Actions bot credentials
- Rewrites authorship for squash and rebase merges to maintain attribution records

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2747.org.readthedocs.build/en/2747/

<!-- readthedocs-preview pymc-marketing end -->