### PR TITLE
docs(theme): Juan Fan Service

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -115,7 +115,7 @@ plot_pre_code = (
     "import numpy as np\n"
     "import arviz  # registers arviz styles with matplotlib\n"
     "from matplotlib import pyplot as plt\n"
-    "plt.style.use('arviz-vibrant')\n"
+    "plt.style.use('arviz-darkgrid')\n"
 )
 
 # myst config

--- a/docs/source/guide/benefits/model_deployment.ipynb
+++ b/docs/source/guide/benefits/model_deployment.ipynb
@@ -50,7 +50,7 @@
     "\n",
     "from pymc_marketing.mmm import MMM, GeometricAdstock, LogisticSaturation\n",
     "\n",
-    "az.style.use(\"arviz-vibrant\")\n",
+    "az.style.use(\"arviz-darkgrid\")\n",
     "plt.rcParams[\"figure.figsize\"] = [12, 7]\n",
     "plt.rcParams[\"figure.dpi\"] = 100\n",
     "\n",

--- a/docs/source/notebooks/clv/dev/bg_nbg_covariates_test_issues.ipynb
+++ b/docs/source/notebooks/clv/dev/bg_nbg_covariates_test_issues.ipynb
@@ -19,7 +19,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "import arviz as az\nimport matplotlib.pyplot as plt\nimport numpy as np\nimport pandas as pd\nimport seaborn as sns\nfrom pymc_extras.prior import Prior\n\nfrom pymc_marketing import clv\nfrom tests.clv.conftest import set_model_fit\n\n# Plotting configuration\naz.style.use(\"arviz-vibrant\")\nplt.rcParams[\"figure.figsize\"] = [12, 7]\nplt.rcParams[\"figure.dpi\"] = 100\nplt.rcParams[\"figure.facecolor\"] = \"white\"\n\n%load_ext autoreload\n%autoreload 2\n%config InlineBackend.figure_format = \"retina\""
+   "source": "import arviz as az\nimport matplotlib.pyplot as plt\nimport numpy as np\nimport pandas as pd\nimport seaborn as sns\nfrom pymc_extras.prior import Prior\n\nfrom pymc_marketing import clv\nfrom tests.clv.conftest import set_model_fit\n\n# Plotting configuration\naz.style.use(\"arviz-darkgrid\")\nplt.rcParams[\"figure.figsize\"] = [12, 7]\nplt.rcParams[\"figure.dpi\"] = 100\nplt.rcParams[\"figure.facecolor\"] = \"white\"\n\n%load_ext autoreload\n%autoreload 2\n%config InlineBackend.figure_format = \"retina\""
   },
   {
    "cell_type": "markdown",

--- a/docs/source/notebooks/mmm/dev/mmm_example_new.ipynb
+++ b/docs/source/notebooks/mmm/dev/mmm_example_new.ipynb
@@ -212,7 +212,7 @@
     "\n",
     "warnings.filterwarnings(\"ignore\", category=FutureWarning)\n",
     "\n",
-    "az.style.use(\"arviz-vibrant\")\n",
+    "az.style.use(\"arviz-darkgrid\")\n",
     "plt.rcParams[\"figure.figsize\"] = [12, 7]\n",
     "plt.rcParams[\"figure.dpi\"] = 100\n",
     "\n",


### PR DESCRIPTION
Changes matplotlib style from `arviz-vibrant` to `arviz-darkgrid` across documentation.

## Changes
- Updated `docs/source/conf.py` plot_pre_code to use `arviz-darkgrid`
- Updated `docs/source/guide/benefits/model_deployment.ipynb`
- Updated dev notebooks (`bg_nbg_covariates_test_issues.ipynb`, `mmm_example_new.ipynb`)

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2791.org.readthedocs.build/en/2791/

<!-- readthedocs-preview pymc-marketing end -->