### PR TITLE
fix(clv): correct daily lifetime value scaling

### DIFF
--- a/pymc_marketing/clv/utils.py
+++ b/pymc_marketing/clv/utils.py
@@ -120,7 +120,7 @@ def customer_lifetime_value(
     else:
         steps = np.arange(1, future_t + 1)
 
-    factor = {"W": 4.345, "M": 1.0, "D": 30, "H": 30 * 24}[time_unit]
+    factor = {"W": 4.345, "M": 1.0, "D": 30.4375, "H": 30 * 24}[time_unit]
 
     monetary_value = to_xarray(data["customer_id"], data["future_spend"])
 

--- a/tests/clv/test_utils.py
+++ b/tests/clv/test_utils.py
@@ -131,6 +131,31 @@ class TestCustomerLifetimeValue:
                 discount_rate=0.1,
             )
 
+    def test_daily_time_unit_uses_average_month_length(self):
+        class TransactionModel:
+            def __init__(self):
+                self.future_t = []
+
+            def expected_purchases(self, data, future_t):
+                self.future_t.append(future_t)
+                return xarray.DataArray(
+                    [future_t],
+                    coords={"customer_id": data["customer_id"]},
+                    dims=("customer_id",),
+                )
+
+        transaction_model = TransactionModel()
+        data = pd.DataFrame({"customer_id": [1], "future_spend": [1.0]})
+
+        customer_lifetime_value(
+            transaction_model=transaction_model,
+            data=data,
+            future_t=12,
+            time_unit="D",
+        )
+
+        assert transaction_model.future_t == [365.25]
+
     @pytest.mark.parametrize(
         "t, discount_rate, expected_change",
         [


### PR DESCRIPTION
## Description

Daily CLV horizons now use the average Gregorian month length (365.25 / 12 = 30.4375) instead of 30 days, preventing annual estimates from being scaled to 360 days. The regression verifies that a 12-month daily horizon requests 365.25 days.

This supersedes #2750, which was branched off `main` and had become conflicting. Same change, re-branched off `v1.0.0` and targeting `v1.0.0` as requested by @ColtAllen and @juanitorduz.

## Related Issue

- [x] Closes #2749
- [ ] Related to #

## Checklist

- [x] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2754.org.readthedocs.build/en/2754/

<!-- readthedocs-preview pymc-marketing end -->