### PR TITLE
fix(docs): drop the OptimizerCompatibleModelWrapper alias from autosummary (#2660)

### DIFF
--- a/docs/source/_templates/autosummary/module.rst
+++ b/docs/source/_templates/autosummary/module.rst
@@ -1,3 +1,12 @@
+{# Classes that should not get their own autosummary page. Deprecated
+   backward-compat aliases (e.g. OptimizerCompatibleModelWrapper, an alias of
+   OptimizerCompatibleModel) resolve to the same class object under a second
+   name; autodoc then appends an "alias of ..." trailer with no blank line,
+   which docutils flags as "Explicit markup ends without a blank line"
+   (issue #2660). The canonical class still gets its page. #}
+{% set excluded_classes = [
+    "OptimizerCompatibleModelWrapper",
+] %}
 {{ name | escape | underline}}
 
 .. automodule:: {{ fullname }}
@@ -34,7 +43,7 @@
       :toctree:
 
    {% for item in classes %}
-      {% if not item.endswith("RV") %}
+      {% if not item.endswith("RV") and item not in excluded_classes %}
       {{ item }}
       {% endif %}
    {%- endfor %}


### PR DESCRIPTION
Fixes #2660

Replaces #2680, which was stacked on #2654. When #2654 merged, its branch was deleted and GitHub auto-closed that PR, and a PR closed that way cannot be reopened.

## Problem

The `Docs` workflow on `main` is currently failing on a single docutils warning (run for 9199e68, artifact `docs-warnings`):

    WARNING: :1: (WARNING/2) Explicit markup ends without a blank line; unexpected unindent. [docutils]

## Root cause

Not a docstring. `OptimizerCompatibleModelWrapper` is a deprecated alias of `OptimizerCompatibleModel`. autosummary gives it its own class page, and autodoc appends an `alias of ...` trailer right after the class template's `.. autosummary::` block, with no blank line:

    ~OptimizerCompatibleModelWrapper.idata
    alias of :py:class:`~pymc_marketing.mmm.budget_optimizer.OptimizerCompatibleModel`

The dedented `alias of` line after the explicit-markup block is what docutils flags. It reports `:1:` because it is a nested parse of a synthesized string.

## Fix

Docs only, no Python change. The module autosummary template skips the alias, so only the canonical `OptimizerCompatibleModel` gets a page. The alias still works for imports and as the base class of `BudgetOptimizerWrapper`.

## Verification

Clean local builds before and after, same environment: 106 warnings to 105, and the one that disappears is the `Explicit markup` warning. No `document isn't included in any toctree` warning replaces it. The remaining 105 are local only (sphinx 9.1.0 autodoc signature errors on the string enums) and do not appear in CI, where `main` reports this one warning and nothing else.

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2854.org.readthedocs.build/en/2854/

<!-- readthedocs-preview pymc-marketing end -->