### PR TITLE
feat: Fourier decomposition visualization — color_dim for plot_curve and plot_decomposition method

### DIFF
--- a/pymc_marketing/mmm/fourier.py
+++ b/pymc_marketing/mmm/fourier.py
@@ -49,6 +49,9 @@ There are three types of Fourier seasonality transformations available:
     fig.suptitle("Yearly Fourier Seasonality")
     plt.show()
 
+The Fourier seasonality can be decomposed into its individual basis
+functions by passing ``sum=False`` to :meth:`~FourierBase.sample_curve`:
+
 .. plot::
     :context: close-figs
 

--- a/pymc_marketing/mmm/fourier.py
+++ b/pymc_marketing/mmm/fourier.py
@@ -32,18 +32,33 @@ There are three types of Fourier seasonality transformations available:
     from pymc_marketing.mmm import YearlyFourier
     from pymc_extras.prior import Prior
 
+    seed = sum(map(ord, "Yearly"))
+    rng = np.random.default_rng(seed)
+
     prior = Prior(
         "Normal",
-        mu=[0, 0, -1, 0],
+        mu=[0.5, 0, -1, 0],
         sigma=Prior("Gamma", mu=0.10, sigma=0.1, dims="fourier"),
         dims=("hierarchy", "fourier"),
     )
     yearly = YearlyFourier(n_order=2, prior=prior)
     coords = {"hierarchy": ["A", "B"]}
-    prior = yearly.sample_prior(coords=coords)
+    prior = yearly.sample_prior(coords=coords, random_seed=rng)
     curve = yearly.sample_curve(prior)
     fig, _ = yearly.plot_curve(curve, subplot_kwargs={"ncols": 1})
     fig.suptitle("Yearly Fourier Seasonality")
+    plt.show()
+
+.. plot::
+    :context: close-figs
+
+    # Reuse yearly and prior from the previous example
+    components = yearly.sample_curve(prior, sum=False)
+
+    fig, _ = yearly.plot_decomposition(components)
+    fig.suptitle(
+        "Yearly Fourier seasonality decomposed into basis functions"
+    )
     plt.show()
 
 Examples
@@ -250,7 +265,12 @@ from pytensor.xtensor.type import XTensorVariable
 
 from pymc_marketing.constants import DAYS_IN_MONTH, DAYS_IN_WEEK, DAYS_IN_YEAR
 from pymc_marketing.mmm.dims import XTensorLike
-from pymc_marketing.plot import SelToString, plot_curve, plot_hdi, plot_samples
+from pymc_marketing.plot import (
+    SelToString,
+    plot_curve,
+    plot_hdi,
+    plot_samples,
+)
 from pymc_marketing.serialization import serialization
 
 X_NAME: str = "day"
@@ -519,6 +539,7 @@ class FourierBase(BaseModel):
         parameters: xr.DataTree | xr.Dataset,
         use_dates: bool = False,
         start_date: str | datetime.datetime | None = None,
+        sum: bool = True,
     ) -> xr.DataArray:
         """Create full period of the Fourier seasonality.
 
@@ -532,6 +553,10 @@ class FourierBase(BaseModel):
         start_date : datetime.datetime, optional
             Starting date for the Fourier curve. If not provided and use_dates is True,
             it will be derived from the current year or month. Defaults to None.
+        sum : bool, default True
+            Whether to sum the Fourier components. If ``False``, returns
+            individual components along the ``{prefix}`` dimension
+            (e.g. ``"fourier"``).
 
         Returns
         -------
@@ -568,7 +593,7 @@ class FourierBase(BaseModel):
             name = f"{self.prefix}_trend"
             pmd.Deterministic(
                 name,
-                self.apply(as_xtensor(dayofperiod, dims=(date_dim,))),
+                self.apply(as_xtensor(dayofperiod, dims=(date_dim,)), sum=sum),
             )
 
             return pm.sample_posterior_predictive(
@@ -645,6 +670,91 @@ class FourierBase(BaseModel):
             hdi_kwargs=hdi_kwargs,
             axes=axes,
             same_axes=same_axes,
+            colors=colors,
+            legend=legend,
+            sel_to_string=sel_to_string,
+        )
+
+    def plot_decomposition(
+        self,
+        curve: xr.DataArray,
+        n_samples: int = 10,
+        hdi_probs: float | list[float] | None = None,
+        random_seed: np.random.Generator | None = None,
+        subplot_kwargs: dict | None = None,
+        sample_kwargs: dict | None = None,
+        hdi_kwargs: dict | None = None,
+        axes: npt.NDArray[plt.Axes] | None = None,
+        same_axes: bool = False,
+        colors: Iterable[str] | None = None,
+        legend: bool | None = None,
+        sel_to_string: SelToString | None = None,
+    ) -> tuple[plt.Figure, npt.NDArray[plt.Axes]]:
+        """Plot the decomposition of the Fourier seasonality into individual components.
+
+        Parameters
+        ----------
+        curve : xr.DataArray
+            Sampled curve with individual components. Must have the
+            ``{prefix}`` dimension (e.g. ``"fourier"``), as returned by
+            :meth:`sample_curve` with ``sum=False``.
+        n_samples : int, optional
+            Number of sample curves to show per component.
+        hdi_probs : float or list of float, optional
+            HDI probability levels for the component bands.
+        random_seed : np.random.Generator, optional
+            Random seed for sample selection.
+        subplot_kwargs : dict, optional
+            Keyword arguments for the subplot layout.
+        sample_kwargs : dict, optional
+            Keyword arguments for sample line plotting.
+        hdi_kwargs : dict, optional
+            Keyword arguments for HDI band plotting.
+        axes : npt.NDArray[plt.Axes], optional
+            Pre-existing axes to plot on.
+        same_axes : bool, optional
+            Plot all component groups on the same axes. Default False.
+        colors : Iterable[str], optional
+            Colors for the component curves.
+        legend : bool, optional
+            Show legend. Default True.
+        sel_to_string : SelToString, optional
+            Function to convert selection dict to title string.
+
+        Returns
+        -------
+        tuple[plt.Figure, npt.NDArray[plt.Axes]]
+            Matplotlib figure and axes.
+
+        """
+        if "date" in curve.coords:
+            x_coord_name = "date"
+        elif "day" in curve.coords:
+            x_coord_name = "day"
+        else:
+            raise ValueError("Curve must have either 'day' or 'date' as a coordinate")
+
+        if self.prefix not in curve.dims:
+            raise ValueError(
+                f"Curve must have a '{self.prefix}' dimension. "
+                "Use sample_curve(..., sum=False) to get individual components."
+            )
+
+        if legend is None:
+            legend = True
+
+        return plot_curve(
+            curve,
+            non_grid_names={x_coord_name},
+            color_dim=self.prefix,
+            same_axes=same_axes,
+            axes=axes,
+            n_samples=n_samples,
+            hdi_probs=hdi_probs,
+            random_seed=random_seed,
+            subplot_kwargs=subplot_kwargs,
+            sample_kwargs=sample_kwargs,
+            hdi_kwargs=hdi_kwargs,
             colors=colors,
             legend=legend,
             sel_to_string=sel_to_string,

--- a/pymc_marketing/mmm/fourier.py
+++ b/pymc_marketing/mmm/fourier.py
@@ -49,8 +49,9 @@ There are three types of Fourier seasonality transformations available:
     fig.suptitle("Yearly Fourier Seasonality")
     plt.show()
 
-The Fourier seasonality can be decomposed into its individual basis
-functions by passing ``sum=False`` to :meth:`~FourierBase.sample_curve`:
+This is the same curve from the figure above, but now decomposed into
+its individual sine and cosine components by passing ``sum=False`` to
+:meth:`~FourierBase.sample_curve`:
 
 .. plot::
     :context: close-figs

--- a/pymc_marketing/plot.py
+++ b/pymc_marketing/plot.py
@@ -372,6 +372,7 @@ def _plot_across_coord(
     patch: bool = True,
     line: bool = True,
     sel_to_string: SelToString | None = None,
+    color_dim: str | None = None,
 ) -> tuple[plt.Figure, npt.NDArray[Axes]]:
     """Plot data array across coords.
 
@@ -392,10 +393,13 @@ def _plot_across_coord(
 
     data = get_plot_data(curve)
 
-    plot_coords = get_plot_coords(
-        data.coords,
-        non_grid_names=non_grid_names.union({"chain", "draw", "ci_bound"}),
-    )
+    faceting_non_grid = non_grid_names.union({"chain", "draw", "ci_bound"})
+    if color_dim:
+        faceting_non_grid.add(color_dim)
+        color_values = list(data.coords[color_dim].values)
+        color_labels = [str(v) for v in color_values]
+
+    plot_coords = get_plot_coords(data.coords, non_grid_names=faceting_non_grid)
     total_size = get_total_coord_size(plot_coords)
 
     if axes is None and not same_axes:
@@ -403,57 +407,77 @@ def _plot_across_coord(
         subplot_kwargs = {**{"sharey": True, "sharex": True}, **subplot_kwargs}
         set_subplot_kwargs_defaults(subplot_kwargs, total_size)
         fig, axes = plt.subplots(**subplot_kwargs)
-        axes_iter = np.ravel(axes)
+        axes_flat = np.ravel(axes)
         return_axes = axes
 
         create_title = sel_to_string
 
-        create_legend_label = None
     elif axes is not None and same_axes:
         fig = plt.gcf()
-        axes_iter = repeat(axes[0], total_size)  # type: ignore
+        axes_flat = repeat(axes[0], total_size)  # type: ignore
         return_axes = np.array([axes]) if not isinstance(axes, np.ndarray) else axes
 
         def create_title(sel):
             return ""
 
-        create_legend_label = sel_to_string
-
     elif axes is None and same_axes:
         fig, ax = plt.subplots(ncols=1, nrows=1)
-        axes_iter = repeat(ax, total_size)  # type: ignore
+        axes_flat = repeat(ax, total_size)  # type: ignore
         return_axes = np.array([ax])
 
         def create_title(sel):
             return ""
 
-        create_legend_label = sel_to_string
     else:
         fig = plt.gcf()
-        axes_iter = np.ravel(axes)  # type: ignore
+        axes_flat = np.ravel(axes)  # type: ignore
         return_axes = np.array([axes]) if not isinstance(axes, np.ndarray) else axes
 
         create_title = sel_to_string  # type: ignore
 
-        create_legend_label = None
-
-    colors = cast(Iterable[str], colors or generate_colors(n=total_size, start=0))
     plot_kwargs = plot_kwargs or {}
 
-    for color, ax, sel in zip(colors, axes_iter, selections(plot_coords), strict=False):
-        ax = data.pipe(make_selection, sel=sel).pipe(
-            plot_selection,
-            ax=ax,
-            color=color,
-            **plot_kwargs,
+    if color_dim:
+        color_list = cast(
+            Iterable[str], colors or generate_colors(n=len(color_values), start=0)
         )
-        title = create_title(sel)
-        ax.set_title(title)
+        for ax, sel in zip(axes_flat, selections(plot_coords), strict=False):
+            for color, cval in zip(color_list, color_values, strict=False):
+                inner_sel = {**sel, color_dim: cval} if sel else {color_dim: cval}
+                data.pipe(make_selection, sel=inner_sel).pipe(
+                    plot_selection,
+                    ax=ax,
+                    color=color,
+                    **plot_kwargs,
+                )
+            title = create_title(sel)
+            ax.set_title(title)
 
-    if same_axes and legend and create_legend_label is not None:
-        handles = create_legend_handles(colors, patch=patch, line=line)
-        labels = [create_legend_label(sel) for sel in selections(plot_coords)]
-        ax.legend(handles=handles, labels=labels)
+        if legend:
+            handles = create_legend_handles(color_list, patch=patch, line=line)
+            for ax in np.atleast_1d(return_axes).ravel():
+                ax.legend(handles=handles, labels=color_labels)
+
+    else:
+        colors_list = cast(
+            Iterable[str], colors or generate_colors(n=total_size, start=0)
+        )
+        for color, ax, sel in zip(
+            colors_list, axes_flat, selections(plot_coords), strict=False
+        ):
+            ax = data.pipe(make_selection, sel=sel).pipe(
+                plot_selection,
+                ax=ax,
+                color=color,
+                **plot_kwargs,
+            )
+            title = create_title(sel)
+            ax.set_title(title)
+
+        if same_axes and legend:
+            handles = create_legend_handles(colors_list, patch=patch, line=line)
+            labels = [sel_to_string(sel) for sel in selections(plot_coords)]
+            ax.legend(handles=handles, labels=labels)
 
     return fig, return_axes
 
@@ -470,6 +494,7 @@ def plot_hdi(
     colors: Iterable[str] | None = None,
     legend: bool = False,
     sel_to_string: SelToString | None = None,
+    color_dim: str | None = None,
 ) -> tuple[plt.Figure, npt.NDArray[Axes]]:
     """Plot hdi of the curve across coords.
 
@@ -542,6 +567,7 @@ def plot_hdi(
             patch=True,
             line=False,
             sel_to_string=sel_to_string,
+            color_dim=color_dim,
         )
 
     return fig, cast(npt.NDArray[Axes], axes)
@@ -559,6 +585,7 @@ def plot_samples(
     colors: Iterable[str] | None = None,
     legend: bool = False,
     sel_to_string: SelToString | None = None,
+    color_dim: str | None = None,
 ) -> tuple[plt.Figure, npt.NDArray[Axes]]:
     """Plot n samples of the curve across coords.
 
@@ -626,6 +653,7 @@ def plot_samples(
         patch=False,
         line=True,
         sel_to_string=sel_to_string,
+        color_dim=color_dim,
     )
 
 
@@ -643,6 +671,7 @@ def plot_curve(
     colors: Iterable[str] | None = None,
     legend: bool | None = None,
     sel_to_string: SelToString | None = None,
+    color_dim: str | None = None,
 ) -> tuple[plt.Figure, npt.NDArray[Axes]]:
     """Plot HDI with samples of the curve across coords.
 
@@ -672,10 +701,16 @@ def plot_curve(
     colors : Iterable[str], optional
         Colors for the plots
     legend : bool, optional
-        If to include a legend. Defaults to True if same_axes
+        If to include a legend. Defaults to True if same_axes or color_dim
     sel_to_string : Callable[[Selection], str], optional
         Function to convert selection to a string. Defaults to
         ", ".join(f"{key}={value}" for key, value in sel.items())
+    color_dim : str, optional
+        Dimension to use for color grouping within each facet subplot.
+        Values of this dimension are plotted with distinct colors and
+        appear as legend entries, instead of being faceted into separate
+        subplots.  For example, ``color_dim="brand"`` facets by geo
+        and colors by brand.
 
     Returns
     -------
@@ -775,6 +810,7 @@ def plot_curve(
 
     if same_axes:
         hdi_kwargs["same_axes"] = True
+    if same_axes or color_dim is not None:
         hdi_kwargs["legend"] = legend if isinstance(legend, bool) else True
 
     if colors is not None:
@@ -782,6 +818,9 @@ def plot_curve(
 
     if sel_to_string is not None:
         hdi_kwargs["sel_to_string"] = sel_to_string
+
+    if color_dim is not None:
+        hdi_kwargs["color_dim"] = color_dim
 
     if n_samples > 0:
         sample_kwargs = sample_kwargs or {}
@@ -801,6 +840,9 @@ def plot_curve(
 
         if sel_to_string is not None:
             sample_kwargs["sel_to_string"] = sel_to_string
+
+        if color_dim is not None:
+            sample_kwargs["color_dim"] = color_dim
 
         fig, axes = plot_samples(curve, non_grid_names=non_grid_names, **sample_kwargs)
 

--- a/pymc_marketing/plot.py
+++ b/pymc_marketing/plot.py
@@ -456,7 +456,7 @@ def _plot_across_coord(
         if legend:
             handles = create_legend_handles(color_list, patch=patch, line=line)
             for ax in np.atleast_1d(return_axes).ravel():
-                ax.legend(handles=handles, labels=color_labels)
+                ax.legend(handles=handles, labels=color_labels, title=color_dim)
 
     else:
         colors_list = cast(

--- a/tests/mmm/test_fourier.py
+++ b/tests/mmm/test_fourier.py
@@ -742,3 +742,90 @@ class TestFourierRoundtrips:
 )
 def test_fourier_type_registered(type_key):
     assert type_key in type_registry._registry, f"{type_key} not registered"
+
+
+def _make_component_data(
+    *, n_draws: int = 10, has_hierarchy: bool = False, seed: int = 42
+) -> tuple[YearlyFourier, xr.Dataset, xr.DataArray]:
+    """Create a YearlyFourier with prior and component data for plot tests."""
+    rng = np.random.default_rng(seed)
+    prior = Prior("Normal", dims=("fourier",))
+    yearly = YearlyFourier(n_order=2, prior=prior)
+
+    coords: dict = {}
+    if has_hierarchy:
+        prior = Prior("Normal", dims=("fourier", "hierarchy"))
+        yearly = YearlyFourier(n_order=2, prior=prior)
+        coords["hierarchy"] = ["A", "B"]
+
+    prior_samples = yearly.sample_prior(samples=n_draws, coords=coords, random_seed=rng)
+    components = yearly.sample_curve(prior_samples, sum=False)
+    return yearly, prior_samples, components
+
+
+@pytest.fixture
+def auto_close_figures():
+    """Fixture that closes all matplotlib figures after each test."""
+    yield
+    plt.close("all")
+
+
+class TestPlotDecomposition:
+    def test_invalid_curve_missing_prefix(self, auto_close_figures) -> None:
+        yearly = YearlyFourier(n_order=2)
+        mock = xr.DataArray(np.ones((10,)), dims=["day"], coords={"day": np.arange(10)})
+        with pytest.raises(ValueError, match="must have a 'fourier' dimension"):
+            yearly.plot_decomposition(mock)
+
+    def test_legend(self, auto_close_figures) -> None:
+        yearly, _, components = _make_component_data()
+        _, axes = yearly.plot_decomposition(components)
+
+        leg = axes[0].get_legend()
+        assert leg is not None
+        labels = [t.get_text() for t in leg.texts]
+        assert labels == ["sin_1", "sin_2", "cos_1", "cos_2"]
+
+    def test_no_legend(self, auto_close_figures) -> None:
+        yearly, _, components = _make_component_data()
+        _, axes = yearly.plot_decomposition(components, legend=False)
+
+        leg = axes[0].get_legend()
+        assert leg is None
+
+    def test_figure_and_axes_types(self, auto_close_figures) -> None:
+        yearly, _, components = _make_component_data()
+        fig, axes = yearly.plot_decomposition(components)
+
+        assert isinstance(fig, plt.Figure)
+        assert axes.size >= 1
+
+    def test_hierarchy_faceting(self, auto_close_figures) -> None:
+        yearly, _, components = _make_component_data(has_hierarchy=True)
+
+        _, axes = yearly.plot_decomposition(components)
+
+        assert axes.size == 2, "Should create 2 subplots for hierarchy A, B"
+        for ax in axes.flat:
+            leg = ax.get_legend()
+            assert leg is not None
+            labels = [t.get_text() for t in leg.texts]
+            assert labels == ["sin_1", "sin_2", "cos_1", "cos_2"]
+
+    def test_same_axes(self, auto_close_figures) -> None:
+        yearly, _, components = _make_component_data(has_hierarchy=True)
+
+        _, axes = yearly.plot_decomposition(components, same_axes=True)
+
+        assert axes.size == 1
+
+    def test_custom_colors(self, auto_close_figures) -> None:
+        yearly, _, components = _make_component_data()
+        colors = ["red", "green", "blue", "yellow"]
+
+        _, axes = yearly.plot_decomposition(components, colors=colors)
+
+        leg = axes[0].get_legend()
+        assert leg is not None
+        labels = [t.get_text() for t in leg.texts]
+        assert labels == ["sin_1", "sin_2", "cos_1", "cos_2"]

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -11,6 +11,8 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+from collections.abc import Generator
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -26,6 +28,12 @@ from pymc_marketing.plot import (
     selections,
     set_subplot_kwargs_defaults,
 )
+
+
+@pytest.fixture
+def auto_close_figures() -> Generator[None]:
+    yield
+    plt.close("all")
 
 
 @pytest.mark.parametrize(
@@ -246,6 +254,86 @@ def test_plot_curve_combined_sample_n_samples(mock_curve_combined) -> None:
     assert axes.size == mock_curve_combined.sizes["geo"]
     assert isinstance(fig, plt.Figure)
     plt.close(fig)
+
+
+@pytest.fixture(scope="module")
+def mock_curve_multi_dim() -> xr.DataArray:
+    coords = {
+        "chain": np.arange(1),
+        "draw": np.arange(15),
+        "brand": np.arange(3),
+        "geo": np.arange(5),
+        "day": np.arange(31),
+    }
+    return xr.DataArray(
+        np.ones((1, 15, 3, 5, 31)),
+        coords=coords,
+    )
+
+
+def test_plot_curve_color_dim_faceting(
+    mock_curve_multi_dim, auto_close_figures
+) -> None:
+    fig, axes = plot_curve(mock_curve_multi_dim, {"day"}, color_dim="brand")
+
+    assert axes.size == mock_curve_multi_dim.sizes["geo"]
+    assert isinstance(fig, plt.Figure)
+
+
+def test_plot_curve_color_dim_same_axes(
+    mock_curve_multi_dim, auto_close_figures
+) -> None:
+    fig, axes = plot_curve(
+        mock_curve_multi_dim, {"day"}, color_dim="brand", same_axes=True
+    )
+
+    assert axes.size == 1
+    assert isinstance(fig, plt.Figure)
+
+
+def test_plot_curve_color_dim_legend(mock_curve_multi_dim, auto_close_figures) -> None:
+    _, axes = plot_curve(mock_curve_multi_dim, {"day"}, color_dim="brand")
+
+    leg = axes[0].get_legend()
+    assert leg is not None
+    labels = [t.get_text() for t in leg.texts]
+    assert labels == ["0", "1", "2"]
+
+
+def test_plot_curve_color_dim_hdi_only(
+    mock_curve_multi_dim, auto_close_figures
+) -> None:
+    _, axes = plot_curve(mock_curve_multi_dim, {"day"}, color_dim="brand", n_samples=0)
+
+    assert axes.size == mock_curve_multi_dim.sizes["geo"]
+
+    leg = axes[0].get_legend()
+    assert leg is not None
+    labels = [t.get_text() for t in leg.texts]
+    assert labels == ["0", "1", "2"]
+
+
+def test_plot_curve_color_dim_custom_colors(
+    mock_curve_multi_dim, auto_close_figures
+) -> None:
+    colors = ["red", "green", "blue"]
+
+    _, axes = plot_curve(
+        mock_curve_multi_dim, {"day"}, color_dim="brand", colors=colors
+    )
+
+    ax = axes.flat[0]
+    colored_lines = [line for line in ax.get_lines() if line.get_color() in colors]
+    assert len(colored_lines) >= 3
+
+
+def test_plot_curve_color_dim_no_legend(
+    mock_curve_multi_dim, auto_close_figures
+) -> None:
+    _, axes = plot_curve(mock_curve_multi_dim, {"day"}, color_dim="brand", legend=False)
+
+    leg = axes[0].get_legend()
+    assert leg is None
 
 
 def test_plot_curve_n_samples_zero(mock_curve) -> None:


### PR DESCRIPTION
Adds a `color_dim` parameter to `plot_curve`/`plot_hdi`/`plot_samples` for designating one dimension as the color/legend axis instead of faceting, and a `plot_decomposition` method on `FourierBase` that uses it to visualize Fourier seasonality as individual sin/cos components with HDI + sample lines.

### `plot.py` — `color_dim` parameter

When `color_dim="brand"` is specified, that dimension is excluded from faceting. Within each facet subplot, every value of the color dim gets plotted with a distinct color + HDI band + sample lines, and the legend is built from color dim values instead of facet labels:

```python
# Before: brand × geo = 15 subplots
plot_curve(curve, {"day"})

# After: faceted by geo (5 subplots), colored by brand (3 colors each)
plot_curve(curve, {"day"}, color_dim="brand")
```

Passed through `plot_hdi`, `plot_samples`, and `plot_curve`. Legend defaults to `True` when `color_dim` is set.

### `fourier.py` — `sample_curve(sum=False)` + `plot_decomposition`

- `sample_curve(prior, sum=False)` returns individual component curves along the prefix dimension instead of the summed total.
- `plot_decomposition` is a thin wrapper around `plot_curve(..., color_dim=self.prefix)` — shows each sin/cos component as a colored HDI + sample line with legend.
- Module docstring now has two linked `.. plot::` blocks: Block 1 creates a seeded model (`mu=[0.5, 0, -1, 0]` so sin₁ is positive and sin₂ is strong negative) and plots the total curve; Block 2 reuses the shared `:context:` to decompose the same draws.

### Tests

- **test_plot.py**: 7 new `color_dim` tests (faceting, legend, HDI-only, custom colors, `legend=False`) + `mock_curve_multi_dim` fixture + `auto_close_figures` fixture.
- **test_fourier.py**: `TestPlotDecomposition` class with 7 tests (prefix validation, legend labels `["sin_1", "sin_2", "cos_1", "cos_2"]`, hierarchy faceting, custom colors, `same_axes`).

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2783.org.readthedocs.build/en/2783/

<!-- readthedocs-preview pymc-marketing end -->