### PR TITLE
ci(docs): skip RTD PR preview builds when no docs-relevant files changed

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,25 +17,22 @@ build:
       # Skip PR preview builds when no docs-relevant files changed.
       # exit 183 cancels the build (shown as green on the PR, not a failure).
       # Pushes to main are unaffected — live docs always rebuild.
+      #
+      # The path list mirrors the `changes` filter in .github/workflows/docs.yml
+      # so the RTD preview and the GH Actions `Docs` job agree on what counts as
+      # docs-relevant. Keep the two in sync.
       # Ref: https://docs.readthedocs.com/platform/stable/guides/build/skip-build.html
       - git fetch origin main --depth=1
       - |
         if [ "$READTHEDOCS_VERSION_TYPE" = "external" ]; then
-          CHANGED_FILES=$(git diff --name-only origin/main -- docs/ .readthedocs.yml pymc_marketing/ scripts/ 2>/dev/null || true)
-          SHOULD_SKIP=1
+          CHANGED_FILES=$(git diff --name-only origin/main -- \
+            .readthedocs.yml \
+            pyproject.toml \
+            docs/ \
+            pymc_marketing/ \
+            scripts/generate_gallery.py 2>/dev/null || true)
 
-          for FILE in $CHANGED_FILES; do
-            case "$FILE" in
-              pymc_marketing/data/*)
-                ;;
-              *)
-                SHOULD_SKIP=0
-                break
-                ;;
-            esac
-          done
-
-          if [ "$SHOULD_SKIP" -eq 1 ]; then
+          if [ -z "$CHANGED_FILES" ]; then
             exit 183;
           fi
         fi

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,6 +13,32 @@ build:
   tools:
     python: "3.12"
   jobs:
+    post_checkout:
+      # Skip PR preview builds when no docs-relevant files changed.
+      # exit 183 cancels the build (shown as green on the PR, not a failure).
+      # Pushes to main are unaffected — live docs always rebuild.
+      # Ref: https://docs.readthedocs.com/platform/stable/guides/build/skip-build.html
+      - git fetch origin main --depth=1
+      - |
+        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ]; then
+          CHANGED_FILES=$(git diff --name-only origin/main -- docs/ .readthedocs.yml pymc_marketing/ scripts/ 2>/dev/null || true)
+          SHOULD_SKIP=1
+
+          for FILE in $CHANGED_FILES; do
+            case "$FILE" in
+              pymc_marketing/data/*)
+                ;;
+              *)
+                SHOULD_SKIP=0
+                break
+                ;;
+            esac
+          done
+
+          if [ "$SHOULD_SKIP" -eq 1 ]; then
+            exit 183;
+          fi
+        fi
     pre_build:
       # Install core dependencies first
       - pip install --upgrade pip setuptools wheel


### PR DESCRIPTION
Ports the docs-build skip already running in `pymc-labs/causalpy` over to this repo.

## What

Adds a `post_checkout` job to `.readthedocs.yml`. On **external** (pull request) builds it diffs against `origin/main` restricted to the paths that can change the rendered docs, and `exit 183` when nothing relevant changed. RTD treats 183 as a *cancelled* build, so it shows green on the PR rather than as a failure.

Watched paths: `docs/`, `.readthedocs.yml`, `pymc_marketing/` (docstrings feed autodoc), `scripts/` (`generate_gallery.py` runs in `pre_build`).

Excluded: `pymc_marketing/data/` — data files do not affect rendered output. Top-level `tests/`, `skills/`, `locales/`, `streamlit/` are outside the watched paths, so a PR touching only those also skips.

Pushes to `main` are unaffected: the guard only fires when `READTHEDOCS_VERSION_TYPE=external`, so live docs always rebuild.

## Why

The docs build is one of the slower checks on this repo, and a large share of PRs (test-only changes, CI tweaks, notebook-unrelated refactors) never touch anything the docs render. Skipping those saves build minutes and PR wait time.

Ref: https://docs.readthedocs.com/platform/stable/guides/build/skip-build.html

## Testing note

This can only be fully validated once merged, since RTD reads `.readthedocs.yml` from the base branch config resolution for the skip semantics to behave identically on subsequent PRs. The equivalent block has been running in causalpy without issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2781.org.readthedocs.build/en/2781/

<!-- readthedocs-preview pymc-marketing end -->