### PR TITLE
docs(skills): fix az.plot_trace call broken under ArviZ 1.x

### DIFF
--- a/skills/mmm-modeling/SKILL.md
+++ b/skills/mmm-modeling/SKILL.md
@@ -110,7 +110,7 @@ mmm.idata["sample_stats"]["diverging"].sum().item()
 az.summary(data=mmm.idata, var_names=[...])["r_hat"].describe()
 
 # Trace plots
-az.plot_trace(data=mmm.fit_result, var_names=[...], compact=True)
+az.plot_trace_dist(mmm.fit_result, var_names=[...], compact=True)
 ```
 
 Use `TimeSliceCrossValidator` to assess model stability **before** the final fit:

--- a/skills/mmm-modeling/references/model_fit.md
+++ b/skills/mmm-modeling/references/model_fit.md
@@ -100,8 +100,8 @@ print(summary[["r_hat", "ess_bulk", "ess_tail"]].describe())
 Visual check for chain mixing:
 
 ```python
-az.plot_trace(
-    data=mmm.fit_result,
+az.plot_trace_dist(
+    mmm.fit_result,
     var_names=["intercept", "saturation_beta", "adstock_alpha", "saturation_lam"],
     compact=True,
 )


### PR DESCRIPTION
## Description

The `mmm-modeling` skill still teaches `az.plot_trace(data=mmm.fit_result, ...)` in two places (`skills/mmm-modeling/SKILL.md` and `skills/mmm-modeling/references/model_fit.md`). Under the ArviZ pin shipped with 1.0 (`arviz>=1.2.0,<2.0`) this call raises:

```
TypeError: plot_trace() missing 1 required positional argument: 'dt'
```

ArviZ 1.x renamed the first parameter and removed the legacy signature, so any agent following the skill verbatim hits a hard error on the diagnostics step.

This PR replaces both call sites with `az.plot_trace_dist(mmm.fit_result, ...)`, which renders the same trace + distribution panels and matches the pattern already used in the `mmm_quickstart` notebook.

Verified against `arviz` 1.2.0 / `pymc-marketing` 1.0.0: the old call fails with the `TypeError` above; the new call works (including `compact=True` and `var_names=`). The neighbouring `az.summary(data=...)["r_hat"]` usage in the same code blocks still works under ArviZ 1.2 and is left untouched.

## Related Issue

- None

## Checklist

- [x] Checked that the pre-commit linting/style checks pass
- [x] Included tests that prove the fix is effective or that the new feature works (n/a — docs/skill only; behaviour verified manually against arviz 1.2.0)

## Modules affected

- [ ] MMM
- [ ] CLV
- [ ] Customer Choice
- [ ] Bass
- [x] Other: agent skill (`skills/mmm-modeling`)

## Type of change

- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Other

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2842.org.readthedocs.build/en/2842/

<!-- readthedocs-preview pymc-marketing end -->