### PR TITLE
Make ScenarioKey a PEP 695 type alias so the docs build stops failing

### DIFF
--- a/pymc_marketing/mmm/counterfactual.py
+++ b/pymc_marketing/mmm/counterfactual.py
@@ -63,7 +63,7 @@ __all__ = [
     "ScenarioKey",
 ]
 
-ScenarioKey = tuple[int, int | None]
+type ScenarioKey = tuple[int, int | None]
 """Which scenario a row of :attr:`CounterfactualScenarios.spend` answers for.
 
 ``(period_idx, channel_idx)``, with ``channel_idx=None`` for the scenario that


### PR DESCRIPTION
Targets `claude/incrementality-link-functions` (#2813), whose Docs job is red.

## The failure

Sphinx runs with warnings-as-errors and there are exactly two, both about the same object:

```
WARNING: error while formatting signature for
  pymc_marketing.mmm.counterfactual.ScenarioKey: list assignment index out of range [autodoc]
api/generated/pymc_marketing.mmm.counterfactual.rst:10:
  WARNING: failed to import object pymc_marketing.mmm.counterfactual.ScenarioKey
```

`ScenarioKey` carries an attribute docstring, so `_get_module_attrs` puts it in the Module Attributes rubric and autodoc is asked to document it. As a bare subscripted builtin it is a `types.GenericAlias`, which autodoc classifies as `data` and then fails to format a signature for. `Estimand` sitting right next to it is a `typing.Literal` and takes a different path, which is why only one of the two aliases warns.

## The fix

PEP 695 `type`, making it a `TypeAliasType`. autodoc classifies that as `type` and documents it without complaint, and it is how the package's other two aliases are already written (`mmm/dims.py` `XTensorLike`, `mmm/components/base.py` `SupportedPrior`).

Runtime is unchanged. `ScenarioKey` appears only inside annotations; the only one evaluated at runtime is the `CounterfactualScenarios.rows` dataclass field, and a `TypeAliasType` works as a `dict` key parameter there. The `:data:` cross-references still point at the documented module attribute.

## Verification

Reproduced both warnings on a minimal module using the repo's exact Sphinx version (9.1.0) and docs extension set (`sphinx.ext.autodoc`, `autosummary`, `sphinx_autodoc_typehints`, `numpydoc`) plus the repo's `autosummary/module.rst` template, then confirmed the same build reports zero warnings with the `type` form. Full docs build left to CI here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2819.org.readthedocs.build/en/2819/

<!-- readthedocs-preview pymc-marketing end -->