### PR TITLE
Change default Fourier seasonality prior from Laplace to Normal

### DIFF
--- a/pymc_marketing/mmm/fourier.py
+++ b/pymc_marketing/mmm/fourier.py
@@ -119,9 +119,9 @@ Even make it hierarchical...
 
     # "fourier" is the default prefix!
     prior = Prior(
-        "Laplace",
+        "Normal",
         mu=Prior("Normal", dims="fourier"),
-        b=Prior("HalfNormal", sigma=0.1, dims="fourier"),
+        sigma=Prior("HalfNormal", sigma=0.1, dims="fourier"),
         dims=("fourier", "hierarchy"),
     )
     yearly = YearlyFourier(n_order=3, prior=prior)
@@ -138,9 +138,9 @@ All the plotting will still work! Just pass any coords.
 
     # "fourier" is the default prefix!
     prior = Prior(
-        "Laplace",
+        "Normal",
         mu=Prior("Normal", dims="fourier"),
-        b=Prior("HalfNormal", sigma=0.1, dims="fourier"),
+        sigma=Prior("HalfNormal", sigma=0.1, dims="fourier"),
         dims=("fourier", "hierarchy"),
     )
     yearly = YearlyFourier(n_order=3, prior=prior)
@@ -330,7 +330,7 @@ class FourierBase(BaseModel):
         "fourier"
     prior : Prior | VariableFactory, optional
         Prior distribution or VariableFactory for the fourier seasonality beta parameters, by
-        default `Prior("Laplace", mu=0, b=1)`
+        default `Prior("Normal", mu=0, sigma=1)`
     variable_name : str, optional
         Name of the variable that multiplies the fourier modes. By default None,
         in which case it is set to the `{prefix}_beta`.
@@ -341,7 +341,7 @@ class FourierBase(BaseModel):
     days_in_period: float = Field(..., gt=0)
     prefix: str = Field("fourier")
     prior: InstanceOf[Prior] | InstanceOf[VariableFactory] = Field(
-        Prior("Laplace", mu=0, b=1)
+        Prior("Normal", mu=0, sigma=1)
     )
     variable_name: str | None = Field(None)
     model_config = ConfigDict(extra="forbid")
@@ -911,8 +911,8 @@ class YearlyFourier(FourierBase):
         rng = np.random.default_rng(seed)
 
         mu = np.array([0, 0, -1, 0])
-        b = 0.15
-        dist = Prior("Laplace", mu=mu, b=b, dims="fourier")
+        sigma = 0.15
+        dist = Prior("Normal", mu=mu, sigma=sigma, dims="fourier")
         yearly = YearlyFourier(n_order=2, prior=dist)
         prior = yearly.sample_prior(random_seed=rng)
         curve = yearly.sample_curve(prior)
@@ -928,7 +928,7 @@ class YearlyFourier(FourierBase):
         "fourier"
     prior : Prior | VariableFactory, optional
         Prior distribution or VariableFactory for the fourier seasonality beta parameters, by
-        default `Prior("Laplace", mu=0, b=1)`
+        default `Prior("Normal", mu=0, sigma=1)`
     name : str, optional
         Name of the variable that multiplies the fourier modes, by default None
     variable_name : str, optional
@@ -976,8 +976,8 @@ class MonthlyFourier(FourierBase):
         rng = np.random.default_rng(seed)
 
         mu = np.array([0, 0, 0.5, 0])
-        b = 0.075
-        dist = Prior("Laplace", mu=mu, b=b, dims="fourier")
+        sigma = 0.075
+        dist = Prior("Normal", mu=mu, sigma=sigma, dims="fourier")
         monthly = MonthlyFourier(n_order=2, prior=dist)
         prior = monthly.sample_prior(samples=100)
         curve = monthly.sample_curve(prior)
@@ -993,7 +993,7 @@ class MonthlyFourier(FourierBase):
         "fourier"
     prior : Prior | VariableFactory, optional
         Prior distribution or VariableFactory for the fourier seasonality beta parameters, by
-        default `Prior("Laplace", mu=0, b=1)`
+        default `Prior("Normal", mu=0, sigma=1)`
     name : str, optional
         Name of the variable that multiplies the fourier modes, by default None
     variable_name : str, optional
@@ -1040,8 +1040,8 @@ class WeeklyFourier(FourierBase):
         rng = np.random.default_rng(seed)
 
         mu = np.array([0, 0, 0.5, 0])
-        b = 0.075
-        dist = Prior("Laplace", mu=mu, b=b, dims="fourier")
+        sigma = 0.075
+        dist = Prior("Normal", mu=mu, sigma=sigma, dims="fourier")
         weekly = WeeklyFourier(n_order=2, prior=dist)
         prior = weekly.sample_prior(samples=100)
         curve = weekly.sample_curve(prior)
@@ -1057,7 +1057,7 @@ class WeeklyFourier(FourierBase):
         "fourier"
     prior : Prior | VariableFactory, optional
         Prior distribution or VariableFactory for the fourier seasonality beta parameters, by
-        default `Prior("Laplace", mu=0, b=1)`
+        default `Prior("Normal", mu=0, sigma=1)`
     name : str, optional
         Name of the variable that multiplies the fourier modes, by default None
     variable_name : str, optional

--- a/pymc_marketing/mmm/mmm.py
+++ b/pymc_marketing/mmm/mmm.py
@@ -1632,7 +1632,7 @@ class MMM(RegressionModelBuilder):
                 "Normal", mu=0, sigma=2, dims=(*self.dims, "control")
             ),
             "gamma_fourier": Prior(
-                "Laplace", mu=0, b=1, dims=(*self.dims, "fourier_mode")
+                "Normal", mu=0, sigma=1, dims=(*self.dims, "fourier_mode")
             ),
         }
 
@@ -2190,7 +2190,7 @@ class MMM(RegressionModelBuilder):
                 "adstock_alpha": Prior("Beta", alpha=1, beta=3),
                 "likelihood": Prior("Normal", sigma=Prior("HalfNormal", sigma=2)),
                 "gamma_control": Prior("Normal", mu=0, sigma=2, dims="control"),
-                "gamma_fourier": Prior("Laplace", mu=0, b=1, dims="fourier_mode"),
+                "gamma_fourier": Prior("Normal", mu=0, sigma=1, dims="fourier_mode"),
             }
 
             model = MMM(

--- a/tests/mmm/test_fourier.py
+++ b/tests/mmm/test_fourier.py
@@ -660,8 +660,8 @@ def test_fourier_to_dict(name, cls, days_in_period) -> None:
             "days_in_period": days_in_period,
             "prefix": "fourier",
             "prior": {
-                "dist": "Laplace",
-                "kwargs": {"b": 1, "mu": 0},
+                "dist": "Normal",
+                "kwargs": {"mu": 0, "sigma": 1},
                 "dims": ["fourier"],
             },
             "variable_name": "fourier_beta",


### PR DESCRIPTION
## Description

This work is based on [observations in my blog post](https://matekadlicsko.github.io/posts/trigonometric-seasonality-priors/), namely

1. seasonality priors should be invariant under certain rotations (this is to ensure that the prior curve remains invariant under phase shifts),
2. well selected priors can make sure the curve ends up being smooth (regularize Sobolev norm).


## Related Issue


## Checklist
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2850.org.readthedocs.build/en/2850/

<!-- readthedocs-preview pymc-marketing end -->