### PR TITLE
chore: group all actions/* updates with 7-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,9 @@ updates:
     labels:
       - "dependencies"
       - "no releasenotes"
+    groups:
+      actions-all:
+        patterns:
+          - "actions/*"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Consolidates all Dependabot updates for `actions/*` into a single PR and adds a 7-day cooldown before updates are proposed, reducing PR noise.

**Changes:**
- Use `groups` to batch all `actions/*` dependency updates into one PR
- Add `cooldown.default-days: 7` to wait 7 days after a new Action version is published before opening a PR

This prevents the flood of individual Dependabot PRs (e.g., #2753, #2752, #2736) by combining them into a single grouped update.

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2755.org.readthedocs.build/en/2755/

<!-- readthedocs-preview pymc-marketing end -->