### PR TITLE
docs: name the uv extras that carry pytest and pre-commit

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Environment
 
-- Run `uv sync` to set up the environment, then use `uv run` for Python commands (pytest, pre-commit, python, etc.).
+- Run `uv sync --extra test --extra lint` to set up the environment, then use `uv run` for Python commands (pytest, pre-commit, python, etc.). pytest and pre-commit live in those extras rather than in the default sync.
 - Run `pre-commit` every time you create or modify a file.
 - Temporary or test scripts that are not meant to be committed should be created in the `sandbox/` folder.
 - Do not insert hard line breaks inside a sentence; let the editor handle word wrap. Line breaks between sentences are fine.


### PR DESCRIPTION
Names the extras that carry pytest and pre-commit, so the setup line produces the tools the rest of the sentence tells you to run.

pytest lives in the `test` extra and pre-commit in `lint`, both outside the default sync. After `uv sync`, `uv run pytest` stops at `Failed to spawn: pytest`, checked in a container with nothing else on `PATH`. On a machine that happens to have a distro pytest available, uv runs that one instead, which is how I ran into it.

This has been the case since the line was added. uv arrived with v1.0.0 (#2677), which added `uv.lock` and the setup line in the same commit, and the `test` and `lint` extras are byte-identical between that commit and `main`. #2780 named the two tools, which makes the gap easy to spot, but did not change behaviour.
