### PR TITLE
Sync agent instructions across Cursor, Claude, and Copilot

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,9 +2,10 @@
 
 ## Environment
 
-- Run `uv sync` to set up the environment, then use `uv run` for commands.
+- Run `uv sync` to set up the environment, then use `uv run` for Python commands (pytest, pre-commit, python, etc.).
 - Run `pre-commit` every time you create or modify a file.
 - Temporary or test scripts that are not meant to be committed should be created in the `sandbox/` folder.
+- Do not insert hard line breaks inside a sentence; let the editor handle word wrap. Line breaks between sentences are fine.
 
 ## Skills (shared with Cursor)
 

--- a/.cursor/rules/basic.mdc
+++ b/.cursor/rules/basic.mdc
@@ -3,6 +3,7 @@ description:
 alwaysApply: true
 ---
 
-- Run pre-commit everytime you create or modify a file.
-- Temporary or test scripts that are not meant to be commited should be created in the sandbox folder
+- Run pre-commit every time you create or modify a file.
+- Temporary or test scripts that are not meant to be committed should be created in the sandbox folder
 - Use `uv run` to execute Python commands (pytest, pre-commit, python, etc.)
+- Do not insert hard line breaks inside a sentence; let the editor handle word wrap. Line breaks between sentences are fine.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,8 @@
+# PyMC-Marketing — Copilot Instructions
+
+Project-wide conventions for this repository.
+
+- Run pre-commit every time you create or modify a file.
+- Temporary or test scripts that are not meant to be committed should be created in the `sandbox/` folder.
+- Use `uv run` to execute Python commands (pytest, pre-commit, python, etc.).
+- Do not insert hard line breaks inside a sentence; let the editor handle word wrap. Line breaks between sentences are fine.


### PR DESCRIPTION
## Summary
- Add a prose formatting rule to `.cursor/rules/basic.mdc` (no hard line breaks mid-sentence) and fix minor typos.
- Mirror the same project-wide conventions in `.claude/CLAUDE.md` and new `.github/copilot-instructions.md` for VS Code Copilot users.

## Test plan
- [x] Verify instruction files render correctly
- [ ] Confirm Copilot picks up `.github/copilot-instructions.md` in VS Code (optional)


Made with [Cursor](https://cursor.com)

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2780.org.readthedocs.build/en/2780/

<!-- readthedocs-preview pymc-marketing end -->