### PR TITLE
Support multidimensional inputs in to_xarray

### DIFF
--- a/pymc_marketing/clv/utils.py
+++ b/pymc_marketing/clv/utils.py
@@ -32,11 +32,16 @@ __all__ = [
 
 def to_xarray(customer_id, *arrays, dim: str = "customer_id"):
     """Convert vector arrays to xarray with a common dim (default "customer_id")."""
-    dims = (dim,)
     coords = {dim: np.asarray(customer_id)}
 
     res = tuple(
-        xarray.DataArray(data=array, coords=coords, dims=dims) for array in arrays
+        xarray.DataArray(
+            data=array,
+            coords=coords,
+            dims=(dim,)
+            + tuple(f"dim_{i}" for i in range(1, np.asarray(array).ndim)),
+        )
+        for array in arrays
     )
 
     return res[0] if len(arrays) == 1 else res

--- a/tests/clv/test_utils.py
+++ b/tests/clv/test_utils.py
@@ -57,6 +57,18 @@ def test_to_xarray():
     assert new_y.dims == ("test_dim",)
     np.testing.assert_array_equal(new_y.coords["test_dim"], customer_id)
 
+    # Test multidimensional input
+    matrix = np.arange(20).reshape(10, 2)
+
+    new_matrix = to_xarray(customer_id, matrix)
+
+    assert isinstance(new_matrix, xarray.DataArray)
+    assert new_matrix.dims == ("customer_id", "dim_1")
+    np.testing.assert_array_equal(
+        new_matrix.coords["customer_id"], customer_id
+    )
+    np.testing.assert_array_equal(new_matrix.values, matrix)
+
 
 @pytest.fixture(scope="module")
 def fitted_gg(test_summary_data) -> GammaGammaModel:


### PR DESCRIPTION
## Description

This PR extends the `to_xarray` helper function to support multidimensional inputs.

Previously, `to_xarray` assumed all inputs were one-dimensional vectors. This change keeps the existing behavior for 1D arrays while automatically creating additional dimensions for higher-dimensional inputs.

## Changes

- Added support for multidimensional arrays in `to_xarray`
- Preserved existing customer dimension handling
- Added tests covering 2D array inputs

## Testing

Passed:


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2785.org.readthedocs.build/en/2785/

<!-- readthedocs-preview pymc-marketing end -->