### PR TITLE
fix(mmm): use original model when clone_model=False in sample_posterior_predictive

### DIFF
--- a/pymc_marketing/mmm/mmm.py
+++ b/pymc_marketing/mmm/mmm.py
@@ -2578,6 +2578,8 @@ class MMM(RegressionModelBuilder):
             model = deterministics_to_flat(self.model, names=names)
         elif clone_model:
             model = self.model.copy()
+        else:
+            model = self.model
         model = self._set_xarray_data(
             dataset_xarray=dataset_xarray,
             model=model,

--- a/tests/mmm/test_mmm.py
+++ b/tests/mmm/test_mmm.py
@@ -1415,6 +1415,48 @@ def test_sample_posterior_predictive_same_data(single_dim_data, mock_pymc_sample
     )
 
 
+@pytest.mark.parametrize("clone_model", [True, False])
+def test_sample_posterior_predictive_clone_model(
+    single_dim_data, mock_pymc_sample, clone_model
+):
+    """
+    Test that sampling from the posterior predictive works with both clone_model
+    values when no deterministics are frozen, and that clone_model=False sets the
+    new data on the original model in place.
+    """
+    X, y = single_dim_data
+    X_train = X.iloc[:-5]
+    X_new = X.iloc[-5:]
+    y_train = y.iloc[:-5]
+
+    mmm = MMM(
+        date_column="date",
+        target_column="target",
+        channel_columns=["channel_1", "channel_2", "channel_3"],
+        adstock=GeometricAdstock(l_max=2),
+        saturation=LogisticSaturation(),
+    )
+
+    mmm.build_model(X_train, y_train)
+    mmm.fit(X_train, y_train, draws=200, tune=100, chains=1, random_seed=42)
+
+    # The clone_model=False branch is only reachable without frozen deterministics.
+    assert mmm.frozen_deterministics == []
+
+    out_of_sample_idata = mmm.sample_posterior_predictive(
+        X_new, extend_idata=False, clone_model=clone_model, random_seed=42
+    )
+
+    assert out_of_sample_idata.coords["date"].values.shape == X_new.date.values.shape
+
+    # clone_model=True samples on a copy and leaves the original model untouched,
+    # while clone_model=False sets the new data on the original model.
+    expected_dates = X_train.date if clone_model else X_new.date
+    np.testing.assert_array_equal(
+        np.asarray(mmm.model.coords["date"]), expected_dates.to_numpy()
+    )
+
+
 def test_sample_posterior_predictive_same_data_with_include_last_observations(
     single_dim_data, mock_pymc_sample
 ):


### PR DESCRIPTION
## Description

`MMM.sample_posterior_predictive(..., clone_model=False)` raised `UnboundLocalError` whenever the model had no frozen deterministics (the default), because `model` was only bound inside the `if`/`elif` branches:

```python
if names := self.frozen_deterministics:
    # This always clone
    model = deterministics_to_flat(self.model, names=names)
elif clone_model:
    model = self.model.copy()
model = self._set_xarray_data(...)  # <- UnboundLocalError when neither branch ran
```

This adds the missing `else` branch, which uses the original model in place — what `clone_model=False` advertises:

```python
else:
    model = self.model
```

Also adds a regression test, `test_sample_posterior_predictive_clone_model`, parametrized over `clone_model=True/False`. It asserts `frozen_deterministics == []` (so the `else` branch is the one exercised), that the posterior predictive is drawn on the new dates, and that the original model's `date` coord is mutated only when `clone_model=False`. The test fails with `UnboundLocalError` on `main` and passes with the fix.

## Related Issue
- [x] Closes #2788
- [ ] Related to #

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)

### Note for reviewers

`_set_xarray_data` has a `clone_model: bool = True` parameter (`pymc_marketing/mmm/mmm.py:2475`) that is never read in the body and never passed by any caller. Left untouched here to keep this fix minimal — happy to remove it in a separate PR if you want.


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2796.org.readthedocs.build/en/2796/

<!-- readthedocs-preview pymc-marketing end -->