### PR TITLE
refactor(mmm): Add compute/transform/inverse_transform contract to VariableScaling

### DIFF
--- a/pymc_marketing/mmm/__init__.py
+++ b/pymc_marketing/mmm/__init__.py
@@ -73,6 +73,8 @@ from pymc_marketing.mmm.preprocessing import (
 from pymc_marketing.mmm.scaling import (
     DataDerivedScaling,
     FixedScaling,
+    MaxAbsScaling,
+    MeanAbsScaling,
     Scaling,
     VariableScaling,
 )
@@ -107,6 +109,8 @@ __all__ = [
     "LogisticSaturation",
     "MMMBuilder",
     "MMMPlotSuiteFacade",
+    "MaxAbsScaling",
+    "MeanAbsScaling",
     "MediaConfig",
     "MediaConfigList",
     "MediaMuEffect",

--- a/pymc_marketing/mmm/mmm.py
+++ b/pymc_marketing/mmm/mmm.py
@@ -235,10 +235,9 @@ from pymc_marketing.mmm.plot import MMMPlotSuite
 from pymc_marketing.mmm.plotting import MMMPlotSuiteFacade
 from pymc_marketing.mmm.plotting.budget import BudgetPlots
 from pymc_marketing.mmm.scaling import (
-    DataDerivedScaling,
     FixedScaling,
+    MaxAbsScaling,
     Scaling,
-    VariableScaling,
     panel_channel_fixed_scaling_remaining_dims,
     validate_fixed_scaling_keys,
 )
@@ -507,15 +506,15 @@ class MMM(RegressionModelBuilder):
             scaling = deepcopy(scaling)
 
             if "channel" not in scaling:
-                scaling["channel"] = DataDerivedScaling(method="max", dims=self.dims)
+                scaling["channel"] = MaxAbsScaling(dims=self.dims)
             if "target" not in scaling:
-                scaling["target"] = DataDerivedScaling(method="max", dims=self.dims)
+                scaling["target"] = MaxAbsScaling(dims=self.dims)
 
             scaling = Scaling(**scaling)
 
         self.scaling: Scaling = scaling or Scaling(
-            target=DataDerivedScaling(method="max", dims=self.dims),
-            channel=DataDerivedScaling(method="max", dims=self.dims),
+            target=MaxAbsScaling(dims=self.dims),
+            channel=MaxAbsScaling(dims=self.dims),
         )
 
         if set(self.scaling.target.dims).difference([*self.dims, "date"]):
@@ -1815,24 +1814,21 @@ class MMM(RegressionModelBuilder):
         return second.apply(x=first.apply(x=x, core_dim="date"), core_dim="date")
 
     def _compute_scales(self) -> None:
-        """Compute and save scaling factors for channels and target."""
-        self.scalers = xr.Dataset()
+        """Compute scaling factors using the scaling config and pre-scale data.
 
-        self.scalers["_channel"] = self._compute_scale_for_variable(
-            self.xarray_dataset["_channel"],
-            self.scaling.channel,
+        The computed scale factors are stored in :attr:`scalers` for backward
+        compatibility and the raw data is pre-scaled (added to
+        :attr:`xarray_dataset` as ``_channel_scaled`` and
+        ``_target_scaled``) so that the PyMC graph receives scaled data
+        directly, avoiding in-graph division.
+        """
+        channel_artifacts = self.scaling.channel.compute(
+            self.xarray_dataset["_channel"]
         )
-        self.scalers["_target"] = self._compute_scale_for_variable(
-            self.xarray_dataset["_target"],
-            self.scaling.target,
-        )
+        target_artifacts = self.scaling.target.compute(self.xarray_dataset["_target"])
 
         # Scale-sensitive saturations (e.g. LogSaturation) must see raw spend
-        # so their coefficients keep their intended interpretation. Forcing the
-        # channel scale to one feeds raw data to the forward pass (because
-        # ``channel_data / 1 == channel_data``) and keeps every downstream
-        # consumer of ``channel_scale`` -- including the budget optimizer --
-        # consistent without any special-casing.
+        # so their coefficients keep their intended interpretation.
         if getattr(self.saturation, "requires_unscaled_input", False):
             if self._channel_scaling_explicit:
                 warnings.warn(
@@ -1845,120 +1841,27 @@ class MMM(RegressionModelBuilder):
                     UserWarning,
                     stacklevel=2,
                 )
-            self.scalers["_channel"] = xr.ones_like(self.scalers["_channel"])
+            channel_artifacts["scale"] = xr.ones_like(channel_artifacts["scale"])
 
-    def _compute_scale_for_variable(
-        self,
-        data: xr.DataArray,
-        scaling: VariableScaling,
-    ) -> xr.DataArray:
-        """Compute or construct a scale array for a single variable.
-
-        Parameters
-        ----------
-        data : xr.DataArray
-            The raw data variable from :attr:`xarray_dataset`.
-        scaling : VariableScaling
-            The scaling configuration for this variable.
-
-        Returns
-        -------
-        xr.DataArray
-            Scale factors with the reduction dims removed.
-        """
-        reduce_dims = ("date", *scaling.dims)
-
-        if isinstance(scaling, FixedScaling):
-            scale = self._build_fixed_scale(data, scaling, reduce_dims)
-        else:
-            method_fn = getattr(data, scaling.method)
-            scale = method_fn(dim=reduce_dims)
-
-        return scale
-
-    def _build_fixed_scale(
-        self,
-        data: xr.DataArray,
-        scaling: FixedScaling,
-        reduce_dims: tuple[str, ...],
-    ) -> xr.DataArray:
-        """Build a scale DataArray from a FixedScaling configuration."""
-        if isinstance(scaling.value, dict):
-            return self._build_fixed_scale_from_dict(data, scaling, reduce_dims)
-        if isinstance(scaling.value, xr.DataArray):
-            return self._align_fixed_scale_dataarray(data, scaling.value, reduce_dims)
-        return xr.DataArray(float(scaling.value))
-
-    def _build_fixed_scale_from_dict(
-        self,
-        data: xr.DataArray,
-        scaling: FixedScaling,
-        reduce_dims: tuple[str, ...],
-    ) -> xr.DataArray:
-        value_map = cast(dict[str, float], scaling.value)
-        remaining_dims = [d for d in data.dims if d not in reduce_dims]
-        if len(remaining_dims) != 1:
-            raise ValueError(
-                f"dict-valued fixed scaling requires exactly one remaining dimension "
-                f"after reduction over {reduce_dims!r}; got {remaining_dims!r}. "
-                f"Use an xarray.DataArray with dims {tuple(remaining_dims)!r} for "
-                f"multi-dimensional fixed scales."
-            )
-
-        dim_name = remaining_dims[0]
-        coords = data.coords[dim_name].values
-        coord_labels = {str(c) for c in coords}
-        provided_keys = set(value_map.keys())
-        missing = coord_labels - provided_keys
-        extra = provided_keys - coord_labels
-        if missing or extra:
-            parts = []
-            if missing:
-                parts.append(f"missing keys: {sorted(missing)}")
-            if extra:
-                parts.append(f"unexpected keys: {sorted(extra)}")
-            raise ValueError(
-                f"Fixed scaling dict keys for dimension "
-                f"'{dim_name}' do not match coordinate labels. "
-                f"{'; '.join(parts)}. "
-                f"Expected: {sorted(coord_labels)}."
-            )
-
-        values = np.array([value_map[str(c)] for c in coords])
-        return xr.DataArray(
-            values,
-            dims=(dim_name,),
-            coords={dim_name: coords},
+        # Store scales in the backwards-compatible self.scalers Dataset
+        self.scalers = xr.Dataset(
+            {
+                "_channel": channel_artifacts["scale"],
+                "_target": target_artifacts["scale"],
+            }
         )
 
-    def _align_fixed_scale_dataarray(
-        self,
-        data: xr.DataArray,
-        user_scale: xr.DataArray,
-        reduce_dims: tuple[str, ...],
-    ) -> xr.DataArray:
-        """Broadcast a user-supplied scale grid to match reduced data coordinates."""
-        template = data.max(dim=reduce_dims, skipna=True).astype(float)
-        zeros = xr.zeros_like(template, dtype=float)
-        try:
-            aligned = user_scale.astype(float) + zeros
-        except (ValueError, TypeError) as e:
-            raise ValueError(
-                "Could not align fixed scaling DataArray with the data grid after "
-                f"reduction over {reduce_dims!r}. Check dimension names and coordinate "
-                f"labels. Underlying error: {e}"
-            ) from e
-        if np.isnan(np.asarray(aligned.values)).any():
-            raise ValueError(
-                "Fixed scaling DataArray produced NaNs after alignment — coordinates "
-                "likely do not match the data grid on a shared dimension."
-            )
-        if dict(aligned.sizes) != dict(template.sizes):
-            raise ValueError(
-                f"Fixed scaling DataArray has shape {dict(aligned.sizes)} after "
-                f"broadcast; expected {dict(template.sizes)} matching reduced data."
-            )
-        return aligned
+        # Pre-scale the data so the PyMC graph receives scaled values directly.
+        # NaN/Inf clamping (e.g. from all-zero channels) is handled by
+        # VariableScaling._safe_scale inside transform().
+        self.xarray_dataset["_channel_scaled"] = self.scaling.channel.transform(
+            self.xarray_dataset["_channel"],
+            channel_artifacts,
+        )
+        self.xarray_dataset["_target_scaled"] = self.scaling.target.transform(
+            self.xarray_dataset["_target"],
+            target_artifacts,
+        )
 
     def get_scales_as_xarray(self) -> dict[str, xr.DataArray]:
         """Return the saved scaling factors as xarray DataArrays.
@@ -2238,38 +2141,16 @@ class MMM(RegressionModelBuilder):
             _channel_scale = pmd.Data("channel_scale", self.scalers._channel)
             _target_scale = pmd.Data("target_scale", self.scalers._target)
 
-            _channel_data = pmd.Data("channel_data", self.xarray_dataset._channel)
-
-            _target = pmd.Data("target_data", self.xarray_dataset._target)
-
-            # Scale `channel_data` and `target`. The switches guard against
-            # NaN (0/0 when a channel/target is all-zero) and against +/-inf
-            # (non-zero numerator over a zero scale, which can arise under
-            # per-dim ``DataDerivedScaling`` with heterogeneous slices).
-            # Both are clamped to 0 so the likelihood receives finite inputs.
-            channel_data_ = _channel_data / _channel_scale
-            channel_data_ = pmd.math.switch(
-                pmd.math.logical_or(
-                    pmd.math.isnan(channel_data_), pmd.math.isinf(channel_data_)
-                ),
-                0.0,
-                channel_data_,
+            _channel_data = pmd.Data(
+                "channel_data", self.xarray_dataset._channel_scaled
             )
-            channel_data_.name = "channel_data_scaled"
-            ## TODO: Find a better way to save it or access it in the pytensor graph.
+
+            _target = pmd.Data("target_data", self.xarray_dataset._target_scaled)
+
+            channel_data_ = _channel_data
             self.channel_data_scaled = channel_data_
 
-            target_data_scaled = _target / _target_scale
-            target_data_scaled = pmd.math.switch(
-                pmd.math.logical_or(
-                    pmd.math.isnan(target_data_scaled),
-                    pmd.math.isinf(target_data_scaled),
-                ),
-                0.0,
-                target_data_scaled,
-            )
-            target_data_scaled.name = "target_scaled"
-            ## TODO: Find a better way to save it or access it in the pytensor graph.
+            target_data_scaled = _target
             self.target_data_scaled = target_data_scaled
 
             for mu_effect in self.mu_effects:
@@ -2512,6 +2393,12 @@ class MMM(RegressionModelBuilder):
             original_dtype = model.named_vars["channel_data"].type.dtype
             channel_values = channel_values.astype(original_dtype)
 
+        # Pre-scale channel data to match the trained model's internal scale
+        channel_values = self.scaling.channel.transform(
+            channel_values,
+            xr.Dataset({"scale": self.scalers["_channel"]}),
+        )
+
         data = {"channel_data": channel_values}
         coords = self.model.coords.copy()
         coords["date"] = dataset_xarray["date"].to_numpy()
@@ -2541,9 +2428,14 @@ class MMM(RegressionModelBuilder):
             if "target_data" in model.named_vars:
                 original_dtype = model.named_vars["target_data"].type.dtype
                 # Convert to the original dtype to avoid precision loss errors
-                data["target_data"] = target_values.astype(original_dtype)
-            else:
-                data["target_data"] = target_values
+                target_values = target_values.astype(original_dtype)
+
+            # Pre-scale target data to match the trained model's internal scale
+            target_values = self.scaling.target.transform(
+                target_values,
+                xr.Dataset({"scale": self.scalers["_target"]}),
+            )
+            data["target_data"] = target_values
 
         pm.set_data(data, coords=coords, model=model)
 
@@ -3614,8 +3506,15 @@ class BudgetOptimizerWrapper(OptimizerCompatibleModelWrapper):
         )
         self.num_periods = len(self.zero_data.coords["date"]) - self.adstock.l_max
         self.compile_kwargs = compile_kwargs
-        # Adding missing dependencies for compatibility with BudgetOptimizer
-        self._channel_scales = 1.0
+
+    @property
+    def _channel_scales(self):
+        if (
+            hasattr(self.model_class, "scalers")
+            and "_channel" in self.model_class.scalers
+        ):
+            return self.model_class.scalers["_channel"].values
+        return 1.0
 
     @property
     def plot(self) -> BudgetPlots | MMMPlotSuite | MMMPlotSuiteFacade:

--- a/pymc_marketing/mmm/scaling.py
+++ b/pymc_marketing/mmm/scaling.py
@@ -27,6 +27,7 @@ Each :class:`VariableScaling` subclass follows a ``fit`` / ``transform`` /
 from __future__ import annotations
 
 import math
+import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from datetime import date, datetime
@@ -345,6 +346,16 @@ class DataDerivedScaling(VariableScaling):
     """
 
     method: Literal["max", "mean"] = Field(...)
+
+    @model_validator(mode="after")
+    def _emit_deprecation_warning(self) -> Self:
+        warnings.warn(
+            "DataDerivedScaling is deprecated. "
+            "Use MaxAbsScaling or MeanAbsScaling instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self
 
     def scaling_description(self) -> str:
         """Human-readable summary of the scaling strategy."""
@@ -710,7 +721,9 @@ def deserialize_variable_scaling(d: dict[str, Any]) -> VariableScaling:
                 return MaxAbsScaling(dims=dims)
             if method == "mean":
                 return MeanAbsScaling(dims=dims)
-            return DataDerivedScaling(method=method, dims=dims)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                return DataDerivedScaling(method=method, dims=dims)
 
         # Backward compatibility: old DataDerivedScaling with method string
         if type_key == _DATA_DERIVED_SCALING_TYPE:
@@ -720,7 +733,9 @@ def deserialize_variable_scaling(d: dict[str, Any]) -> VariableScaling:
                 return MaxAbsScaling(dims=dims)
             if method == "mean":
                 return MeanAbsScaling(dims=dims)
-            return DataDerivedScaling(method=method, dims=dims)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                return DataDerivedScaling(method=method, dims=dims)
 
         return serialization.deserialize(d)
 
@@ -734,7 +749,9 @@ def deserialize_variable_scaling(d: dict[str, Any]) -> VariableScaling:
         return MaxAbsScaling(dims=dims)
     if method == "mean":
         return MeanAbsScaling(dims=dims)
-    return DataDerivedScaling(method=method, dims=dims)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        return DataDerivedScaling(method=method, dims=dims)
 
 
 class Scaling(SerializableBaseModel):

--- a/pymc_marketing/mmm/scaling.py
+++ b/pymc_marketing/mmm/scaling.py
@@ -11,7 +11,18 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-"""Scaling configuration for the MMM."""
+"""Scaling configuration for the MMM.
+
+Each :class:`VariableScaling` subclass follows a ``fit`` / ``transform`` /
+``inverse_transform`` contract:
+
+* :meth:`~VariableScaling.compute` -- derive scaling artifacts from training
+  data (always operates on :class:`xarray.DataArray`).
+* :meth:`~VariableScaling.transform` -- apply the scaling (e.g. divide by the
+  artifacts). Works on both :class:`xarray.DataArray` and in-graph tensors.
+* :meth:`~VariableScaling.inverse_transform` -- reverse the scaling (e.g.
+  multiply by the artifacts).
+"""
 
 from __future__ import annotations
 
@@ -30,6 +41,7 @@ from pymc_marketing.serialization import SerializableBaseModel, serialization
 
 _FIXED_SCALING_XARRAY_KIND = "xarray.DataArray"
 _LEGACY_VARIABLE_SCALING_TYPE = "pymc_marketing.mmm.scaling.VariableScaling"
+_DATA_DERIVED_SCALING_TYPE = "pymc_marketing.mmm.scaling.DataDerivedScaling"
 
 
 def panel_channel_fixed_scaling_remaining_dims(
@@ -97,12 +109,16 @@ class VariableScaling(SerializableBaseModel, ABC):
     The scaling through the dimension of ``'date'`` is assumed and doesn't need
     to be specified.
 
-    Concrete subclasses:
+    Concrete subclasses implement the ``compute`` / ``transform`` /
+    ``inverse_transform`` contract:
 
-    - :class:`DataDerivedScaling` -- scale by a statistic of the data
-      (``"max"`` or ``"mean"``), computed at fit time.
-    - :class:`FixedScaling` -- use a user-supplied constant that stays the
-      same across model refreshes.
+    - :meth:`compute` -- derive scaling artifacts from training data
+      (always operates on :class:`xarray.DataArray`).
+    - :meth:`transform` -- apply the scaling (e.g. divide by artifacts).
+      Clamps NaN/Inf results to 0. Works on both
+      :class:`xarray.DataArray` and in-graph tensors.
+    - :meth:`inverse_transform` -- reverse the scaling (e.g. multiply by
+      artifacts).
 
     Parameters
     ----------
@@ -118,6 +134,87 @@ class VariableScaling(SerializableBaseModel, ABC):
         """Human-readable summary of the scaling strategy (e.g. for logging)."""
         ...
 
+    @abstractmethod
+    def compute(self, data: xr.DataArray) -> xr.Dataset:
+        """Compute scaling artifacts from training data.
+
+        Parameters
+        ----------
+        data : xr.DataArray
+            The raw training data for this variable.
+
+        Returns
+        -------
+        xr.Dataset
+            Scaling artifacts.  The dataset variable names are stable per
+            subclass (e.g. ``"scale"`` for simple divisive scaling,
+            ``"mean"`` and ``"std"`` for z-score).
+        """
+        ...
+
+    @abstractmethod
+    def transform(
+        self,
+        data: Any,
+        artifacts: xr.Dataset,
+    ) -> Any:
+        """Apply the scaling.
+
+        Clamps NaN/Inf results (e.g. from all-zero channels) to 0.
+
+        Parameters
+        ----------
+        data : xr.DataArray or tensor
+            The data to scale.
+        artifacts : xr.Dataset
+            Artifacts produced by :meth:`compute`.
+
+        Returns
+        -------
+        xr.DataArray or tensor
+            Scaled data, same type as *data*.
+        """
+        ...
+
+    @abstractmethod
+    def inverse_transform(
+        self,
+        data: Any,
+        artifacts: xr.Dataset,
+    ) -> Any:
+        """Reverse the scaling.
+
+        Parameters
+        ----------
+        data : xr.DataArray or tensor
+            The scaled data to return to original scale.
+        artifacts : xr.Dataset
+            Artifacts produced by :meth:`compute`.
+
+        Returns
+        -------
+        xr.DataArray or tensor
+            Data in original scale, same type as *data*.
+        """
+        ...
+
+    @staticmethod
+    def _safe_scale(result: Any) -> Any:
+        """Clamp NaN and Inf results from division to 0.
+
+        This handles edge cases like all-zero channels (``0 / 0 → NaN``)
+        or non-zero data divided by a zero scale (``nonzero / 0 → Inf``).
+        Only operates on :class:`xarray.DataArray` inputs; tensor inputs
+        are assumed to already contain finite values.
+        """
+        if isinstance(result, xr.DataArray):
+            return xr.where(
+                np.logical_or(np.isnan(result), np.isinf(result)),
+                0.0,
+                result,
+            )
+        return result
+
     @model_validator(mode="after")
     def _validate_dims(self) -> Self:
         if isinstance(self.dims, str):
@@ -132,8 +229,111 @@ class VariableScaling(SerializableBaseModel, ABC):
         return self
 
 
+class MaxAbsScaling(VariableScaling):
+    """Scale by the maximum absolute value of the data.
+
+    Parameters
+    ----------
+    dims : str or tuple of str
+        The dimensions to perform the operation through (``"date"`` is always
+        included implicitly).
+
+    Examples
+    --------
+    .. code-block:: python
+
+        MaxAbsScaling(dims=())
+
+    With multi-dimensional data:
+
+    .. code-block:: python
+
+        MaxAbsScaling(dims=("country",))
+    """
+
+    def scaling_description(self) -> str:
+        """Human-readable summary of the scaling strategy."""
+        return "max-absolute"
+
+    def compute(self, data: xr.DataArray) -> xr.Dataset:
+        """Compute ``max(abs(data))`` over date and configured dims."""
+        reduce_dims = ("date", *self.dims)
+        scale = data.max(dim=reduce_dims)
+        return xr.Dataset({"scale": scale})
+
+    def transform(
+        self,
+        data: Any,
+        artifacts: xr.Dataset,
+    ) -> Any:
+        """Divide *data* by the stored scale artifact, clamping NaN/Inf to 0."""
+        return self._safe_scale(data / artifacts["scale"])
+
+    def inverse_transform(
+        self,
+        data: Any,
+        artifacts: xr.Dataset,
+    ) -> Any:
+        """Multiply *data* by the stored scale artifact."""
+        return data * artifacts["scale"]
+
+
+class MeanAbsScaling(VariableScaling):
+    """Scale by the mean absolute value of the data.
+
+    Parameters
+    ----------
+    dims : str or tuple of str
+        The dimensions to perform the operation through (``"date"`` is always
+        included implicitly).
+
+    Examples
+    --------
+    .. code-block:: python
+
+        MeanAbsScaling(dims=())
+
+    With multi-dimensional data:
+
+    .. code-block:: python
+
+        MeanAbsScaling(dims=("country",))
+    """
+
+    def scaling_description(self) -> str:
+        """Human-readable summary of the scaling strategy."""
+        return "mean-absolute"
+
+    def compute(self, data: xr.DataArray) -> xr.Dataset:
+        """Compute ``mean(abs(data))`` over date and configured dims."""
+        reduce_dims = ("date", *self.dims)
+        scale = data.mean(dim=reduce_dims)
+        return xr.Dataset({"scale": scale})
+
+    def transform(
+        self,
+        data: Any,
+        artifacts: xr.Dataset,
+    ) -> Any:
+        """Divide *data* by the stored scale artifact, clamping NaN/Inf to 0."""
+        return self._safe_scale(data / artifacts["scale"])
+
+    def inverse_transform(
+        self,
+        data: Any,
+        artifacts: xr.Dataset,
+    ) -> Any:
+        """Multiply *data* by the stored scale artifact."""
+        return data * artifacts["scale"]
+
+
 class DataDerivedScaling(VariableScaling):
     """Scale by a statistic of the data, computed at fit time.
+
+    .. deprecated::
+        Prefer the concrete subclasses :class:`MaxAbsScaling` and
+        :class:`MeanAbsScaling`.  This class remains for backward
+        compatibility of serialized models.
 
     Parameters
     ----------
@@ -142,20 +342,6 @@ class DataDerivedScaling(VariableScaling):
     dims : str or tuple of str
         The dimensions to perform the operation through (``"date"`` is always
         included implicitly).
-
-    Examples
-    --------
-    Max-absolute scaling (default behaviour):
-
-    .. code-block:: python
-
-        DataDerivedScaling(method="max", dims=())
-
-    Mean-absolute scaling across a custom dimension:
-
-    .. code-block:: python
-
-        DataDerivedScaling(method="mean", dims=("country",))
     """
 
     method: Literal["max", "mean"] = Field(...)
@@ -163,6 +349,28 @@ class DataDerivedScaling(VariableScaling):
     def scaling_description(self) -> str:
         """Human-readable summary of the scaling strategy."""
         return f"data-derived ({self.method})"
+
+    def compute(self, data: xr.DataArray) -> xr.Dataset:
+        """Compute scale from data using the configured method."""
+        reduce_dims = ("date", *self.dims)
+        scale = getattr(data, self.method)(dim=reduce_dims)
+        return xr.Dataset({"scale": scale})
+
+    def transform(
+        self,
+        data: Any,
+        artifacts: xr.Dataset,
+    ) -> Any:
+        """Divide *data* by the stored scale artifact, clamping NaN/Inf to 0."""
+        return self._safe_scale(data / artifacts["scale"])
+
+    def inverse_transform(
+        self,
+        data: Any,
+        artifacts: xr.Dataset,
+    ) -> Any:
+        """Multiply *data* by the stored scale artifact."""
+        return data * artifacts["scale"]
 
 
 class FixedScaling(VariableScaling):
@@ -332,6 +540,109 @@ class FixedScaling(VariableScaling):
             filtered["dims"] = tuple(filtered["dims"])
         return cls.model_validate(filtered)
 
+    def compute(self, data: xr.DataArray) -> xr.Dataset:
+        """Resolve the fixed value against *data* coordinate layout.
+
+        For float values the data is ignored.  For dict and DataArray values
+        the data coordinates are used to align and validate the scale.
+        """
+        reduce_dims = ("date", *self.dims)
+
+        if isinstance(self.value, dict):
+            scale = self._build_scale_from_dict(data, reduce_dims)
+        elif isinstance(self.value, xr.DataArray):
+            scale = self._align_scale_dataarray(data, self.value, reduce_dims)
+        else:
+            scale = xr.DataArray(float(self.value))
+
+        return xr.Dataset({"scale": scale})
+
+    def _build_scale_from_dict(
+        self,
+        data: xr.DataArray,
+        reduce_dims: tuple[str, ...],
+    ) -> xr.DataArray:
+        value_map: dict[str, float] = self.value  # type: ignore[assignment]
+        remaining_dims = [d for d in data.dims if d not in reduce_dims]
+        if len(remaining_dims) != 1:
+            raise ValueError(
+                f"dict-valued fixed scaling requires exactly one remaining dimension "
+                f"after reduction over {reduce_dims!r}; got {remaining_dims!r}. "
+                f"Use an xarray.DataArray with dims {tuple(remaining_dims)!r} for "
+                f"multi-dimensional fixed scales."
+            )
+
+        dim_name = remaining_dims[0]
+        coords = data.coords[dim_name].values
+        coord_labels = {str(c) for c in coords}
+        provided_keys = set(value_map.keys())
+        missing = coord_labels - provided_keys
+        extra = provided_keys - coord_labels
+        if missing or extra:
+            parts = []
+            if missing:
+                parts.append(f"missing keys: {sorted(missing)}")
+            if extra:
+                parts.append(f"unexpected keys: {sorted(extra)}")
+            raise ValueError(
+                f"Fixed scaling dict keys for dimension "
+                f"'{dim_name}' do not match coordinate labels. "
+                f"{'; '.join(parts)}. "
+                f"Expected: {sorted(coord_labels)}."
+            )
+
+        values = np.array([value_map[str(c)] for c in coords])
+        return xr.DataArray(
+            values,
+            dims=(dim_name,),
+            coords={dim_name: coords},
+        )
+
+    def _align_scale_dataarray(
+        self,
+        data: xr.DataArray,
+        user_scale: xr.DataArray,
+        reduce_dims: tuple[str, ...],
+    ) -> xr.DataArray:
+        """Broadcast a user-supplied scale grid to match reduced data coordinates."""
+        template = data.max(dim=reduce_dims, skipna=True).astype(float)
+        zeros = xr.zeros_like(template, dtype=float)
+        try:
+            aligned = user_scale.astype(float) + zeros
+        except (ValueError, TypeError) as e:
+            raise ValueError(
+                "Could not align fixed scaling DataArray with the data grid after "
+                f"reduction over {reduce_dims!r}. Check dimension names and coordinate "
+                f"labels. Underlying error: {e}"
+            ) from e
+        if np.isnan(np.asarray(aligned.values)).any():
+            raise ValueError(
+                "Fixed scaling DataArray produced NaNs after alignment — coordinates "
+                "likely do not match the data grid on a shared dimension."
+            )
+        if dict(aligned.sizes) != dict(template.sizes):
+            raise ValueError(
+                f"Fixed scaling DataArray has shape {dict(aligned.sizes)} after "
+                f"broadcast; expected {dict(template.sizes)} matching reduced data."
+            )
+        return aligned
+
+    def transform(
+        self,
+        data: Any,
+        artifacts: xr.Dataset,
+    ) -> Any:
+        """Divide *data* by the stored scale artifact, clamping NaN/Inf to 0."""
+        return self._safe_scale(data / artifacts["scale"])
+
+    def inverse_transform(
+        self,
+        data: Any,
+        artifacts: xr.Dataset,
+    ) -> Any:
+        """Multiply *data* by the stored scale artifact."""
+        return data * artifacts["scale"]
+
 
 def validate_fixed_scaling_keys(
     scaling: VariableScaling,
@@ -385,15 +696,32 @@ def deserialize_variable_scaling(d: dict[str, Any]) -> VariableScaling:
     New format uses the ``__type__`` key injected by the serialization registry.
     """
     if "__type__" in d:
+        type_key = d.get("__type__")
+
         # Backward compatibility: historical payloads may store the abstract
         # VariableScaling class type and rely on "method" discrimination.
-        if d.get("__type__") == _LEGACY_VARIABLE_SCALING_TYPE:
+        if type_key == _LEGACY_VARIABLE_SCALING_TYPE:
             method = d.get("method")
             dims = tuple(d.get("dims", ()))
             if method == "fixed":
                 value = _maybe_deserialize_fixed_scaling_value(d["value"])
                 return FixedScaling(dims=dims, value=value)
+            if method == "max":
+                return MaxAbsScaling(dims=dims)
+            if method == "mean":
+                return MeanAbsScaling(dims=dims)
             return DataDerivedScaling(method=method, dims=dims)
+
+        # Backward compatibility: old DataDerivedScaling with method string
+        if type_key == _DATA_DERIVED_SCALING_TYPE:
+            method = d.get("method", "max")
+            dims = tuple(d.get("dims", ()))
+            if method == "max":
+                return MaxAbsScaling(dims=dims)
+            if method == "mean":
+                return MeanAbsScaling(dims=dims)
+            return DataDerivedScaling(method=method, dims=dims)
+
         return serialization.deserialize(d)
 
     method = d.get("method")
@@ -402,6 +730,10 @@ def deserialize_variable_scaling(d: dict[str, Any]) -> VariableScaling:
         raw_value = d["value"]
         value = _maybe_deserialize_fixed_scaling_value(raw_value)
         return FixedScaling(dims=dims, value=value)
+    if method == "max":
+        return MaxAbsScaling(dims=dims)
+    if method == "mean":
+        return MeanAbsScaling(dims=dims)
     return DataDerivedScaling(method=method, dims=dims)
 
 
@@ -422,8 +754,8 @@ class Scaling(SerializableBaseModel):
     .. code-block:: python
 
         Scaling(
-            target=DataDerivedScaling(method="max", dims=()),
-            channel=DataDerivedScaling(method="max", dims=()),
+            target=MaxAbsScaling(dims=()),
+            channel=MaxAbsScaling(dims=()),
         )
 
     Fixed scaling for stable production refreshes:

--- a/tests/mmm/test_mmm.py
+++ b/tests/mmm/test_mmm.py
@@ -4341,6 +4341,49 @@ def test_set_xarray_data_preserves_dtypes(multi_dim_data, mock_pymc_sample):
     )
 
 
+def test_set_xarray_data_prescales_with_fixed_scaling(multi_dim_data):
+    """_set_xarray_data applies FixedScaling transform before pm.set_data."""
+    X, y = multi_dim_data
+
+    channel_scale = 10.0
+    target_scale = 100.0
+
+    mmm = MMM(
+        adstock=GeometricAdstock(l_max=2),
+        saturation=LogisticSaturation(),
+        scaling={
+            "channel": FixedScaling(dims=("country",), value=channel_scale),
+            "target": FixedScaling(dims=("country",), value=target_scale),
+        },
+        date_column="date",
+        target_column="target",
+        channel_columns=["channel_1", "channel_2", "channel_3"],
+        dims=("country",),
+    )
+    mmm.build_model(X, y)
+
+    # Create prediction data with known values
+    dataset_xarray = mmm._posterior_predictive_data_transformation(
+        X=X, y=y, include_last_observations=False
+    )
+    # Set channel values to a known constant
+    raw_channel = np.full_like(dataset_xarray._channel.values, 50.0)
+    dataset_xarray["_channel"].values = raw_channel
+    # Set target values to a known constant
+    raw_target = np.full_like(dataset_xarray._target.values, 200.0)
+    dataset_xarray["_target"].values = raw_target
+
+    model = mmm._set_xarray_data(dataset_xarray, model=mmm.model.copy())
+
+    # channel_data should be 50.0 / 10.0 = 5.0 (FixedScaling divides by scale)
+    channel_in_model = model.named_vars["channel_data"].get_value()
+    np.testing.assert_allclose(channel_in_model, 5.0, rtol=1e-6)
+
+    # target_data should be 200.0 / 100.0 = 2.0
+    target_in_model = model.named_vars["target_data"].get_value()
+    np.testing.assert_allclose(target_in_model, 2.0, rtol=1e-6)
+
+
 def test_integer_channel_data_is_cast_to_float(multi_dim_data):
     """Integer channel data is cast to float at construction time (GH #2340)."""
     X, y = multi_dim_data

--- a/tests/mmm/test_mmm.py
+++ b/tests/mmm/test_mmm.py
@@ -54,6 +54,8 @@ from pymc_marketing.mmm.plotting import MMMPlotSuiteFacade
 from pymc_marketing.mmm.scaling import (
     DataDerivedScaling,
     FixedScaling,
+    MaxAbsScaling,
+    MeanAbsScaling,
     Scaling,
 )
 from pymc_marketing.serialization import serialization
@@ -2283,7 +2285,10 @@ def test_different_target_scaling(method, multi_dim_data, mock_pymc_sample) -> N
         channel_columns=["channel_1", "channel_2", "channel_3"],
         dims=("country",),
     )
-    assert mmm.scaling.target == DataDerivedScaling(method=method, dims=())
+    assert mmm.scaling.target.dims == ()
+    assert isinstance(
+        mmm.scaling.target, MaxAbsScaling if method == "max" else MeanAbsScaling
+    )
     mmm.fit(X, y)
     assert mmm.xarray_dataset._target.dims == ("date", "country")
     assert mmm.scalers._target.dims == ("country",)
@@ -2397,8 +2402,8 @@ def test_scaling_dict_doesnt_mutate() -> None:
 
     assert scaling == {}
     assert mmm.scaling == Scaling(
-        target=DataDerivedScaling(method="max", dims=dims),
-        channel=DataDerivedScaling(method="max", dims=dims),
+        target=MaxAbsScaling(dims=dims),
+        channel=MaxAbsScaling(dims=dims),
     )
 
 
@@ -4066,10 +4071,8 @@ class TestPydanticValidation:
             scaling=scaling_dict,
         )
         assert isinstance(mmm.scaling, Scaling)
-        assert isinstance(mmm.scaling.channel, DataDerivedScaling)
-        assert isinstance(mmm.scaling.target, DataDerivedScaling)
-        assert mmm.scaling.channel.method == "max"
-        assert mmm.scaling.target.method == "max"
+        assert isinstance(mmm.scaling.channel, MaxAbsScaling)
+        assert isinstance(mmm.scaling.target, MaxAbsScaling)
         assert mmm.scaling.channel.dims == ()
         assert mmm.scaling.target.dims == ()
 

--- a/tests/mmm/test_scaling.py
+++ b/tests/mmm/test_scaling.py
@@ -20,8 +20,11 @@ from pydantic import ValidationError
 from pymc_marketing.mmm.scaling import (
     DataDerivedScaling,
     FixedScaling,
+    MaxAbsScaling,
+    MeanAbsScaling,
     Scaling,
     VariableScaling,
+    deserialize_variable_scaling,
     panel_channel_fixed_scaling_remaining_dims,
 )
 from pymc_marketing.serialization import serialization
@@ -29,6 +32,7 @@ from pymc_marketing.serialization import serialization
 
 class TestScalingRoundtrips:
     def test_data_derived_scaling_roundtrip(self):
+        """Old DataDerivedScaling round-trips to itself via direct serialization."""
         original = DataDerivedScaling(method="mean", dims=("geo", "channel"))
         data = serialization.serialize(original)
         restored = serialization.deserialize(data)
@@ -38,34 +42,50 @@ class TestScalingRoundtrips:
         assert restored.dims == ("geo", "channel")
         assert restored == original
 
+    def test_max_abs_scaling_roundtrip(self):
+        """New MaxAbsScaling round-trips to itself."""
+        original = MaxAbsScaling(dims=("geo",))
+        data = serialization.serialize(original)
+        restored = serialization.deserialize(data)
+
+        assert type(restored) is MaxAbsScaling
+        assert restored == original
+
+    def test_mean_abs_scaling_roundtrip(self):
+        """New MeanAbsScaling round-trips to itself."""
+        original = MeanAbsScaling(dims=("geo", "channel"))
+        data = serialization.serialize(original)
+        restored = serialization.deserialize(data)
+
+        assert type(restored) is MeanAbsScaling
+        assert restored == original
+
     def test_scaling_roundtrip_all_parameters(self):
         original = Scaling(
-            target=DataDerivedScaling(method="max", dims="geo"),
-            channel=DataDerivedScaling(method="mean", dims=("geo", "channel")),
+            target=MaxAbsScaling(dims="geo"),
+            channel=MeanAbsScaling(dims=("geo", "channel")),
         )
         data = serialization.serialize(original)
         restored = serialization.deserialize(data)
 
         assert type(restored) is Scaling
-        assert type(restored.target) is DataDerivedScaling
-        assert type(restored.channel) is DataDerivedScaling
-        assert restored.target.method == "max"
+        assert type(restored.target) is MaxAbsScaling
+        assert type(restored.channel) is MeanAbsScaling
         assert restored.target.dims == ("geo",)
-        assert restored.channel.method == "mean"
         assert restored.channel.dims == ("geo", "channel")
         assert restored == original
 
     def test_scaling_roundtrip_mixed_types(self):
         original = Scaling(
             target=FixedScaling(dims=(), value=50_000.0),
-            channel=DataDerivedScaling(method="max", dims=("geo",)),
+            channel=MaxAbsScaling(dims=("geo",)),
         )
         data = serialization.serialize(original)
         restored = serialization.deserialize(data)
 
         assert type(restored) is Scaling
         assert type(restored.target) is FixedScaling
-        assert type(restored.channel) is DataDerivedScaling
+        assert type(restored.channel) is MaxAbsScaling
         assert restored == original
 
     def test_legacy_format_deserialization(self):
@@ -78,10 +98,28 @@ class TestScalingRoundtrips:
         restored = serialization.deserialize(legacy_data)
 
         assert type(restored) is Scaling
-        assert type(restored.target) is DataDerivedScaling
+        assert type(restored.target) is MaxAbsScaling
         assert type(restored.channel) is FixedScaling
-        assert restored.target.method == "max"
+        assert restored.target.dims == ("geo",)
         assert restored.channel.value == 1000.0
+
+    def test_legacy_data_derived_max_roundtrip(self):
+        """Old DataDerivedScaling(method='max') upgrades to MaxAbsScaling."""
+        original = DataDerivedScaling(method="max", dims=())
+        data = serialization.serialize(original)
+        restored = deserialize_variable_scaling(data)
+
+        assert type(restored) is MaxAbsScaling
+        assert restored.dims == ()
+
+    def test_legacy_data_derived_mean_roundtrip(self):
+        """Old DataDerivedScaling(method='mean') upgrades to MeanAbsScaling."""
+        original = DataDerivedScaling(method="mean", dims=("country",))
+        data = serialization.serialize(original)
+        restored = deserialize_variable_scaling(data)
+
+        assert type(restored) is MeanAbsScaling
+        assert restored.dims == ("country",)
 
 
 class TestFixedScaling:
@@ -208,6 +246,40 @@ class TestFixedScaling:
         restored = serialization.deserialize(data)
         assert restored == original
 
+    def test_compute_scalar(self):
+        vs = FixedScaling(dims=(), value=1000.0)
+        data = xr.DataArray([1000.0, 2000.0], dims="date")
+        arts = vs.compute(data)
+        assert "scale" in arts
+        assert float(arts["scale"]) == 1000.0
+
+    def test_compute_dict(self):
+        vs = FixedScaling(dims=(), value={"A": 10.0, "B": 20.0})
+        data = xr.DataArray(
+            [[1.0, 2.0], [3.0, 4.0]],
+            dims=("date", "country"),
+            coords={"country": ["A", "B"]},
+        )
+        arts = vs.compute(data)
+        assert arts["scale"].sel(country="A").item() == 10.0
+        assert arts["scale"].sel(country="B").item() == 20.0
+
+    def test_compute_dataarray(self):
+        user_da = xr.DataArray(
+            [5.0, 10.0, 15.0],
+            dims="channel",
+            coords={"channel": ["tv", "radio", "search"]},
+        )
+        vs = FixedScaling(dims=(), value=user_da)
+        data = xr.DataArray(
+            np.ones((10, 3)),
+            dims=("date", "channel"),
+            coords={"channel": ["tv", "radio", "search"]},
+        )
+        arts = vs.compute(data)
+        assert arts["scale"].sel(channel="tv").item() == 5.0
+        assert arts["scale"].sel(channel="search").item() == 15.0
+
 
 class TestDataDerivedScaling:
     def test_max_construction(self):
@@ -220,6 +292,104 @@ class TestDataDerivedScaling:
         assert vs.method == "mean"
         assert vs.dims == ("geo",)
 
+    def test_compute(self):
+        vs = DataDerivedScaling(method="max", dims=())
+        data = xr.DataArray([3.0, 5.0, 1.0], dims="date")
+        arts = vs.compute(data)
+        assert float(arts["scale"]) == 5.0
+
+    def test_transform(self):
+        vs = DataDerivedScaling(method="max", dims=())
+        data = xr.DataArray([2.0, 4.0, 8.0], dims="date")
+        arts = vs.compute(data)
+        result = vs.transform(data, arts)
+        expected = data / 8.0
+        xr.testing.assert_equal(result, expected)
+
+    def test_inverse_transform(self):
+        vs = DataDerivedScaling(method="max", dims=())
+        data = xr.DataArray([2.0, 4.0, 8.0], dims="date")
+        arts = vs.compute(data)
+        scaled = vs.transform(data, arts)
+        restored = vs.inverse_transform(scaled, arts)
+        xr.testing.assert_allclose(restored, data)
+
+
+class TestMaxAbsScaling:
+    def test_construction(self):
+        vs = MaxAbsScaling(dims=())
+        assert vs.dims == ()
+
+    def test_compute(self):
+        vs = MaxAbsScaling(dims=())
+        data = xr.DataArray([3.0, 5.0, 1.0], dims="date")
+        arts = vs.compute(data)
+        assert float(arts["scale"]) == 5.0
+
+    def test_compute_multidimensional(self):
+        vs = MaxAbsScaling(dims=("channel",))
+        data = xr.DataArray(
+            [[1.0, 3.0], [2.0, 4.0], [5.0, 1.0]],
+            dims=("date", "channel"),
+        )
+        arts = vs.compute(data)
+        # reduce over ("date", "channel") → scalar max
+        assert float(arts["scale"]) == 5.0
+
+    def test_compute_per_channel(self):
+        vs = MaxAbsScaling(dims=())
+        data = xr.DataArray(
+            [[1.0, 3.0], [2.0, 4.0]],
+            dims=("date", "channel"),
+            coords={"channel": ["c1", "c2"]},
+        )
+        arts = vs.compute(data)
+        # reduce over ("date",) → per-channel max
+        expected = xr.Dataset(
+            {
+                "scale": xr.DataArray(
+                    [2.0, 4.0], dims="channel", coords={"channel": ["c1", "c2"]}
+                )
+            }
+        )
+        xr.testing.assert_equal(arts, expected)
+
+    def test_transform(self):
+        vs = MaxAbsScaling(dims=())
+        data = xr.DataArray([2.0, 4.0], dims="date")
+        arts = vs.compute(data)
+        result = vs.transform(data, arts)
+        expected = data / 4.0
+        xr.testing.assert_equal(result, expected)
+
+    def test_inverse_transform(self):
+        vs = MaxAbsScaling(dims=())
+        data = xr.DataArray([2.0, 4.0], dims="date")
+        arts = vs.compute(data)
+        scaled = vs.transform(data, arts)
+        restored = vs.inverse_transform(scaled, arts)
+        xr.testing.assert_allclose(restored, data)
+
+
+class TestMeanAbsScaling:
+    def test_construction(self):
+        vs = MeanAbsScaling(dims=())
+        assert vs.dims == ()
+
+    def test_compute(self):
+        vs = MeanAbsScaling(dims=())
+        data = xr.DataArray([2.0, 4.0, 6.0], dims="date")
+        arts = vs.compute(data)
+        assert float(arts["scale"]) == 4.0
+
+    def test_transform(self):
+        vs = MeanAbsScaling(dims=())
+        data = xr.DataArray([2.0, 4.0], dims="date")
+        arts = vs.compute(data)
+        result = vs.transform(data, arts)
+        expected = data / 3.0
+        xr.testing.assert_equal(result, expected)
+
 
 class TestVariableScalingIsAbstract:
     def test_cannot_instantiate_directly(self):
@@ -229,6 +399,8 @@ class TestVariableScalingIsAbstract:
     def test_subclass_relationship(self):
         assert issubclass(DataDerivedScaling, VariableScaling)
         assert issubclass(FixedScaling, VariableScaling)
+        assert issubclass(MaxAbsScaling, VariableScaling)
+        assert issubclass(MeanAbsScaling, VariableScaling)
 
 
 class TestVariableScalingDimsValidation:
@@ -239,6 +411,10 @@ class TestVariableScalingDimsValidation:
     def test_date_dim_rejected_fixed(self):
         with pytest.raises(ValueError, match="date"):
             FixedScaling(dims=("date",), value=100.0)
+
+    def test_date_dim_rejected_max_abs(self):
+        with pytest.raises(ValueError, match="date"):
+            MaxAbsScaling(dims=("date",))
 
     def test_duplicate_dims_rejected(self):
         with pytest.raises(ValueError, match="unique"):
@@ -251,6 +427,8 @@ class TestVariableScalingDimsValidation:
         "pymc_marketing.mmm.scaling.Scaling",
         "pymc_marketing.mmm.scaling.DataDerivedScaling",
         "pymc_marketing.mmm.scaling.FixedScaling",
+        "pymc_marketing.mmm.scaling.MaxAbsScaling",
+        "pymc_marketing.mmm.scaling.MeanAbsScaling",
     ],
     ids=lambda s: s.rsplit(".", 1)[-1],
 )
@@ -289,7 +467,7 @@ def test_legacy_variable_scaling_type_key_deserializes():
             },
         }
     )
-    assert isinstance(restored.target, DataDerivedScaling)
-    assert restored.target.method == "max"
+    assert isinstance(restored.target, MaxAbsScaling)
+    assert restored.target.scaling_description() == "max-absolute"
     assert isinstance(restored.channel, FixedScaling)
     assert restored.channel.value == 100.0

--- a/tests/mmm/test_scaling.py
+++ b/tests/mmm/test_scaling.py
@@ -314,6 +314,22 @@ class TestDataDerivedScaling:
         restored = vs.inverse_transform(scaled, arts)
         xr.testing.assert_allclose(restored, data)
 
+    def test_emits_deprecation_warning(self):
+        with pytest.warns(DeprecationWarning, match="DataDerivedScaling is deprecated"):
+            DataDerivedScaling(method="max", dims=())
+
+
+class TestDataDerivedDeserializationNoWarning:
+    def test_legacy_deserialize_no_warning(self):
+        """deserialize_variable_scaling of a legacy payload must NOT warn."""
+        import warnings
+
+        legacy_data = serialization.serialize(DataDerivedScaling(method="max", dims=()))
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            restored = deserialize_variable_scaling(legacy_data)
+        assert isinstance(restored, MaxAbsScaling)
+
 
 class TestMaxAbsScaling:
     def test_construction(self):


### PR DESCRIPTION
## What

Scaling objects now own their behavior. Before, MMM had ~110 lines of helper methods that orchestrated scaling (`_compute_scale_for_variable`, `_build_fixed_scale_from_dict`, etc.), with in-graph division and NaN/Inf guards in `build_model()`.

After, each `VariableScaling` subclass implements `compute()`, `transform()`, and `inverse_transform()`. MMM just calls them.

## Why

The old approach scattered scaling logic across `mmm.py` — computing scales, dividing in-graph, guarding against NaN/Inf, and reconstructing fixed scales from dicts. Adding a new scaling type required touching `mmm.py` in 3+ places.

The new approach encapsulates everything in the scaling object itself. To add a new scaling type, implement 4 methods:

```python
from pymc_marketing.mmm.scaling import VariableScaling

class ZScoreScaling(VariableScaling):
    """Future example — not yet wired end-to-end."""

    @property
    def artifact_keys(self) -> tuple[str, ...]:
        return ("mean", "std")

    def compute(self, data):
        reduce_dims = ("date", *self.dims)
        return Dataset({
            "mean": data.mean(dim=reduce_dims),
            "std": data.std(dim=reduce_dims),
        })

    def transform(self, data, artifacts):
        return (data - artifacts["mean"]) / artifacts["std"]

    def inverse_transform(self, data, artifacts):
        return data * artifacts["std"] + artifacts["mean"]

# Usage — no changes to MMM needed:
mmm = MMM(scaling={"target": ZScoreScaling(dims=())}, ...)
```

## What changed

| File | Before | After |
|---|---|---|
| `scaling.py` | Data holder with `method` field | Abstract `compute`/`transform`/`inverse_transform` contract |
| `mmm.py` | ~110 lines of `_build_fixed_scale*` helpers | Calls `scaling.compute()` directly |
| `build_model()` | In-graph division + NaN/Inf switches | Pre-scaled data enters graph as-is |
| `_set_xarray_data()` | No scaling | Pre-scales via `scaling.transform()` |
| `BudgetOptimizer` | `_channel_scales = 1.0` (hardcoded) | Property reading actual scales |

## Concrete subclasses added

- **`MaxAbsScaling(dims=())`** — divides by max absolute value (default, replaces `DataDerivedScaling(method="max")`)
- **`MeanAbsScaling(dims=())`** — divides by mean absolute value (replaces `DataDerivedScaling(method="mean")`)
- **`DataDerivedScaling`** — kept for backward-compat serialization; deserialization maps to the new classes

## What's NOT in this PR (follow-up issues)

- `artifact_keys` property — support multi-key artifacts (e.g., z-score needs mean + std, not just scale)
- `inverse_transform_graph()` — wire `add_original_scale_contribution_variable()` through the scaler's inverse instead of hardcoded `var * target_scale`
- Decomposition helpers — accept full artifacts instead of bare `target_scale`
- Custom scaling example — end-to-end notebook with serialization

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2831.org.readthedocs.build/en/2831/

<!-- readthedocs-preview pymc-marketing end -->