### PR TITLE
docs(mmm): address review suggestions in the credibility disaggregation notebook (adstock, compositional likelihood, proxy caveats)

### DIFF
--- a/docs/source/notebooks/mmm/dev/mmm_credibility_disaggregation.ipynb
+++ b/docs/source/notebooks/mmm/dev/mmm_credibility_disaggregation.ipynb
@@ -65,15 +65,22 @@
    "id": "21fe2938",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:37:00.101202Z",
-     "iopub.status.busy": "2026-08-11T12:37:00.101123Z",
-     "iopub.status.idle": "2026-08-11T12:37:03.270932Z",
-     "shell.execute_reply": "2026-08-11T12:37:03.270473Z"
+     "iopub.execute_input": "2026-08-12T10:15:24.475572Z",
+     "iopub.status.busy": "2026-08-12T10:15:24.475379Z",
+     "iopub.status.idle": "2026-08-12T10:15:29.029996Z",
+     "shell.execute_reply": "2026-08-12T10:15:29.029199Z"
     }
    },
    "outputs": [],
    "source": [
     "import warnings\n",
+    "\n",
+    "# Without ipywidgets in the kernel, tqdm.auto warns at import time and rich warns at\n",
+    "# the first live progress render. Both are cosmetic, so silence them before the\n",
+    "# imports and the sampling that would trigger them.\n",
+    "warnings.filterwarnings(\"ignore\", message=\"IProgress not found\")\n",
+    "warnings.filterwarnings(\"ignore\", message='install \"ipywidgets\" for Jupyter support')\n",
+    "\n",
     "from dataclasses import dataclass\n",
     "\n",
     "import arviz as az\n",
@@ -83,6 +90,8 @@
     "import numpy as np\n",
     "import pandas as pd\n",
     "import pymc as pm\n",
+    "import pytensor.tensor as pt\n",
+    "import pytensor.xtensor as ptx\n",
     "import seaborn as sns\n",
     "import xarray as xr\n",
     "from arviz_base.labels import NoVarLabeller\n",
@@ -90,10 +99,12 @@
     "from scipy.stats import spearmanr\n",
     "\n",
     "from pymc_marketing.metrics import crps, per_observation_crps\n",
+    "from pymc_marketing.mmm.transformers import geometric_adstock\n",
     "from pymc_marketing.paths import data_dir\n",
     "\n",
-    "# The only warning this notebook raises is seaborn passing the deprecated `vert` kwarg\n",
-    "# through to matplotlib's boxplot, which is out of our hands here.\n",
+    "# Beyond the progress-bar cosmetics above, the only warning this notebook raises is\n",
+    "# seaborn passing the deprecated `vert` kwarg through to matplotlib's boxplot, which\n",
+    "# is out of our hands here.\n",
     "warnings.filterwarnings(\n",
     "    \"ignore\",\n",
     "    message=\"vert: bool will be deprecated\",\n",
@@ -133,10 +144,10 @@
    "id": "85fd3eda",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:37:03.272546Z",
-     "iopub.status.busy": "2026-08-11T12:37:03.272316Z",
-     "iopub.status.idle": "2026-08-11T12:37:03.470995Z",
-     "shell.execute_reply": "2026-08-11T12:37:03.470550Z"
+     "iopub.execute_input": "2026-08-12T10:15:29.031762Z",
+     "iopub.status.busy": "2026-08-12T10:15:29.031476Z",
+     "iopub.status.idle": "2026-08-12T10:15:29.283584Z",
+     "shell.execute_reply": "2026-08-12T10:15:29.282912Z"
     }
    },
    "outputs": [
@@ -234,10 +245,10 @@
    "id": "b755e6a2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:37:03.472201Z",
-     "iopub.status.busy": "2026-08-11T12:37:03.472115Z",
-     "iopub.status.idle": "2026-08-11T12:37:03.501511Z",
-     "shell.execute_reply": "2026-08-11T12:37:03.500991Z"
+     "iopub.execute_input": "2026-08-12T10:15:29.284832Z",
+     "iopub.status.busy": "2026-08-12T10:15:29.284718Z",
+     "iopub.status.idle": "2026-08-12T10:15:29.321899Z",
+     "shell.execute_reply": "2026-08-12T10:15:29.321399Z"
     }
    },
    "outputs": [
@@ -392,10 +403,10 @@
    "id": "9206f349",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:37:03.502628Z",
-     "iopub.status.busy": "2026-08-11T12:37:03.502555Z",
-     "iopub.status.idle": "2026-08-11T12:37:03.531917Z",
-     "shell.execute_reply": "2026-08-11T12:37:03.531472Z"
+     "iopub.execute_input": "2026-08-12T10:15:29.323428Z",
+     "iopub.status.busy": "2026-08-12T10:15:29.323303Z",
+     "iopub.status.idle": "2026-08-12T10:15:29.362202Z",
+     "shell.execute_reply": "2026-08-12T10:15:29.361724Z"
     }
    },
    "outputs": [
@@ -630,10 +641,10 @@
    "id": "3f11ed02",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:37:03.533048Z",
-     "iopub.status.busy": "2026-08-11T12:37:03.532949Z",
-     "iopub.status.idle": "2026-08-11T12:37:03.765880Z",
-     "shell.execute_reply": "2026-08-11T12:37:03.765425Z"
+     "iopub.execute_input": "2026-08-12T10:15:29.363411Z",
+     "iopub.status.busy": "2026-08-12T10:15:29.363309Z",
+     "iopub.status.idle": "2026-08-12T10:15:29.620120Z",
+     "shell.execute_reply": "2026-08-12T10:15:29.619619Z"
     },
     "lines_to_next_cell": 0
    },
@@ -696,10 +707,10 @@
    "id": "57790231",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:37:03.767007Z",
-     "iopub.status.busy": "2026-08-11T12:37:03.766937Z",
-     "iopub.status.idle": "2026-08-11T12:37:03.920992Z",
-     "shell.execute_reply": "2026-08-11T12:37:03.920612Z"
+     "iopub.execute_input": "2026-08-12T10:15:29.621802Z",
+     "iopub.status.busy": "2026-08-12T10:15:29.621695Z",
+     "iopub.status.idle": "2026-08-12T10:15:29.792386Z",
+     "shell.execute_reply": "2026-08-12T10:15:29.791828Z"
     }
    },
    "outputs": [
@@ -760,10 +771,10 @@
    "id": "f02f23d6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:37:03.922258Z",
-     "iopub.status.busy": "2026-08-11T12:37:03.922181Z",
-     "iopub.status.idle": "2026-08-11T12:37:04.093375Z",
-     "shell.execute_reply": "2026-08-11T12:37:04.092980Z"
+     "iopub.execute_input": "2026-08-12T10:15:29.793919Z",
+     "iopub.status.busy": "2026-08-12T10:15:29.793761Z",
+     "iopub.status.idle": "2026-08-12T10:15:29.976746Z",
+     "shell.execute_reply": "2026-08-12T10:15:29.976269Z"
     },
     "lines_to_next_cell": 0
    },
@@ -848,10 +859,10 @@
    "id": "45927ecb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:37:04.094849Z",
-     "iopub.status.busy": "2026-08-11T12:37:04.094746Z",
-     "iopub.status.idle": "2026-08-11T12:37:04.204847Z",
-     "shell.execute_reply": "2026-08-11T12:37:04.204328Z"
+     "iopub.execute_input": "2026-08-12T10:15:29.978066Z",
+     "iopub.status.busy": "2026-08-12T10:15:29.977961Z",
+     "iopub.status.idle": "2026-08-12T10:15:30.102274Z",
+     "shell.execute_reply": "2026-08-12T10:15:30.101744Z"
     },
     "lines_to_next_cell": 0
    },
@@ -929,10 +940,10 @@
    "id": "13b33269",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:37:04.206021Z",
-     "iopub.status.busy": "2026-08-11T12:37:04.205923Z",
-     "iopub.status.idle": "2026-08-11T12:37:04.326916Z",
-     "shell.execute_reply": "2026-08-11T12:37:04.326220Z"
+     "iopub.execute_input": "2026-08-12T10:15:30.103400Z",
+     "iopub.status.busy": "2026-08-12T10:15:30.103285Z",
+     "iopub.status.idle": "2026-08-12T10:15:30.234296Z",
+     "shell.execute_reply": "2026-08-12T10:15:30.233826Z"
     },
     "lines_to_next_cell": 0
    },
@@ -994,10 +1005,10 @@
    "id": "89484945",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:37:04.328418Z",
-     "iopub.status.busy": "2026-08-11T12:37:04.328313Z",
-     "iopub.status.idle": "2026-08-11T12:37:04.485015Z",
-     "shell.execute_reply": "2026-08-11T12:37:04.484629Z"
+     "iopub.execute_input": "2026-08-12T10:15:30.235543Z",
+     "iopub.status.busy": "2026-08-12T10:15:30.235427Z",
+     "iopub.status.idle": "2026-08-12T10:15:30.407199Z",
+     "shell.execute_reply": "2026-08-12T10:15:30.406676Z"
     }
    },
    "outputs": [
@@ -1066,7 +1077,16 @@
     "- **The denominator is reach-days, not people.** That is the unit the daily allocation later spends, and matching the two is what makes the credit add up. Divide by unique reach instead and full trust in the click signal no longer reproduces the click split, because a campaign's frequency leaks into its share.\n",
     "- **We work with the log of the rate**, so \"twice as effective\" is the same size step whether a campaign is weak or strong.\n",
     "\n",
-    "One more thing to be precise about, since the framing is \"one number you trust, seven shaky signals\". The MMM total $T$ enters $y_c$ as $\\log T + \\log \\text{clickshare}_c - \\log R_c$, an identical shift for every campaign, which the collective mean $\\mu$ absorbs. So the MMM sets the level of the whole channel, and the *ranking* of the direct estimates comes from click share and exposure alone."
+    "One more thing to be precise about, since the framing is \"one number you trust, seven shaky signals\". The MMM total $T$ enters $y_c$ as $\\log T + \\log \\text{clickshare}_c - \\log R_c$, an identical shift for every campaign, which the collective mean $\\mu$ absorbs. So the MMM sets the level of the whole channel, and the *ranking* of the direct estimates comes from click share and exposure alone.\n",
+    "\n",
+    "::: {.callout-important title=\"Clicks are a stand-in, and every click is priced the same\"}\n",
+    "Two assumptions ride along with this construction, and neither is innocent.\n",
+    "\n",
+    "- **Clicks are a proxy, not the thing itself.** Nothing in the machinery is attached to clicks: conversions, last-touch revenue, or a lift-informed signal slot into the same $y_c$, and if you have a metric you believe tracks incrementality better, use it. What the model disciplines is the *noise* of whichever proxy you feed it; the proxy's *bias* passes straight through (\"it cures noise, not bias\", as the closing section puts it).\n",
+    "- **A click is priced the same wherever it came from.** The split hands out credit per click regardless of the campaign that earned it, yet the EDA showed median daily CTR differing by a factor of nearly four across campaigns. Two campaigns can deliver identical impressions with very different click counts simply because they were *optimised for different things*, say an awareness push against a click-optimised conversion campaign, and that difference is structural rather than noisy. Evidence turns the dial between a campaign's own story and the collective average; it cannot repair a story that is told in the wrong currency.\n",
+    "\n",
+    "The same precision applies to the MMM itself: it enters this construction only as the trusted total $T$, not through its media variables or response curves. One structural piece of the MMM *can* be inherited cheaply, its carryover, and the adstock extension later in the notebook does exactly that.\n",
+    ":::"
    ]
   },
   {
@@ -1075,10 +1095,10 @@
    "id": "c876c1c0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:37:04.486292Z",
-     "iopub.status.busy": "2026-08-11T12:37:04.486195Z",
-     "iopub.status.idle": "2026-08-11T12:37:04.514462Z",
-     "shell.execute_reply": "2026-08-11T12:37:04.514083Z"
+     "iopub.execute_input": "2026-08-12T10:15:30.408317Z",
+     "iopub.status.busy": "2026-08-12T10:15:30.408207Z",
+     "iopub.status.idle": "2026-08-12T10:15:30.448802Z",
+     "shell.execute_reply": "2026-08-12T10:15:30.448389Z"
     }
    },
    "outputs": [
@@ -1263,10 +1283,10 @@
    "id": "7f67e717",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:37:04.515600Z",
-     "iopub.status.busy": "2026-08-11T12:37:04.515515Z",
-     "iopub.status.idle": "2026-08-11T12:37:04.660974Z",
-     "shell.execute_reply": "2026-08-11T12:37:04.660318Z"
+     "iopub.execute_input": "2026-08-12T10:15:30.450034Z",
+     "iopub.status.busy": "2026-08-12T10:15:30.449929Z",
+     "iopub.status.idle": "2026-08-12T10:15:30.611596Z",
+     "shell.execute_reply": "2026-08-12T10:15:30.611191Z"
     }
    },
    "outputs": [
@@ -1373,10 +1393,10 @@
    "id": "b012d4bb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:37:04.662478Z",
-     "iopub.status.busy": "2026-08-11T12:37:04.662378Z",
-     "iopub.status.idle": "2026-08-11T12:37:04.843106Z",
-     "shell.execute_reply": "2026-08-11T12:37:04.842437Z"
+     "iopub.execute_input": "2026-08-12T10:15:30.612768Z",
+     "iopub.status.busy": "2026-08-12T10:15:30.612666Z",
+     "iopub.status.idle": "2026-08-12T10:15:30.815251Z",
+     "shell.execute_reply": "2026-08-12T10:15:30.814596Z"
     }
    },
    "outputs": [
@@ -1389,10 +1409,10 @@
        "<!-- Generated by graphviz version 15.1.0 (20260618.0150)\n",
        " -->\n",
        "<!-- Pages: 1 -->\n",
-       "<svg width=\"574pt\" height=\"551pt\"\n",
-       " viewBox=\"0.00 0.00 574.00 551.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
+       "<svg width=\"634pt\" height=\"551pt\"\n",
+       " viewBox=\"0.00 0.00 634.00 551.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n",
        "<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 547.45)\">\n",
-       "<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-547.45 570.01,-547.45 570.01,4 -4,4\"/>\n",
+       "<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-547.45 629.86,-547.45 629.86,4 -4,4\"/>\n",
        "<g id=\"clust1\" class=\"cluster\">\n",
        "<title>clustercampaign (7)</title>\n",
        "<path fill=\"none\" stroke=\"black\" d=\"M20,-8C20,-8 318,-8 318,-8 324,-8 330,-14 330,-20 330,-20 330,-328.63 330,-328.63 330,-334.63 324,-340.63 318,-340.63 318,-340.63 20,-340.63 20,-340.63 14,-340.63 8,-334.63 8,-328.63 8,-328.63 8,-20 8,-20 8,-14 14,-8 20,-8\"/>\n",
@@ -1401,182 +1421,182 @@
        "<!-- Z -->\n",
        "<g id=\"node1\" class=\"node\">\n",
        "<title>Z</title>\n",
-       "<polygon fill=\"none\" stroke=\"black\" points=\"106.12,-215.32 15.88,-215.32 15.88,-157.82 106.12,-157.82 106.12,-215.32\"/>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"61\" y=\"-198.02\" font-family=\"Times,serif\" font-size=\"14.00\">Z</text>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"61\" y=\"-181.52\" font-family=\"Times,serif\" font-size=\"14.00\">~</text>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"61\" y=\"-165.02\" font-family=\"Times,serif\" font-size=\"14.00\">Deterministic</text>\n",
+       "<polygon fill=\"none\" stroke=\"black\" points=\"214.12,-215.32 123.88,-215.32 123.88,-157.82 214.12,-157.82 214.12,-215.32\"/>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"169\" y=\"-198.02\" font-family=\"Times,serif\" font-size=\"14.00\">Z</text>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"169\" y=\"-181.52\" font-family=\"Times,serif\" font-size=\"14.00\">~</text>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"169\" y=\"-165.02\" font-family=\"Times,serif\" font-size=\"14.00\">Deterministic</text>\n",
        "</g>\n",
        "<!-- theta -->\n",
        "<g id=\"node2\" class=\"node\">\n",
        "<title>theta</title>\n",
-       "<polygon fill=\"none\" stroke=\"black\" points=\"322.12,-215.32 231.88,-215.32 231.88,-157.82 322.12,-157.82 322.12,-215.32\"/>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"277\" y=\"-198.02\" font-family=\"Times,serif\" font-size=\"14.00\">theta</text>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"277\" y=\"-181.52\" font-family=\"Times,serif\" font-size=\"14.00\">~</text>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"277\" y=\"-165.02\" font-family=\"Times,serif\" font-size=\"14.00\">Deterministic</text>\n",
+       "<polygon fill=\"none\" stroke=\"black\" points=\"106.12,-215.32 15.88,-215.32 15.88,-157.82 106.12,-157.82 106.12,-215.32\"/>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"61\" y=\"-198.02\" font-family=\"Times,serif\" font-size=\"14.00\">theta</text>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"61\" y=\"-181.52\" font-family=\"Times,serif\" font-size=\"14.00\">~</text>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"61\" y=\"-165.02\" font-family=\"Times,serif\" font-size=\"14.00\">Deterministic</text>\n",
        "</g>\n",
        "<!-- y_obs -->\n",
-       "<g id=\"node3\" class=\"node\">\n",
+       "<g id=\"node4\" class=\"node\">\n",
        "<title>y_obs</title>\n",
-       "<ellipse fill=\"lightgrey\" stroke=\"black\" cx=\"223\" cy=\"-81.16\" rx=\"41.01\" ry=\"40.66\"/>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"223\" y=\"-92.61\" font-family=\"Times,serif\" font-size=\"14.00\">y_obs</text>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"223\" y=\"-76.11\" font-family=\"Times,serif\" font-size=\"14.00\">~</text>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"223\" y=\"-59.61\" font-family=\"Times,serif\" font-size=\"14.00\">Normal</text>\n",
+       "<ellipse fill=\"lightgrey\" stroke=\"black\" cx=\"169\" cy=\"-81.16\" rx=\"41.01\" ry=\"40.66\"/>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"169\" y=\"-92.61\" font-family=\"Times,serif\" font-size=\"14.00\">y_obs</text>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"169\" y=\"-76.11\" font-family=\"Times,serif\" font-size=\"14.00\">~</text>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"169\" y=\"-59.61\" font-family=\"Times,serif\" font-size=\"14.00\">Normal</text>\n",
        "</g>\n",
        "<!-- theta&#45;&gt;y_obs -->\n",
        "<g id=\"edge12\" class=\"edge\">\n",
        "<title>theta&#45;&gt;y_obs</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M262.39,-157.58C257.56,-148.34 252.06,-137.81 246.73,-127.61\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"249.93,-126.16 242.2,-118.92 243.72,-129.4 249.93,-126.16\"/>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M90.23,-157.58C102.95,-145.4 118.02,-130.97 131.56,-118.01\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"133.85,-120.66 138.66,-111.21 129.01,-115.6 133.85,-120.66\"/>\n",
        "</g>\n",
        "<!-- theta_raw -->\n",
-       "<g id=\"node4\" class=\"node\">\n",
+       "<g id=\"node3\" class=\"node\">\n",
        "<title>theta_raw</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" cx=\"233\" cy=\"-291.98\" rx=\"48.97\" ry=\"40.66\"/>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"233\" y=\"-303.43\" font-family=\"Times,serif\" font-size=\"14.00\">theta_raw</text>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"233\" y=\"-286.93\" font-family=\"Times,serif\" font-size=\"14.00\">~</text>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"233\" y=\"-270.43\" font-family=\"Times,serif\" font-size=\"14.00\">Normal</text>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" cx=\"65\" cy=\"-291.98\" rx=\"48.97\" ry=\"40.66\"/>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"65\" y=\"-303.43\" font-family=\"Times,serif\" font-size=\"14.00\">theta_raw</text>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"65\" y=\"-286.93\" font-family=\"Times,serif\" font-size=\"14.00\">~</text>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"65\" y=\"-270.43\" font-family=\"Times,serif\" font-size=\"14.00\">Normal</text>\n",
        "</g>\n",
        "<!-- theta_raw&#45;&gt;theta -->\n",
-       "<g id=\"edge11\" class=\"edge\">\n",
+       "<g id=\"edge10\" class=\"edge\">\n",
        "<title>theta_raw&#45;&gt;theta</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M249.01,-253.35C252.78,-244.48 256.81,-235.02 260.6,-226.11\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"263.79,-227.56 264.48,-216.99 257.34,-224.82 263.79,-227.56\"/>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M63.45,-251C63.15,-243.15 62.83,-234.91 62.53,-227.08\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"66.03,-226.96 62.14,-217.11 59.03,-227.23 66.03,-226.96\"/>\n",
        "</g>\n",
        "<!-- psi -->\n",
        "<g id=\"node5\" class=\"node\">\n",
        "<title>psi</title>\n",
-       "<polygon fill=\"none\" stroke=\"black\" points=\"214.12,-215.32 123.88,-215.32 123.88,-157.82 214.12,-157.82 214.12,-215.32\"/>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"169\" y=\"-198.02\" font-family=\"Times,serif\" font-size=\"14.00\">psi</text>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"169\" y=\"-181.52\" font-family=\"Times,serif\" font-size=\"14.00\">~</text>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"169\" y=\"-165.02\" font-family=\"Times,serif\" font-size=\"14.00\">Deterministic</text>\n",
+       "<polygon fill=\"none\" stroke=\"black\" points=\"322.12,-215.32 231.88,-215.32 231.88,-157.82 322.12,-157.82 322.12,-215.32\"/>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"277\" y=\"-198.02\" font-family=\"Times,serif\" font-size=\"14.00\">psi</text>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"277\" y=\"-181.52\" font-family=\"Times,serif\" font-size=\"14.00\">~</text>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"277\" y=\"-165.02\" font-family=\"Times,serif\" font-size=\"14.00\">Deterministic</text>\n",
        "</g>\n",
        "<!-- psi&#45;&gt;y_obs -->\n",
        "<g id=\"edge13\" class=\"edge\">\n",
        "<title>psi&#45;&gt;y_obs</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M183.61,-157.58C188.44,-148.34 193.94,-137.81 199.27,-127.61\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"202.28,-129.4 203.8,-118.92 196.07,-126.16 202.28,-129.4\"/>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M247.77,-157.58C235.05,-145.4 219.98,-130.97 206.44,-118.01\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"208.99,-115.6 199.34,-111.21 204.15,-120.66 208.99,-115.6\"/>\n",
        "</g>\n",
        "<!-- volume_relative -->\n",
        "<g id=\"node6\" class=\"node\">\n",
        "<title>volume_relative</title>\n",
-       "<path fill=\"lightgrey\" stroke=\"black\" d=\"M131.25,-320.73C131.25,-320.73 50.75,-320.73 50.75,-320.73 44.75,-320.73 38.75,-314.73 38.75,-308.73 38.75,-308.73 38.75,-275.23 38.75,-275.23 38.75,-269.23 44.75,-263.23 50.75,-263.23 50.75,-263.23 131.25,-263.23 131.25,-263.23 137.25,-263.23 143.25,-269.23 143.25,-275.23 143.25,-275.23 143.25,-308.73 143.25,-308.73 143.25,-314.73 137.25,-320.73 131.25,-320.73\"/>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"91\" y=\"-303.43\" font-family=\"Times,serif\" font-size=\"14.00\">volume_relative</text>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"91\" y=\"-286.93\" font-family=\"Times,serif\" font-size=\"14.00\">~</text>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"91\" y=\"-270.43\" font-family=\"Times,serif\" font-size=\"14.00\">Data</text>\n",
+       "<path fill=\"lightgrey\" stroke=\"black\" d=\"M266.25,-320.73C266.25,-320.73 185.75,-320.73 185.75,-320.73 179.75,-320.73 173.75,-314.73 173.75,-308.73 173.75,-308.73 173.75,-275.23 173.75,-275.23 173.75,-269.23 179.75,-263.23 185.75,-263.23 185.75,-263.23 266.25,-263.23 266.25,-263.23 272.25,-263.23 278.25,-269.23 278.25,-275.23 278.25,-275.23 278.25,-308.73 278.25,-308.73 278.25,-314.73 272.25,-320.73 266.25,-320.73\"/>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"226\" y=\"-303.43\" font-family=\"Times,serif\" font-size=\"14.00\">volume_relative</text>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"226\" y=\"-286.93\" font-family=\"Times,serif\" font-size=\"14.00\">~</text>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"226\" y=\"-270.43\" font-family=\"Times,serif\" font-size=\"14.00\">Data</text>\n",
        "</g>\n",
        "<!-- volume_relative&#45;&gt;Z -->\n",
-       "<g id=\"edge8\" class=\"edge\">\n",
+       "<g id=\"edge7\" class=\"edge\">\n",
        "<title>volume_relative&#45;&gt;Z</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M82.88,-262.99C79.61,-251.73 75.79,-238.54 72.26,-226.38\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"75.69,-225.66 69.55,-217.03 68.97,-227.61 75.69,-225.66\"/>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M210.57,-262.99C204.24,-251.5 196.8,-238 189.98,-225.63\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"193.06,-223.97 185.17,-216.9 186.93,-227.35 193.06,-223.97\"/>\n",
        "</g>\n",
        "<!-- volume_relative&#45;&gt;psi -->\n",
        "<g id=\"edge6\" class=\"edge\">\n",
        "<title>volume_relative&#45;&gt;psi</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M112.11,-262.99C121.04,-251.15 131.57,-237.19 141.13,-224.52\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"143.74,-226.87 146.96,-216.78 138.15,-222.66 143.74,-226.87\"/>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M239.8,-262.99C245.47,-251.5 252.13,-238 258.23,-225.63\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"261.23,-227.45 262.52,-216.93 254.96,-224.35 261.23,-227.45\"/>\n",
+       "</g>\n",
+       "<!-- sigma_s -->\n",
+       "<g id=\"node7\" class=\"node\">\n",
+       "<title>sigma_s</title>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" cx=\"570\" cy=\"-502.79\" rx=\"55.86\" ry=\"40.66\"/>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"570\" y=\"-514.24\" font-family=\"Times,serif\" font-size=\"14.00\">sigma_s</text>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"570\" y=\"-497.74\" font-family=\"Times,serif\" font-size=\"14.00\">~</text>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"570\" y=\"-481.24\" font-family=\"Times,serif\" font-size=\"14.00\">Halfnormal</text>\n",
        "</g>\n",
        "<!-- s2 -->\n",
-       "<g id=\"node7\" class=\"node\">\n",
+       "<g id=\"node12\" class=\"node\">\n",
        "<title>s2</title>\n",
-       "<polygon fill=\"none\" stroke=\"black\" points=\"493.12,-426.13 402.88,-426.13 402.88,-368.63 493.12,-368.63 493.12,-426.13\"/>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"448\" y=\"-408.83\" font-family=\"Times,serif\" font-size=\"14.00\">s2</text>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"448\" y=\"-392.33\" font-family=\"Times,serif\" font-size=\"14.00\">~</text>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"448\" y=\"-375.83\" font-family=\"Times,serif\" font-size=\"14.00\">Deterministic</text>\n",
+       "<polygon fill=\"none\" stroke=\"black\" points=\"615.12,-426.13 524.88,-426.13 524.88,-368.63 615.12,-368.63 615.12,-426.13\"/>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"570\" y=\"-408.83\" font-family=\"Times,serif\" font-size=\"14.00\">s2</text>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"570\" y=\"-392.33\" font-family=\"Times,serif\" font-size=\"14.00\">~</text>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"570\" y=\"-375.83\" font-family=\"Times,serif\" font-size=\"14.00\">Deterministic</text>\n",
        "</g>\n",
-       "<!-- s2&#45;&gt;psi -->\n",
-       "<g id=\"edge5\" class=\"edge\">\n",
-       "<title>s2&#45;&gt;psi</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M455.08,-368.14C461.38,-335.65 465.69,-282.75 437,-251.32 374.39,-182.73 318.8,-241.04 225.5,-215.52\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"226.57,-212.19 215.99,-212.62 224.53,-218.88 226.57,-212.19\"/>\n",
+       "<!-- sigma_s&#45;&gt;s2 -->\n",
+       "<g id=\"edge2\" class=\"edge\">\n",
+       "<title>sigma_s&#45;&gt;s2</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M570,-461.81C570,-453.96 570,-445.73 570,-437.9\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"573.5,-437.92 570,-427.92 566.5,-437.92 573.5,-437.92\"/>\n",
+       "</g>\n",
+       "<!-- mu -->\n",
+       "<g id=\"node8\" class=\"node\">\n",
+       "<title>mu</title>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" cx=\"487\" cy=\"-291.98\" rx=\"41.01\" ry=\"40.66\"/>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"487\" y=\"-303.43\" font-family=\"Times,serif\" font-size=\"14.00\">mu</text>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"487\" y=\"-286.93\" font-family=\"Times,serif\" font-size=\"14.00\">~</text>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"487\" y=\"-270.43\" font-family=\"Times,serif\" font-size=\"14.00\">Normal</text>\n",
+       "</g>\n",
+       "<!-- mu&#45;&gt;theta -->\n",
+       "<g id=\"edge9\" class=\"edge\">\n",
+       "<title>mu&#45;&gt;theta</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M457.53,-263.27C451.16,-258.58 444.17,-254.27 437,-251.32 307.24,-197.84 255.51,-253.92 117.45,-215.56\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"118.51,-212.22 107.93,-212.79 116.56,-218.94 118.51,-212.22\"/>\n",
        "</g>\n",
        "<!-- tau -->\n",
-       "<g id=\"node11\" class=\"node\">\n",
+       "<g id=\"node9\" class=\"node\">\n",
        "<title>tau</title>\n",
        "<polygon fill=\"none\" stroke=\"black\" points=\"428.12,-320.73 337.88,-320.73 337.88,-263.23 428.12,-263.23 428.12,-320.73\"/>\n",
        "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"383\" y=\"-303.43\" font-family=\"Times,serif\" font-size=\"14.00\">tau</text>\n",
        "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"383\" y=\"-286.93\" font-family=\"Times,serif\" font-size=\"14.00\">~</text>\n",
        "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"383\" y=\"-270.43\" font-family=\"Times,serif\" font-size=\"14.00\">Deterministic</text>\n",
        "</g>\n",
-       "<!-- s2&#45;&gt;tau -->\n",
-       "<g id=\"edge4\" class=\"edge\">\n",
-       "<title>s2&#45;&gt;tau</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M430.41,-368.4C423.11,-356.79 414.53,-343.14 406.69,-330.67\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"409.69,-328.87 401.41,-322.26 403.77,-332.59 409.69,-328.87\"/>\n",
-       "</g>\n",
-       "<!-- sigma_s -->\n",
-       "<g id=\"node8\" class=\"node\">\n",
-       "<title>sigma_s</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" cx=\"448\" cy=\"-502.79\" rx=\"55.86\" ry=\"40.66\"/>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"448\" y=\"-514.24\" font-family=\"Times,serif\" font-size=\"14.00\">sigma_s</text>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"448\" y=\"-497.74\" font-family=\"Times,serif\" font-size=\"14.00\">~</text>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"448\" y=\"-481.24\" font-family=\"Times,serif\" font-size=\"14.00\">Halfnormal</text>\n",
-       "</g>\n",
-       "<!-- sigma_s&#45;&gt;s2 -->\n",
-       "<g id=\"edge2\" class=\"edge\">\n",
-       "<title>sigma_s&#45;&gt;s2</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M448,-461.81C448,-453.96 448,-445.73 448,-437.9\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"451.5,-437.92 448,-427.92 444.5,-437.92 451.5,-437.92\"/>\n",
+       "<!-- tau&#45;&gt;theta -->\n",
+       "<g id=\"edge11\" class=\"edge\">\n",
+       "<title>tau&#45;&gt;theta</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M352.98,-262.75C347.04,-258.34 340.59,-254.27 334,-251.32 247.25,-212.4 211.29,-243.78 117.35,-215.62\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"118.57,-212.33 107.98,-212.65 116.45,-219.01 118.57,-212.33\"/>\n",
        "</g>\n",
        "<!-- k -->\n",
-       "<g id=\"node9\" class=\"node\">\n",
+       "<g id=\"node10\" class=\"node\">\n",
        "<title>k</title>\n",
-       "<polygon fill=\"none\" stroke=\"black\" points=\"363.12,-426.13 272.88,-426.13 272.88,-368.63 363.12,-368.63 363.12,-426.13\"/>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"318\" y=\"-408.83\" font-family=\"Times,serif\" font-size=\"14.00\">k</text>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"318\" y=\"-392.33\" font-family=\"Times,serif\" font-size=\"14.00\">~</text>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"318\" y=\"-375.83\" font-family=\"Times,serif\" font-size=\"14.00\">Deterministic</text>\n",
+       "<polygon fill=\"none\" stroke=\"black\" points=\"452.12,-426.13 361.88,-426.13 361.88,-368.63 452.12,-368.63 452.12,-426.13\"/>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"407\" y=\"-408.83\" font-family=\"Times,serif\" font-size=\"14.00\">k</text>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"407\" y=\"-392.33\" font-family=\"Times,serif\" font-size=\"14.00\">~</text>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"407\" y=\"-375.83\" font-family=\"Times,serif\" font-size=\"14.00\">Deterministic</text>\n",
        "</g>\n",
        "<!-- k&#45;&gt;Z -->\n",
-       "<g id=\"edge7\" class=\"edge\">\n",
+       "<g id=\"edge8\" class=\"edge\">\n",
        "<title>k&#45;&gt;Z</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M321.28,-368.21C323.39,-335.53 321.34,-282.2 291,-251.32 237.45,-196.81 194.18,-237.93 117.16,-215.48\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"118.61,-212.28 108.02,-212.53 116.46,-218.94 118.61,-212.28\"/>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M452.51,-389.8C482.03,-382.92 518.35,-368.93 537,-340.63 558.85,-307.49 563.42,-280.94 537,-251.32 492.35,-201.26 307.88,-232.57 225.42,-215.15\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"226.5,-211.82 215.95,-212.73 224.77,-218.6 226.5,-211.82\"/>\n",
        "</g>\n",
        "<!-- k&#45;&gt;tau -->\n",
-       "<g id=\"edge3\" class=\"edge\">\n",
+       "<g id=\"edge4\" class=\"edge\">\n",
        "<title>k&#45;&gt;tau</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M335.59,-368.4C342.89,-356.79 351.47,-343.14 359.31,-330.67\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"362.23,-332.59 364.59,-322.26 356.31,-328.87 362.23,-332.59\"/>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M400.51,-368.4C397.92,-357.25 394.89,-344.22 392.09,-332.16\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"395.51,-331.41 389.84,-322.46 388.69,-332.99 395.51,-331.41\"/>\n",
        "</g>\n",
        "<!-- log_k -->\n",
-       "<g id=\"node10\" class=\"node\">\n",
+       "<g id=\"node11\" class=\"node\">\n",
        "<title>log_k</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" cx=\"318\" cy=\"-502.79\" rx=\"41.01\" ry=\"40.66\"/>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"318\" y=\"-514.24\" font-family=\"Times,serif\" font-size=\"14.00\">log_k</text>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"318\" y=\"-497.74\" font-family=\"Times,serif\" font-size=\"14.00\">~</text>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"318\" y=\"-481.24\" font-family=\"Times,serif\" font-size=\"14.00\">Normal</text>\n",
+       "<ellipse fill=\"none\" stroke=\"black\" cx=\"407\" cy=\"-502.79\" rx=\"41.01\" ry=\"40.66\"/>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"407\" y=\"-514.24\" font-family=\"Times,serif\" font-size=\"14.00\">log_k</text>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"407\" y=\"-497.74\" font-family=\"Times,serif\" font-size=\"14.00\">~</text>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"407\" y=\"-481.24\" font-family=\"Times,serif\" font-size=\"14.00\">Normal</text>\n",
        "</g>\n",
        "<!-- log_k&#45;&gt;k -->\n",
        "<g id=\"edge1\" class=\"edge\">\n",
        "<title>log_k&#45;&gt;k</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M318,-461.81C318,-453.96 318,-445.73 318,-437.9\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"321.5,-437.92 318,-427.92 314.5,-437.92 321.5,-437.92\"/>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M407,-461.81C407,-453.96 407,-445.73 407,-437.9\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"410.5,-437.92 407,-427.92 403.5,-437.92 410.5,-437.92\"/>\n",
        "</g>\n",
-       "<!-- tau&#45;&gt;theta -->\n",
-       "<g id=\"edge9\" class=\"edge\">\n",
-       "<title>tau&#45;&gt;theta</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M354.31,-262.99C341.82,-250.81 327.03,-236.38 313.75,-223.42\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"316.39,-221.11 306.79,-216.63 311.51,-226.12 316.39,-221.11\"/>\n",
+       "<!-- s2&#45;&gt;psi -->\n",
+       "<g id=\"edge5\" class=\"edge\">\n",
+       "<title>s2&#45;&gt;psi</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M577.06,-368.16C583.29,-335.92 587.61,-283.51 560,-251.32 531.09,-217.62 407.76,-200.1 333.78,-192.46\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"334.16,-188.98 323.86,-191.46 333.46,-195.94 334.16,-188.98\"/>\n",
        "</g>\n",
-       "<!-- mu -->\n",
-       "<g id=\"node12\" class=\"node\">\n",
-       "<title>mu</title>\n",
-       "<ellipse fill=\"none\" stroke=\"black\" cx=\"525\" cy=\"-291.98\" rx=\"41.01\" ry=\"40.66\"/>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"525\" y=\"-303.43\" font-family=\"Times,serif\" font-size=\"14.00\">mu</text>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"525\" y=\"-286.93\" font-family=\"Times,serif\" font-size=\"14.00\">~</text>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"525\" y=\"-270.43\" font-family=\"Times,serif\" font-size=\"14.00\">Normal</text>\n",
-       "</g>\n",
-       "<!-- mu&#45;&gt;theta -->\n",
-       "<g id=\"edge10\" class=\"edge\">\n",
-       "<title>mu&#45;&gt;theta</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M493.19,-265.55C485.84,-260.4 477.86,-255.33 470,-251.32 426.14,-228.93 372.74,-212.01 333.24,-201.24\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"334.26,-197.89 323.7,-198.69 332.45,-204.66 334.26,-197.89\"/>\n",
+       "<!-- s2&#45;&gt;tau -->\n",
+       "<g id=\"edge3\" class=\"edge\">\n",
+       "<title>s2&#45;&gt;tau</title>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M524.48,-381.5C497.92,-371.81 464.36,-357.79 437,-340.63 431.16,-336.97 425.33,-332.68 419.78,-328.19\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"422.38,-325.81 412.48,-322.03 417.86,-331.15 422.38,-325.81\"/>\n",
        "</g>\n",
        "</g>\n",
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x13593c590>"
+       "<graphviz.graphs.Digraph at 0x12de57380>"
       ]
      },
      "execution_count": 13,
@@ -1639,6 +1659,8 @@
     "\n",
     "so $s^2$ and $k$ enter only through that combination. What separates them is the spread of relative reach across campaigns, which here runs from 0.49 to 1.70. With seven campaigns and a 3.5-fold spread, that separation is weak, and the posterior for $k$ stays wide. This is the honest reason the priors below deserve a check rather than a shrug.\n",
     "\n",
+    "Could more data sharpen it? The tempting route is time series: cut each flight into weeks and let dozens of weekly direct estimates $y_{c,w}$ inform $s^2$ and $k$ instead of seven flight totals. We deliberately do not. The extra rows are far from independent evidence: unique reach is cumulative, so consecutive weekly evidence increments are strongly autocorrelated; the weekly click shares are still one composition per week; and within a campaign, whatever moves its share in one week (a creative, an audience, a promotion) tends to move it in the next. Modelling that dependence honestly costs more structure than seven campaigns can support, so this notebook keeps the flight-level model and spends its scepticism on the prior and seed sensitivity checks at the end instead.\n",
+    "\n",
     "One more disclosure: $\\mu$'s prior is centered on the mean of the observed $y_c$. With a prior standard deviation of 1.0 against a data spread of 0.40 the effect is mild, but it is the data informing a prior, not prior information.\n",
     ":::"
    ]
@@ -1649,10 +1671,10 @@
    "id": "14ea3e0b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:37:04.844616Z",
-     "iopub.status.busy": "2026-08-11T12:37:04.844523Z",
-     "iopub.status.idle": "2026-08-11T12:37:05.529510Z",
-     "shell.execute_reply": "2026-08-11T12:37:05.529045Z"
+     "iopub.execute_input": "2026-08-12T10:15:30.816592Z",
+     "iopub.status.busy": "2026-08-12T10:15:30.816461Z",
+     "iopub.status.idle": "2026-08-12T10:15:31.606425Z",
+     "shell.execute_reply": "2026-08-12T10:15:31.605879Z"
     }
    },
    "outputs": [
@@ -1959,10 +1981,10 @@
    "id": "0d8ce7a3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:37:05.530817Z",
-     "iopub.status.busy": "2026-08-11T12:37:05.530746Z",
-     "iopub.status.idle": "2026-08-11T12:37:07.999598Z",
-     "shell.execute_reply": "2026-08-11T12:37:07.999126Z"
+     "iopub.execute_input": "2026-08-12T10:15:31.607721Z",
+     "iopub.status.busy": "2026-08-12T10:15:31.607601Z",
+     "iopub.status.idle": "2026-08-12T10:15:34.362326Z",
+     "shell.execute_reply": "2026-08-12T10:15:34.361871Z"
     }
    },
    "outputs": [
@@ -2152,10 +2174,10 @@
    "id": "05433eec",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:37:08.008187Z",
-     "iopub.status.busy": "2026-08-11T12:37:08.008131Z",
-     "iopub.status.idle": "2026-08-11T12:37:08.362872Z",
-     "shell.execute_reply": "2026-08-11T12:37:08.362487Z"
+     "iopub.execute_input": "2026-08-12T10:15:34.363560Z",
+     "iopub.status.busy": "2026-08-12T10:15:34.363442Z",
+     "iopub.status.idle": "2026-08-12T10:15:34.752658Z",
+     "shell.execute_reply": "2026-08-12T10:15:34.752134Z"
     },
     "lines_to_next_cell": 0
    },
@@ -2189,10 +2211,10 @@
    "id": "b3f38373",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:37:08.364199Z",
-     "iopub.status.busy": "2026-08-11T12:37:08.364045Z",
-     "iopub.status.idle": "2026-08-11T12:37:08.484388Z",
-     "shell.execute_reply": "2026-08-11T12:37:08.483850Z"
+     "iopub.execute_input": "2026-08-12T10:15:34.754257Z",
+     "iopub.status.busy": "2026-08-12T10:15:34.754137Z",
+     "iopub.status.idle": "2026-08-12T10:15:34.899250Z",
+     "shell.execute_reply": "2026-08-12T10:15:34.898839Z"
     },
     "lines_to_next_cell": 0
    },
@@ -2253,10 +2275,10 @@
    "id": "1ff45e4b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:37:08.485750Z",
-     "iopub.status.busy": "2026-08-11T12:37:08.485662Z",
-     "iopub.status.idle": "2026-08-11T12:37:08.634237Z",
-     "shell.execute_reply": "2026-08-11T12:37:08.633781Z"
+     "iopub.execute_input": "2026-08-12T10:15:34.900477Z",
+     "iopub.status.busy": "2026-08-12T10:15:34.900363Z",
+     "iopub.status.idle": "2026-08-12T10:15:35.078906Z",
+     "shell.execute_reply": "2026-08-12T10:15:35.078452Z"
     }
    },
    "outputs": [
@@ -2514,10 +2536,10 @@
    "id": "8ebc7cb8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:37:08.635728Z",
-     "iopub.status.busy": "2026-08-11T12:37:08.635618Z",
-     "iopub.status.idle": "2026-08-11T12:37:08.678201Z",
-     "shell.execute_reply": "2026-08-11T12:37:08.677800Z"
+     "iopub.execute_input": "2026-08-12T10:15:35.080134Z",
+     "iopub.status.busy": "2026-08-12T10:15:35.080026Z",
+     "iopub.status.idle": "2026-08-12T10:15:35.136214Z",
+     "shell.execute_reply": "2026-08-12T10:15:35.135735Z"
     }
    },
    "outputs": [
@@ -2668,10 +2690,10 @@
    "id": "bcec38dc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:37:08.679534Z",
-     "iopub.status.busy": "2026-08-11T12:37:08.679445Z",
-     "iopub.status.idle": "2026-08-11T12:37:08.708101Z",
-     "shell.execute_reply": "2026-08-11T12:37:08.707665Z"
+     "iopub.execute_input": "2026-08-12T10:15:35.137355Z",
+     "iopub.status.busy": "2026-08-12T10:15:35.137247Z",
+     "iopub.status.idle": "2026-08-12T10:15:35.178712Z",
+     "shell.execute_reply": "2026-08-12T10:15:35.178409Z"
     }
    },
    "outputs": [
@@ -2842,10 +2864,10 @@
    "id": "99e1b081",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:37:08.709274Z",
-     "iopub.status.busy": "2026-08-11T12:37:08.709185Z",
-     "iopub.status.idle": "2026-08-11T12:37:08.739984Z",
-     "shell.execute_reply": "2026-08-11T12:37:08.739508Z"
+     "iopub.execute_input": "2026-08-12T10:15:35.180185Z",
+     "iopub.status.busy": "2026-08-12T10:15:35.180070Z",
+     "iopub.status.idle": "2026-08-12T10:15:35.225528Z",
+     "shell.execute_reply": "2026-08-12T10:15:35.224953Z"
     }
    },
    "outputs": [
@@ -3000,10 +3022,10 @@
    "id": "ebe73388",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:37:08.741110Z",
-     "iopub.status.busy": "2026-08-11T12:37:08.741026Z",
-     "iopub.status.idle": "2026-08-11T12:37:08.766350Z",
-     "shell.execute_reply": "2026-08-11T12:37:08.765832Z"
+     "iopub.execute_input": "2026-08-12T10:15:35.226909Z",
+     "iopub.status.busy": "2026-08-12T10:15:35.226765Z",
+     "iopub.status.idle": "2026-08-12T10:15:35.262756Z",
+     "shell.execute_reply": "2026-08-12T10:15:35.262066Z"
     }
    },
    "outputs": [
@@ -3083,10 +3105,10 @@
    "id": "6a37f9f9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:37:08.767510Z",
-     "iopub.status.busy": "2026-08-11T12:37:08.767432Z",
-     "iopub.status.idle": "2026-08-11T12:37:08.889279Z",
-     "shell.execute_reply": "2026-08-11T12:37:08.888830Z"
+     "iopub.execute_input": "2026-08-12T10:15:35.264360Z",
+     "iopub.status.busy": "2026-08-12T10:15:35.264213Z",
+     "iopub.status.idle": "2026-08-12T10:15:35.398839Z",
+     "shell.execute_reply": "2026-08-12T10:15:35.398225Z"
     },
     "lines_to_next_cell": 0
    },
@@ -3183,10 +3205,10 @@
    "id": "be23276d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:37:08.890481Z",
-     "iopub.status.busy": "2026-08-11T12:37:08.890397Z",
-     "iopub.status.idle": "2026-08-11T12:37:09.158085Z",
-     "shell.execute_reply": "2026-08-11T12:37:09.157652Z"
+     "iopub.execute_input": "2026-08-12T10:15:35.400200Z",
+     "iopub.status.busy": "2026-08-12T10:15:35.400064Z",
+     "iopub.status.idle": "2026-08-12T10:15:35.696380Z",
+     "shell.execute_reply": "2026-08-12T10:15:35.695858Z"
     },
     "lines_to_next_cell": 0
    },
@@ -3238,10 +3260,10 @@
    "id": "1a550b41",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:37:09.159306Z",
-     "iopub.status.busy": "2026-08-11T12:37:09.159210Z",
-     "iopub.status.idle": "2026-08-11T12:37:09.332591Z",
-     "shell.execute_reply": "2026-08-11T12:37:09.332081Z"
+     "iopub.execute_input": "2026-08-12T10:15:35.697964Z",
+     "iopub.status.busy": "2026-08-12T10:15:35.697814Z",
+     "iopub.status.idle": "2026-08-12T10:15:35.894966Z",
+     "shell.execute_reply": "2026-08-12T10:15:35.894385Z"
     },
     "lines_to_next_cell": 0
    },
@@ -3351,10 +3373,10 @@
    "id": "982d8874",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:37:09.333891Z",
-     "iopub.status.busy": "2026-08-11T12:37:09.333797Z",
-     "iopub.status.idle": "2026-08-11T12:37:09.532581Z",
-     "shell.execute_reply": "2026-08-11T12:37:09.531953Z"
+     "iopub.execute_input": "2026-08-12T10:15:35.896493Z",
+     "iopub.status.busy": "2026-08-12T10:15:35.896351Z",
+     "iopub.status.idle": "2026-08-12T10:15:36.110288Z",
+     "shell.execute_reply": "2026-08-12T10:15:36.109740Z"
     }
    },
    "outputs": [
@@ -3445,10 +3467,10 @@
    "id": "93574ebd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:37:09.533779Z",
-     "iopub.status.busy": "2026-08-11T12:37:09.533684Z",
-     "iopub.status.idle": "2026-08-11T12:37:09.557518Z",
-     "shell.execute_reply": "2026-08-11T12:37:09.557152Z"
+     "iopub.execute_input": "2026-08-12T10:15:36.111493Z",
+     "iopub.status.busy": "2026-08-12T10:15:36.111379Z",
+     "iopub.status.idle": "2026-08-12T10:15:36.147524Z",
+     "shell.execute_reply": "2026-08-12T10:15:36.146725Z"
     }
    },
    "outputs": [
@@ -3479,9 +3501,446 @@
    "id": "0714c6e3",
    "metadata": {},
    "source": [
-    "> **Fig.** Top: daily credit per campaign, stacking to the MMM social curve by construction, with the `broad_prospecting` slice appearing from nothing in April. Bottom: the daily posterior for `flash_sale_burst` against the hidden truth. Notice the tail: the truth decays for about a week after the burst stops, while our allocation drops to exactly zero the day delivery ends, because the daily shape is inherited from daily reach and nothing in the method knows about adstock.\n",
+    "> **Fig.** Top: daily credit per campaign, stacking to the MMM social curve by construction, with the `broad_prospecting` slice appearing from nothing in April. Bottom: the daily posterior for `flash_sale_burst` against the hidden truth. Notice the tail: the truth decays for about a week after the burst stops, while our allocation drops to exactly zero the day delivery ends, because the daily shape is inherited from daily reach. The extension below repairs exactly this, by pushing the reach through the MMM's own adstock transform.\n",
     "\n",
     "The stacked figure takes for granted that the daily shape is right, and the correlations above measure it. The claim holds well for five campaigns, from `flash_sale_burst` at 0.94 down to `brand_always_on` at 0.77, and poorly for `lookalike_conversions` at 0.56 and `niche_interest` at 0.28. That is the expected failure mode: the daily shape is inherited entirely from daily reach, so a campaign whose true impact does not track its delivery cannot be fixed by any reweighting of the level."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "79b988a9",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "### Extension: letting the credit outlive the flight\n",
+    "\n",
+    "The daily allocation spends each day's MMM credit in proportion to that day's raw reach, so a campaign's credit stops dead the moment its delivery does. The MMM itself disagrees: it was fit with a geometric adstock on the channel's media variable, so the channel curve it hands us already contains carryover, revenue arriving days after the exposure that caused it. Splitting an adstocked curve by un-adstocked reach hands the tail of every burst to whichever campaigns happen to still be delivering.\n",
+    "\n",
+    "The repair is one line: push each campaign's daily reach through the **same transform the MMM used**, {func}`geometric adstock <pymc_marketing.mmm.transformers.geometric_adstock>`, before computing the daily weights. Because the weights are renormalised every day, the split still reconciles to the MMM total exactly; only the *shape* of each campaign's credit changes. And crucially, the decay rate is not a new free dial to agonise over. Your fitted MMM has a posterior for the channel's adstock decay (`adstock_alpha` in pymc-marketing), and inheriting it is precisely what \"aligned with the main model's structure\" means.\n",
+    "\n",
+    "The data package here ships only the contribution curve, not the fitted decay, so this notebook does the next best thing: sweep the decay rate and grade each setting against the hidden truth, the same oracle-grading already used for the $Z$ sweep. Two caveats to read alongside the table. This grading is a validation your own data cannot repeat, which is why the production recommendation is to inherit the MMM's decay rather than tune it. And in this simulation each campaign's true carryover decays at its own rate, so a single channel-level decay, which is all a channel-level MMM can offer, is itself an approximation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "30ab1681",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-12T10:15:36.148878Z",
+     "iopub.status.busy": "2026-08-12T10:15:36.148739Z",
+     "iopub.status.idle": "2026-08-12T10:15:36.420815Z",
+     "shell.execute_reply": "2026-08-12T10:15:36.420314Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>mean_daily_corr</th>\n",
+       "      <th>corr_brand_always_on</th>\n",
+       "      <th>corr_spring_promo</th>\n",
+       "      <th>corr_lookalike_conversions</th>\n",
+       "      <th>corr_video_product_launch</th>\n",
+       "      <th>corr_flash_sale_burst</th>\n",
+       "      <th>corr_niche_interest</th>\n",
+       "      <th>corr_broad_prospecting</th>\n",
+       "      <th>spearman</th>\n",
+       "      <th>mae</th>\n",
+       "      <th>crps</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>alpha</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0.0</th>\n",
+       "      <td>0.744</td>\n",
+       "      <td>0.774</td>\n",
+       "      <td>0.912</td>\n",
+       "      <td>0.559</td>\n",
+       "      <td>0.885</td>\n",
+       "      <td>0.939</td>\n",
+       "      <td>0.285</td>\n",
+       "      <td>0.856</td>\n",
+       "      <td>0.893</td>\n",
+       "      <td>0.035</td>\n",
+       "      <td>0.025</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0.2</th>\n",
+       "      <td>0.761</td>\n",
+       "      <td>0.796</td>\n",
+       "      <td>0.914</td>\n",
+       "      <td>0.590</td>\n",
+       "      <td>0.895</td>\n",
+       "      <td>0.944</td>\n",
+       "      <td>0.317</td>\n",
+       "      <td>0.870</td>\n",
+       "      <td>0.893</td>\n",
+       "      <td>0.035</td>\n",
+       "      <td>0.026</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0.4</th>\n",
+       "      <td>0.779</td>\n",
+       "      <td>0.816</td>\n",
+       "      <td>0.912</td>\n",
+       "      <td>0.634</td>\n",
+       "      <td>0.903</td>\n",
+       "      <td>0.942</td>\n",
+       "      <td>0.359</td>\n",
+       "      <td>0.887</td>\n",
+       "      <td>0.893</td>\n",
+       "      <td>0.035</td>\n",
+       "      <td>0.026</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0.6</th>\n",
+       "      <td>0.797</td>\n",
+       "      <td>0.834</td>\n",
+       "      <td>0.900</td>\n",
+       "      <td>0.695</td>\n",
+       "      <td>0.905</td>\n",
+       "      <td>0.923</td>\n",
+       "      <td>0.414</td>\n",
+       "      <td>0.908</td>\n",
+       "      <td>0.893</td>\n",
+       "      <td>0.036</td>\n",
+       "      <td>0.026</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0.8</th>\n",
+       "      <td>0.787</td>\n",
+       "      <td>0.824</td>\n",
+       "      <td>0.858</td>\n",
+       "      <td>0.729</td>\n",
+       "      <td>0.876</td>\n",
+       "      <td>0.856</td>\n",
+       "      <td>0.434</td>\n",
+       "      <td>0.929</td>\n",
+       "      <td>0.893</td>\n",
+       "      <td>0.036</td>\n",
+       "      <td>0.027</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       mean_daily_corr  corr_brand_always_on  corr_spring_promo  \\\n",
+       "alpha                                                             \n",
+       "0.0              0.744                 0.774              0.912   \n",
+       "0.2              0.761                 0.796              0.914   \n",
+       "0.4              0.779                 0.816              0.912   \n",
+       "0.6              0.797                 0.834              0.900   \n",
+       "0.8              0.787                 0.824              0.858   \n",
+       "\n",
+       "       corr_lookalike_conversions  corr_video_product_launch  \\\n",
+       "alpha                                                          \n",
+       "0.0                         0.559                      0.885   \n",
+       "0.2                         0.590                      0.895   \n",
+       "0.4                         0.634                      0.903   \n",
+       "0.6                         0.695                      0.905   \n",
+       "0.8                         0.729                      0.876   \n",
+       "\n",
+       "       corr_flash_sale_burst  corr_niche_interest  corr_broad_prospecting  \\\n",
+       "alpha                                                                       \n",
+       "0.0                    0.939                0.285                   0.856   \n",
+       "0.2                    0.944                0.317                   0.870   \n",
+       "0.4                    0.942                0.359                   0.887   \n",
+       "0.6                    0.923                0.414                   0.908   \n",
+       "0.8                    0.856                0.434                   0.929   \n",
+       "\n",
+       "       spearman    mae   crps  \n",
+       "alpha                          \n",
+       "0.0       0.893  0.035  0.025  \n",
+       "0.2       0.893  0.035  0.026  \n",
+       "0.4       0.893  0.035  0.026  \n",
+       "0.6       0.893  0.036  0.026  \n",
+       "0.8       0.893  0.036  0.027  "
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def adstocked_reach(reach: xr.DataArray, alpha: float, l_max: int = 12) -> xr.DataArray:\n",
+    "    \"\"\"Daily reach pushed through the MMM's geometric adstock along the date axis.\"\"\"\n",
+    "    values = (\n",
+    "        geometric_adstock(\n",
+    "            ptx.as_xtensor(pt.as_tensor_variable(reach.to_numpy()), dims=reach.dims),\n",
+    "            alpha=alpha,\n",
+    "            l_max=l_max,\n",
+    "            normalize=True,\n",
+    "            dim=\"date\",\n",
+    "        )\n",
+    "        .transpose(*reach.dims)\n",
+    "        .eval()\n",
+    "    )\n",
+    "    return xr.DataArray(values, dims=reach.dims, coords=reach.coords)\n",
+    "\n",
+    "\n",
+    "def daily_truth_correlation(contribution: xr.DataArray) -> pd.Series:\n",
+    "    \"\"\"Correlation of each campaign's posterior-mean daily credit with the truth.\"\"\"\n",
+    "    daily = contribution.mean(\"sample\")\n",
+    "    return pd.Series(\n",
+    "        {\n",
+    "            campaign: float(\n",
+    "                np.corrcoef(\n",
+    "                    daily.sel(campaign=campaign).to_numpy(),\n",
+    "                    data.truth[campaign].to_numpy(),\n",
+    "                )[0, 1]\n",
+    "            )\n",
+    "            for campaign in campaigns\n",
+    "        }\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "def evaluate_decay(alpha: float) -> dict[str, float]:\n",
+    "    \"\"\"Allocate with adstocked reach at one decay rate and grade the result.\"\"\"\n",
+    "    contribution_alpha = allocate(\n",
+    "        social_draws, allocation_weights(theta_draws, adstocked_reach(reach, alpha))\n",
+    "    )\n",
+    "    residual = float(np.abs(contribution_alpha.sum(\"campaign\") - social_draws).max())\n",
+    "    assert np.isfinite(residual) and residual < 1e-9, (  # noqa: S101\n",
+    "        \"the adstocked split must still reconcile to the MMM draws\"\n",
+    "    )\n",
+    "    correlations = daily_truth_correlation(contribution_alpha)\n",
+    "    shares = flight_share(contribution_alpha).transpose(\"sample\", \"campaign\")\n",
+    "    scores = score_shares(true_share, shares.to_numpy())\n",
+    "    return {\n",
+    "        \"mean_daily_corr\": float(correlations.mean()),\n",
+    "        **{f\"corr_{campaign}\": correlations[campaign] for campaign in campaigns},\n",
+    "        \"spearman\": scores[\"spearman\"],\n",
+    "        \"mae\": scores[\"mae\"],\n",
+    "        \"crps\": scores[\"crps\"],\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "decay_grid = (0.0, 0.2, 0.4, 0.6, 0.8)\n",
+    "corr_columns = [f\"corr_{campaign}\" for campaign in campaigns]\n",
+    "adstock_sweep = pd.DataFrame(\n",
+    "    [{\"alpha\": alpha, **evaluate_decay(alpha)} for alpha in decay_grid]\n",
+    ").set_index(\"alpha\")\n",
+    "\n",
+    "# alpha = 0 is an identity kernel, so it must reproduce the main allocation\n",
+    "assert np.allclose(  # noqa: S101\n",
+    "    adstock_sweep.loc[0.0, corr_columns].to_numpy(),\n",
+    "    daily_correlation.reindex(campaigns).to_numpy(),\n",
+    "), \"alpha = 0 must reproduce the un-adstocked daily correlations\"\n",
+    "assert np.isclose(adstock_sweep.loc[0.0, \"crps\"], credibility_row[\"crps\"]), (  # noqa: S101\n",
+    "    \"alpha = 0 must reproduce the main scoreboard row\"\n",
+    ")\n",
+    "adstock_sweep.round(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "b165f216",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-12T10:15:36.421930Z",
+     "iopub.status.busy": "2026-08-12T10:15:36.421807Z",
+     "iopub.status.idle": "2026-08-12T10:15:36.557295Z",
+     "shell.execute_reply": "2026-08-12T10:15:36.556793Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "The sweep favours carrying credit forward: the mean daily correlation with the truth rises from **0.744** with no carryover to **0.797** at a decay rate of **0.6**. The campaigns that gain are `lookalike_conversions` +0.14, `niche_interest` +0.13, `brand_always_on` +0.06, `broad_prospecting` +0.05, `video_product_launch` +0.02. The correction is not free everywhere: `flash_sale_burst` -0.02, `spring_promo` -0.01. Window-total shares barely move: the largest change in any campaign's mean flight share between no carryover and a decay of 0.6 is **0.0026**, so this is a repair to *when* the credit lands, not to *who* gets it."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "best_alpha = float(adstock_sweep[\"mean_daily_corr\"].idxmax())\n",
+    "display_alpha = best_alpha if best_alpha > 0 else 0.4\n",
+    "corr_change = pd.Series(\n",
+    "    (\n",
+    "        adstock_sweep.loc[display_alpha, corr_columns]\n",
+    "        - adstock_sweep.loc[0.0, corr_columns]\n",
+    "    ).to_numpy(),\n",
+    "    index=campaigns,\n",
+    ")\n",
+    "improved = corr_change[corr_change > 0.005].sort_values(ascending=False)\n",
+    "worsened = corr_change[corr_change < -0.005].sort_values()\n",
+    "\n",
+    "\n",
+    "def mean_share_at(alpha: float) -> pd.Series:\n",
+    "    \"\"\"Posterior-mean flight share of each campaign at one decay rate.\"\"\"\n",
+    "    weights = allocation_weights(theta_draws, adstocked_reach(reach, alpha))\n",
+    "    return (\n",
+    "        flight_share(allocate(social_draws, weights))\n",
+    "        .mean(\"sample\")\n",
+    "        .to_pandas()\n",
+    "        .reindex(campaigns)\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "share_shift = float((mean_share_at(display_alpha) - mean_share_at(0.0)).abs().max())\n",
+    "\n",
+    "\n",
+    "def named_changes(changes: pd.Series) -> str:\n",
+    "    \"\"\"Render per-campaign correlation changes as a readable list.\"\"\"\n",
+    "    return \", \".join(\n",
+    "        f\"`{campaign}` {change:+.2f}\" for campaign, change in changes.items()\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "if best_alpha > 0:\n",
+    "    sweep_verdict = (\n",
+    "        f\"The sweep favours carrying credit forward: the mean daily correlation with \"\n",
+    "        f\"the truth rises from **{adstock_sweep.loc[0.0, 'mean_daily_corr']:.3f}** with \"\n",
+    "        f\"no carryover to **{adstock_sweep.loc[best_alpha, 'mean_daily_corr']:.3f}** at \"\n",
+    "        f\"a decay rate of **{best_alpha:.1f}**.\"\n",
+    "    )\n",
+    "else:\n",
+    "    sweep_verdict = (\n",
+    "        \"The sweep does not favour carrying credit forward on this dataset: no decay \"\n",
+    "        f\"rate beats the raw-reach allocation's mean daily correlation of \"\n",
+    "        f\"**{adstock_sweep.loc[0.0, 'mean_daily_corr']:.3f}**, so the figure below uses \"\n",
+    "        f\"a decay of {display_alpha:.1f} purely for illustration.\"\n",
+    "    )\n",
+    "improved_text = (\n",
+    "    f\"The campaigns that gain are {named_changes(improved)}.\"\n",
+    "    if not improved.empty\n",
+    "    else \"No campaign's daily correlation improves by more than 0.005.\"\n",
+    ")\n",
+    "worsened_text = (\n",
+    "    f\" The correction is not free everywhere: {named_changes(worsened)}.\"\n",
+    "    if not worsened.empty\n",
+    "    else \" No campaign's daily correlation degrades by more than 0.005.\"\n",
+    ")\n",
+    "share_text = (\n",
+    "    f\"Window-total shares barely move: the largest change in any campaign's mean \"\n",
+    "    f\"flight share between no carryover and a decay of {display_alpha:.1f} is \"\n",
+    "    f\"**{share_shift:.4f}**, so this is a repair to *when* the credit lands, not to \"\n",
+    "    f\"*who* gets it.\"\n",
+    "    if share_shift < 0.01\n",
+    "    else f\"Window-total shares move too: the largest change in a campaign's mean \"\n",
+    "    f\"flight share is **{share_shift:.4f}**, so the decay rate affects who gets the \"\n",
+    "    f\"credit, not only when it lands.\"\n",
+    ")\n",
+    "\n",
+    "display(Markdown(f\"{sweep_verdict} {improved_text}{worsened_text} {share_text}\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "92ce049f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-12T10:15:36.558889Z",
+     "iopub.status.busy": "2026-08-12T10:15:36.558752Z",
+     "iopub.status.idle": "2026-08-12T10:15:36.734796Z",
+     "shell.execute_reply": "2026-08-12T10:15:36.734318Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABLsAAALHCAYAAABmNkB7AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQABAABJREFUeJzs3QV4XGX6BfAzErdq6qUt1FukhhXX4u7utrAs+8cWWGSxBRZdoIs7FCnuXZxtC4UCNVrqLnEdvf/nfJObTpJJMklmIpPze550kjsz9965I505837v57Asy4KIiIiIiIiIiEgCcLb1DoiIiIiIiIiIiMSKwi4REREREREREUkYCrtERERERERERCRhKOwSEREREREREZGEobBLREREREREREQShsIuERERERERERFJGAq7REREREREREQkYSjsEhERERERERGRhKGwS0REREREREREEobCLhFJaEcccQSGDx+OMWPGoKCgoEXr4nr4kyhOP/10c3tmzZrVpvux7777mv1Ys2YNEgmPK28Xj7NIR3rdufbaa80233rrrbg+x2O9nUTw8MMPm2PC03A8RlzOYxZrXq8X//rXv3DggQea/yu5Hd5nba24uBi33HIL9tlnn+r9sl9P6ztOrYGP4/ZyjFqqLZ+Difp/v4i0Hwq7RCRh/frrr/j999/N7z6fD++++25b75ICENFjTUTaVfDywAMPYOrUqSgrK8N+++2Ho48+GgcddFCb30s33ngjXn75ZTgcDhxwwAFmv/bYY4+23i2RagrsRdo3d1vvgIhIvLzxxhvmtFevXti4caP5+8wzz9QBl1ax/fbb48MPP0RaWpqOuHRqzz77rPnCga/F0jwMe3bYYQdkZWXF/BB+/PHH5vSll17CoEGD0B7w8fL5558jJSXFfFGVmZnZ1rskIiIdjCq7RCQhVVRU4IMPPjC///Of/0R6ejoWL15sqr1EWgNDrm233RZ9+/bVAZdObeDAgea5kJSU1Na70mEx5OIxzM3Njfm6161bZ07bS9BFmzdvht/vR48ePRR0iYhIs6iyS0QSEr+pLi0txbBhw7DLLrvgkEMOMZVd/GHFTX1+/vln/Pvf/8bcuXMRCAQwePBgnHLKKTjuuOPqvc6KFSvMEBD2aNq0aZP5QNelSxcMHTrUDAU59thjzeXYa2T27Nnmd56G9+Hp168f/vvf/1b/zTf5r7/+Ot555x0sWbLE9FTp06cP9txzT5x//vn1Vkgw5HvttdfwySef4I8//jB/9+zZ02zr0EMPxeGHHx7V8XvzzTfx97//3QQ27InCY2j73//+ZyoAeIwKCwvNh7Bx48bhvPPOw0477RRxfdyXhx56yBwj7hM//HJIyllnnYXmWLt2rQkzv/32W6xatQpbtmxBamqqOeZHHnkkTjjhBDidkb/P+fHHH/HYY4/hl19+MffxkCFDzH1z1FFHVd8n9vBXG0NSPqZ4v61fvx5FRUXIzs42j6UzzjgDu+22W53t8LbyvEmTJuGFF16oMeyIQ4V4n8+YMQPTpk0z99myZcvgcrlM9caf/vSniMcyHo+1+vB+f+SRR3DZZZeZ9fL37777zhxrPo7uuusuc7lPP/0UX331lTmerKCsrKw0j7mdd97ZPFZ5fMPdeeedptKHwz/OPvvsGufxebp06VKMHTu2ujLTxu1zny655BJcccUVje5/7fvgP//5j/nh/cgP9927d69xHObNm4dnnnkGc+bMMbeRATn3g9ffa6+9Ij6mWbn3/fffm8cjewJmZGRg5MiR5vHH21IfHiceAz5++XiwLMs8p3mf87p8PkXC5zWvx8dnMBjEiBEjcPHFF0fcv8bwucvXOlbPMFhgqMChcJdffnm918nPz8f777+Pb775xtxPPE5ut9uEJAcffLCpnGUlTm1cL48RH+/9+/dvcL+uueYavP322/jLX/6CCy+8MOJleNyvvPLKiI+ThjTluIe/FvD1kM9T3uf8fyX8dnCdTz/9NL7++mvzuOLrDh/zfH076aSTzPGpjc+RJ554Au+99565Dp/Du+++e4OPa/ZUuu6668x67ecen0PTp083v/P41u7tVvt1rL77pfZttp+nxxxzTPXffL3lMVi4cCHKy8vNc5z/L1xwwQXm/8n61s1jtWjRIjz//PPmlK+d/J2vD/UJ34/at6ux67IijI8P3h/z5883r5P8/5T/f3IIZH3/f5aUlODJJ580rwmrV6821+H9wvt51113Na87kcJaPoaa8hreFNG+3rfkdjemqa+LzfXZZ5+Z5xEfszym7NHG9xSRttHY64n9vKj9GA5fzvU/+uij5v1AXl6euX95n9FHH31k7k8+1vl8Z1Uh/7/g68Npp51mXnft/8dtfG7yx8b/N+31iUjbUdglIgnJ/gBkvxnkKZfxzeD1119vgpHa+AbnqquuMgEIQzL+MNi44YYbzIecSFgtdvLJJ5s3RHzDz0a6/LDDD0A//PCDObX3gW84k5OTzQctfrAM7z3StWvX6t8ZbPFDHj9E84Mj39jzzRaDOIYm/LD51FNPYfTo0TX2hfvKN4fcV4ZUfGPGN8bcB76h475GE3Y9+OCD5k0gQxGGA9ttt131eXfffbd5Q8rbyDeL48ePN9vlm84vvvgCt912W4034MRt8402PyANGDDAfKhjMHD//febgKQ5GAJyP/lGlx+0eVv5gZ3H6KeffjKhDMM19noJxw9sf/3rX01QYN/HPD58k1rffUxs3swPHDwWPO48vvxAxNvMHz6mmjNEltvl/cnjuPfee5s319x3PnZefPFF86Epno+1aD9w8QM2P2jxOPODSPg6/vznP5ttseqEH375AYsBLT+cM1jiYzU8RGAwyMCBj+/wsIv7zwCF+GGNzakZKIaHrPb1m8rj8ZgAkOufMGGC+bDCsMf23HPPmQCBjwuGVQwx+cGO9zmPIT+08MNLOH4A5GsKgw0+jrivfC7wOtxXPrbDP/yE3w4GSrx9/ADFD9I8tvzwxscCRQq7+Hjm85IfoPkBkB+s+XjnawVDQA5zixZv26mnnmru25ycHPNY4m1n+MIgK/w5H47n3X777eZD8zbbbIMdd9zRBGC8rffdd58JChhG8PHQXPwQzbDr1VdfNa9nDA9qYx8n4gfPaDX3uPM1jdvjcedzlM97+3WFz7tLL73UBDh8veRjk6/fv/32m7keXxsef/zxGiEJw36G/PyygMHB5MmTzes8H2dffvml2Ua0+LrB11WGoFxXU/ts8fJ8LbYDMz7PbfxCgvh8Z0jA+4TBHZ8/PH58jvI5zv83+djkFzGR8HnC1zL+f8HXIYYwke7TcNyP+m4XX88awuDi6quvrq6EY1DGY87XVv7/yf8D+Nji49fG8/mlFl9ju3XrZl7HuF3+n7J8+XLzvONrVaSwqymv4U3RlNf75t7uxjTndbE5uH/8P4GPEd5OfoHFL2n4w/dfsZ7kha+b/DKPgS0fzwyf+UVF+JcqfKzzOc/XOgahfG3n6z1fG/n/Bx8ffJwyBOT+8rUj/NjyeIlIO2CJiCSYZcuWWcOGDbNGjx5t5eXlVS8/+OCDzfLp06fXuc6mTZusnXbayZz/zDPP1Djv+++/t8aOHWvO40+4a6+91ix79NFH66yzoqLCmj17do1lM2fONJc/7bTT6t3/e+65x1xm//33t1avXl293Ov1Wtdff705b99997U8Hk/1eYFAwDrmmGPMeeecc06N202VlZXWl19+WWMZ94GX5z4R13fVVVeZZVzX5s2ba1z+tddeM+cdcMAB1sKFC2ucx9vJ48djvnz58hrb3Wuvvcz1br/9dsvv91efx3XsvPPO1cc1/LY25pdffrF+//33Oss3bNhgHXHEEWZ9H374YZ3zdtxxR3Pec889V2f/7fNq38fEY7dx48Y6y3/66Sdr3Lhx5nZz/dHc17yd9nb22Wcf83i18fhcd9111fdjvB9rDXnooYeq9/Ovf/1rjcdbuA8++MAqKyursSwYDFovvviiue6hhx5q/rbxsjxePN7h6+Tzkpc//PDDzeknn3wS8Tp8HkTLPgb2evk8r+3rr7+2hg8fbh6LtY/hokWLrD333NNcf9asWTXO49+rVq2qs76lS5dWX4eP03Dr1q2zxo8fb86799576xzTLVu2WD/88EONZfb+T5gwwZo7d27E++jAAw+0muJPf/qTud4pp5xiFRcXVy8vKCiwjj/++OptvvnmmzWu98cff1g///xznfUVFhaaxyuv88QTT9Q5n4/zSM/xa665JuJ2TjrpJLP8008/rbMuPu953i677FLvY7K2lhx3Pr8j3WY+liZNmmQeOy+99JJ5Dbbl5+dbZ5xxhrn+ww8/XON6d911l1nO/4/CXzPKy8utiy++uHq7vG/D8RhxOY9ZpNcTHuPmqu91j15++WVzHp8fCxYsqF7O57T9+ONjs/b/OfZ9PnLkSOvzzz9v8j41drvsbdc+TiUlJWZ7te9jvm7cd9995jrnn39+jfPs157zzjuvzusL71c+18PX19zX8KZo6ut9c253Q8/B5r4uNoX9GOF23nnnnTr/r3D5qFGj6vxfX9/rSWO3yV5uvw6EP2eJx2777bc3/8/wdby2NWvWmNfAaLYlIu2DenaJSMLhkBO71J3f0trsb0Ht88PxGzvORMVKhdpD61gBcOKJJ0bcFr9NpUil9qwemzhxYpMrUDhE0P7GOLxEn98q81tOfrPNEnp+621jRQWHG/CbSn7LHn67iZUDDQ05YGXCueeeayo7eNz4jXT4N+j8Ztee4p1VTvxmMxxvJ4cBcCgFy/9t3Ed+I8qhFP/3f/9X4xt9ruOiiy5Cc/AbZlbT1MZvYbmd8KbL4fcxqwX4bS2rR2rvP4cc1YfHLlKvHK6LFTJ2M+Wm4v0ZPgSIx4fDs4jfanO98XqsRYvVgTfddFO91TocrsdvucOx8oXHhceHVV52xRbxsqx24H3B6hYbK72I1ZXE6ggbKxl4LPgtfHP7PvE28PlRGx/XrF655ZZb6hxDVkewqoX4nAjHoZGsVKyNlV58LkR6DLLKhVUCrF7g7ax9TFkxw9sYCauSaleJsKqLlRys0OLzLBq8HIcM8T7ibQ5veM77msvqw4oRvkbWxuowPpYj3ebmsJ+f9mthOPt+OP7446OuIGvJcT/nnHMi3mZWvbA6kI9zVgWFD5tm5SN7RfKxytvAxxexgsR+feTre/iwMlaL8thHGgballjJS6xgC69W4eOHVT18jrBajkP5IuHw8PDhXvHGKmhur/Z9zPuCQ2P5Os4KRVZM2VitRKw6rv36wvuVz/X6HmtNeQ1viqa+3jfndjekua+LzcH9PuKII+r8v3LggQeaSuHwNgCxwGpwViTXbnXAY8PnKF/Xaw+/J1Zv8jVQRDoODWMUkYTCN0YcbkG1h9PxTTeHzvGDM8vO7WEaZPc3qm+YH8vVOTwnUujCfkU333yzKennm+KWfFjh8BeGAPzQGWkqeX4g4ptA7guHEtj7yzex9v7b5fjRYnDG/eewKA4L+tvf/lbnTeCCBQvM8BMeMw41iIS33R4iUPu4TpkyJWJIwePK/hnNweFCHErBY8YPBvxQwTfnDC2Jw0/C8X5v6D7mm237g10kHO7D+5rDS/jhjo81YtAQaXuN4TCJ8OGFNgYyDA8YQPLDtB3QxPqxFi2GvY3NALdy5UrzGOQpjz/D0fAPkTw24UPjuE4Ob2XAZT9uOMyMw0DsYNEethgehDVnCGNDYQaH4LEfGz88MgiJxO4PxOGxtfG2skcOhwrx8WF/sOXwJ/t2h7Ofp/WF5w2JtH/8YMsPZnx+clgTQ+XG8HnA+4fDcSMNV2SgwQ+z9fV74jBvPq95PHg7GdDzeWcHOk19HkTCIZm8LXwMMCi1P2AysGIgz0CBQ7yi1ZLjzl5kkfC5aL+2RWIP9eTwaL5GMBDh0D8+ZhiGRRr2x+c6A5doeuq1hg0bNpj/K2sPcQwPvNgTia/h/P8o0pcXTR1aGSvsD8bHD/9/4/+p9uOTj18+/nm7Ro0aZZaxBxWxZxf/7+VwRJ7G+jW8KZr7et+U212flr4uNlWkx5b9no1fmNnvI2Jl//33jziUll8SMtDiax+Hb7JXa31DukWkY1DYJSIJhT1P+AGMHzTYCyUcK5X4AYMfJFjdZX/7ar+pp/qaJ9e3nNVQ7NnAD+PsL8NAhx8U+U0oQ6mGmuFHwkCJ+IarPnZIxw+3tWfTivRtZDQVLwxuWClx4403RrwM+9QQ3yjXboIc6Y1ytMeVHwgYpPBDbFOwIoj3n327I6n9Dba9L/Ud24aOOasW+IGOHx7qY4ds0eIHoPqqlPgtPT8oMUiI12MtWg0dF36AuvXWW021iv2hKpr7gqEVKwf4oYzfsDMQ4GPfDjAYhrEvG/spcft22MXlNoYgbPJdG3vn8LEczW2wm5Tz23z7A299GGaF4+sIq3PCe381drtb8jytb1ZPPlYo/LHSkMaek/Z5kcIuhjas5mG1Xn2irRxpLERgtRT7gLEyiq9RxN5SfA7aYVi0WnLc63vs2K+JrOxqDF8TGXbZr9kNPacaa+Dfmuz9ZfBjP86i+f+oLW8PHx/sXcXqxYaEP07tyTTYX5ATJDDEY1DJPkysOuIXT5EmPGnqa3hTNPX1vjm3uz4teV1sjsbed9mvWbHS0POPFZmsomU1KH/42OexZgjNL8RqV82LSPumsEtEEordmJ5vMCM1L7bfkLOxLt/QNNYotzGstOIbIn4LyuoBVjXxx57BiB/Y2Ai1PeMbOFbDsWKCHyIjDZuwgwy+ua8dItbW1AboTcWmuxxSw6ohVhUwIOEHE3644P3JypL6qjGodtP6xpbzvuSHba6bze35wYcftHnf8zoMenh+Q2FPJPXNFtneHmuRJnOwscKQTY/5uOCwFg5bZKhsVyBwyBibN9c+NvzwwPuLVXkMOu0wix8o7DCMYReX83gzXGF1VnjQyvvfbqxdW+2wq77bYO9XU5t783WEYSs/DPKDKKsF+cGM6+H9yopDfliNpaY+XuKBr5m8L1jtwdvNiivej/wgzkrLxj4YNwXvQ84Wac/MyIpVuzF9NAFTrNT32LGrF/m4qT2Mt7ZoqoQSVWsPy+QwewY+DDb5+sPHJP9Psof3cbg6XzdrvybxtZ3ncVIBhkysWOL7BP5wHXytq30/x/M52dTX++be7li+LsZLU/9vtZ+bzfk/jRXA/CKDX5yyCpbHjK/nrOBliwi+JoV/6SIi7ZvCLhFJGKwM4RsSYrVFQ+X1vCzfQNozX7ESjMP4wqdhD1ff8vAP7/Y3raySYv8mfkPMD2d8s8jZnaJh94VqaHt2RUF4vxe7yoG3oak4VIBDMfitMEMkVlPUfoPbu3fv6g9t9rT30bD3kd8UR8LhgE2t6uIbUAYdHIYVaQgkh9LVty8Mwurbl/qOOXsQ8c02w1N++1+bPYyxtcTqsRYLnImN2NclUl+e+o4NK3dYocAPlhz+xFCLYaI9NMb+MMHl/GDC489l4YEkL1vfULto2Y9rrveOO+6I+sMrPwwx6GI4bPeIi+YxyOcpH4N8njZlVrRYsp+TDb3GRDqPlXQ83gwdOWMZ78NobnNz8YM6Q8TXX3/dBJ/ss2MPh23qh814HHeuk49vviZEG/JF8/re2P81bfFY4f+nrAiKVN0V6f+jtmS/JrFlQe3eko29XjOw5sx/9ux/DJr4/GYozyGODHtbW7Sv9y253bF6XWwu/p8caZ/t54K9Pza7mq6+auqGKr6jwf9z+IWZ/aUZKzMfeOAB88UWZ17m/1si0jG0/deEIiIxwioPDqtiE2d+KKvvhxUJ4VVgZDdgZXVTJHYfsGjwQyDfJNkVUOyhUftNmt3vqTZ+aOK3qfxwMWPGjDrn8wP2hx9+aH63gwGy+7+wiqahoXb14bAIfoDlm1pWrNS+vfa3xBxu1tAQptrs48rAKFKj3qYcVxuHhlB9w5jefffdBveFU7BHUt99b28v0jAyVhB++umnaCsteazFgn1sIg0L4eMkfH9qs/tvMaBmgMlecNnZ2dUfnFk1xGGOkYYwxgq3w2oxfmiy+zpFo6HHBIO5+h5Ldn+f+pp5twY+D/ghln2+wicOsPE+ixQi2reZgU3toKuh511L2KEDhzLajbBZ0dJU8Tju9jrtkCEafIzz9Z1Dv1gtUhtD/PCJGaIRz+c5QwZ7mCIrnCI91u3qyvD/j9pSQ69JfI43ZdgdQyb78ca+fG2todf7WN7u5r4uNhfD7Ejs9wd2X8faoXGk1y+2sWBvvFji0EX7Sw0GafaxDn/+8b2niLQ/CrtEJGHYsyyyUqkh9vksU7f7S7ERKT+EsGS9diN6Vp5wqFYk/BAWqZqKb7g43KD2B2L7G0pWQUQKfzjkwx6ic/fdd9f4lp+Xv/322826+Q10ePUVh3qx6Swr1q644oo6b2wZytgNlevDKrf//Oc/Zh84JC18JjS+oWOvHn644Smbi9fGN3sMJ8Jn2OMbc75x5htEDrMIH17ARu+PPfYYmspuVs1tMXwLx29e7TCwNt7HHBrCISq1Z3njMnuIVH3b4xvv8H4nPKZsHlxfpVisxfqxFgt2DyTuW/h9y8chqw8a+gBuh132ca3dfJ5/83Fsh5PNbU7fGPYMI/bfitQYnI/5X375pUY4YT8m2DzZ7rNnPwcefPDBGpM0hDv77LPNcDxuhxUYte8XTrQQ6bkVS3yMsCKN9xcfv+GPaX6I47JIw4ZYWcXqOz5v+ZoYjrfn2Wefjfm+8gM3K1f4oZbbYGVRY6/vrXXc+aUJw1nebk5swWGckaqewj/Is2LEbpLPqtTwxw6/yOCx52lTP4jz9ZlBWUP945qLs1HSo48+WiNc4WOEyxgC8TiccMIJaA/s16TaM/jxtbO+Yd4c/mdP3BCOjxM77Gmoz1N7eL1vzu2O9etic/H41/4Sil+Q8YskBny1W1LY/xew2o7V4Ta+n+P/O835wo/4fouVpJH6mtnHgH1Gwysc7YrGpnwJKCKtR8MYRSQhcLYefqhnf4pDDz20wcsOHTrUDIHjt3/8oM0383zD8o9//MN8e8dAiW94hg0bZnrz8EPQmWeeGfHDHCsF2KCb4RPXyzdB/IDO6/BDCz+ohc+qyDen/Hafb1Y5RIe/M1xi1RR7hhCHSvB8hjmsuOI35vygxhCJoRGHEvIDdfgU46zIYmUW+wSxUoY9ddiom5flbeCHFH4gaWyWL+4vbyeH5vB28ZvdCy64wJzHN5zcPpv4MpDj7eW3/vwAxzfg3AbfePID24477miuw/Puvfdesw5+IOQQDFaJ8UMZ7zPuJ++HpgzdYajHIXOsfOMHXx4fvgHlhy4OVbrwwgvx+OOP17kewx8Ot2OQZzdV523gB07eX2eddZbZx9oNh9kXjAEoK2G4Xfb04Id++z4+44wzIs7UGWvxeKy1FGdf44dB7hsDEN43/KDAD46cJZChSn0Nkzkcjd/Q2x/47X5dNlZy8YMbQ0UGLfU1aG8pHjPOQMpw+eKLLzbD3NhM3D6+fFwzDOFzwq6o4OPWfg1h6MzKAwapHPbE28PLRmqez9vAvi98jvMxyupSPlf4gY7PLT6GDzvssIgzR8YSe8zxdvE5yMc0958fXnkf2jPB1n6tYKjC5z0f63yucB95//E5x+PAY9ec8Dqa6q6ZM2dWz9rW1Nlm43Xc+XrCsIcz5fGxww/efF6yfx2fAwzoOKEHK42PPPLI6utxHxiu87HCxw5fv/i85DKGK3xNa0rFK1+veH8xeOV1+bpv9yTi/2UtZfd6YmjHGY5ZGcihrLzPed/br/HtpXE3v4zhMeb/kay6433C5y+PL48NH7O1w2g+D/i45msjX8N4W/h/H8McXpfvD+yK8NbS1Nf75tzuWL8uNhf/D2VfPvYi43YYEvPYE8Or2kMc+TrE92h8DPILNT6X2cuTw01Z8c3ZFvleo6n4/uWGG24w7xO4TbtBPt9b8v9/VsTyPWJ4r1dui328+H8VAy++LvD9GI9fpKH9ItK6VNklIgnBHpLID6EMPhpjf/gIH8rIkIxvePnGjR+AGKbwDS/f+PDbzUg45I8N0hkk8c0Zv41ktRGHP9gfgGoP+eEsdPxgxQ9EfFPKfQivRmKIxevx21i+4eKbWwYGXA8/+HG4EIOL2vjNM6vbGGQwSOAbW34zytvCDyjRBhz8cMbjwA807N/FSggb+3q98sorJjzht6cMOlghxw/4/MDMwJABXTgu5xv3Aw880LyZ5G3h7Ep8Yx6+7qbgG3ruC9988808h/7wAy2DuNrNyWvf788995wJVhiw2ffxbbfdZt5wR2omzfuW9xGHs/B3hok8tlwHh/CMHDkSrSEej7WW4mOFjzm+sefjgQEJP6gwGGU1ZH0zuNnsoYmsqrQDUhtDAPv2xLshMO973pesuuEHGgbNfGwwrOD9yw9A9pA64n7xww3DPn4Q5uX5gZmX5e22h7hFwtcXDjfmNjkTKZ9DfEzxucHJIhguxBsDGT4neZsYVrAHDT8o8rnLELi+11D2q2GAwtvJEJXVorw+n8d2JUis8b7nh0veL80ZwhjP487XVVakXHLJJeZDLo8hn5cMz/j6yQCCry3h+Fjn6yuvw8kcWBnD13iGF3wuNWf2QoYi9mOXoRef5+H/t7UE18kZ6vh/AWcnZMDAbTBw4RcBfN5EmtSkrfD/GQ555eOGX8LwNYkVP7wvGEBHmj2Rt4NfyLA6iq+pvA/55RLvU4YwDPpq941qb6/3zbndsX5dbC5uhz2xeHu43wyNGDwzmGawXhuPCd+H2FWefB5zn1hdyNdfPr+bg1/Q8DWOVe7sJcrXN/7w/zZui8+p2u8v+B6N/8/y/y/eTzxevBzDMRFpew6rqVNciIiIJCBWU/BbZAamkSrDRKT1sYKDH6oZVjHMFhEREYmGKrtERKTTYJUbv/WujdVh/LacOFRHRNoeKyqmTp1a3XdLREREJFrq2SUiIp0Ge/+wDwmHHrC3B4dHcfiD3XiZw1nYZ0pE2g6HaHEoE0NoDovlsNCW9gUSERGRzkXDGEVEpNNg02g2oWePHDbXZVNb9vdg/xFWdLG/lYi0LfYBYg80NgznsGJOKhFNL0aR9vr/TqQJK+rDpu/2jK8dAXuDsa9btDgzcrwn4RARIYVdIiIiIiIiccBZTu0JUKLBCQw4QUdHsWbNmibNPHjnnXeaKmoRkXhT2CUiIiIiIiIiIglDDepFRERERERERCRhKOwSEREREREREZGE0S5nY9y4cSM++ugjfP3111i2bBm2bNliGpOOGzcO5513HnbYYYcal3/44YfxyCOP1Lu+GTNmoH///nWWf/PNN2ZK6/nz58PhcGD06NG45JJLsOuuu0Zcz/Lly/HAAw+Y2bzY1HjQoEE46aSTcPLJJ5vrN6SgoACJgPdDUVFRW++GiLRDen0Q6Vj0nBURvT6ISEd8b8BJbDpk2PXCCy+YWUsGDhyI3XffHd26dcPKlSvx+eefm5/77rsPhxxySJ3rHX300ejXr1+d5dnZ2XWWvfPOO7j66qvNuu0miR9++CHOPvtsE2gdfPDBNS7/xx9/mGCrsrISU6ZMQW5uLr766ivccsstZpaVG2+8EZ2B06liQBHR64NIItD/6SKi1wcRSdT3Bu2yQf2nn36KLl26YNKkSTWWc6r4s846C+np6fj222+RnJxco7Ir2tlLmFTuv//+cLlcePvtt9G7d2+zfMOGDTjqqKPM7wzVMjMzq69z2mmn4YcffsB//vMf7LXXXmaZ1+s14Rj369VXX8VOO+2U8JVdTFAT5baISGzp9UGkY9FzVkT0+iAiHfG9QTSVXe0ytjvwwAPrBF00YcIEE2YxrPr999+bvf6PP/4YxcXFJsCygy7i71zGO5dhV/jwRQZd3LYddBHDtiuuuML8Pm3atGbvj4iIiIiIiIiIxEa7DLsa4na7a5yGsyuvnnzySRNWlZWVRVzH7NmzzenkyZPrnGcvsy/T2OXHjx9vKs24bRERERERERERaVvtsmdXfdatW4fvv/8ePXv2xLBhw+qcz+GMtXt1/e1vf6semmhbsWKFOd1mm23qrMNexh5h0VyeQyHZ/J49vfx+f8QQzm70lijjX6MpGRSRzkmvDyIdi56zIqLXBxFJxPcGHSbs8vl8pqE8+2T99a9/NSGTbcSIEbjjjjvM0Ec2jt+8eTO+/PJLPPTQQ7j22muRlZWF/fbbr/rypaWl5pTLa7P7dJWUlER1ecrIyEAwGDSVZAy1IukIMxok0hheEWl9en0Q6Vj0nBURvT6ISEd8b9BhZ2OsjUESQysOFTzhhBPqVGodcMABNf5mpRV7b2277bbVsyuGh10iIiIiIiIiIpKYnB0h6Lr++uvx/vvv44gjjsAtt9wS9XV33XVXDBw4EIsXL66uzqqvequhKq6GLk+s6HI4HKbCS0RERERERERE2o67vQdd1113Hd5++20cdthhuOuuu5rc94rlbey/VVFRUR1aDRo0CPPmzTPLa5e/2b26wvtz8fLh54ULBAJYs2aNqSarr19XU3g8Fnw+xFxSEpCS4oj9ikVERERERERE2hF3Rwi6DjnkEPzzn/+s0acrGuXl5ViyZImZLTE81Jo4caKpFPv222+x44471rgOlxH7f4Vf3j7vggsuqHH5OXPmmO0cfPDBiEXQ9c23Fkq2FqHFTFYmsMfk2AVevM377rsvZs6c2eCEAjz/mGOOadG2dtllF3z22Wf19kyLxkEHHYRnnnkGffv2bfByCxYswP3332/CUVbrXXHFFZgwYUKNyyxfvhxnnXWWGU575ZVXmmXvvfceXnrpJSQnJ5tKRPaRI84OyuCU24+Ej8Ovv/7aPL7DH1McevvCCy9U334OySX2rOO6zznnHAwePNgse+KJJ0xFor0vIiIiIiIiIp2Zsz0PXWTQxRDpnnvuqTfo4od8hg+1VVZW4sYbbzRDDLmO8KqrKVOmmODkxRdfxIYNG6qX83cuYzC2//77Vy8fMmSICbxmzZqFr776qno5g4cHH3zQ/H788ce3+HazootBV3Iyh1HG7ofr43rjUTHWkPXr12P69OnoKCzLwjXXXIPzzz/fPA5uv/123HbbbeaxZOOMm6ww3GuvvWpc9+mnnzZhGgOn5557zixbtmyZmaWzvqCrKR5//HETpr322mvYaaedTOjKMFFEREREREREOkBl17///W8TkrAii0MIH3vssTqXYRg1cuRIFBYWmvBq7NixpvqlR48eyMvLw/fff2/Cq2HDhplZHMNxxkQGYVx+9NFHm8ox+vDDD836WNljD3m0/f3vf8fJJ5+MSy+91Fy+Z8+eJvhi5Rib4Y8bNy5mtz8lBUhNjeWQQwteb3SXvOmmm7Bq1Soz+2WvXr3wt7/9Dd27dzfn8T559dVXkZKSgr333rv6OgyDGAotXbrUhIrdunUzM2GyWon3wemnn27Wde+992LhwoX417/+ZSrDuB5WTu2www5mPd999x2efPJJs21WVTF4GjNmzNZbYVnmsbFixQr84x//wKZNm0wFFGeLYPDISis7dGS1FC/L/WFlVDQ4Yybvf7uqj/3e+Dj43//+h3322ccse+qpp0xFW3FxcY0+cAxjuQ+sCEtKSjKBLfeN1YmxxGG8rJT76aef8Oabb+JPf/pTTNcvIiIiIiIi0tG1y7Br7dq15pSBCCtaIunXr58Ju7p06YJTTjkFv/76qwmfGEIwRGHwxZCFQVRqamqd6x955JGmgmvq1Kl46623zDIGKxdffDF22223OpcfOnQopk2bZgIMbof7xiCO4RC3nyhYmWQP+Xz++edN+MTQiUEWh8u98847JswJDyA5VJHBD4MwOzQihonhw/EYYnFWTQZADKDmzp1rfn/jjTewZcsWE2BxvTyurKAKr6hikMSAkkHl3XffbZbx2N98883m8rzsueeei9GjR6N3795mXbxvOdSPFYL2PjWEjyUGe59//rkJUzmkkcEfK9SIfd5+++03PPzww+a4hGMIyuCJkxTweDGI2n333dGnT59Gt8thi3ys2hiYpaWlNXgd3s7Zs2c3um4RERERERGRzqZdhl0cJsafaLDyhqFHc+y5557mJ1oczsiKpUT26aef4qOPPjLhEn8YLtGPP/5oZrfMzc01lVSsLrKH6zEIZLUVK7k4xC5SWGg3+GfFll1pxX5prALjbJkc7sfl9mQArMgKr6676qqrzH3FXlXEoav8YQBmYwDJZQzOtttuu+qeVocffjjuu+++qG4/h8yyIoxBH6/PqjNWbTFM43l33nmnuQ21sfLLrv7auHGjqSxj0Mfwzp7AgEFqJOPHj4/Ys6shrHITERERERERkQ4SdknbYKUVq9dYwcUQioENf48kPPBhld0rr7xiArEffvihOiyKRqTgqL5AiJVMJ554oqmeYtiTnZ1dXTUWjvvdnG3YwV140MTtMeRkYMUQ65JLLjHLWcnGoYolJSV1wlYO0+TwTA413Lx5s+n9deutt5oQi7cjFjgclPslIiIiIiIiIh2gQb20DQY37JPGai4OOeTwPxtnJORwRYY3ZA/9JPbOYqDEyqvLL7/cBFEMhhhKhfe14qyEPI+N/olDT9lfjX3Vdt55Z7N+VogRhzGGX5ezH7JPGIcKckgi+2lxXzmboW316tXmPPZvY6WYvS7OlMjbY3v00Ufx+uuvRzwGrAqz8fZzOCFvOyvFPv74Y7OMPwzBWDFWO+jirJGsTuPl7RkdiaesPGspBmzcPo/Vscce2+L1iYiIiIiIiCQaVXa1Qx4P/7VivL7GcZgiAx0GOaya4gyUdrjFHmjnnXceTj311DoN6hkscbgeg6xAIGBmv2SFFAMrVh+xp1nfvn1Ng3oOT2XlE4eDcj133HGHCa34wyGJ7MHF67ERO3tfsTeV7aSTTjL919gfi7NgcmgiJxNgVRlDIPbcuuWWW8xQyxtuuMFcn/3FODzSHo5JnFRgxIgREY8Bg6RPPvnE3BaGVuwPFm1lGPvFsVeXPUMnj+e7775rjhlvP/9urosuusiccmjp8OHD8Z///MesU0RERERERERqclhq/tMq2OeqMR6PhW++tVCytaApZrIygT0mO5CS0rJZHtm8Pprb0l4xjGNox1kVGaiJSOx09NcHkc5Gz1kR0euDiHTE9wb2pHoNUWVXO8Igao/JnLUw9utOSgqtv7Njs/lnnnmmrXdDREREREREROJEYVc7w0AqJaWt90JEREREREREpGPSOC4REREREREREUkYCrtERERERERERCRhKOwSEREREREREZGEobBLREREREREREQShsIuERERERERERFJGAq7pFnKy8uxyy67NHiZdevW4a233mrxEeZ2SkpKWrSOgw46yOxPUzzxxBO4//77ze/vv/8+rr76asTDnDlz8L///a/6782bN+PCCy+M+Xa+/fZb3H333RHPW7p0KY466ii0tXnz5uG0007D8ccfj0svvRSbNm2q97I//fQTzj77bJx88sk46aST8Ntvv1XfzjvvvLMV91pERERERETaE4Vd7YhlWaioiM8P193a1q9fj+nTp7f6djsahjYzZ86s/rtnz56YOnVqzLfz2GOP4YwzzkB7FQwGcfPNN+PKK6/E66+/jt122w0PPPBAxMsyELz11ltx00034ZVXXsHzzz+PQYMGmfMmT56MRYsWYdWqVa18C0RERERERKQ9cLf1DkgIw6hL/mTht3nxOSJjxwCPPgw4HI4GL8fwgCGBz+dDr1698Le//Q3du3c35zG4evXVV5GSkoK99967+jqVlZW47bbbTHWQ2+1Gt27d8NBDD+Gf//wnNmzYgNNPP92s695778XChQvxr3/9y1SGcT1XXHEFdthhB7Oe7777Dk8++aTZNvfzmmuuwZgxY2oco3//+99YsWIF/vGPf5iqH4YhBQUF8Hq9pjKJFUH09ddfm8tyfxqqQPvjjz/MfvI2cB0HHnggzjnnnEaP54svvogPPvgATqcT2267ran6yszMNPv++OOPm0otntejRw+zj/VtZ/Hixea4Muhh6MXjOmXKFBNKff7552ZbDMIeffRRBAIBZGdnm20NHjzYVITdd9992HHHHfHrr7+a83n/jRw5ss7+zp071+xfnz59alSuffLJJ8jIyMCuu+5a4/Lc5tNPPw2PxwOXy2WqrMaPH19d5fbaa6+Z+4PH94477kBubi6uuuoqFBUVmesMHToU1113HdLS0sxy3l5W19GsWbNMmMf1h2NAxW3Z2+H9yctxfXyshHvzzTfN+ngcKDk52fzY9ttvP7z77ru47LLLGr0vRUREREREJLEo7JIaWFXTtWtX8zurZRg+MXRikMVw5J133kFSUpKpEgoPRkpLS00QRgw8iKEMg54XXnjB/M0g6NprrzUhCAMoBjD8/Y033sCWLVtMgMX1skLH7/ebYMjGgOjGG29ETk5O9VA8BjusBOLledlzzz0Xo0ePRu/evc26GJQwDHn77ber96k2hj+PPPKICUq4jgsuuACTJk2qEbLV9v333+O9994zxyYrK8sMmWOwxuP03HPPmbDw2WefNetkENfYdo4++mhz/HjsKXy4ZX5+vrmdDLu22247fPzxx+aYsZqJVq5cieuvv94caw4ZZdD24IMP1tlnBmk8NjYGi//973/N/qanp5vjaFu7dq25bVwPg7DVq1fjoosuMqEchwo+9dRT5rHAIM++jxhSsdKK9w9DMAZ7rM5iaHfCCSeY9dlhF+9vO5QMx2CU952N2+YPHxv9+vWrcdnly5ebY8owi/ctA1MGcgzXaOzYsRGPg4iIiIiIiCQ+hV3tBCuZWHkVlu/EVGpq41Vd9Omnn+Kjjz4y4RJ/GF7Qjz/+aKp/WMHDAOeYY44xQQmxiofVVgw4dtppJzP8LBIGM9wHu9KKFUmsAmN1EyufuNweisaKIVYi2VgdtOeee1ZXXTHs4A8DMBurxbiM4QiDIbvq5/DDDzcVUJGwauiee+7BkiVLzL6xWoz701DY9cMPP2D//fc3QRfxWLACzg6RGLrYVUZ2cNic7dD8+fNN5RhvDx188MGmQo7D+Kh///7V62DA8/LLL0dcD7fHy4bfBlY/MUwiBm6//PKL+Z1VaWvWrDEBl41VagyjGPSx8oxBF6XygVU1BJEBHM9nhRnDO+4P7bzzzib0/P33301l2oIFC3D77bejJbiNn3/+GQ8//LAJ61hZyADu8ssvN+ezGrGhfl8iIiIiIiKSuBR2tSMMQaoKU9oEK62mTZtmQgOGUBwKyN8jCQ/OWHXDoIOBGEMUVjmxKiwa0QRwxKFts2fPxoknnmgCGlYPMTixq8bCcb+j3QYrybp06WKCOwZsrM5iyNcU0dyGWGwnkvChewykWBEXCUOppmyPVWes1IoWh0NyWCVvJ+8fDnPk3zZWd7HSi4+rww47rMZ+21jVxUDNVlZWZkIzO1irfdlhw4aZxwBxmKQdvlKkoY8iIiIiIiLSOahBvVTjjIeskmE1F4cccvifbcKECWa4ol1RFD7LIitoGPiw8oqVNQyiNm7caEIPhhW2bbbZxpzHnk3EPlN5eXkmtGD1D9fPCjFiaBN+3bPOOsv0s/rTn/5khq0NHDjQ7Cv7R9k43I7nsaKIlWL2ujjkkLenvtvMhvAMoFh5xrCuMRMnTsSMGTNMGEMc3sdwiPbYYw8T9NjBkj2MsaHt1D5O4Vi1xSGk/KHPPvvMrIc/TcHKMG7Xxv3lMEbeBt4nHJ5q433B/WMVWniFmd38nUMpWT1HHMbIH94+Pm54W7hO9jMLx2ow3u+8v1gJF8mIESPM/W6HZHz8cXuRQiuGW7ycfZxZjcYKQxvv+/C/RUREREREpPNQZZdU4zBFBhmsnmLFDEMdO9ziULrzzjsPp556ap0G9QyWWNHD0ITDyzjUjkEDg4shQ4bglFNOQd++fc3wu7vuuss0qGcDe66Hzc0ZWvGHQxLZO4rXY5USq5/C+0yddNJJpkKJwwTZj4lDE++//35TVcZhdKycuuWWW8xQyxtuuMFcn/3FODzSHo5Z29lnn22u8+GHH5phfnZz9IZwmOayZcvM8QhvUE9sxs++WWeeeaYJtliVxH1saDs8ljzuvK7doN7GYZC8Hn/sBvU8ZtFWxNl2331302uL62B/Ld4GBljcz9oN6gcMGGC2x95oDLIYFA4fPtxUenGYKnujcWIB7gOPL/fnkEMOMRV1rODi/cAhquFVWrzf9tprLxOScbKCSHgsef/zMcIQi8cuvJcYe5qx1xkb8G+//fYmWGRPMN4eDlnl/W1jcLrPPvs06RiJiIiIiIhIYnBYTCgk7uwKn46O4Uui3JbOhj3Dxo0bZ3p1tTaGbKzOY+81BmHxVFhYaAJRThLAME5aj14fRDoWPWdFRK8PItIR3xvYvbEbomGMIp0Eq6Ji0SesqVjxdeyxx5ohmfEOuojN9e2qPhEREREREel8VNnVSjpCOppISa+ItD69Poh0LHrOioheH0SkI743UGWXiIiIiIiIiIh0KhrGKCIiIiIiIiIiCUNhl4iIiIiIiIiIJAyFXSIiIiIiIiIikjAUdklCWbduHfbff/8Wr+fWW2/Fq6++an5/4okncP/99yMevvrqK8ybN6/674ULF+Jvf/tbXLYlIiIiIiIi0hko7JJ6+f3+uB+dQCDQqe+B2mHXyJEjcfvtt7fpPomIiIiIiIh0ZO623gGpqcJXZk5T3elwOBzmd1/AC3/QB5fTjWRXSp3LprjT4HSEcktejpd3OVxIdqc2+fDusssuOPfcc/H9999j3LhxmDJlCv75z3+isrISXq8XRx55JE4++WRz2cMPPxxPP/00evbsaaqRNm3aZKqgeLnDDjsM77//PpKTk2usn8s+/PBDZGdnY/Xq1bj22mvhcrnw73//G2VlZQgGgzjzzDOx3377mbDtqquuQlFRETweD4YOHYrrrrsOaWlp1et67bXXYFkW3G437rjjjurtcD++/fZbs86//OUv2G233erc1h9++AFTp041++vz+cztOuKIIxoN5x599FH873//M3/zGF1xxRVISkpCaWkpHnzwQcyfPx9OpxMjRozADTfcUO92eIy5jzz/gw8+wHHHHYf+/fvjgQcewAsvvGDW/9FHH+HFF180v/fq1cscr9zcXHPbP/74YzPl6rJly8z2GZL169evyfe5iIiIiIiISCJR2NXOHP7Ctub0jZPnoUtaD/P7tN8exTM/3YUpw07FVZPvq77s8a+MQaW/Ai8ePxu9swaaZe8sfAaPzboJ+w45Btfv/Wiz9oFBzTPPPGN+Z1j0yCOPmNCKgdfFF1+MsWPHYsyYMZgwYYIJag4++GAsWbLEhFa8/IIFC0zQUzvosjEMev7557HNNtugpKQEl156Kf71r3+hR48eKCwsNGEXt8EQjcMJc3JyTKDF0O3111/HGWecgTlz5uCpp54yoRavx32j/Px8Ezptu+22OP/8800oxSGIkcKu4cOHmxCK+81Ajdtl2McwqT5vv/22uX3PPvusOU7/93//h1deecXsE7eTkpJiwimeV1BQ0OB2uE+TJ0/GsGHDcNJJJ5nL8nbZli5diocffthsi/vE+4SBHsMwe8gjQ7G+ffuasJC/MwwTERERERER6cwUdkkdrNiysaLqnnvuMWEWK802b96MxYsXm7Br4sSJJuwaMmSIqbpilRHDGg7LYxBWHwZZDLrot99+w9q1a3HllVfWuMyqVatMiMUgiRVQrKhiiMXrEpex6oyXodTUrVVsDJz22Wef6m1x/ZEweGI1FCvM7CCKAVNDYRdv76GHHlod5LHS7Y033jBh13fffWcCOAZdxOPR3O0Qj2V4+HbssceaSjp76CdvG4Mu+/dp06Y1uD4RERERERGRzkBhVzvz3ulLq4cx2k4YewmOGX2+GcYY7vWT51UPY7QdOfJsHDLsVDOMsbnsYYL02GOPoUuXLnjuuefMUMEbb7zRDMcjhl08f/Dgweb3bt26mTCIYdfVV19tLsNhh2vWrDG/s0KM0tO33jZWbDEsY4VWbRzCx8CH28jIyDBDFsMrn+rDIX32EFAGT/X1Bbv77rtNddVdd91lLs/Ayr5t0bK305BYbCfStsIr5xq6nSIiIiIiIiKdiRrUtzNpSRnmJzzYSHIlm2Xh/brCL2v36yK3Myl02Wb064qEwww5nJBB18qVK031ko3LGUK99dZbJuwaP368OX/9+vVm6B7deeedZngdfzgcsTZWJHEGxdmzZ1cvY+UYe1tx27wOt8HhkexrZePwP/as2rJli/mbwxjtoYxNuW29e/c2x/rnn3/GH3/80eh1eDsZwnH/2FPs3Xffxc4772zO22OPPfDSSy+ZvmNkD2NsaDu8baxYi4THc+bMmaaajqZPn24q5lgdJiIiIiIiIiKRqbJLGnT22WfjlltuMU3l2Tydw+pqhz8MuOzG6N27dzc9qOyhfI1ho/r77rvP9KZ66KGHTIDEYIjVUIcccgi+/vprnHDCCaa6bMcdd8SGDRvM9XbaaSfTSJ/N4RkisZorvEF9NC655BIzRJO9sDgMc/To0Y1e56ijjjLDItl3y25Qb/fb+vOf/2z6aZ166qkmHOTMitdff32D2+FQzNtuu83cTg5T5DG2se/Yn/70J7Neu0E9K+VEREREREREpH4Oi+PIJO7sKp+Ojn2oEuW2iEhs6fVBpGPRc1ZE9PogIh3xvYHdH7shGsYoIiIiIiIiIiIJQ2GXiIiIiIiIiIgkDIVdIiIiIiIiIiKSMBR2iYiIiIiIiIhIwlDYJSIiIiIiIiIiCUNhl4iIiIiIiIiIJAyFXSIiIiIiIiIikjAUdkkNTzzxBDwej46KiIiIiIiIiHRICrvaG195/T9+T/SX9VU2a/NPPfUUvF5vneV+v7+5t0hEREREREREpNW4W29TEo3Mh8fXe55/8J6oPHpq9d8Zj02Gw18R8bKB/hNRccLzTTrod999tzm96KKL4HQ60aNHD3Tv3h1r1qxBQUEBXnvtNQwfPhyfffYZsrKyzGUPOuggPPPMM+jbty9WrVqFBx54wFyWgdlRRx2F448/Xne8iIiIiIiIiLQahV1S7ZprrsH06dPx+OOPmzDr1ltvxaJFizB16lRkZGQ0eKQCgQBuuukm3HzzzRg0aBAqKytx7rnnYvTo0Rg1apSOsoiIiIiIiIi0CoVd7Uzpn+bUf6bDVePPsou/jfsI1X333bfRoItY1bV8+XLceOON1cvKy8vNMoVdIiIiIiIiItJaFHa1N0np8blsM6Wn19yGy+VCMBis/tvu72VZFrKzs/HCCy/EfZ9EREREREREROqjBvVSJ9wqLS2t96gMHDgQ8+fPN79/8cUXqKioqF7O677//vvVl129ejWKiop0hEVERERERESk1aiyS2o45ZRTcPnllyM1NdU0qK/tuuuuM7282Ndr9913R05OTuiB5Hbjvvvuw/33349XXnnFVH916dIFt9xyi46wiIiIiIiIiLQah8XxZxJ3nKEwEXTt2jVhbouIxJZeH0Q6Fj1nRUSvDyLSEd8bcD8bo2GMIiIiIiIiIiKSMBR2iYiIiIiIiIhIwlDYJSIiIiIiIiIiCUNhl4iIiIiIiIiIJAyFXSIiIiIiIiIikjAUdomIiIiIiIiISMJQ2CUiIiIiIiIiIglDYZeIiIiIiIiIiCQMhV0iIiIiIiIiIpIwFHaJiIiIiIiIiEjCUNglIiIiIiIiIiIJQ2GXiIiIiIiIiIgkDIVdIiIiIiIiIiKSMBR2iYiIiIiIiIhIwlDYJSIiIiIiIiIiCUNhl4iIiIiIiIiIJAyFXSIiIiIiIiIikjAUdomIiIiIiIiISMJQ2CUiIiIiIiIiIglDYZeIiIiIiIiIiCQMhV0iIiIiIiIiIpIwFHaJiIhI+2ZZbb0HIiIiItKBKOwSERGRdi35v/9A+hP7wv3rtLbeFRERERHpABR2iYiISLvmLFwFZ8l6wOlq610RERERkQ5AYZeIiIi0a86i1ebUyu7f1rsiIiIiIh2Awi4RERFpv4IBOAtXml9T3zqvrfdGRERERDoAhV0iIiLSbjlKN9ZcoGb1IiIiItIIhV0iIiLSbjmL1lT/7gj6AW9Zm+6PiIiIiLR/CrtERESk3XJU9euq/rsiv832RUREREQ6BoVdIiIi0m5ZyVkI9Btf/bejPK9N90dERERE2j+FXSIiItJuBYYdiIoTX0Sg9/bmb0e5KrtEREREpGEKu0RERKTds9K6mlMNYxQRERGRxrgbvYSIiIhIWwn4AFcSgrkjEPCWwkrJ0X0hIiIiIg1S2CUiIiLtk7cMGf+eBCuzF8rP+gDY/c9tvUciIiIi0gEo7BIREZF2yVm0Bg4rCPgqgKS0tt4dEREREekg1LNLRERE2iVH0WpzGswZsHWhZbXdDomIiIhIh6CwS0REROKrmQEVK7so2KU/nGt/QvrUPZH28gkx3jkRERERSTQKu0RERCR+bzRWz0b61D3gXvRBk6/rqAq7LFZ2uVPgLNsMR+mmOOyliIiIiCSSdtmza+PGjfjoo4/w9ddfY9myZdiyZQtycnIwbtw4nHfeedhhhx3qXKe0tBQPP/wwPv30U2zevBm5ubk46KCDcNlllyEjI6PO5YPBIF566SVMmzYNK1euRHp6OnbbbTdceeWVGDAgbLhEmG+++QZTp07F/Pnz4XA4MHr0aFxyySXYdddd43IcREREOrqU/94KZ3keUj/8K0pHHNqk6zqrhzH2h5Xe3fzuqCgIVYo5HHHZXxERERHp+NplZdcLL7yAO++8E6tXr8buu++Os88+G+PHj8eMGTNw0kkn4cMPP6xx+fLycpx22ml49tlnMWTIEJx11lkYPHgwnn76aZx55pnweDx1tnHTTTfhH//4ByzLwumnn4499tjDBGXHHXccVqxYUefy77zzjgnali5dimOOOQZHH300/vjjD7NvH3/8cVyPh4iISIflTm/2VZ1hlV1WWjfzuyPoAzwlMds9EREREUk87bKya/vttzeB16RJk2os//HHH02QdfPNN2P//fdHcnKyWf7kk09i4cKFOP/88/HXv/61+vL33nsvnnjiCROCXXjhhdXLZ86ciddffx0TJ040gZi9nsMOOwwXXHABbrvtNjz11FPVly8qKjLBWNeuXTF9+nT07t3bLOf2jjrqKLM/kydPRmZmZtyPjYiISEcS7DIQro2/hf7gzIqO6L9nC/QbDys1x6wD7mRYyZlweEvhqMiDlZodv50WERERkQ6tXVZ2HXjggXWCLpowYQJ23nlnEz79/vvvZhkrsxhccRgihxSG499czvPD2X9fccUV1UEX7bXXXma73377LdatW1e9nJVbxcXFpnrMDrqIv3NZQUEBPv/88xgeARERkQSRlGpOPLv/uUlBl7nOAbei4qSXYWX3NX9XV3eV58dhR0VEREQkUbTLsKshbre7ximHHG7atMn082KwFY5/czmHQ65fv756+axZs6rPq43DGWn27NnVy+zfWb1Vm70s/PIiIiJSxV/VSsCd0uJDYqUr7BIRERGRBAu7WG31/fffo2fPnhg2bJhZxubyNGjQoIjXsZfbfbjY34sN7Pv37w+Xy1Xn8ttss02N9YZf1z6vscuLiIhIiGe/m1B23gz4h+wNR8Hy6A+LrxwI+GosCvQajUC/CUBS8/uAiYiIiEjia5c9uyLx+Xy4+uqr4fV6TV8uO6gqKQk1qa2vX5a9nLM1NuXy9uXCr5uVlRXV5SPhbJJOZ4fKFuvF3mUiInp9kCj/10Dw17cReP0iOAbtAve5b0d1rcCM/yD41YNwTr4ErgNvCC089j5zEhoYKbGg/9NFRK8PIpKI7w06RNgVDAZx7bXX4ocffsAJJ5xgmsJ3NOwzligPfPYoExHR64NEy5naC6zFCq5fgIL8fMDhaPQ6KRv+QJIVRIWVDJ/+34kL/Z8uInp9EJGO+N4gmkDO3RGCruuvvx7vv/8+jjjiCNxyyy01zrerrezqq9rs5XYFVrSXD6/iCq/eqn1QG6r6EhER6eySfnwajuLQpC8OTzEcpRthZW2d7KU+zqLV5jTYZUDc91FEREREEouzvQdd1113HaZPn47DDjsMd911V52hgHbPLLuvVm32crt3FxvTs+fXmjVrEAgE6lze7r0V3p/Lvm6kvlyRLi8iIiIh7oXvI3nuS9WHw7llcVSHxlG8xpxaOVvDLteyL5H++B5IffM8HV4RERER6Xhhlx10vf322zjkkEPwz3/+M2JDeQZRubm5+Omnn0zz+XD8m8vZjL5Pnz7VyydNmlR9Xm3ffPONOZ04cWL1Mvv3b7/9ts7l7WVcp4iIiNTk8FeG/l/PyDWnzs2/N36IfBVwlm0JXS+n/9blriQ4y7fAUbpJh1lEREREOlbYZQ9dZNB18MEH45577okYdJHD4cDxxx9vwqtHH320xnn8m8vZ5yuc/feDDz5oGt7bvvrqK8yePRuTJ09Gv379qpdPmTLFDFN88cUXsWHDhurl/J3LOLRx//33j9ntFxERSRh22NV7rDl1blnS6FWcRVVVXSk5QGpO9XIrvbs5dVS0/14SIiIiItJ22mXPrn//+99m6CKHHLJy67HHHqtzGYZLI0eONL+fd955mDFjBp544gksXLgQo0aNwoIFC0zV1dixY3HmmWfWuO4uu+xiArLXX38dxxxzDPbaay9s3rwZH374Ibp06YIbbqia9SlsJsUbb7zRzAZ59NFHm0oz4uULCwtx//331zu7o4iISKcWCH2pFOizPdxLZ8C5pfHKLkdV2BXsElbVxbArrdvWsMsKAo52+Z2diIiIiLSxdhl2rV271pyyKuvxxx+PeBlWXtlhF0MxVlg9/PDD+PTTTzFr1izTl+ucc87BpZdeitTUupOU33rrrRg2bBimTZuG559/3qzjgAMOwJVXXomBAwfWufyRRx5pKrimTp2Kt956yywbM2YMLr74Yuy2224xPgIiIiKJNYwx0HccvDuehmCvUY1ex0rrCt+Iw2Hl9K21vEtonVYAqCwC0hJjamwRERERiS2HZVlWjNcpEXSE6TsTaSpSEWl9en2QSDIeGAtH0I+y87+EldWrxQcp4987m1kdy858H1b3bXXQW0DPWRHR64OIdMT3BtzPxqj+X0REROIj6DdBF1nu5Jis0kq3hzLmx2R9IiIiIpJ42uUwRhEREUkADhfKzv0s1KQ+JRvwlsG5ZbFZHuyzff1XK9kAK6MH4Kz7NiXQeyysjJ6AMynOOy8iIiIiHZXCLhEREYkPhwNWztYm8+6F7yJ1xq3wD94TlUdPjXwdy0L60webqrDycz+Blb11dmTyTPmn7i0RERERaZCGMYqIiEirCPYYFnrzsWVJvZdxlG2GI+Bh6gUrI1f3jIiIiIg0mcIuERERiQtHeR6Sv74XSbOfMH8Huw8NvfkoWR+aTTHSdYrWmFMrqw/g0lBFEREREWk6hV0iIiISF46yLUj+8Skk/fR8aEFqNoIMsRqo7nIWrTanwZwBEc93L3wP6Y/vgZQPrtK9JiIiIiIRqWeXiIiIxIffU/VuI7nGUEZWdrFRfbD/hPoru8J6fdXgdMFZvgVW2WYkKq/XwvIVQDAIOJ2A02FuNlugweUEHFXLOOt2RoajrXdXREREpN1R2CUiIiLxwVkYzbuN1Jp9u5Z/BdeWxfA3VNnVJXJll5XWzZw6yvORiCzLwqLfLfw2LxR0hWOsZVVfDujTG9hlZyAtTYGXiIiISDiFXSIiIhIXjqrKLsuVUr0s2HO4OWVlVyROu7Kr1iyMNiu9KuyqSMywa9064PfFQPfuQGZm/SFWIGBh7Rpg3nwL43YCXC4FXiIiIiI2hV0iIiISH2ZWRb7b2Bp2BfqNg2fv6xHoNTriVfzb7otgZu/qmRvrq+xCRSEQ9APOxHkrU1Ji4dd5lqnoaijoIoZbub0s/LEUyM62MHyYwi4RERERW+K8QxQREZH2WdkVFnZxlkXfuNPrvY5vwjkNrtNK6wILDjj4b0UhrIweSAR+v4X5CywUFAD962lXVltqqsMEXfMXANlZFvr0UeAlIiIiQpqNUUREROLcoH5r2NVirORKzUm4oYxLl1lYvhzo3Zu9uqIPrXJyHKaR/a+/WSgusTt6iYiIiHRuquwSERGRuPBvtz/Ke42uUdllz7joWvsjrMxeCAzcdesZFQVweMthZfVqcHhioO9OgLcsYe61TZssLFgIZOcAyclNr87KzYXp3/XrrxYmTWzeOkREREQSicIuERERiY/UbARTs+u++Vj8MVK+uQ++4VNqhF1Jiz5Eyhf/gH/ogag8/MF6V1t51KMJc49VVFj4bb4Fnw/o2bN5IRUrwXr3sbByFZCVZWH7sYDDocBLREREOi8NYxQREZFWZTefrz0jo6Nodej87CibVnVwwaCFhYssbNgA9OrVsnUlJTnQo2doJkeGXiIiIiKdmcIuERERiQvXyu+QNPNRuFb9r8byYI/hoTch+SsAv3frmxI77OrSOcKuVauBJUtCwxA5u2JLZaQ7kJIS6t+Vl6f+XSIiItJ5KewSERGRuHCt+BYp3z9sTsNZmbmwUnLgsAJw5i+tXu4oDIVdVs6ABtebNPclpD8+Gckzbuuw91xBoYV58y2kpAFpabEbcti9uwMVFcDcXy0zRFJERESkM1LYJSIiInGejTG15nKHA8Ge9lDG30PLLAvOojXm12BOw5VdFhxwlufBWbYZHZHPZ+G3eRZKS4Hu3WK/fs7ouHEjzDYCAQVeIiIi0vko7BIREZG4cFSFXbVnY6SA3bdr85LQZcvz4PBXmCDLyurb4Hqt9FBC5KjIR0e0YiWwZnWoT1c8GslzSCSHRq5eDRQVxXz1IiIiIu2ewi4RERGJc2VXSgNN6n+v0ZzeyuoNuJMbXK2VVhV2lXfMsGvLFgvJKaGm8vGSmuqAxwsUFcdtEyIiIiLtlrutd0BEREQSk8NfaU6t2sMYWdk1eE9UHPU4gj1HhC6T3h3eSRfCciU1ul5etqOGXRxWyGqr1LqHJOZc7lCwNnhQ/EI1ERERkfZIYZeIiIjER6BqpkVX3couVnAFWMVl/91lILyT/xzVaquHMXqKgIAPiCIgay/YPL7SA6RnxH9bGenA5i2A32/B7VbgJSIiIp2HhjGKiIhIXCu7Ig1jbJHUHFiO0FsYR0UBOpKycqCyEkhpeKRmTKSnA2Vl6tslIiIinY8qu0RERCQuKve/BY7KQgS7bBPxfOe6n+Fe8S0CvbeHldkTVmoXWJm9AKer4RU7nAj2HQeLlwv60JGUl5uJJ00T+XhLTnbA77NM367uoZGfIiIiIp2Cwi4RERGJC6vbYFgNvQlZ/jWSZz0O35jj4Fr5HZwl61F+8qsI9tmh0XVXnPgCOqLSUgtxmICx0b5dQwZrGKOIiIh0HhrGKCIiIm0i0HO4OXVunAdHyQbzezBnQELfGwWFrLhqve1lZDDsAny+hmJHERERkcSisEtERETiIunnl5A051mgnlkTgz2GmVPX5kVwwIKVlA6kdU3Ye4OBU0lx68zEWKdvV3HrbVNERESkrSnsEhERkbhInvlvpHx1N5zleRHP5wyMlmtrmVMwpz+iHeOXNGsq0h+fjOTvHkRH6tfFmRhTYtyvvyFJSQ74/EBxUettU0RERKStKewSERGR+PB7zInlrqeUyelGsPt21X9aTRnCaAVMiOYo24KONBOjz8sAqnW3604CNm/RMEYRERHpPBR2iYiISFzDLrjrL2WyhzJWV3ZFyUrrZk4dFQXoKDickJGT09m6zeIz0tW3S0RERDoXhV0iIiISewEfHFbA/GpFGXY1pbLLSq8Ku+oZItkelZRYcLpaf7vs28UhlEUayigiIiKdhLutd0BEREQSUMC79XdX/WGXf+ThQNAPR2URAn13jHr1Vnp3c+qoiNz8vr2xLAsFBa3br6tm3y7LNKnv0aP1ty8iIiLS2hR2iYiISMw5/JVh7zbqT3isjB7wTTq/yeuvHsZYz0yP7Y3HE6quSm2DsIvYJ2zzZgvbDmndIZQiIiIibUHDGEVERCT2qsIuM9tilDMsNkX1MEZvKeAPqyJrx/26WnsmxtpDGbfkAV6vGtWLiIhI4lNll4iIiMScld4D5Se8AEfQH5+jm5KNQM8RsFK7AP4KwJ2M9qy8AvD7Q0MK20JGBrB5U6hvV8+ebbILIiIiIq1GYZeIiIjE4R1GCoL9J8TvyDocqDh9OjraTIxtxe3e2rdLYZeIiIgkOg1jFBEREYmzoiILyUlte5iTk0N9u0REREQSncIuERERiTlH8Tok/fwiXIs/7fRHNxi0UFjYdv26wvt25eWzWb4CLxEREUlsCrtEREQk9m8wtixByhe3I/mH/8Tt6CZ/fQ8yHtsNST89h/asogKoqGwfYRdnhCwubtv9EBEREYk3hV0iIiISewFP6NQVx4Qn6IejogCOsi1o7/26PG04E2N4366AHygsatv9EBEREYk3hV0iIiIScw5/KOyy3PFLeKy0bqFtleejvc/EGAwALlfbzMQYLikZ2LRJwxhFREQksSnsEhERkdjzV4ZO4xp2dTWnjor2HXaVllpwtJN3XBzKWFCovl0iIiKS2NrJWy8RERFJJA6/15xa7tS4bcNK794hKrvyC0IzIbaXsIvDKos0lFFEREQSmMIuERER6ZiVXend2n1ll99vobSk7ft1hfftCgYVdomIiEhiU9glIiIiHbJBfUfo2cXZDyvbQXP6cKwy26i+XSIiIpLA3G29AyIiIpJ4/CMOQzB3NKysXnEdxhjoMSwUegV8gCspbtsKbdCCo2AFrK7bINomXBwy6PW2n2GM9lDGwkKgokKN6kVERCQxKewSERGRmLO6DESgy8D4HtmUTFSc8Q5aS9KPTyHlm/vg2fUy+Ha9NKrrlJUDVhBwOtt+JsbwsGv9eqCwKIjUdlRxJiIiIhIrGsYoIiIiEgUGXeb0f49EfbxKSiw4Xe3r8LpcDhapobBAlV0iIiKSmBR2iYiISMy5Vs2Ee95bcOQtTZijG+g1tsnXKShoX/26bBxWuX5DsK13Q0RERCQuFHaJiIhIzLl/fQ2pn/4N7pXfx/Xopnx2EzIe3RXuBW8j3rxVQxcDuaOiurzHY5kG9U0Nu1K8m81PvIcy5hcE1bdLREREEpLCLhEREYk5R8BrTi13nMua/B44KgvhKMtr+HJsnBWDhvjkKG9kW2HN6TkTY2pq9NtwBL3Y56e9zA9/j2fYVVZmoag4bpsQERERaTMKu0RERCT2/JWhU3cTkp5msNK7mVNHRX79F6ooRPpTByD5u4eAqhCuyYKB6tkeHeX5ZmbGxrCqy+cFkpKib06f7C+o/j3Nsw7x7NsVDFooVtglIiIiCUhhl4iIiMScw+9plcouK63b1gCqHkm/vQ5n8Tq4ln0BBHzN2o6jeB3SXzjK/O7b8eSo1sOZGNHESRiT/EXVv6d6NyGeOEMkh1qKiIiIJBqFXSIiIhJ7VWEX4h12NTa0MOBF0s8vml9dmxch/ZkpzdqOo3SjOQ3mDIR37+sAd3Kj1ykqsuB2N207yb5Cc1qeMgD5OZMQTy4nUFlVgCciIiKSSBR2iYiISAcOu7qaU0fF1uF/4dyLP4GzbBMsR+gtj6NsS7OGMnIdZnuZuVFdnkMECwuBlCaO4kzyh8IuT3JPxJvLBXjj1xZMREREpM0o7BIREZE4DmOMc8+utAYquywLSXOerZ5J0XIlwQELjrKmz3ToKK0Ku9K7h373lDR4eVZMVVQ0fSZGO+zyunMQby43hzHGfTMiIiIirU5hl4iIiMScZ/+bUHnovxDsOiiuR9fK7IlAj+EI9hxe5zzn2h/h2rQAlisFvh1OhpXZyyx3lISGJDZnGKN7ySfI+M9eSFrwbqMzMXq8QGoTw6713Q/Bz8MeRIovD2OW3oB4D2Nk2GVF0WxfREREpCNpYicJERERkcYFttm9VQ6TldUHFWe8HfG85DnPmVP/qCOBtK6wMnsDRWvgLN2AYDPDruq/y7c0OhNjgBM4uprWoT7gzkRZ6iB0Kf0VGRUrMG/bfyCewxgDQcDv54yRcduMiIiISKtT2CUiIiIJyTP5SjPs0DvuDPN3MKs3XM2s7HJWDWMMdB8KV96S+hviVykts5o6EWO1ipR+5jQpUAy3vwj+OA1pZNgVDCjsEhERkcSjsEtERERiy7LgXvguLHcKAkP2jWrmwniwum8LzwG3bP27ehjj+iavyz9wV1ipXcywyWjCroICIKkZN7v/pjeQ4t3aUyzdsxbF8Qq73A5TfcbKLhEREZFEop5dIiIiElsBH1I/vhZp718JBOLfAT3l/SuR8eiucC37osHLBXuNgn/bfRHsMbTJ2/Dteikqj3wE/oG7mb8bCrv8fgvFJUBqM3rz99s0HUPXPFz9d1rlasSzZ5c9jFFEREQkkaiyS0RERGLLXxn2TqOJHdqbweErh6OyEI6yUACV9NPzcG6YB9/E8xDsOWzrbg0/xPy0hJXRo9Gwi/26PJVAVnbT12/PxliZ3Aup3o1I96xBXHt2qbJLREREEpAqu0RERCSmHFXVXKZrlTP+nc+ttG6h7VYUmKqypDnPImnRe3Bu/C02G/B7AK7bskwPMLOtqmCt3rDLCyQ3YxhjclXYVZQx2pymVcYz7HIgqMouERERSUAKu0RERCS2GA6ROxVwNLdNe/Ss9KqwqzwP7iWfwlmyHsH07vCPOCzChS2gshiwop+P0bV6FjIf2w1pr5xkKrt8Iw6Db/sTgGDk8X9l5aHNOJ1NvO1WEEn+IvNrUeYYExa6A6WIJ+6hPxDXTYiIiIi0Og1jFBERkfgMY2ylxvTVlV3l+WYII/l2OLnuEErLQsaju8DhKUbZ+V/Ayuod1fodpaHZG620LkBSOjyH3NPg5UtKLDia8XWiO1ACB0Ih3Kpep2J5n3NgOeN/DH2+uG9CREREpFUp7BIREZGYclRVdlms7GoF9tBC99IZpn+X5UqGf4eTIuyYA1ZKpgm7HCUbmhB2baoxm2Nj8guA1JTmD2H0O9Pgd2ehNVicT0AN6kVERCTBKOwSERGROA1jjH9z+hrDGH3loc2PPLw6AKtz2czeQPE6OEo3RL1+Z1VlVzCzF4JBC+WlPlil+fA50uFzZVU3eecPgyP27Eppxk1P8oXCLp+7C1qLhjGKiIhIIlLYJSIiIjFldd0GlVPugdVawxgze8FKzoTDG+pv5Rt3Rr2XDWb1gosBVskGRNuqqnoYY0YufvnVwqCZf8aA8i/wXbe/Y2H6CaY/lyOsUoqtunr3afrtKMkYjm+3fwfOoNf8PXTV/eha8jN+H3gVirJ2QDw4XEBlJfc6/r3VRERERFqLwi4RERGJKVZV+UdGaA4fJ8Gew1F2/n+R9OtrcOYvQ7DHsPr3jZVdYQFWU4YxbvHm4o8VQL/kbkA50CM1D337NqMRfT2CzlSUpg+t/junbD66lfyIzIqlcQu7XE7AU1WIJyIiIpIoFHaJiIhIx5eSBd/E8xq9mN2niz27mhp2LVqXC6eLFV49gEIgNZAfs6ArkvKU/uY0zbMmbttwuQBvqJBMREREJGEo7BIREZGYchStgXPTQhMsBXuPbVdHN1hV2WX34WqUZcE/fAqK127EmpLeyN0G8GwK9QNL8W2J6b71KPjaVHPlZ09EQfYEVKQOMMvT4xx2VaqyS0RERBJMMybGFhEREamfa+X3SHvvciTPmtruDpPVbRD82+6HwMBdo7uCw4EVI/+G99IfRFavHFPJ5XWHwq5kX35M9y238EsMXfMwuhf9z/xdntLPnKZVxjfsMo31A+zbJSIiIpIYVNklIiIiMeXwV5rT1mpQ3xTs51V55CNRX57N2+fPt5h5ISM9NGTRm2SHXXkx3bfaszFWpAyI+zBGpzM0gyQDLwZfIiIiIolAlV0iIiISW/6qcXHu1A5/ZP9YUIyijYXo2WNr5ZMn2R7GGOOwyx8Ku7zuHHNanhrq2ZXq2wJnoALx4HID/gAru+KyehEREZE2obBLREREYspRHXaltM8ja1lAZRHgazhA2rDBguuXN3HWxt2x0/Jrqpd7knKxtsfhWJN7TGhdMZLkL6pR2eV358DrykZlcq+YB2vhszEy6GJll4iIiEii0DBGERERia1AKOyyXO0z7Ep9/Sy418xGxWEPIjDswIiX8XgszF9oYVt/aCZGT3KP6vP87iz8tt3dMd+v5KrKLl9SKOyiL8Z/A8uZhHjh0MVgAPD54rYJERERkVanyi4RERHpXMMY07qaE2fphnovsuQPCxs2AN2S7LCrV9x3a+swxq1hVzyDruqeXcHQUEYRERGRRKGwS0REROIyjLE9NqinYFZvc+oo2Rjx/I2bLPy+GOjWjf2yQmFXZVLNsMsR9CLFuxEuf2lM9onrcwcragxjbA2cXZIjMTWMUURERBKJhjGKiIhITPlGHYFAr1EI9hrTLo+sZYddESq7OHxxwQLL9LHKynIg1WtXdvWscblxv1+GnkXf4rcht2Nt7tEt3yeHC99u/47p2+V3ZVUv71Y0C9uteRRladtg/pBbES9+DWMUERGRBKKwS0RERGIq2G+8+WmvrMxQlZazpG7Y9cdSC+vWA/05EaJlmeotYpP4cN6k0IyMybFqHO9woTR9aJ3FTsuLbiU/VA9xjBcNYxQREZFEomGMIiIi0qkE66nsWrbcwqJFoeGLLpfDVFm5LK85z5OcW+OynqqwK16zJNrKUwaY0zTPmpjO/FibhjGKiIhIIlFll4iIiMSUc93PcPjKEew5AlZ6KBRqj5VdjtJNgBWEBQf++MPC3F+BlJTQ8MWqS2Jlr1PgDpQi6Eypp7JrS0z2KatsEXILvkBJ+lBs6rZ/9fKKlL5m/9jPK9mfX73dWHI4AK+XQZp9u0VEREQ6NoVdIiIiElMpX98D17qfUXH4QwgMPaDdHV0rMxf+bfdDMLMXgt5KLF6eil/nARkZQE7O1sDHl9QVCwffEHEd1WGXPz8m+9Sl9BcMXfMwNnbdp0bYZTmTzRDKNO8GpFWuiUvY5XSxV1nMVysiIiLSMcOutWvXYuHChSgoKEBxcTGys7PRtWtXjBw5Ev369YvdXoqIiEjHUTUbI9w1q6HaDacblUc+gkDAwsJFFubNZ8gVXtHVuFgPY7R7ckWaibEipb8Ju9I9a1CUtQNizeVU2CUiIiKdPOxatGgRXnvtNXz11VdYv359vZfr06cP9t57bxx//PEm/BIREZHOwVEddqWivfL7GXIx7AK6dgUyM+sGXWw+b8EZCqA41i+ODerZH6yhsAslPyLNsxrx4HIr7BIREZFOGnbNmjUL//rXv/Drr7/Csiy43W6MGjUKQ4YMQU5ODjIzM1FaWoqioiIsXboUixcvxssvv4xXXnkFO+ywA/7yl79g0qRJ8b01IiIi0vYCobDLciWjPfL5LPz2WxDLFxWhdzcgKbNrxMsNXf0QBmx6HUv6X4ql/S+tcV5lcm+s7XE4PEk1G9e3tLLLGyHsKk8dgEqznfjMK8TKLp+P/e8tOGqFeiIiIiIJG3ZdeOGF+Prrr5GVlYVjjz0Whx12GMaNG4fk5PrfxHq9XsyZMwfvvfcePv/8c5x55pnYa6+98Pjjj8dy/0VERKS98VeGTpPaX2WXx2Phl18t9PjpHpxZ9hyWOc7F4uyrIl42xbspdJ2knnXO8yV1wW/b3R2z/UpuoLJrab+LsLT/xYgXlys0G2MgALjVzVVEREQSQFRvaebPn49rrrkGJ598MlI4TVEUGITtuuuu5ufvf/+7qfB68sknW7q/IiIi0kGGMVqu9tWzq7LSws9zLSxbDuTm9ATKgFTvhnovn+rdaE49yaHZG+MpyVfVsyupbthVewhlrDmdgNcfCrwUdomIiEinCbtmzJgRdcgVCa971llnmbBMREREElw7bFDPIXq/zbOwfDnQty/gL+pdI9BqqLKrMjnyUEVH0ItkXz787iwEXBlxG8YYbwy4KipCYZeIiIhIpwm7WhJ0xWM9IiIi0n559r4WDl8lrNQctBcbNgArVgA9c4GkJAcqUxoOuxhkpfjzze+V9VR2TVh0IboXz8Iv2/0T63sc1qL9+3n4I6bZfUn68Ijnj1t0EbLK/8DsUU+jInUgYl3ZFQwAPoVdIiIikiDi0pkhPz8f2dnZpol9c73zzjum59e8efNMs3ufz4c777wTxxxzTJ3LPvzww3jkkUcarEzr379/neXffPMNpk6daoZpsiHr6NGjcckll5ihl5EsX74cDzzwAGbOnImKigoMGjQIJ510kqlYU0NXERGREP8OJ7e7hvSLfrdgOYC0NEeNAMsMY7SsOkMFU72bzWnQkQSfO3ID+1jOyFiWNtj81CfNsxZp3nVIr1wT87CLPbsCQSCgsEtEREQSRLPSqN9++w1fffUVDj74YGy33XbVyz/77DPcfPPNJuxKT0/H5ZdfbhrTN8eDDz6ItWvXomvXrsjNzTW/N+boo49Gv3796ixn8BYpTLv66qvRrVu36gDtww8/xNlnn20CLd62cH/88YcJtiorKzFlyhSzTzwGt9xyi5l98sYbb2zW7RQREZH4WrHCwvoNoeGLNjadt+CA0/Ih2Z9fHVzZUnxhQxjr6ZnlqbpOSgzCrsZUpAxAVsVSpHnWxHzdprIrqGGMIiIi0snDrhdffNEEQ6eeemr1stWrV+PKK6+E3+9Hz549kZeXh7vuugsjRozAzjvv3ORt/OMf/8A222xjwqv//Oc/uO+++6IKu6LZVlFRkVk/g7Tp06ejd+/QUIbzzz8fRx11lAnsJk+ejMzMzOrrcFlJSYnZF84qSVdccYUJx3g8OEPlTjvt1OTbKSIiklD8HrjWzYWVlIpgnx3aem9QUmLh9yVAZhZ7U20NrSxnsgmrUn1bzFDG2mEXZ0Vc2ftU+J319+LaWtm1pUX7yMqwARtfgyc5F2tyj4t4mYrU0Jd56XEIu1idzp5mGsYoIiIiicLZnCvNnTsXo0aNMmGR7c033zRBF2dt5PDAadOmwel04vnnn2/Wju22224Rq7Ri4eOPP0ZxcTFOO+206qCL+DuXFRQU4PPPP68xfPGHH34wQZoddNkzTjLwIt5eERGRzs5RuhFpb5yFtDfOaetdMQHOkj8sFBcBXSP0fWefrZW9ToE/QnN5DilcOOhvWDLwz/WuP1aVXWmVazB0zSPYds3j9V6mPGVA1WVXIx5YvKYG9SIiItKpK7tYtTVy5Mgay77//nukpaVVV3uNGTMG48ePx6JFi9BaGEj98ssvJmRjPy323srIqPsGdvbs2eaU1Vu1cRl7gPEyrPJq7PK8jRyyyW2LiIh0do52NBPjxk3AsuVAj56h6qXaft/m6hatf2tlV6iRfYtnYkyqfybGipT4VXYZlsIuERER6eRhVyAQMD+2srIyLFiwwFQ+sdrJxr5WDJ9aC0Oq2r26/va3v1WHVrYVnI4JMMMka7OXrVy5MqrLu1wu0/yePb1Y2daSpvwiIiIdXlXYZblT23Y3/BYWLbJgBYH09Mg9txqS6lmPgDPVDGdsrGdXSxvUJ/uLzKnPXf/sleWpVZVd8Qq7zDGL26pFREREWlWzkpm+ffuaGQxtbNTOoIdDD8OVlpYiKysL8ca+YHfccQcmTZpkArbNmzfjyy+/xEMPPYRrr73W7MN+++1XY78o0r7ZfbrYnyuayxOrx4LBoAn9cnIiv1HlclacJYLw4asiInp9kHDBoiTw6zBnclqb/n/x+2I/Cgq9GDTYhaSwXl01WBbc/iI4AxXwpvapcdbYRdcjp3AWFo1+BFt6HxHx6i73dtjY+1hz3cyMrX0+myozrzy0Oyk96l2PM2W46elVmTYQWaluWK7YhIn29jIyAkhOdqFr161fWopI56b3/CKdU9cE+bzfrLBrn332wZNPPonLLrvMVHPxdwY54YESLVy40ARj8XbAAQfU+JuVVuy9te2221bPrlh731obm+InygOfPc1ERPT6IJG4CrcgjVXgjiSUttH/F6WlFmb/YMHpAjweBzxVIytr67PlA+zwx/8hL3tn/DDqmRrnuSvWmdMiKxulZaEvvepKQ8Gg20K/1nuZxgXLQzM/ljsyG9gW8MW4L0O/VLIEq/nbCw+67O15vBby8oCCgsT4Yk5EWkbv+UU6p64d5PN+NIFcs97RnHPOOaZ5PJu433777di4cSPOPPNM0yfLxuGLXD5hwgS0FfbsGjhwIBYvXlxdnVVf9VZDVVwNXZ5Y0cVeIJH6g4mIiHQqbdyzi03pFy+xUFwMdGvkfVBlci9zmurdUHslSPVtrnGZeEqu6tllhky2ERaf1xcKioiIiHSKyq5u3brh3XffxSeffIL8/HyMHj3aBEvhOJTwjDPOwBFHRC79b83Ej/23KioqqkMrhnLz5s0zy2sngnavrvD+XHaIF97Hy8beZWvWrDHVZOrXJSIinZ3DX9mmYdemzZxFGejeI3JT+ohhl2eDCbjs3lzuQDFcwdDt4NDBhjiCXjMbo8+djUCEWR2jkeRrYtgVtq+x4nIDlVV3nYiIiEhH1+xadVYxHXPMMTjvvPPqBF20//774/rrrzf9tNpKeXk5lixZYmZLDA+1Jk6caE6//fbbOtexl7H/VzSXnzNnjtmOfRkREZHOLNBjODx7XAXf2OPbrCk959DJiKIpvR1kuSwPkqqaxFOqNzSs0OvOQdDZcGg3aeE52Pvn/dCj8Jtm7/figVdh1qjnsbHb/g1ert+mN7Hnzwdg5Mo7EGsuJ+DzA8GgFfN1i4iIiHSIsIsVW0888USjl3vqqafM8MZ44rDD5fwKt5bKykrceOONZojhwQcfXKPqasqUKWaY4osvvogNG7YOXeDvXMZgjGGdbciQISbMmjVrlmnGb/N6vXjwwQfN78cf3/pv6kVERNobq/u28E08D/6Rh7f6tletAtatA3o2XIxVjUGWx92tzlDGVO9Gc+qJYgijPSMjq7uaqyK1HwqyJ6AypWaT/EjSPWuRXlG30rylXC4GXZqRUURERDrxMMbZs2ebnl2NYQjFyzbH66+/bqqmiD237GX2+saPH28CpsLCQhNejR071jSk79GjB/Ly8vD999+b8GrYsGG4+uqr68yMyCCMy48++mgccsghZvmHH35o1nf//fdXD3m0/f3vf8fJJ5+MSy+91Fy+Z8+eJvhi5Rib4Y8bN65Zt1NERERarqTEwqLfLaRnAElJ0Q/xq0zpjRR/vgm4SjJC1egpVWFXZVLjqZm3KuxKbkHYFa2KlNB7r3TPmriEXT5vKOxK1oSMIiIi0hnDrmh5PB64+O6pGRh0TZ8+vcayn376yfzYGHZ16dIFp5xyCn799VcTPhUXFyMlJcUEX6effroJolJT607PfeSRR5oKrqlTp+Ktt94yy8aMGYOLL74Yu+22W53LDx06FNOmTTMzO3I7HLrIXl433XST2b6IiIgAjpINcJRtgZXRA1ZW71Ybvjh/gYXCIs7I3LTrsm9XTtmCGpVdZWlDsKL3aShLHdIqlV1D1k6F35WJtT2PRsCVXu/lKlIGmNM0z1rACgKO2M2cyLdr/oAqu0RERCQxuOM5vPDnn39Gbm6UYwlqueuuu8xPY1iBxcCpOfbcc0/zEy0OZ3zooYeatS0REZHOIOm315E881F4dzgZ3v2a9/9zUy1fEfrp3ZuzCjatcfvmLnuhMrkPStO2rV5WmLWT+YlGSyu72OB+2OpQS4R1PRoe+lmZ0gtBhxtOy4cU7yZ4UnrHdDZG9jpjZZeIiIhIpwm79ttvvxp/cybG+oYocobCLVu2mNNTTz215XspIiIiHUP1bIx1q6rjIS/PwsKFFrKyOPyu6TMUrul1Qou2721hZVeyPzQTYxAu+F1ZDV7WcrhNMJfuWW2GMsYy7GJll8IuERER6XRh19q1a6t/51TeHMbHn4grdbtNRde+++6Lq666KjZ7KiIiIu2f3xM6dce/8ZPHY2HefAsVFUC//k0PuuqTXrECPnc2fO6ufNPT8D5UV3blN2tbSVVhl8+d0+i2qDy1vwm70jxrUIAJiBVWxFmWZYYyioiIiHSasGvRokXVv48YMcI0dr/zzjvjtV8iIiLSATmqwi4rzpVdDGYWL7GwZi0QxZw5Da0ISYEiE1axVxftvOB0U6n13dg3UJIxqtGm8Wt7HImKlL7N2nyyzw67ukR1+eKM0XAFKhBwpiEe/L64rFZERESk/ffsYsg1cODA2O+NiIiIJEhlV3zDrvUbOFsz0L07K8qbX9WV7lmFPedOgd+Zhs8n/giH5a+u0vIk92r0+rzMb9s1/8u/6squpOjCrsUD/4J4Us8uERER6bRhF6u6RERERGpzVPXsslzxG8ZYXm5h3jwLlpmopmXDFzkbI7mDFXAHiuEOlMEByzSC93IYY5zZYZeXwxjbAQ1jFBERkU4Tdq1bt86c9urVCy6Xq/rvaPXt27zSfhEREelgAvGt7AoGLcxfYGFLHtC/fwzW50w1oVayvwCp3o1wB0L9SD1JuYDDGdU6nEGPmY2RfbcCroxmNaiPdhhjNSsAOFyIKQfg9TJCjF3/MxEREZF2G3ax0bzT6cQHH3yAwYMHm7/ZpD4avNyCBQtaup8iIiLSAfhHHI5g7igEc0fGZf0rVwHLlgO5uaGm6rHA6i4TdnnWwxWsrFHxFY1J889Al7Lf8NOwh7GpW83ZqxuzpufRKMgaF2pQHwVXoAy7/3o0Ur0b8PnE2SasixWXk2FXzFYnIiIi0r7DrokTJ5rTtLS0Gn+LiIiIhPOPPCxuB6SwMFTVlZoKpKbGrvqoMrk3sssXmcouVzBUmVaZnBv19b3VMzLmNXnb3uSe5idaAWe6GfrotPxI86xFWdq2iBWXizNcxmx1IiIiIu077HrhhRca/FtEREQknvx+C/PmWygpic3wxXB2FRfDLmfQG3VzepunKuziDI5x53CYGSCTyn9HeuUahV0iIiIisWpQLyIiIhKJI2+pCWSs7H6AOyWmwxdXrQb69Am1SIilyhQ77NqAjd0OwArLg7zsSa1S2dVv05tm6OSmrvuiMqVPVNcpTxmA7PLfkeZZg1hyqrJLREREEoTCLhEREYmZtOkXwFm8DuUnv4Zgn+1jtt716y2kpABJSbFvnl6YuRNW9joFBVnjsbnr3uanKVoSdg1e9zQyK5ejNG1o9GFX6jbmNKf0N8QSe3YFAqEqOrdbTepFRESkk4Zdq1evxpw5c7Bp0yZ46+loym9fL7300pZsRkRERDoKvz0bY+yquioqLBQUAOnpiIv8nJ3NT3O1ZBijPRujNyn62Rg3ddsHQ9Y/hV75n2N+oAJBV6inaix6dvm8ocDLra9DRUREpANr1lsZBls33HAD3nvvPfO3ZXGa6sgUdomIiHQejqqwy4ph2FVUDJSXA72jK3xqPstCVvkieJJz4XV3M8Mxm1bZld/E7QWR5C8yv/rcXZpUiVae0g/pnrXILfwSG7pPQazCrgpT2QVTRSciIiLSqcKuhx56CO+++y6ys7NxxBFHYNCgQcjIyIj93omIiAg6e2VXUREQtBjGxG9oXZKvEJkVS7DzgjPN359O+glBR2pU1y1P7Y+1PY5CeeqAJm3THSiBA0Hzu7cJYRdDuNW5JyLdsxqlqUMQKwy7gkHA54vZKkVEREQ6Ttj1/vvvm6Br+vTp6NevX+z3SkRERDqeYACOYCgpsdzRBUXR2Lgx1K8rnvaYezCSA8Xmd68rG0Fn9PtfmdIPv213R7OHMPqdabCcyU267vJ+5yHWTNjFyq5AzFctIiIi0qqczblSXl4exo8fr6BLREREtgpUVXWRq2nhTX3Kyy0UFsavX5fNk9J76+/JodkZ443VZE0dwhhPTjaoD4aGMYqIiIh0urCrb9++sd8TERERSYwhjBSjyi4OYSyviH/YVRkWcIX/Hi1n0INUz1q4AuVRXyfJbk7f3LDLstClZC62Wf8cYoF9VtmG1a9hjCIiItIZhzEee+yxmDp1KvLz89GtW7fY75WIiIh0PM4keCddAAS8gNMVk1UWFlkmgHE649eviyqTwyu7cpt8/V3mnYTs8t/x4/DHsaXrnlFdpzBrJ8wa9TwsR7O+e0SKdyN2nn8qHLCwsdsBqEyJzZeRGsYoIiIiHV2z3l2dd9552HPPPXHGGWdg5syZDc7GKCIiIp1ESia8k6+Ed69rYrI6vr/YuLF1ZgYMD7sqmxF2eZN6mNMUX17U1/G7s1GQPQGFWePQ3KGXBVkTzO998j5CLDBS1DBGERER6ZSVXQcccIA5XbduHc4++2y43W707NnTlL/XxmWff/55y/dUREREOpXy8tAwxtaY8Dl86GJzKrs8Sd3NaXITwq5YWNfjUHQr+QF9tryP5X3PbfH6+PWlwi4RERHplGHX2rVra/zt8/lM8CUiIiKdmK8CjtKNQFI6rMymB0a1FVb16+rarXUru4oyxjT5+l477PJHH3b1LPgKaZ7VyM+aiNKM4WiOjd0PxKgV/zBDKDPLl6A0fShagiMqPR5GXvEdNioiIiLS7sKuRYsWxX5PREREpENzbpyH9GlnINh1MMrP/rDF6ysoCLVJiHe/LipLG4yVvU9FWeo2KM4c0+zKrqYMY+y7+R30yf8YC7e5rtlhF2dy3NxlT/Qq+K+p7loy8Eq0hMsJeL0tWoWIiIhIm2teR1QRERGRWhxVszFaMZiJ0fTr2gSkprXOYa5M6YOFg/6GVb1Pa9b1qyu7mhB2bZ2NMQctsb7Hoea075YPACvYonW5XAq7REREpONT2CUiIiKx4a8MnbqTW7yq0lKgpATISEeHsDXsyo/6OslVYRers1piU9d94HdlwIEAUr0bWhx2VYYySxEREZHONYzxhx9+aNLlJ06c2JzNiIiISCet7GJj+ooKoFsr9OuKhbLUgVjT8yiUp27T5MouX1LLwq6gMxX/GzPNDME0TbdaWtnlCVXWRZp4SERERCRhw67TTz+9SW+AFi5c2JzNiIiISEdSFXbBndLiVRUUtl6/rlioSB2Iedve0aTrJPmLzKm3hZVdds+xWGDYFQiEZmRMSorJKkVEREQ6Rth11FFHRQy7gsEg1q9fjwULFqC0tBT77bcfsrOzY7GfIiIi0t4FqsIuV8vCrmDQwoYNQFoHGcLYHM6gB+5gRUyGMYZzWH64/SXwJXVt3n65AJ9XYZeIiIh0wrDrrrvuavD8oqIi3HjjjVi8eDFee+215u6biIiIdMJhjOzXVVoGZGaiQ3EGK5HizYMnqRuCrrSohjAG4YLflRWT7ffK/wyjlt2C/Jxd8MvQe5s9GyMru3x+oJXmBhARERHpGA3qc3JycPfdd5vqrvvuuy8emxAREZF2JthzBLw7nobANru1aD1FxUBlBZDa8tZfrWrX347HXnMPQJfSuY1eltVcM0e9gJ+GPwI0szfW3KJp8ARKq/+uSO6NFH8+cgv+C1egrPnDGINAwN+sq4uIiIh03MquaKSlpWHs2LH473//i1tvvTVemxEREZF2IjBwF/PTUvn5lumz3tEapJsZGSuWIsWX1+hlg84UFGaPr7GstNTC3F+An34GCgtDPbOS3EBSctVp0tafsn5PYF2vv+PH1Odx1jZvwe1IRnHGGNMoP6NyFXLzZ2B9zyNa1LNLREREpKOKW9hF5eXlKC4ujucmREREJIGwX9fGTR2zX5cJuwAkRxF22QIBC0uWAD/MARYtCgVN9UoqgiNnCawtE+BYPxEp+3dBD+eBJugyHA6s734Ytlv7KPpueb9ZYRcnBOB9oLBLREREOrK4hV2s6Prxxx+x7bbbxmsTIiIi0p5UFMAR9MNKzgKSmjcGsaQk1LOrI85v46kKu6Kp7AqsmYfKJXPxxcLh+HbNhOrl/fsDE8YDg7YB/Oyd5Q31z/L5gFnWzVjlnIZhFTehcPaFWPXOl5jtzUX/oy1MGB+qglvXIxR2dS/6nwnd7ACuKbgmblNERESkU4Vd1113XYPVXCtWrDDN6S3LwjnnnNOS/RMREZEOIuXre5E0/y14Jl8J36QLmrWOoiLA4wFSWjahY7ut7Nq82cKbbwH75z6By/p8BlePo/Fz/gTstFMo5OrdO/LQzaAVwOL1FlYVA5NHjEOfscDrb+Ti19+AN94E8vJ9CG5/G3btdgEKM8aiS9lv6J33MVb1PrVZt0WVXSIiItLpwq7p06c3epm+ffvi0ksvxVFHHdWcTYiIiEhHUzUbI9zNT6ry8i04HR2vX1e0Yde33wGr055Et0HvAZ5U9Nk2E9cdA7jdDd9ep8OFo/s+iMndL0XPlGFm2UknWujeHfjiS+CbojvhLngCS0pnYGz380zYxaGMzQm7LFaeqbJLREREOlvY9fzzz9d7XlJSEnr27In+rMMXERGRTsMRCIVdlqt5YRf7V21iv64MdEhbhzHm13uZlauAoHcSugZDfba69O6OgkaCrnB20GX31zroQKB7dwtvfXIugv2+QGDtNVi+/zik99lshjQ2B/eGQyhFREREOlXYNWnSpNjviYiIiCRIZVfz+nUVs19XGdClCzqk8tRBWNPzaJSlDYl4fkH5FuTveBZcBWMwOnk3wDcTPnfXBtf5R9mX+L3kU+yf+zekOCOngOzX1aVLX7z48qfYWOHG/SuAs878P/RIDwVXTeVwAZWVrO/qeNV1IiIiIuTUYRAREZHYhl1VswM2u19XxwxZytIGY962t2N533Mjnj9vzQI4c+cgqf9XyHJUmmW+pC6mH9dPhS+b03D+oAfvrf8//FD4DL7L+3eD295uWwcuudCNrl05FBT491OFeHLxGQhYvibfDrcrdD+IiIiIdFQKu0RERCQmHP5QgGM1s7IrL8+Cy5W4d0bZ+lHwfv1v9Nr8FyT7C80yr7sL3t3wV7y74Sq8v+GaGpd3O1NwRJ97MSh9d0zuflmj68/NdeDSi4EBAywMn3w8hnm+QmH+903eT6cL8HqbfDURERGRdkNhl4iIiMS2sqsZPbv8fgubNgMZHbRfV7jM8sXoUfhtneUbVnRHcMXRGJN1HJKqwi6fuwuGZuwHtyMVQzL2rHOdbTP2wlkD30CyMz26bWc6cMF5DlzuKMWd5Zmwls9v8v67nEClKrtERESks/XsEhEREanNP/QABHuNRjC7T5MPTnExUFYGdOvWsY9rz4KvMP73i1GR3Bdf7fQp4Ah9r2hZFlatDl1m4EDgpy6PIsmXj4qUfhidPhQD0iYgO6m3Od8TLINlBZDqym7WPiQlOZCEXQB8ispV2cCEpl2f1XV+f2jCAJerYw4pFRERkc5NYZeIiIjEhG/XS5t93cIiwOcFkpM7driSl7MzfK4spHnXoVvxj8jPCU3qs3mLH5W578NdPBp9em+HwqQda1zPDrroqy334fv8x3DGgNcxJGNys/YjrVtXoAjwlxSiqMhCTo6jaWGXLxR4JfKwUhEREUlcGsYoIiIibY79upwJ8BVc0JmKDd0PNr/33fJ29fIFa5Yhec9LkHTwIXA1cDvZlH5l+cyqvzgjYvM4M0NTWnZJzsfPv1hN7tnlD7Cyq9mbFxEREWlTCrtEREQkNioKAG8Zx+w1uV/XZvbriq4tVbu3tscR5rR33qdwBcrN7+s2ViC4aTyyvOOR7t2Ibda/gJ75/61zXTal36P75Ti533MYkrFHs/fB6wqFXd2Gvogff19hhlE2pWcXgy5f0ydyFBEREem4YdcjjzyCDRs2xH5vREREpMPKeHwPZD4yAY6yzU26Xnl5qCF6WhoSQmHWOJSlDIA7WI5e+Z+bZZuX7ADvx+/hgKRXkVW+GCNX3ont1j4a8fojsg7G8KwDW7QP3qSu5rQLLOQH52F9E962cehiMBAaxigiIiLSqcKu/fbbDxdddBFmzJiBYDAY+z0TERGRjiPoh8MKjXuzXMlNump5BeD1srE6EoPDgXU9jzS/9t3yDrxeC/Z3hGxOHz4TY7zY6+5RPhzBVYfg55+jv66TlV3B0FBGERERkU4Tdv35z39Gnz598OWXX+Kyyy7DXnvthQceeABr1qyJ/R6KiIhI++f3bP3dndqkq3oqQyMfnc6O3Zw+3LoeobCLVVwbVnF2RSAnhz+OVgm7SjKGY/6gmzA3569MHzH3FyAYjG4oI+8H7q8qu0RERKRThV2s6Pr888/x9NNP4+CDD0ZhYSEef/xxHHjggTj33HPxySefwK93SCIiIp2Gw1+59Q930yq7KiqQcCpS+2HWqOfx5U7/xaK1XqQcPxbOfU5EwPIjuSrs8sYx7PIk98Lq3ichefReSE8DSkqApUubtg7OyCgiIiLSEbVo3qPddtvN/BQUFODtt9/GG2+8ge+++w7ff/89unXrhqOPPhrHHXccBg0aFLs9FhERkXZb2WWGMDqa9l1acYkFdwLMxFhbQfYEc7qsYCEcvfJgJa+Ey+FGks+u7MqJ+z78Xv4+uu/7M8pnXISf5/bE0KHRX1fDGEVERKRTz8bYtWtXnH322fjggw/w8ssv49BDD0VeXh6eeuopTJkyBWeeeSY+++yzWGxKRERE2vMwxiYOYSRWHSU3rRisw+AsiJsX7gjXx29hz/S7zbLWGMZIXYt/hHfN7Sjr9hic3X/BvPnsjRb9rIwq0hcREZFOHXbZVq1ahS+++AIzZ86sXta7d2/MmjULl19+uanyWr9+fSw3KSIiIu2AI1BV2dXEIYwMXyoqEzfsylj1KV7f+Qhc0fszTBqwl1lWPYwxKb5h1w5L/oLriotxYPpRyE7KNZMALFgQ3XUdjqYFYyIiIiIJFXb5fD5T0cXqrYMOOghPPPGE6dfFSq+PPvrIhF+vvPIK9txzT8ybNw+33nprbPZcRERE2g0rORO+kUfAv90BTbpeZWVoJsZEDbvWbclA3/T1mNL/QyQ5Q02wFm1zNeYMewT5WRPjum2fu6s53a/L6Rg/ZHvz+89zo7uu0wV4wuYcEBEREelImt0hY+nSpZg2bRreeecdFBUVmTL9nXbaCSeddJIZupgc9q6Vy6dOnYoTTjgBP/zwQ6z2XURERNoJK6c/PFNCw/SaoqIq7EpKQkL6au1E7NMtA73cxehRMAObu09BScZI8xNv3qSuQAVMj7CddgRm/BdY8geHjVrIymp45ku3wi4RERHpbGHXySefjLlz55qAKzMz0/zNkGvYsGENXm+77bbDb7/91tx9FRERkQRTWcG+VoDT2XD40lEtz1uFTwbk4QxPKvpvfs+EXa3F7gmW5CtAUo/16L9NV6xZmYpffgUm797wdVXZJSIiIp0u7Pr5558xatQoE3IddthhSEtLi+p6xx9/PCZOjG/JvoiIiLSBgA8IBgB3SqjhUxMquxIVe15t2uTAexv3xhldZqJn0bdI8WxA7/zPTL+u9d0PARyu+G2/Kuz6Le8RPFD0V4wf9xrWrNzDDGVsLOxyOUMVd/xi09GE+1NERESkw4Zdb7zxBsaMGdPk63E4I39EREQksbgXf4zUj66Gf+AuqDzumaivxyF1rmY3VWjf1q4FgkXbYuPcp1B46InoUjYP22x4EUPWP40gXFjf/bC4bt/HYYwAuiMNDrjQY+AaOJ2h/dq0yULm4Pqv63IBgUDox52g94+IiIgkrmY1qG9O0CUiIiIJzF/Vzdyd2qSrFRcnbnP6VatDpwMGAOt6HmV+H7T+OXPq40yMca6Ysiu7hiePxvXDlmDXXqfA7jjRWKN6O+zy++O6iyIiIiJtF3bl5+fHZGOxWo+IiIi0L46qsMtqQtjFYX4cxpiSoGHXylUM/0qxzUCYIYurc4/HH/0vNef53Dlx335ezq6YP/gmrO99JpKcoZYT43bcGnYFg1bDYVdQYZeIiIgkcNi133774b777mt2WJWXl4d//vOfZj0iIiKSgAJVlV2u6JOrygSeiZG9rlZtKELqKcMwK3cSyl0pmD/kFpSlDapRdRVPpenDsLrXSSjInlC9bORIICUFKCwEli0L1HtdDndkCzafKrtEREQkUcOugw8+GE899RT22msvXHLJJfjwww+xefPmBq+zadMmvP/++7jooovM9Z599llMmdJ6MxCJiIhIK/JXdZpvQmVXRVXYlYjDGAsKgTLnEvO7y2VVV1Yl+wtrzJTYWmYVPI1X15yDLYF5GFvVjWL2j/4GK7v87NmlsEtEREQ6oKhajt55550466yz8MADD+DLL7/EF198YZbn5uZi8ODByM7ORkZGBsrKylBUVITly5dXh2FOpxP77LMPrrjiCgwdOjS+t0ZERETahMPvNacWZ2OMUmUFK6D4XiHxZvtbvQqwtkxAt68X4MQzN1Yv7174vTnNKv897vvgCHrRteRnJPmL8Ef5f7GkbAaGZOyJnXYcgx/ncCijD1MOZmVd3ePvcjnMMEf17BIREZGOKOr5dYYPH47HHnsMGzZsMLMxMvBatGgRNm7cWHelbrdpYs+KruOOOw69e/eO9X6LiIhIu6zsSmlSZVeiMv262JC+Txf0SgnNikgOBM3p2qqG9fHkCnowaeHZ5vcJI27H4IzJGJy+G7rnADk5QFERsOh3VFd6RaJhjCIiItIRNXkyaQZXl112mfkpLy/HH3/8YXp5lZSUICsrC926dTMVXGlpoXJ9ERERSXzBHkPh325/BHtUTfcXhZISC64mvxOJD0+wDB9suBabPb/jwsGfVi//asv9WFb2NSZ2PRtjso9o8kyMAwfWXD536L/Qs/Br5OXshnjzuzIRdLjhtPzYPm1XeFK2fvk4epSF7/8XCuXqC7s4WaQqu0RERKQjatFbzPT0dGy//fax2xsRERHpkPxjjjU/TVFc0n76da2pmIPfit9CmqtmL63NnsVYWTETI7MOiXpdPp+FdeuCcO/6f9jSfRh8wa2zIVrOZGzqtj9ahcNhZn1M8eUh2V9QI+zqUnUzy0rrvzqHmCrsEhERkY6onXyfKiIiIp0JA6GKCiC5nczEuG3Gnji6z8OMeGos36XbBSbo6pU6yvyd512Ob/Iewo45J2BQ+q4R17V2HWBlrIR76CuYWZaKfR3no6143V1N2JXkL0RFoAgbKuejR8p2yMjoac4vLWv4+gq7REREpCNS2CUiIiItFwwATlfUF2fQ5fMCWdltd/CLfeuR7MxAqiu0E9vnHFPnMv3TdjI/tv/lP465Ra+iyLcWgwZGDrtWsTm9Pw1d1/4VI8eWwemI/rjEmj3rY7KvEK+tPQcryr/Hkb3vR2bmiWZ5aQOVXU4n4PEw/Eu8CQREREQksSnsEhERkRZLnX4hXKtmwjPlbvhHHNro5SsrAY8X6N5GwxjzvSvw/OoTkOXujdMHvIpkZ3pU15vc/TIU+zdgj+6X13sZhl2o6I0d3H/B3rltGxR5k0LN8VnZ1SdlLAp9qxFEAJkZofPLGqjscrkAb2iSTREREZEORWGXiIiItJjDXwmHFYDldEdd2cWeUE5n24RB3mAZKgPFcMKNikBh1GFXl6QBOKX/c/Web1lWvc3p27Syy1+AA/rdiIN63Wz+LnJY1ZVdwaAV8X5g2FXpaeUdFhEREYkBhV0iIiLScv6qEiB3dKVabR2i9E4dbSq6spP6IsudG7P1FhUBxcWAq9tC9O4zGEDbzk69vvshKM4YhcLM7WsMp8yoquwKBkNVdukRsj6OSvVUtuLOioiIiMSIM1YrEhERkU7MX5WKuFOjunhxsQVXK3/ltqp8tmkwb+uXtmOzgy5vsBzf5z+Ot9f/ue4QxqQSJB22H+5ZMdQ0hW9L+Tk7Y3WvE1GSMbLGcrfbgbSqHK6+vl0uJ+Dzhyq/RERERDoShV0iIiLSYg5/qFTLcqVEdfmSEiC5Fft1ra6Yg+dXn4jnVx1vGtO3VIl/Iz7bdBvmFr2GtRVzq5dzCKMjYy1cga7IdOcizZWD9uSrLffj0eX7Yn7x+8jKcjQ4IyOHMbLySzMyioiISEejYYwiIiLScoGqcYnuxsMun89CeQWQnNR6Bz5o+ZCbMhypzhykxiCA6p482DSr75o0yAyJrO7XxZkYC0fgUO88jBxRjLbm8pcip2weHAgiL2c3lPg3YJNnIdZVzkVW5hHYtCmAstIGGtR7QmFXawaTIiIiIm0adq1evRpz5szBpk2b4K1nuh6Hw4FLL720JZsRERGRDtCgnqwohjFWVAI+L5CVjVazTfouOH+bj+C3PEhyRjfUsjH79bzODPFbvQqYv8DCggXAlryq7Q10IM0Vag7fljIrlmLSwnNQntIPX+/0GcZ1OQVDM/ZD37QdsSWzqrKrnrDL7Qb8gdCMjJF6eomIiIgkVNjFYOuGG27Ae++9V/1NZn0UdomIiCQ+/8Bd4fAUAylZjV62sgLweIFurVjZZb8nSXK0POjy+y0sXcqAC1iwsGZYxGqocTsB3bqhXfAlVc3G6Cswp31TdwCqDkF2I8MYGXb5fKEfERERkYQPux566CG8++67yM7OxhFHHIFBgwYhw57WR0RERDodz2H3R31Zzv7H78lcrlDYEk9rKn5GnncpxmQfBZejZd0btmyx8OlnwKLfQ9VOtpSBXyJ9wv3YNeUOTNxuJF7ffAo+2DgY+/e8HqmuVixfi8Dr7mpO3cFyOIJeWM6t4xEzsxqu7HI6HeYLzXqK90VERETarWa963v//fdN0DV9+nT069cv9nslIiIiCYvDGFtrfr//br4Ly8q/xmbvYhM+Ndfy5RZeeBGm1xhlZQGjRwGjRgFz017FgtIfsDHrEVS4rjPbW1kxE1N6/QNtze/KQhAuOBFAsr8QnuRcbPL8jtUVPyKYNRHA0Horu2yswhMRERFJ+LArLy8PkydPVtAlIiIiTVZSYsHtiv+BC1pBDM7YHZs8izA+57Rmr+fnuRbeeBMIBIAB/YHDDwf69wtVPlEXz1+QndQbu3e/BEmONBzT598oC2xpcSVZTDgcZihjii8PSb4CE3Z9l/cofimehrHp1wC4ot7KLpsqu0RERKSjada7sL59+8Z+T0RERKRDcpRtRvqT+wHudJRd8j8TsDSkuLh1ZvdzOpzYo/vl2K3bxXA5mt4gjEP4/vsF8Nnnob/HjAZOOJ77XvP2cZbHg3vdUv339jnHoD3xuXNM2JXsL6hu1l/sX48e1jbm7/pmYySnC6ioYB1e/IecioiIiMSKszlXOvbYYzF79mzk5+fHbEdERESkg/J74Aj4gICn0aDL57PMUMDWCLtszQm62ISe1Vx20LXnHsApJ9cNuiJpaOKetuzbleQvNKfjupyMMwdOw4Tup5q/GxrGmOQGystbZz9FRERE2jTsOu+887DnnnvijDPOwMyZM9vdmzoRERFpRX5P6NSdElW/Lp83/mEXh+qtq/y1WddlJdMzzwJzfuJQReCoI4FDpjiqhy3Wp8i3Fvf+sSOeWnUEglYA7cXK3qdh3uCbUZwxqsbyrKoG9ZwwgOFefTMylinsEhERkc4wjPGAAw4wp+vWrcPZZ58Nt9uNnj17mim9a+Oyzz+v+lpUREREEo7DX2lOLXdqo5etrAg1PO/W9GKrqG2oXIDPNt8Gx2Yn/rztbOQkRT+ZTn6+hWefAzZtDgVyp54CDB8W3RC+skAeSv0bzU9FoAAZ7h5oDzZ2Pyji8pTUAJxJFQj60lBWBuTkRA672LOLYZjbraGMIiIiksBh19q1a2v87fP5TPAlIiIinVCgaro+V+OVXawiYkG4yxW/4CTFmYmx2cfAsoJNCrpWr7bw3POhYX3Z2cBZZwJ9+0S/n31Tt8cxfR4xv7eXoKs+/918N2YWPIG0sX9G2U+XoqS0/rCLwxgZePF3ERERkY6gWW9bFi1aFPs9ERERkQ5e2RXdMMZ465o8EMf2/beZjTFaP86x8PY7rGDiRDzAmacz/Gl6ILd9zrFob5J9ecgsX4KAMw1FWTuYZX7LC2+wDCmZWxpsUs+AK+APVeOlp7fmXouIiIg0n76jExERkVbr2VVaasHlap0DztkYG8OG+e+9D8z+IfT3yBHASScCKSmJM2SvR+E32H7p9dicMxlzRv7HLNut20XYo8/5eGl2CooaaFLPsMvnD1V2iYiIiHQUCrtERESkRayUbPgH7Ayr66BGL1tUHL/m9Hne5filaBp26XY+0l3dGr18QYGFF19me4bQJJIH7A/svReb0idO0EU+dxdzmlw1GyNlunsiMzUTWWkl5u/Seiq7eCw4EZHCLhEREek0YReHM7788sv48ccfsXHjRrOsV69emDBhAk455RSMGDEiVvspIiIi7VSw3zhUHv9so5djk/OK8viFXd/kPYS5Ra9is3cJTuz3ZIOXXbzEwquvAuUVoeF5rOYaNjSxQi6b193VnCb5C+qcl5kROmWD+oZwBk0RERGRhA+7nnvuOdxzzz0IBALmGz/bsmXLzM9bb72F//u//8OZZ54Zq30VERGRDqyiAvD6gKys+Kx/ROZB2FA5D7t3u6TeywSDFr74Evh8RqhRfv9+oRkXu3ZNzKCLfO6cOpVdW7xL8UvZLFR053mHmAb1DVFll4iIiCR82PXdd9/hzjvvRFpaGk4//XQceeSR6NevHxwOB9asWYN33nkHr776Ku666y4MGzYMu+66a+z3XERERDoUzsTI0CQpKbbr5ZdufA8yIutgDM88yPweSUWFhddeZ2V66O9JE4HDD+P+JG7QRd6kUGWXO1AGR9ALy5mMdRW/YPr6q9Ajc7IJu+prUE/ssVZewS82E/s4iYiISCcPu5555hm43W489dRTGDduXI3zOHSRPwceeCBOO+00PP300wq7REREEljSnGeRPOtx+EYdCe/e1zU4EyMnSHS5YhOasDrpy833wmuV45T+z5ll9QVdW7ZYeOZZIC8/1HT9qCOBCeM7R3jjd2XBghMOBJHsL4InuaeZsXL7LkfBKhyKNQ00qCcer8aGOYqIiIh0+LDrt99+w8SJE+sEXeF22mknTJo0Cb/++mtL9k9ERETaO28ZHJVFcNizMjYwjHFr44Om81teeIOl1c3nXUjGvJK34YATJf5NyHLnRr6e38JLr4SCrq5dgdNOAfr16xxBl+FwwuvughR/vunbxbBrQNoEjOyxNxYtLsEPDTSoJ3dS1X1XVUEnIiIikpBhV0VFBbp1a3yWI16GlxUREZHE5fBXmlPLndrg5crKLDMkrjl+LnwNn2z6O8ZkH4nDet9tlnVNHoCDcm/GgLRJyHT1rPe6n34GrF8PZKQDF18IZGd3vsDmjwF/ggUHPEk96m1QX1+YleQO9Vrz+2M/BFVERESk3YRdffr0wc8//wy/32+GM0bC83gZXrY52Pdrzpw5mDdvHhYvXgyfz2f6hB1zzDERL19aWoqHH34Yn376KTZv3ozc3FwcdNBBuOyyy5CRUfVOLkwwGMRLL72EadOmYeXKlUhPT8duu+2GK6+8EgMGDIi4jW+++QZTp07F/PnzzZvB0aNH45JLLtEwTRER6dzsii53SoMXKyxq/kyMWUm9UBkswuqKH2uEMrt2u7DB6/3xh4Wvvwn9fuyxnTPootW9Toy43H6LFAiEhpmmp9W9DN/qeTzx6bcmIiIiEg/O5lxp3333xbp163D99dejuLg4YvB04403Yv369dhvv/2atWMPPvggXnvtNbMdBlcNKS8vN/3Bnn32WQwZMgRnnXUWBg8ebPqFcTZID9+h1XLTTTfhH//4h3nDzCb7e+yxhwnKjjvuOKxYsSJi+Hbeeedh6dKlJnA7+uij8ccff+Dss8/Gxx9/3KzbKCIikgjs4YtWA2EXhxJWlEcfdnmD5djoqeokD2Bw+mScNfBNXDjo06iH0pWVW5j2Ruj3nScBo0Z2zqArkjzvctz263A8umo3pFTdbfU1qWfYxaouzcgoIiIiCV3ZdeGFF+Kzzz7De++9hxkzZpigiLMxEsMpVkAx8GKFFC/bHAyittlmG7Pe//znP7jvvvvqveyTTz6JhQsX4vzzz8df//rX6uX33nsvnnjiCROChe/HzJkz8frrr5u+YwzEkqveeR922GG44IILcNttt5nm+7aioiKzP127dsX06dPRu3dvs5zbO+qoo3DzzTdj8uTJyMzMbNZtFRER6dCqhjHCVX/Yxa4GHAqXldX46gq8q/HymtNQESzCxYM+R4a7B1wONwal7xb1LvHLrOnTAX4n17MHcOgh6NRSPeuQXrkSnuRclKVtCyfcKPKtg9uRiqzMUOUW+3b1jDAalENPGXZ5vG2x5yIiIiKtVNnVpUsXMwRwr732QllZmalsYjjEn48++sgEXXvvvTdefPFF5OTkNGcTZkihHaA19maWwRWHIXJIYTj+zeU8P5z99xVXXFEddBFvD5vqf/vttya0s/H2sYKN1WN20EX8ncsKCgrw+eefN+t2ioiIdHiBqhSkgZ5dlZXRD4PLcHeHVdXKvsi/tlm7NOcnYN58wOkETjyRFWWdu6pr4MZXMWnhuRiw8fXqYaFXjvwWFw36DBlV39XVNyOj0+kwMwuosktEREQSurKLevXqhccffxyrV682vbU2bdpklnPI4fjx4+vtexVrHHLIbbOyisFWOP7NGSMZXnFIpd0/bNasWdXn1cYqtdmzZ5sfVm0RfyduozYuY6+w8MuLiIh0JlbOAAR6jUUws/4m8ewHFQyySshR77DFZGfo/3GentT/GaQ6c5DprtlQPRpb8iy8+17o9wMPAPp3ppkX68HZGImzMZLbkYx+6Tug1CpFZobV4DDG6nWosktEREQSPeyyMdRqrWArEjaXp0GDBkU8n8sZdjEUY9jF/l5sYD9s2DC4IkwJxaGT4eslu4eXfV5jlxcREelMvHv8pdHLsLKrqlirjlXlP+CNdReZmRVHZx9ulvVI3rZZ+xIIWHhtWiiYGTwY2HOPZq0m4fiqwq5kf2Gd8+wuDCWNhl28AxUcioiISCcIu9paSUmJOa2vX5a9nEMrm3J5+3Lh182K0Ggk0uUj4XBOJ8dSJAD2LhMR0euDNIXD4UVmVgCZGTW/aApaQXy88gYU+9dhZuFUTOp9UtQN6CP54EMPVq/2Ii0NOPuMDGRnJcb/vS3lygxVt6cGi5FZNW7xp7zXUBksRVa3IwGkwOtJQmZG5KGovO/4JWHXrs2cTlNEOhy95xfpnLomyOf9qMKut99+25zuv//+Jtyx/46WhveFmtwnygOfPcpERPT6IE2xZm0Q/gD7QtUNss4f+DHWVf6CHsnboay8nsZRUVix0sLHn4Z+P+pIIDmlvN4+VJ2NOxAKsVyePJRWjVd8a/VVqAwUYXIK2zpsh4JCH0rL/BGv7/NZ2LgRKChQeCjSGeg9v0jn1LWDfN6PJpCLKuy69tprzbesO+ywgwm77L+jaR7Py8Uz7LKrrezqq9rs5XYFVrSXD6/iCq/eqn1QG6r6EhER6QzSXjsdjpJ1qDzkPgT77ljnfL/fQkU5kFxPc3q+V+iXVvd6TVFZGRq+aFnATjsBO2yv4XbhvO7Q+5eksGGMI7MPRIWvFJm+UBDWUDDododm1LTf24mIiIi0Z1GFXZdeeql5Y2MHPfbf7YHdM8vuq1Wbvdzu6cXG9D179sSaNWsQCIRK8sPZvbfC+3PxuvPmzTPn1Q67Il1eRESkM3GUboCzeF29TbkYkni8W3tDxRrDtLems+oI6NYVODLU9kvC+JKqGtQHSuEIemE5k3HqkKdNldcy04uLX+A1HHb5fKFeaCkpOrQiIiKSAGHXn/70pwb/bksMojgD5E8//WSaz4fPyMi/ubx///7VMzHSpEmT8MEHH5jzJk6cWGN933zzjTkNX87f33//fdPofscda37zzGX2OkVERDolf2XVu4rUepvTMyRJrtXuKd+7Eq+sORPDsw7Efj2ua9YXaVu2WHj1NQ6TZIUYcMIJQGpq+/hCrj3xubKxeMCfqyu8wtkhZENhV1JS6H5k4KWwS0RERNq7Dt94gW+Mjz/+eBNsPfroozXO499cfgLf+Yax/37wwQfhDZtH+6uvvsLs2bMxefJk9OvXr3r5lClTzDDFF198ERs2bKhezt+5jNVe7GcmIiLSGTn8of9LLXfkkp+KSiAYBFyumiHUkrIZ2Oz9HavLf2xy0MXhdHN+svDQI6GgKz0NOP00YNA2Croi30lOLOt3Adb0Ot5UdUUKuxhmsUquvsouf1Vll4iIiEhCzsY4cuRIHH300bjjjjsavNwNN9yAt956CwsWLGjyNl5//XXMmTPH/L548eLqZQyjaPz48SbkovPOOw8zZszAE088gYULF2LUqFFmm6y6Gjt2LM4888wa695ll13Mdbm+Y445BnvttRc2b96MDz/8EF26dDH7XXsmxRtvvBFXX321ud2HHHKIWc7LFxYW4v777693dkcREZHOU9kVOexiiBLJ9tnHIMPVHcnOzCb355r+NvDLr6G/Bw8GTjqB/18r6GqKV5ZfgCXFX+Hg3NvgdE4xgWRZGY9j3cuy60MgqLBLREREEjjs4rep/In2ss3BoGv69Ok1lnHYIX9sdtjFoYussHr44Yfx6aefYtasWaYv1znnnGP6i6Wm1h1Wceutt2LYsGGYNm0ann/+ebOOAw44AFdeeSUGDhxY5/JHHnmkqeCaOnWqCfBozJgxuPjii7Hbbrs16zaKiIh0eGxYHvA2OIyxvNyCM0IteZqrC8ZkH9mkza1aFRq2mF8As8799wP23ou/K+hqTHrFCqR616M8dRAqU/qgzJ+HYv86eILFyMjgRDyhJvWRwi5W3vE9nSq7REREJGHDrmhx9sLk2g06onTXXXeZn2hxmOH1119vfqLhdDpxxhlnmJ9o7bnnnuZHREREqvg91YfCckWu7GIvKPZ8aolg0MKXXwGfzwgNieR8MSedCGwzUCFXtIavuhe9Cv6L+YP/jtW9TsRh/W/HHmVXomvyQHydWRV2NdC3i0eaEw2IiIiIJEzYtW4dZ1nair2wai+zcZbDZcuW4bvvvotYJSUiIiIJwgogkDsy1LcrwjBGVgNxaJy7Vtg1t2iaOW9Y5v7IcHdvcBOsDHvxJWDZ8tDfO2wPHH2UGtE3ld2cPslfYE57p41AZjCUbmVmND4jI9Muj4eXU8AoIiIiCRJ27bvvvjWax3K4IH8awjex9lBDERERSUDJGag4LTS8PxIOe+MMfsm1wq6vtzyIfN8ynNDvSYzKOrTBTbCai0EXi8WPPAIYt1NoWJ00jc/dJXSX+YrqnGe3HmUwWR82qS8v11EXERGRBAq7Jk6cWP37Dz/8gO7du2MwO8JGwKGLubm5JiBjHywRERHpnDwewOsD0tK3LgtYfozJPgJLy77CkPSG2wNwdsC5v4R+P/kkYOQIhVzN5U3qUqOya135PCwv+hHdk7dFRuaOjVZ2KewSERGRhAu7XnjhherfR4wYgT322AN33nlnvPZLREREEiTsYmUXgxKby+HGvj2vMT+NWfR7qJooKwsYPiy++9pZKruS/IXm9JeCNzFjw73Yueu5yMyoCrsaqeyqqAj1T9OEACIiIpJwDepnzJhhZi8UERGRzs25eTFS370MwZx+qDzumTrnV3pCDeVdruZVZNmTMO+0o2ZcjFXPrmRfqLKrZ+pQU1nXLXkIXFXDGBur7PJVDUtNiTwXgYiIiEjHDbv69esX+z0RERGRjsdbAmfRasDhrLeyK5wvWIlNnkXok7o9nPVcx1ZaapnKLho/LmZ73Gn5qoYxJldVdk3ofgpGpB5hfl9U1aC+rJGwq6I8NCOjwi4RERFJuLDrkUceifqybCB76aWXNmczIiIi0s45/JXm1IowEyNVVloI7yW/svx/ePH/27sP6Liqc+3jz5mu3mUVW7KNbWxjY7ANpveQUEILLYUSIDchJDchnSSk3hvSvvSE3DQIJCFA6CWEYFoMGHDBuGNcZRVbsnqfcr61z5FklZEsd2n0/62lNTNntkZHM9LMmWfe/e7tH1JhcLY+PmnohW5WvO1WhY0vlsaNo1fX/moNlmj9hFvVERg3aIP6PU1jjETc6i4AAICEDLtMiGVWW4yne4Ukcz1hFwAACSzSlXz4QnGvNtPievfraoxUKuBJVWFo9rCnMM6lquuA6AzkanPxx+Je1xN2Ne8+fuvP57MUidrOCpsAAAAJF3YN1pg+FoupsrJSr776qpYtW6YPf/jDmjVr1v7uIwAAGOGVXRqkssuEJ37/7stzMz+kozMuV2dsiPlykqqqbJVXmF5f0pw5B3SX0WVD44t6eOvnlR+coUvy73S2RaPu1NNQ/OzSQdgFAAASMuy69NJLh7z+U5/6lH7/+9/rN7/5ja688sp93TcAADDSRdymXLZ3YNgVDttOg/reYZfhswLyebOHvNmlXVVd04+UUpKZwnigpLZuUDBcrYaUWYqoQ9Wd78jvSZLfbykYtJ2gq6mZsAsAAIxuQ3eG3Q8f+9jHNG7cOP30pz89WD8CAAAcbtGOQSu7THBiVu7rDrtidmx4Nxm1tfwt9/y8eQduVyEd885nddzam5TWul4lKfN13YR/6KKC/+fcNakp2mOTejO7sb0jfhsLAACAhA+7jGnTpmnp0qUH80cAAIDDyZekWGapYmkFccOuSK+w6/7yG3TX1su0va2rbGsQG951pz+mpEhHTjtYOz42hf1ZPSsypvhyNCnlZBWEjhrQt2swpv9ayxBN7AEAAEbtNMbhKisrU8Qs2wMAABJSZOZFzlc8ZgpjJOo2Ng/H2rWx5SVF7Hb5PcnDakx/zBzTs4spjAdSpy/DOfWH6wZclzKcFRn9UmvrAd0lAACA0RF2NTQ06M4779TatWu1YMGCg/EjAADACGcqu7r5PSF9ctIL2ty6SPmBIwf9ntY2W6vXuOdZhfHAC/u6K7vq1Blr1bqmZxS1Izoq/cKeaYxDVnZ53RAzFrPl8RBEAgCABAq7zj777EGva21tVX19vbNsdSgU0uc///n92T8AADBKdfYKu4zswETnayhvv+2uCFhQIBUVHtz9G4s6fZnOqT9Sr7ZIg/5e/lFZ8mpmWtmwpzGa1RjN11ArNgIAAIy6sKu8vHzwG/T5VFhYqOOOO85pUj9lypT92T8AADCC+V//rXzrn1F4ztWKzLm6z3VNzba8e3mk0T2Fce6xphk6lUMHrWdXuF5Bb4rGh+bJ5wkppqhSUrzOdUP15PJ3TWMk7AIAAAkXdq1bt+7A7wkAABh1PA3l8tasV6RtYA8oE5qYcKS2c6teq/0/HZn6Hk1JPXPQ26qutrWtTPJ4pGOPOcg7rrFe2VWnkDddN018sue6tFR7WJVdph2rCbsAAADGZIN6AACQ4KJdcxV9fee0RaO2WtukgF9a1/yc3qy/S9Wd7wwZdi3tquqaNlVKS6Oq62BoSD1a6yfcquakI/apQb1ZMMA8th2EXQAAYCyEXaYpvZGens60AwAAxggr4oZdti84oDl9JCwFk6SiwBzNy7xGxaHBy7VMw/Plb7nnaUx/8DQnT3W+jK5sq8dwGtR3C4cPws4BAACMhLBr4cKF+utf/6rly5ervb3d2Waa0h977LH60Ic+pHPOOedA7ScAABiJIu7rv/qHXZ1uIJKaJk0IzNeEpPlD3szGTeaDM7fp+YzpB3OH0dtfyj6kxkiVriz+vVJTJzvb2trMVEVbPt/g1XVMYwQAAAkXdpmVFr/61a/q0Ucfdc53V3QZjY2NevXVV/Xaa6/p4osv1h133EGlFwAAiSrSGXcaY0e7FI64PZ72pjH9nKNNny+mMB40dkxpreucBvUdyWeruuMdNUTK1R5tVHaS2y8tFnOb0Hcd2g1geUwgZo7/eJwAAEAChV1//vOf9cgjjyg/P1+f/OQndeGFFyq1a73q5uZmPfXUU/r1r3+txx57TNOnT9f1119/oPcbAACMAFZXZVe8aYzm87AdnasU8mQo0z9h0A+/2tttrVrtnp837+Dv81hmKaaTVl4hS7Zez1umiwt/Jlsx5QaOkMdjKSXFVlOTO5VxsLDL73PDMAAAgJHKsy/f9MADDygpKcmZwnj11Vf3BF2GOX/VVVc515kpjWYsAABITHYoQ7GUXCnQ1fCpS3cD86d3fE0/37RAKxsfGfQ2Vq5ypzzm5UoTxh/sPR7bbMunsM9NsXydtZqccoqOSDnNWZnRSEnZc5N6U61H2AUAABKusmv79u06+eSTNWHChEHHmOtOOOEEvfLKK/uzfwAAYARrv/S3cbe3tNiyLFuWPPLIp6KkOXucwmga0w9W/YUDJ+zLVCDSIH+4TgoU9bmu+/PLoZrUm7DLWYBgD329AAAARlXYlZ2dLb/fv8dxZkxWVta+/AgAADCKmbAkELB0Q/6jCsfa5LP69vTqPYVxy1b3/LGDL9Y4ZphVKaurzf3i9s9KS3O/vN4DFyp1+rKUoq1O2FUZW6WmSJXyg0c6U02HsyKjE3aZnmzh4fdkAwAAGPHTGM0qi6+//roazLJJg6ivr9fixYtZkREAgDHGLF5jprl1fy7m9yQNWrG1vdzt7WU+G8vMHNtVQs3NtraXSWmp0oknWJo5Q/JYUmWlVL7dVmOj7YRh+yvsdz+I9IVr9WLNj/W37dfo3eYXnG0pXZVdLXuYxmgWH2BFRgAAkFBh12c/+1mNHz9e1113nbPqYn8m5LrhhhucqYy33nrrgdhPAAAwAiU9cK2S/v5hWU1VPdtMCGK+hlEEru3b3dPxxRqzzHTAinLbCZiOOko69RRLkydZmnO0R2efZTmXp0yRYlGpvFwqr7CdYGxfg69OX4Zz6g/XKjcwRUWhOQp5M51tJmgbTmVXhLALAACMYMMqPr/22mvjTlFcvXq1E2plZGSoqMjt+VBZWelUdRlz5szRLbfc4qzeCAAAEo+n8i1Z0bCp5+rZZvo5mcqf++vPU0Z9gc4f97/K8BcPHXaN0cb09fWmYksqKpRmzrCUn9+3ui0YtFRcJBUXWWprs1VdI1VU2Nq5U6qtlfLzbYVCe1cRF/Z1V3bV6z1FX+9z3XAa1JsplSZoo7ILAACM6rDrjTfeGHKqggm3ugOu3t566y0azQIAkKjC7V1Bl2QH0no2m35Tde2VqupcoR2dK3VZ0a8HvQkzjXEshl2dnbZ27JBSkqV5c+VUcvn9Q4dWSUmWSiZIJRMsNTXZWv+OrY0bpWDIVk7O8Jv7V2ee5vTt6sg9YcB1w2lQ33/FTQAAgFEZdi1cuPDg7wkAABhVrHb3gy7b45MCKX1CkJBydWPpE6rp2KigZ/d1vZnAxnxWZjKasTSNsaHBVlOTNGmidOSRlrL2oVdZWpqlucdKebnS6jW2ysqkggLbWRRgT2ozFjhfqaZBV0vfVGs4Deq7mQb1AAAAozbsKi4eQ0egAABg78KuUKabWPWq7PJafo1Pmq8JSfP3WNVlAhszXW+sMOv7HHuMpWlT92+VRY/HUmmp29zfBF5mVcu0NHuvGv2vaHhQS+rv1dSUs3Va7mf6NKg31fuDVYuZlSLNtEpp7DxuAABg9GDBaAAAsE+stjrn1E5yG553a2+3ZQ8jAxmL/brMfRMMmiqs/Qu6ektPt3TcfCk3x9badeZ+tZ3b9/kGCapiHUpt26jUsNQU2amytjeV7Z/Up7LLNKA3vddCocGb1A+1YiMAAMDhRNgFAAD2idXW1a8z5DY871bf2KGVkf9TuGWeJiafJI8Vf/HnsRh2NTVLmZlSRvqBvV0TbE2daiknx9aqNba2l0lZ2bYz3bG/pI7tOmnl5Qr7MjT96L8oJzBJmf4S5zozDTIQcJvPmyb1g4Zdfqm19cD+DgAAAIc07Jo+fbo8Ho+eeuopTZo0STNmzBj2DzDl72vWrNmffQQAACORHVMsOVexlNw+mzfWrdIb7d/XqopsfXHKqvjfattjMuxqb5NmTHOnIB4M2dmWTlwgvZNta/UayeO1lZLc92eFfZnOqT/SoDx/qXIDRwxoUm9WejR9u3Jz4v8cv8/t2RWJ2INWkAEAAIzosKuoqMgdbGrWJRUWFh7cvQIAACNeZPoFzldv4bCtWCSgI0MXKSWYNmjPp7p6qaXV7f1UWKAxwdw3Pq+Uk3NwwyGzquNRMy21tsb07kZ3xcc+++HbPe3UBF6d/r6JlpnK2B12DcYcEprgzlSAdR0eAgAAjBjDOjx5/vnnh7wMAADQ3Zw+S7N1ybjfKilp8FCnu6rLBF0mnBkLTHiUmuY2lD8UJk2ytK3MVmurreRe1V225VOnN12BaKNiHWXaEl4vrxXoWUygp0n9HsKucMQNu5L7hWkAAACHW/wmGnvQ3NzsfAEAAPTW0SlFwibAGvp+GYtTGE14VFQ4eOP4Ay0nW5ow3q3S6i/sd6cyNrYu0d3bPqAnq77cc11aV9hlenYNGXaF3bALAAAgIcKu+fPn68YbbzzwewMAAEaN4MJvK+n+a+TdtrhnW1Nrm1ojjXsMdMZa2BWN2s5pbu6hq2IzU0gnT7Kc/lptbe7P7xb2ueVl6TFbuYEpyvRP6LkupWtFxqE+1zQ9x2ybsAsAACRQ2JWWlqbxY+XoFAAAxOWpWi1v+RIpvHtZvjcrntO9rTP0QPl/DXqvxWK2yivc8+OLx8ad29LiNn431VaHUk6OVFws7drVd3tnV9hV4MnSpyb/Rx8cf3fPdWY/jeEU8VPZBQAARqJ9ailqVmMsKys78HsDAABGDau93jm1Q+6UOGN74wazRcnewVOdmhqpo8Od6pifrzGhqVmaVCqFQoe2P5lb3SVtL7fV3m73/PyKvPerJfdENSTNGvA9pkH9nqYxurdN2AUAABKosutjH/uYVq5cqWeeeebA7xEAABhdYVfS7rDr1Kxb9ZG0t3RqzqcH/b6yrimMZrFnrzfxm9Pbtq1oRBqXf3h+17w8t4Kud3VXVc55Ki+9WU0p0weMH06DesPySG3tfadHAgAAjNrKrlAopCuuuEK33nqrHnvsMZ111lkqLCxUMBiMO/64447b3/0EAAAjSSwiq6NpQGWXqQbKDOYrY4gVFrv7dZnm6WNBa5u7YmH2IZ7C2Lu6a+JEqaysb3WX0R5t0oMV/6VwrE3Xlzwsj+UZVoN6w/QCa909gxUAAGB0h13XXHONc+BkPql84YUX9OKLLw45fu3atfu6fwAAYASy2ht2Xwil9zRhb2sbxkqM5e7pWGn/2dwk5eft7oV1OJifbyrpzH1vengZodYtKq15XtVNL6nRYytitytgJfc0qDdBlnlMB6u+MysythB2AQCARAm7LrnkEifsAgAAY1Rb1xTGYLrkcQ8nnln/D/1r1yualX6xMnRG3G+LRGxVVo6tsMv0JysstA7rsZNZPfGIyVJ5ha2ODlvBoKUZb9+olJYN+vj4j2tL+jx5LPdxNFVoZlfNaoumsX66m2XGDbtMg/pw2JZ/iEo+AACAURF2ff/73z/wewIAAEYNK9KuWEquFMzo2ba47Fmt6XhC+dFJmjlI2LVjhwm8pKSkQ78y4eHgBksj43c1iwEUFUoVlW6VV2PGcU7YNTearJT0C/sEYynJtjONsXmosMsvtba4gdeeqvkAAABGfNgFAADGtti4o9T68f+45T9dzii+Vq07J2laWvygq3e/LtMwfSxUiTc1SelpUsbuTPCwMSHW5Mkm7LLV2WmrMfM4FVb8TVlNywaMTU1zg66hmtSbnl2m8X5nWOqa+QgAADB6V2OcMWOGvvrVr+5x3Ne//nXNnDlzX34EAAAYDXoFVlPSTtH8wFdUlHT0oMPLxli/rrZW93c1QdNIMC5fKiiQamrkhF1GWstqbW/+j9Osvltqyp6b1Hu9UtiEXZ0HfbcBAAAOfthlGtObr+GOBQAAia+9Q9rTq35PZdcYCLtMfzKP10xhHBlBl2GazR8x2ZIdk5o849Xuz5PXjmjJlg9pR8eannHdTeqbh6jsMgGeOcwj7AIAAAkRdg1XU1OTAoHAwfwRAADgMPAv+7OS7r9GvlUPO5fX7Fyid2tWyfJEB/0eM3XO9OzqnsaY6ExQZKYwZmVpRCkY51Z3VdfYqkub62w7IZYnq9dhYffKkUOFXd0IuwAAwKjt2VVRUdHncmtr64Bt3aLRqDZt2qRXXnlFJSUl+7+XAABgRPHUbJC3fIkiE092Lt/5+je1tnqpzk75pSbo8rjfYw4bTCVQmtPDauRUOx0sJiiafqRp3j6yfle3ukta9pa0K2WuCmv/pQsCx2lpsjutsU/YNcQ0RsP8Zu3tpp5vZP2OAABgbBt22HXWWWf1aST77LPPOl97msJ4xRVX7N8eAgCAEcdqq3dO7VCm83qfHsyS30rR+JBbKRRP2RiawhiLmZYPUl7uyAyBTGVXYYFH6zadpc5phapPO7bP9d1h11AN6g1/QGpoOIg7CgAAcDDDruOO2/1p35tvvqmcnBxNmjQp7lgzdTE/P98JyN7znvfsy34BAIARzGrvCruSMp0Pw24/7V498++IggHPsFZiTHQtLW6T9+xsjUg+n6Xx4716d2ORdmYPfEB6enbtobLLdKswK06acG+kNOEHAAAYdth177339pyfPn26Tj31VN1xxx3cgwAAjOHKLoUynZOODika8SrQVREUz/aulRgnjIHKLhMAlUyQkpJGbgAUCrn79mrtb7Wp5T+al/lhzUg7f696dgWCUkebmcooJScf9F0GAAA4sGFXbwsXLlQyRzQAAIxdPZVdWc40RhN2hcOmP1X84a1ttnbtcs8XJ3jYZe6PSMRMFRy5QZcRCkmmQ0W0aYnOqH1VJe1BxbrDrl6rMZrfp3cri96CAamxXmprI+wCAACjPOwqLh4D8w8AAEB8Jvzo1bPrhodPVbInT3OiP9N4T/yFacq7pjCaaX0pySM7BNpfJvhJShq5Uxi7JYUsJ5yc7zlRl3a8qmZ7oxZ1XWcWETD5lgntnCmZqYNPh4xEbbW2STmHcucBAAAOdNjV7fXXX3f6d1VXV6tzkHWnzSeB3/ve9/bnxwAAgJEk3Co7OUtqa1B1rE1lDe/Ko81akJyzxymMY6Ffl5nCmJcrpQ0xpXOkTGP0myPB0FWK6WdK7axWqKNS7cFCZwXJrExbtXXSzp2Dh129Az4AAIBRHXY1NTXpk5/8pJYsWeKUtg+FsAsAgAQTSFHrx//jVHhly9YfLn1Ri1ZukK8qOeFXYmxstNXaKnk8ktcn+bx9z3u9Uke7VFhoDTr1b6QIBt0G8+2RFDWlTFdGy2plNi1XVbDQuT4vT07YVV0tTZ48+O2Y37m52RwPjuzfFwAAjB37FHb96Ec/ciq6SktLdfXVV2vixIlK6V62BwAAjA2WJY8sTcyargr/NFUO0q+rz0qMozjs2rXL7cVlqtNMfzLTlD0cMY35uxr0R92v1DQpZ4RPYTTM6onm8K1sZ63Kk0qdsCuraZmqct2+XXn50vp3pJ3Ve25SX9+1XgEAAMCoDbuef/555ebm6v7771dmprsKEwAAGLuaWySff/BqqMZGtwdUcZFGpZ07TZN2af5cS6WluyuYYjHbCb5MCOacRiU7JmVlaVQwvbnWbH1IW1of0PeU6oRd3fLz3FNT2TUU06Te9Ozq7LQVCFDdBQAARvE0xtNPP52gCwCAMci76UUF3vyDwhMW6E9JHSpInqy2jgsUGGQpxu5+XSY8CQZHVxhi2jXs2CEF/NK8uZaKi60B1VFmOqD5Go3MYgEBO0Mbg5lSa0Rpre/IG2lW1JfaE3btsbIr4FZ2mb5d5jwAAMDh5tmXbzLTF1tNwwoAADDmeOq3yVu+VJ07V+me5T/WzxZ/TtGw11nZL5GmMJqgq7LSNHKXjj9uYNCVCExIN9V/pT565NtqDU5Q1JuklPYtPdMYDRNkdXQM3qPVPO6mqo0m9QAAYFSHXddcc43eeOMNbd269cDvEQAAGNGsNrdBUyyUrvdN/aBOKLpI0YhHPl/ihF1memJFubui4oLjLBUUJF7QZQRD7vRS8/u+PvPPem7+YjWmzuqp+upuyVpTM/htmOo2s16RmcoIAAAwasOuK664wgm8PvKRj+ihhx5SVVXVgd8zAAAwIlntdc5pcnqJvnDqT3XjzJ87vap8PituddRoC7ucoKvC7bu14HhLeXmJGXQZoeDuyqyOYIFkeftcb1ZkHM5URhOYtbYOvUI3AADAiO7ZNWPGjJ4D2K9//etDjjXLbq9Zs2bf9g4AAIw8XZVddshdpMasRDiY2jq34sfrlQoLNOJFo7bKK6Rx+W4z+oyMxA26DDNFs8V6V89X/UhpwWxdWPD9Ptebvl1btuy5Sb3p1dXQcHD3FQAA4KCGXYWFhfvybQAAIAFY7W7Y1RlIkomC2jts5zSe7qouc+gQr/JrJGlptbWrWioqcpvRp6WN7P09EExIFfM1aX3bE8oIj9f0LXcor+5FvT31R2pIPXp3ZdfOPd9OQ6MbFnq9iX+/AQCABAy7nn/++QO/JwAAYFSw2twSnh8t+Y7eePubunbCg/L6pscda6YDGsVFGpFMlXpTk9uEPSkkTZkizTrKUnLy2AhsTAV+UXqJTmn6rvIzs5RcuVApHWXKbFruhF35+cNfkdGsXdTerp4+XwAAAKMq7AIAAGOYxyPb41NZ5y7Vx6LydowbdCXG7ulv3aHJSGEqkOobpJYmKTVNOmqmVDLBUlbW2Ai5ehuXmaPpO27U+AxLdc11yq9/UVlNy7S18DpnGqOxa9fQVVsm7DKBoVmRkbALAAAkTNjV0NWoISMj40DdJAAAGIHaPvwPUxKlH4ZbtK1+szYuzRo1YVc4bKuuzq1AMg3oj5wrjS+2lJo69kKubk4VW8xtLl+XPtc5NWGXeYzNYV13A3vTfy0vN/5tmCmqJgxjRUYAADDqw66XXnpJ99xzj5YtW6Z2c9ToNDoNae7cubr22mt1+umnH6j9BAAAI4llKSmQqgmps7QubCspeeAQE37sqnXPd1cIHc7piiZ4M6FNbq507DGWigqlYHDshlzdAsGYGmJb5TfHcskzFLUCCoZ3Kbl9q1qTJiovz12d0tx/g4VdhonLTGUXAADA4ebZ12/83ve+p0984hN65ZVX1NbWptTUVKWlpTnnzTZz3R133HFg9xYAAIwoZiXGcMSt/unPTH2LxdwpbunpOmxiMVsV5e7KgyedaOn0Uy1NmmgRdHUJBKJ6sO0k3bnlLLWpQ42ps5ztWU3LndPugGtPTep9Pqmx0a0QAwAAGHWVXU8//bRT0ZWTk6Obb75ZF198sRN0Gc3NzXrsscd05513OmPmzJmj888//0DvNwAAOAys2k0K/fsb2mqF9e9pJ2p66nmKRKY6QUd/3U3NzYp+phH64Zq2aKqSCsZJc48dmz259iQlya+glSGv5VPE7lRd2lxnGmNm0zKV51867Cb1wa6+XaaK7nA93gAAAPscdv3tb39TMBjUX/7yF02aNKnPdabC68Mf/rBOOukkXXLJJbrvvvsIuwAASBCe5h3yli9VMODXXc0v6ZOzp8i2p8YNN6p7hV2HQ0eHrR07TON5N+hKSSGAiScYlG7OXyuvT0rzWapNm6e85JfVFizuMwW1+/EcjKngMzMhOzvd2wQAABhVYde6det0wgknDAi6ejPXmTFLly7dn/0DAAAjiNVW75x6U/J17hFnaFzwKG3THprTH4awq7nZVm2tNHWKdPRspizuKaQKBN2gyqjJOt356tYdVpppjENVbZmAq7VFTpN6wi4AADDqenaFw2ElJSXtcZwZY8YCAIAE0e6GXbk5M/Sl036hFLtU1iBHE4ersqu+3pZZJPro2W4jeprQD82EV6kpbvP+eExDf5Nvmf5sTU2D347p29YZpkk9AAAYpWFXSUmJ3nzzTbW2tg46xjSqN2PMWAAAkFiVXXYo0zltaZH8cerETQXQzkNc2eX8zJ22M41u3lxLR8205PMxdXE4FjX8SM823aId7Wt7tlmxToU6Kp37MDt7z327nIovm7ALAACM0rDrfe97n3bt2qVbbrlFW7ZsGXD9tm3b9KlPfUq1tbU677zzDsR+AgCAEcDqquzqDCQ74VJLa/yVGE0FkKkEMvlHTs6ha0Qf8EsLjrM05QiLJul7YX3T89oYeUQNkXLncm7dyzrnzeN1zIbP9e3btYcVGU2Vn5lCCgAAMOp6dt14441auHChXnvtNV1wwQWaOXOmiovdJqYVFRVavXq1otGoZs2apRtuuOFA7zMAADhMrLY65/SPa36rSFJMRZ23xQ27uiuATEXQwayuamm1VW92yZZy86Q5R1vKzaGaa2+dW3qj3n6nTrmBqe79mjRZXrtT6S2r5Y22KD8/WWvX7XlFRtP/q6FxXx9NAACAwxh2hUIh3XvvvfrJT36ihx56SCtXrnS+el9/9dVX63Of+5xzHgAAJAhbiliWGixbRYFCp89TvJf6g9mcPhZze3KZ6rGkkFRaYlosWM7PYtrivjlr0hXSVlsZXveyWYmxJThBKR1lyml4TXl5Zw9rRUbTmL65SYpEbB4LAAAwusIuIyUlRbfffru+8IUvOJVcO80SPeagNj9fRx111LAa2AMAgNGl4/wfSuf9QB/rqFdtvVevbzQB06FpTt/Zaauuzp0emZlpqrikoiJLWZlUcu2vYMidAmrCS68JvCxL1VmnK6XqL8qre0n5XWHXcCq7mpvdvl1pafu9WwAAAIc27OpmQq358+fv780AAIDRwqzeF8pSQ8xWJBq/gudAh13VNbYine7tTZxoqWCcqSgj5DpQolajWj31sjtSFQq53eirM8/QRBN21b+kvBkxp9VrY6PU3m4Pet+bsMssEEDYBQAARl2D+paWFq1bt85pQD8Yc50ZM9SKjQAAYPQyFVaDOZArMZopce1t7gqLp55iaWKpRdB1gP3pre/orpoFWtZ4T8+22vT5iniSFQrXaFxsXU+l1lBTGb1eS7EYKzICAIBRGHbddddduvTSS1VWVjboGHOdGXPPPbsPmgAAwCgWi8i+92KV/el0Pbf2HnUOEnZ1dLg9tQ5UZZf5bC03x/TlcsMUHHhJvmT5rJCiUVPB5bI9AdVknOScz6t/seex3NNURsNUdgEAAIyqsOuFF15QSUmJ5syZM+gYc50Z89xzz+3P/gEAgBHCam9QWvU7mlG/U4srXnJWQnT6O/VTXeOepqZIycn7F05Fo7ba26UjjrBoeH4Q3bzgO/rx8Zs0x3trn+3b8y/X+pLPqzLngp4qvT01qTerczY02gdxbwEAAA5C2LV9+3ZNnjx5j+PMGDMWAAAkgLZ656TDF9Apky5SS4sbbBzMfl31DVJWllRctP+3hcFZlqWkJMssttlHTdZp2lx0o1qTJg67ssv07WpolGybwAsAAIyisKu9vV2heOuM92PG0LMLAIDEYLW7YZc/tUCnTTz4YVcsZqu5STpishQMMn3xYAsFh74+P989rXYX4B4y7DLVeOYLAABg1IRdBQUFWrly5R7HmTH53UdGAABgVLPa6pxTO5TprLgXjki+OOs679x5YMIus/JfRoY0vpig62BbWfW67ln3Ra2N/MFZEKA3X6RJhdWP6xTP3c7lXbXuogGDCQZ3r8gIAAAwasKuU089VeXl5br7bvegJ54///nPzhRGMxYAAIx+0Ra3GVc0lOasxBgOD13ZtT8rMZopcCbsmjRx//t+Yc8qmjZr4da/aHvsRUUifa9Lbt+mORu/otk1v1JKsNNZbXGIBbmdANT8bbRR2QUAAA6TOJ/H7tlNN92kxx57TD/4wQ/02muv6corr3Sa0Rvbtm3TAw88oJdfflmpqanOWAAAMPo11m9UqqSXq17R5EHCLtNQvmaXez5vP4q7m5vdBvcTxhN0HQpTc47WNXO+qF1bjnCqsnp3q2hMmaF2f65C4RqdOWmJnlx3klO9N1jxvun/Zbp/tbYekl0HAAA4MGGXmcZ455136tOf/rReeuklJ9jq/2lsVlaWfv7zn6u4uHhffgQAABhhOjoa1Wl6aYUy1NFpempJHk/fMKqu3gRebnVPZsa+/6z6Omn6dCk9nbDrUJicPdP5WtgQU3NLvystj6ozT9eE6od0euFLbti1hyb1lscElmaqI48fAAAYJWGXMX/+fD3zzDNOFdfixYtVWVnpbC8sLNSJJ56oK664Qhmm0QYAAEgIeef+QJ3v+b7mhZtVVmYqeIZuTt8/CBuullZbwZBUWkJQcqilpbmBZX/VWW7YNTflJUlfUXX10I9NICg1NBy8/QQAADgoYZdhwqyPfexjztfhdtZZZzl9xOI5/vjjde+99/bZ1tnZqd/97nd6/PHHnaDO/C5nnnmmPvvZzyonJyfu7Zix99xzj9599135/X7NnTtX//3f/62jjjrqoPxOAACMOJalYCBN7e2xuGFXT3P63H3/EXW7pMmTpexswq5DJRqLqrmzQRF/h8LhcQOu35VxomKWXzmeMk1M3ayd1ZOHvL1gQM5qnaaRvc/H4wgAAEZR2DXSpKWl6brrrhuwvf9UylgspptvvlmLFi3SMccco3PPPVdbt27Vgw8+6PQgM9Vq2dnZfb7HTNv82c9+5tzW1VdfrZaWFj311FPOedOof968eQf99wMAYKQwQUa8lRh7V3bti/Z2W16fNLGUgORQ2ly3Vp947BxlBMbpcv/yAddHvSnalb5AeQ2LdNq4l/T3sslO2wrTnyueQEBqapRa26T0tEPwCwAAACRq2JWenu70EduTRx55xAm6LrzwQv34xz/uOVC777779K1vfcsJtb7zne/0jN+yZYt+9atfaeLEifrHP/7hhGrGhz70Iac5/+23364nn3xSHs8+LW4JAMCIZ4KNdX86WelWQFnn/1QtLXPkG2olxn1sTm9W+SsuknL3ozIMey/oczvSx9RvKcZeqrNOc8KuCSllThN7M00xM1ODhl2mr1sbYRcAADgMxmQ6Yyq4jM997nN9PpE0VVoTJkzQE088ofb23etlP/zww4pEIk41WHfQZcyYMcMJzDZu3KilS5ce4t8CAIBDp769Rkc07tKR9TvkjXplXib9voGB2M79qOzq7LRl29KkSdY+9/vCvilOn6x/Xb9dfzhvlXxed/phfxW579cLc1/S7yq/4Vweqkm9efzsmBt2AQAAHGoJFXaZPlwmmPrtb3+rv/zlL1qxYsWAMR0dHc72SZMmDZjeaIKvk046Sa2trVq1alXP9jfeeMM5Pfnkkwfc3imnnNJnDAAAiSjoDSmzqyDc9ucrHJb8/oFTG024YT5Hyo3f/nKPVV3j8t0vHFoeyyOvx6dQSPIHpM7wwDERX4Y6AnnKz+tbxTcoS2ptHRiaAQAAHGwJNY2xurpat912W59ts2fP1k9+8hOVlJQ4l7dt2+b07DJTEuPp3m6mLpoVJ7vPJycnKy/Ox9SlpaXOqen5BQBAokqO2fKYUh1JbVamwhEpvV/Y1V3pY6a2BQJ7V5llKolMgDZ5kiWvl6quwyUYdCv2wp2SkuKPMYdDPiusnTvjzGPtN5WxPs7KjgAAAAdbwoRdl112mdMkftq0aU4wZQKqu+66S4899piuv/56ZyXF1NRUNTU1OePN+Xi6tzc3N/dsM+f7N6zvP777dgdjVntMlJ5eWVlZh3sXAIxQPD8kLru2we3m5E9SKDVffn+HMjO8fdoBNDaahKRDhQVepaYk79Xt79gRU2mJpRkzAwr4CbsOx//sz176itrCLZqRfbs6m9OVmjLwuMXfsUO3Zn9GX33PBn1604tKTYl/PGV0ZsYUjZljoCDTUoFRiNd0YGzKSpD3+wkTdn3qU5/qc9n00/rhD3/onDeBl+nT9dGPfvQw7Z1p4tqgRPnDr6urO9y7AWAE4vkhsW1d+4yOMg3MgxnaubPBmZ7W0to3lNq+3Z2ylp0dVXPL7g+N9iQWs7WrVpo6xVJLc6taDvjeYzj/sw8s/606om364pE3qrHBq6TkgaGjZQd1TGyVgqFGZbUuV3PL3EHv3HDUVnOtVFnZquQ4twVg5OI1HRibskbJ+/3hBHKJUWo0hKuuuso5XbZsmXPa3WC+d+VWb93be1d+9a4IG2x878b1AAAkmseW/cQ5bfH5nVX24qnex+b0ptdXWqpUWLi/e4n9ceXsT+qaYz6vnPRURQZZlNG2fKrOdPuVHpf+klrbBu/JFfCbXqk0qQcAAIdewodd3YmfaTpvmNUWzXRCM80xnu7tvXt6mfPm+01PsP66e3V19+4CACDRmFUWM73J6pQtb0quU9UVb2b+voZd5nOj3FwpKYnqn8PpurlfdL6yU+O3bui2K+cM5/TUgpeGbFLv91tOaMaKjAAA4FBL+LDr7bffdk67V14MhUI6+uijtXnzZpWXlw84mH/11Vednl+zZs3q2X7cccc5p6+88sqA21+0aJFzevzxxx/U3wMAgMPF9OW69oMvqOOzaxT9wF1OJZavXyOEcNhWXVcz8u7V+oYrEjYrMBJ0jRRmRcbu46J4ajJPUdT2aFr6O2rfUTH0jVmEXQAA4NBLiLBr48aNaovzsaHZ/uMf/9g5//73v79n+5VXXumcmlUaex/I/f3vf1dZWZkz1oRivZvf+3w+3XnnnX2mM65du1ZPPvmkjjjiCKc5PgAAicwy5VzegFpaTdVO3+uqa0w4YqqzpJSU4d9mR4etQNBUYh/w3cVeCkc71dzRIK+vwwkzB5vKGPZlanPkGOd8YePLQ96mxys1NQ8+1REAAOBgSIgG9U8//bSz8qKpwCoqKlJSUpIzHfHll19WOBzWxz/+8Z7qLOPSSy91vscEVdu3b3eu27Ztm5599lmNHz9en/3sZ/vc/qRJk5wG+D/72c908cUX69xzz1VLS4ueeuop5/rvfve7CbPSIgAAQwmHpc7OOGFX9e6qrt4rNA5nCmN6mpSezv1+uH3+n5dpzc4l+uopf1LA/z7nse7/OHfb7D9dU7RMU+yXtFMfHPQ2gwGpvqviDwAA4FBJiLBrwYIFThWXqbRasmSJ2tvbnV5dp512mj70oQ/plFPcRqrdTDBlqrR+97vfOSs13n333crMzNTll1/uBF3Z2QN7Vdx8883OVMg///nPuu++++T3+zV//nx95jOf0VFHmfWpAABITHcv+4EmrXpKx/nHyXvMZxUOn9gz1W1/+3WZlppHTJa8XqYxHm5Bb5JzGlWbE3KZsGsw1VlnaNG6N/V649nOKp2DCQSk1jYTkNoKBHiMAQDAoZEQYZfpl7W3PbMCgYBTrWW+huuiiy5yvgAAGEtW73hTC+orlB+pVvWUXU6Prf49u/Yl7IpGbZkisOxsQpCR4Dvn3C2fx+98vVhpq6Fh8LH+oin61J//z3n8vhO2nWb08ZhQtK7WXXHTBF8AAACHAnPvAADAkP7ruG9oavJ453y7J1ORqAm7+oYbO/ch7DJVXSnJUlYmD8BIkORPkd8bcKahpqVKnUNUdqWmukGW6dO2a9fg40w1l7mdxsaDsssAAABxEXYBAIAhTc09WukxN9xqtwYmU7GY3adn197068rNNU3tqewaaVJTLEUHaVBvmECsMC+s0pTNsqpWD3lbpvqrvoEm9QAA4NBJiGmMAADg4LLa3S7jbRoYdtU3uCv3eb17t6qi6Qk1bhxB10jxetlzervqNc0uOEHjQufscfxpExbr1mM/ocqWqVqhxwYdZ1bo3LnTVIGZaas83gAA4OCjsgsAAAxqW/0GLd70hKxIu3O5MZLphFq9dVd15eYMv9F8R4etYHDvwjEcXG9VvqL7V/5aKypfVSjobjMB1WC8uSXOabZVJtmxIcOulla3bxcAAMChQGUXAAAY1MtbntDTS36kc5Qp2+NTQ1uKs1Lf/janN1MY09OkjHTu/JFiTsGJJt5yTk0/LvM4m4q9/o93t8yJRYps8iroaZevbaciyQVxx5nbqt0lNTW5vb4AAAAONiq7AADAoNICmZqRcaSiHq/sUIZa26wB4YeZorYvzekLCyWPh2ltI8UJJefq48d/yzk1VXcB/9BN6vPG+VXZXuycb92+ddBx5jE2BWKNTQdjrwEAAAaisgsAAAzq4pk3OF9tpjl9c7vCL5oV9vqO2dvm9NGo6d0k5WQTdI1UJuzy+aVwp6Tk+GNM/61alWiCtqlzxzYFpi0Y9PYCQammxtaR03jMAQDAwUdlFwAAGJaOaNBpKj/oNMb84Vd1pabQr2skisai6oy0O73XkpPcRQSG0ppU6pz6Ggav7Oru21VX7/ZqAwAAONgIuwAAwLB0dGhA2NXaaqu5q/F4Xu7wbqepWcrNNb2cqPIZSRZufFjvvbtYX3/uWudyevqewy4r221Snx7Z5lTsDRV2tbW6jz0AAMDBxjRGAAAQ16odb+j7L92ia/2lusjKVyjnHNn2JX36bFXXuKcZGWbq2/DCq0hYys8n6BppAl53CcaOiJm0KqWkWEMGWEa4aJ7+sOQWLa+erTkVUsmE+OP8fkuRiK3GRnfVTgAAgIOJsAsAAMRV1vCuqprLlOlJkq92tbyeIwaM2dvm9O3tttMPKiuLO32kWTD+bD30oTUK+ZKcyyE3+xpSS9pMPR+boTU7pfTNg4ddhscr1deb8IygEwAAHFxMYwQAAHGdVPJe/fT8RzUnc7pzud2T4TSWj9uva5hTGM2Ux/Q0KSOdO32kCfhCyghlK9gVdplQ0jzesdjQ1V2TJrmnmzYPfftmKmNNzZ5vDwAAYH8RdgEAgLgyQjmaXXCCMmLu5RY7Sz7fICsxDrM5venbVFioPlMhMTIFQ25/tkhk6HFHTyjXSXn/UWtl1ZDTHpOTpZYWqZm+XQAA4CAj7AIAAEOy2huc06ZohnyDrcQ4jGmMJggxlUI52QRdI1FDe63+8tZPnC/DrJiZFJLa3BZegzqr9dv6zYmf0LzMV1RZOfi4QEBq75Camg7wjgMAAPRD2AUAAOJ6YdOjenXbv2S31TqXm6OZ8veq7AqHbdXWuefzhxF2maoeE6DQr2tkags36+5lP9R9K37Z01TerJrZ0jr097WGSp3TCSnbhpzK2F3N19DINEYAAHBw0aAeAADE9cvXvqrGjlqd1TbeudxqZzrT2rrt2GH6L7nT09LShtevq2S8FApR2TUSpQYzdcGR1yjkS+7Zlptj6d2N9rDCrpKUrXpus3TaqYOPNX3AnGrAGQduvwEAAPoj7AIAAAPE7Jhmj1ugXS0V8jS7Sy4225lK7RV2VVa5p0WFppH5ngOsSNj09iLoGqlSA+m69eQf9dmWkeH27TJVfKbSK57WUIlzWpKyTZtXuQ3oB+vJZprUNza6q3ISegIAgIOFsAsAAAzgsTz69jl3OefNLLYd21vV8kpQmb2OHLr7MxUU7vkONOGGqephCuPoYsKulBR3CmpmZvwxLb2mMZrHuarKUlGRBg27djS6fbtCoYO44wAAYEyjZxcAANij9miSbFl9KrgqKndXdg1nCmN6mpSRzp09Gqr6bNuduujzWcrbQ9+utmCRbHmU7GtTbrBmyL5d5vbM1NdGmtQDAICDiLALAADsUUdn38smDOmu7Cos2PP3t7VKhYW7m5RjZLryvqN17l1FKm/c1LMtJ8dSLDL499iegBN4dfft2jxE2GV4vVJtLU3qAQDAwcM0RgAAMMCT6+7VAyt/rQ/nnKSLG9uUo9nyeD7Rc31dndTR4QYXeXtYiTEatWUKwnKyCbpGi45Ie8/5TNO3KyB1dtoKBOI/hu+O/6RqdklbWiaqfcvQfbvMggZmbCRiO5VeAAAABxphFwAAGKCqeZsqmrYoOXCEfJuWKTkzJl/WwOb0+fnu1LShmH5PqSn06xoNfn3RM/J5/EoP7n6w09Pdvl2trVIgEP/7KvIuUTTbVlNMCndIO3dKBQWD9+2qr5eamwfvAwYAALA/mMYIAAAGuGzmx/TT8x/V3KzZzuVWK9NZla9bzxTGYfbrys01Dcmp4hnp8lKKlJWUJ69n9+ehJszMz3NDy6F4vZZK3V71Q05lNIGZqQqkbxcAADhYCLsAAMAA2cn5ml1wgrK6isDb1Dfs2pvm9JGwqQAj6BrNsrPdxvKD8UZblFP/ii454mnn8lBN6s0iB2aGY2MjfbsAAMDBQdgFAAAGZbXXO6dt/Sq7qobZnL6jw1YwKGUxXW1UeHnzE/rbip9rU+3aPttN366A33084wl17tBx6z6mq0LfMC3rncqu7hUd445Pcqc6DjUGAABgX9GzCwAADPD0+r8qI5SjM1trncttdqZ8XUcN7e22auuGN43RTGFMS3X7PmHke2bDfXpj+/PKSR6nydkzeranpe3u22XCy/5ag+NlyyO/3aZxKTXa0ZKn6mq3p9tgfbtMz662NrdhPQAAwIFEZRcAAOijI9Kmn7zyeX1z4fVSW21Pz67uRvTd/boyMkxQMfT0xNYWt1G56eeEkW9e8Rl639QPqihtYp/tTt+ufDfsisf2BNQWdJPP+RO37bFvVyjkBl307QIAAAcDlV0AAKCPjmi7Ti45Tw0dtfLWdbrbPJny7mW/rljMnaKWk03QNVp84Kj/GvQ68ziu73pM42kNlSq5o1yzi7fpqdXznL5dCxbEH2vCz5htq6lRKhh3IPYcAABgN8IuAADQR3owS98+5y7nfJuk9avbVLnSo/Fd11dWDW8Ko6kCSkmWsrK4gxNBekb3SoqmD9vAALM1VCI1vKqpWVudy5u3uD25TEP6eEwPuF21tqaKMBQAABxYTGMEAABDamoPytOrO/1wm9O3tLhB156mOmJ0SE+TUlOklkGmMraESp3TwtA2eb1mtUUTZg1+e6ZvV22tFA7TpB4AABxYhF0AAGCPoZW/qxY8GrVVtcM9X1g09Pd1dpgpagRdo8lf3/qZLrxnsu58/Ztxpx6avl1tLfG/16nskpTSsU0TusoAh+rbZcKu1japqenA7DsAAEA3wi4AANDHn5f9UNc+eIKeWfpTBR+5WdM3fseZcmbU1EiRiDudLXuI6YmmWses3sgUxtHFlq32SKvawi2D9u0ybbvM9MT+GlJma+Xk/9WaSd/QpEnuNtO3azCBgKXOTsIuAABw4NGzCwAA9FHZtE0VTVvkb6uTf/OLKvAVyFfcdV2vKYwejzVkNVhKqrtiI0aP90+/VmdNvlRpwcy416enS8Gg6dvlrqjYW2cgV+X5lzrnJ0+y9cKLQ1d2GV6PVFdvq7SUCkAAAHDgUNkFAAD6uGn+1/TT8x/T8dlznMvtnsyeyq7hNqc3YZdZZc/vJ8QYTTJCOSpKnzho2JW2h75d3UpLTRgq1ddLtXWD9+QKJUnV1btX7gQAADgQCLsAAEAfuSmFml2wQFlyE652K2t32FW557DLTHGLRqXcHIKuRNPTt2uQsCutZY0m7LhfuZ2rNL54eH27THBmVu4EAAA4UAi7AABAXFZ7XU9lV/eUxYphhF1t7W6IkRm/OAgjWGXTVj2y5g9auPHhQcdkm75dsfh9uybseFBHbf62xtUuHFbfLjMVsr1NaqRJPQAAOIAIuwAAQI/OSLseW3uXXtn6T6nJnbPY6slxTpuabDU3S5blTlEcagqj6e2UmsodO9psrVuvXy/+uh5e/btBx2SkS0kht2/XYCsyJrdv0+SusGvzpsF/nglRTWRWX880RgAAcODQoB4AAPSobq3UL1+7TSFfss7KOM/Z1uQv6TOFMTfHXUlvMKZS58ipQzewx8iUnzpep0+6SMXpkwcdY/p2mcUHTKjZv0l9S6jUOU3u2KaJ08y0R9OzS6qosFVUFP/vITlZ2r5dmjbVrODJ3wwAANh/hF0AAKCHJUunlJ4vj+WRp7rR2dbaFWAMpzl9NGrLZFzZWYQWo9Hk7Jm6/czBq7oME2KOy7e1dt3glV0p7VsVDEgzZ0grV0lLl0tFRfFvz1QBmib1NbuGrhgEAAAYLsIuAADQw6zE962z/+Scb4nZWvjPJoXtgNKH2ZzeVPukpNCvK9GZvl12zHb6dllmXmuXttAE2bLki7YoEKnVvHnZTtj11nLpvPfGr9wyK3aa1RirqmwVjCMkBQAA+4+eXQAAIK72dqktlipvKDDs5vQm7MrNNdPbCC0SmenbFUpy/0Z6i3mCag8U9PTtmjrFnfZoVlxc/87gt2fGbC83fcDo3QUAAPYfYRcAAIirrc1tQh7wS+GwrZoad3vREGFXJCzl5xF0jVZ1bdW68r6jddlfZw45ziw+kJrihliDN6nfKq/X0rHHuNuXLhv69pqapJ3V+7f/AAAABmEXAADo8eP/3KprHlygdS99S7nP3KipDX93ppnt2CHFYlJKsluFE4+pygkEmMI4mvk8ftW27VRjR60isfCQfbsKCqS2OGHXhgmf1usz79HOrDOdy3OPdbevWyc1N8ev3DKhmNcjlZdT2QUAAPYfPbsAAECPyqatzldmoFwpO15TRsoUNfdrTt+7R1P/KYwmCMvI4A4drZL9afrtxc8p5EuSx/IOOTYr0/wd2E6/rd4rb9anze0zrqDA0vhi25mmuOJt6eST4t9eeoa0c6cbiKWmUh0IAAD2HZVdAACgx5dP+6V+dsHjKo66FTaN/q6VGIfRr6u1RRo3zq3Swejk9Xg1JWeWxmcc4azIORQTaoZCUnvHnm937tw9T2U0Cxs0tzCVEQAA7D/CLgAA0CM/tVizxh2vYGNVn/5Le2pOb6p7TDyWk03QNVaYPlvp6W7I2Zsn2qbxOx7U1G0/k2w3NJ0zx4SgUkWFCU7jT1U0FYPBoLR9u7vKIwAAwL4i7AIAAH3ForIatjln25NLneChu7JrsOb0ppl9cpKUlcWdOdq9sOlRPbb2LtW3da1IMAgTThWMGxh2ybI0a/M3dUTF7+SP1DmbUpItzZjuXr10+dDVYtU1Un39fv8aAABgDCPsAgAAPSvxPbbmT1rxzkOyomFF5Vc4pVB1de6qjKYyJy8v/p3V3OwGXSkpVHaNdr9/87v65Wu3qaq5bI9ji4osJSWbVRl3V2LFPCG1BQqc8yntW3u2z5vnnr61XIp2TZPtLxSynL+1HTup7AIAAPuOsAsAADi21q/XLxd/Vc8v+X/O5SbfBAWC3p7m9EP14zIBhWlEjtHvuPFn6dSJFyjZn7rHsaZJfXGRVFfbd3tryO31ltzuVgga06ZKqV19uda/M/htJidLZWVSJELgBQAA9g1hFwAAcCT5U3VK6fmamTldkWCWGnwl8vms3c3p3WKdAcJhWz6fCT64IxPBrSf/SN88648qyZw6rPElJZa8Hqmzc3c41d3rrXfYZYLSY47dc6N6M5Wxrl6q7RegAQAADJdv2CMBAEBCOzL3GH3r7D8551e+a2v5kg4VDaM5fUuLW7GTSdg1JuXnuVV/O6tNdZ+7raUr7Oo9jdGYd6y0aJG0bp079dH08urP77ecaY5VO2zl51MtCAAA9h6VXQAAYICWFlsxb8A5XzWMsCs/3w0pMPZ4PJYmTrQUDu/uxRVvGqNRWOhOe4xGpRUrBr/NtDRpe7mZHstURgAAsPcIuwAAwACNTVLAL7W326qtGzzsMis1muAiL5egK1H8/NUv6+q/H6tnNzww7O8xqzJmZ7nTD/uGXVvNH0mfsXPn7nkqowm7GhukmqEXhAQAAIiLsAsAADi+/MxVuvb+42T9/kwdu/q/lOJt7OnXZaYoJicNDLTa2qWkJKYwJpLmjgbVtFaqubNh2N8TCFiaPNlSa4sUi9lqCZXqjRl3adHRjw0Ye8wcd2XP8nKpqip+5Zbp72V5zBRaKrsAAMDeI+wCAACOyqatshvLldJUpfyWN2SFUnpWYhysOX1To5STI6Wncycmiuvmfkl3XvSszj7isr36PjM9MT1NamqSbE9AtRkL1BEskKy+IWlKiqXpR7rnly0f/PbM35QJW82UWgAAgL1B2AUAABw/Ou9B3XHc/zjnm3wTFAh6h2xOb6YwdnRI44ssWf0CDYxe4zMma2ru0coI5ezV9yUnWyopkRqGURA2b97usKu7z1d/KSlSc4tUzVRGAACwlwi7AACAY1zqBE1UyDlf7yuVz2cN2Zy+rc2dwpibyx0I14QJlpJC7kqLmU3LNHXbT1Ww658D7p4jp3WFWc3Shg2DHKR6LAUCUlmZ7QSrAAAAw0XYBQAAdh8Y1G91Tpt8JU7FTdWOwcOuxkYpN8dtJo7EsbVuvf797oNaWfX6Xn9vVqaloiKpvlbKalquIyp+r/za5+P25DrmmD03qk/PcJvUD6daDAAAoBthFwAAUHnjZj265o9qqnSbKDX6S52QIRIxzcfdlfZ6M5U2nZ1ScTFTGBPNa2XP6gcvf1rPbPjbPn1/aanbXL7BV+JcTm7fFnfcvK5VGdeslVpb41dumUURTAVhdfU+7QoAABijCLsAAIDW7FyiXy3+msK73nHujdZQaZ/m9GZKWW+tbaZHE1MYE1FR+iTNKz5DpZldXeT3Ul6uNC5fqmh3w660tg0qqfqbfJGmvj+n0HIqBqPRoau7klKkbWX2oL29AAAA+iPsAgAAyk7K1ykl5yuWlKUOT7raU0pUtt29Y8y0tP4aG9xQIz2NxvSJ5rSJF+oH7/27rpz9yX36fjNFcdJES7s0UW3+cfLG2jVzy//ozGWna9bGr8mKdfaMPfEE93Th86Z/V/wwKzPDbVJfXr5vvw8AABh7CLsAAIDmFZ+ub53zJ3muel4PTn5N4eRCbdns3jETJw6cwhgOmxCMoAvxFRRImdkBPTnhEa2Z+FU1JU1xQq/Utk2yPYGecccd2+lUd7W3S8/+O/5t+f1uo/p16221t1PdBQAA9oywCwAA9DChg+nFFYtZquhaiXFSv7CrpUVKMVMYc7jjEF8gYGnyJEu1bRnakv9hvXL0Y1p81F+0vuTzPWP8kXqd/daZ+slp31Cav0FvLpG2b48fZpkVP01116bNhF0AAGDPCLsAAECPtna3Kb2ZMmbbUk6OlJ7et4KrsUnKyzOrMFLZlYjW7FyqGx46Vbf964P7dTtm+mt6mtRkWnVZlurT5qoufX7P9fm1CxWI1GtG20P68Wnfdf7eHn/CBK0DAy3TMy4zU9qwQaqrJ/ACAABDI+wCAAC64eFT9e/fHa0JT5yt6a0PafOW+FVdJoiIMIUxoUVjEW1r2KCKpq37dTspKZZKSqSGhvjXl+ddpiVH3ilblhak/FPz85dpW5m0/K344zMyLLW0mcDLjhuIAQAAdCPsAgBgjDM9uCqbtim/vVWpbZXyWFFt7urXNWlS37GtrVJqitucHolpUvYM/b/zHtbtZ/5uv2+rZIKlpCSpsTFOOGVZqsk6XdvzP+Bc/ObxP5ClmP75jJlOGz/Mys+TtmxVz0qhAAAA8RB2AQAA3f2BRZqXNMG5J5r8JdpeHr+yq7FRys93q3aQmFID6ZpTeJKm5Mza79vKyrJ05DSpvl4Kh+MHWBvGf1oRT7ImeFbpqulPqrnZXZ0xnlDIMhmZ1r9jFkmgugsAAMRH2AUAwBhnWZbGJRcq2FLjXN7cWKpo1EwbM2FFvymMEamwgKALwzd1iqXx46Udg1RjdQbytLH44875Tx35U4W8rXrlVWnnzvhhlukXV1XlVngBAADEQ9gFAABkNVbIikUUsYJ6p2pcT1WXCcJ6r8LoTGHM4w5LZOFopxZteVoLNz6kmB3b79vz+y3NPspScrJUWxc/wNpaeK1agxNUn3uyZh3ZqVhMeuJJd4ptfz6fpdRUt7qruZnqLgAAMBBhFwAAY9yGmre1eIXbn6nJN0Hbyjxx+3WZVRjNFMbkZCq7ElkkFta3nr9Bd7x0izqj7QfkNs10xqOOstTSLHV2DgyoYp6gXjn6Ea064n915nmZ8vmkDe9Kq9cMdnvulNp3NhB2AQCAgQi7AAAY494sf1FvrbnXOV/vKXVWxOvfr8tMYYxFpKIigq5EF/CGdFT+cZpbdJqisegBu92Jpe7flJmCGG81xag32TnNybF06inutqeejt/ry1Qc5uTIWTV0sOmOAABg7CLsAgBgjBufPknFeUdrR3KBtnZOd/pypfSbrmimMKakSrk5h3NPcSh4PV79/MIn9MP3PaCUQNqBu12vpZkzLWVmSrtqBx+X3LZFX5rw31ow/m3V1UkvvRx/nFkkwfSWM9MZIxECLwAAsBthFwAAY9xpk96vCy9/QusXLNT9Oz8Zt19XU6NUMI4pjNg/6WmWZs20FO6U2triB1STK36nwoaFun3+DyTZevElqW6QXl8mkDUrh3avHgoAAGAQdgEAAEdDo1RVqQH9usyUs2hMKixkCiP2n1mZccoRUvXO+NMZN0z4jCKeJI2PvaVrjnnGqTQ0zerjjTXN70NJ0vr19qDhGQAAGHsIuwAAGOPsWEyRzoiam6TyioH9upqb3VUYmcI4dnxr4Y266eHT9U7NigN+2x6PpelHWk5V1s6dA6/vCIzT5qIbnfMfn/QTJfnatWat9PgT8VdnzMmWanZJa9fZikYJvAAAAGEXAABjmgkPbr5nmlJ+NVtnvHups1JeKCQVFOwe09TkXk5KorJrrKho3Kwt9evV1FF/UG7frOg56yhL5i+quXlgQLW58KNqCxQoNVqh773/HpkZtYtfjx94mfDMrBK6/h038IpXAQYAAMYWKrsAABjDGjtqldfRLr+ZrtgZM+vcOavmmQChZxVGM4WxgKBrLPn0iXfoR+/7h6bmHn3QfoaZFjt1qrRrlwY0mI95k/ROya3O+VPt3+u6S6udwOu1xdKTTw0MvEwQm50trVotvbPBjlsBBgAAxg7CLgAAxrDUQKa+NudLzvmylokD+nWZKYxpaVJu7uHaQxwOswsW6NiiU5QezDqoP+fIaZaKi6TKSg2YgliZc4HqU4+WL9aqi/Pu1mWXuttfeVV66umBgZdZnTE9XXp7pbRp80HdbQAAMML5DvcOAACAw8fr8Sqptck5v6G2ZEC/rsZGaeoUKRSisgsHXjBo6dhjJHu5rfLtUmGR7TSdd1gerS29TTmNi7Wl8DodV2o5lYaPPCotesVUH0rnvc/us2poero75q0Vtvw+qaSEv1sAAMYiKrsAABjjPPVbndNNDaXy+6XiYnd7a5sJHqRSAoMxZ1PtGr267V/a3rDpoP+sjAxLC463VFLiVnh1dOyu2GpIm6NNxR9XzBNyLp88t0mfuWiJc/7l/0jP/GtghVdmpiWvT1r2lq2KSqYzAgAwFhF2AQAwhi2vWKTWnSud82UtJSotlbxetxqmdpecKWY5OYd5J3HIPbjqTn3juev0yrZ/HpKfZxrWHzffcqoId+yQWlrjhFS2raM2fVPX63r97P2/kteK6KWXpX89OzDwys2xFI1Ky5bZqq4m8AIAYKwh7AIAYAxbtOkxJbfWOee3tZT2TGFsb7fl80lHTLb6TBPD2FCcPlnT8+YqK5R7iKc0WjpqplRXa6bQ9g2pLDuiiDdVlmydYd2phy68QeNClXrxJenfzw0MvMaNs9TWJi1Zaqu2lsALAICxhLALAIAxbEbmdK1Kz9WqthLtbM/vCbt21Ujji2lMP1Z95Jhb9av3P61zp151SH+uz2dp9ixLx8yRWlqkXb1CKtvj1+ojvqsVU36kiDdFE62leuQ9H9Dp457X8y9If7/fLKjQN9QqKHT7zi1ZZg8IzwAAQOIi7AIAYAw7Z9aNajn+ZX3k3/90pi9OmOBWdZnm35MmUdWFQ8/jsZxVGs20RjtmpjXafaq2KnMv0Kuz/6GGlKOUbDXo5ws+rS/NukNrVnXqpz+T05y+e7ypSiwsknbtkt5camvnTgIvAADGAsIuAADGuBUr3NMJ4+WshGeCAdOkPu/QzWAD+jAh1cRSSwuOsxQKSRUVUiSyO6hqDZVq8VF/1ebC65zLF0/5l6YWN6il1a3w+vO9UkOD3ROeFZnAq0Za9Kqtt1fGnEAXAAAkLt/h3gEAAHB4mOoXu6NJq9ckO59/TZrkroTnsaTJkywnJMDY9PLmJ/TAqjt1TOHJumn+1w7bfhQWWjohIL31tu2s1BgM2s6CCaYK0fYEtL70y6pNP0Ed/hx9aG6e07DeTGlct076yWbpvPfZOv44d3xRsdTUZGvVardabOZMqajQDdYAAEBiobILAIAxqr69Rmt/P08/yZutswv/5fTrMtUvpgomP/9w7x0Op8aOOq2rXqay+ncP+wORk2PptFMsnXiCpbRUqbxcqqmxFY261VnVWaerMXWW0+/r7LMs/fijz+qyWS+po0N69DHp93+QqmvcsWlpllO12NAovfqqrWXLbbW0UOUFAECiobILAIAxqqa1SsVRS0ETfHXm6IRCU/lCVRek+cVn6Dvn/Fl5yYUj4u4w02snlrqVWNu3SxvetVW+XUpJs5WV6U5VNFJbN+jE6q/ojMmdOm7iF/TNZ6/T5i2Wfv4L6dRTbM2fL+VkWyookFrbbK1/R04frxkz3Gm8pgIMAACMfoRdAACMUZPTpygt5pcUU1tyqZqbpMICady4w71nONwK0kqcr5EmELA0ebLbU25bmfTuu7YTfqWl2crIkFpCE1WRd5Em7HxQ53l+pKlXbdLti7+utRsCeuFFOV+lpbaOPUY6erY0frxUWystft1WVZU05QgpO3t3eAYAAEYnwq699Pbbb+uXv/ylli9frkgkomnTpun666/X+eeff3AeIQAADhJfU5U8iqk1kqS0wlzFbGnyZHp1YeQLBi1NnSKNL5a2brP17kZ3eqPX51NT3jfVFDpCM7b9UFMaHtKvj9+qv877mV5ekuWM27rV/XriSWn6kdKxx5pqRmnzVml7ua2sLKlkvJSXJydAo6cXAACjD2HXXli8eLFuuukmBQIBXXDBBUpJSdGzzz6rW2+9VVVVVbrhhhsO3iMFAMAB5qnf6pyWtZQoN9dyqroKqOqCpJbOJm3YtUIey6ujC04csfdJUpKl6UdaKplgq7paqqg0p5YWRa7R9ryJOnPX55XdtEQ3Bj+oYz54pyrDk/TWCmn5W3Ia3q9e434lJUmzZ0klE6TGRqmqylZykpSb61Z/mZVJU1Op9gIAYLSwbLMUE/bIVHGdd955Tqj1wAMPaIZp7iDT26RJl19+ucrLy/Wvf/1LxaauPo66urqEuJezsrIS5ncBcGDx/DD6vPvUl3XM+sf17+oT9c7MP+ics0zzbt7QjxVD/c+u3blMn37yfBWkTtBfrnxTo4lpOF9TI1VW2eooe1enlt+i9Oh2vVT6BzXmnuj0/8pqXKJQ+SK9VX6EXlp3hFZVTVZnzHSvc4VCZiVIKTfH9PiSs3iDO33SUka6Cb7o74XExms6MDZljZL3+2Y/94TKrr2o6tq2bZsuu+yynqDLSEtL0yc+8Ql95Stf0SOPPKJPfepT+/6IAQBwCNWULXZOqwJSaQm9urBbajBdpZnTlJtSNOrulpQUSykppjeXpZZZU1VZcb/aXv2War1TVF8tRaK2xjUs0pzm32lOqnTdfNO1zqOaaLEqWou1raFAd669RZs3F2nzZinV16QXba88wWTlZNvKyHQDsOIiW6Wl5udIpRPcyi+mPAIAMDIQdg3TG2+84ZyecsopA67r3vbmm6Prk08AwNi2LTxbz3e+pQp7vuYfYcnno6oLrgkZU/THy14e9XeHE3xNzZam/kKntttqaZFaWiXfpjkqK7tCoaaNSu94V8FYo/K9ZcpPK9MxaVLVkZ/Uxl3Sjh3S+3x/1NXFv1d9Z4Z2teeqrjNLDW2ZaliboboVWbpt47WqD+coI93WjMLtKsmqUXKqR6lpXqVneJSR6VFaute5HCooVkpGQKGg5LdbZMXCkscnebxdpz7J8hzuuw0AgFGPsGuYtmzZ4pyWmo/v+snLy1NycrK2mm6nCWz5W7a2P3ehpnnXyh8uli+S42yPWR3qCK2XbK9+X/6iIs4i9tIp+TdpduBt+cOF8kXyusaG1RFaK9mW7q74t9rsdGf7CXm36Njgm/KFx8kfcRvG2FZU7aHVzvm/VDyupliBc35e7ud1fOg/zm2a23bGKqb2pFXO+ft2/E314SnO+aNzvqaTk/4tbyRHgfDuKaZtoZVmEq8e3Pk71XQe42w7Kvu7Oi35CXkjWQqEJ/Qau1qyonqk5v+pqv1UZ9u0rB/r7JQH5I1mKNC5+2+iPbRWthXWE7Xf0fbW9znbJmf8Ru9Nu1ueaJqCnZN2jw2ul+3p0D/rvqItLZc520rS79YF6b+RJ5qqYOfkXmM3yPa06d8Nn9a7Tdc42wpTH9AlmT+WJ5asYIf7+xodwY2KeVr0QuONWtf4cWdbXvJTujz727JiIYU6pu0eG9ikmLdZ/2n+kFbVf9bZlp30gq7K+bIsO6BQ+/ReY7co5m3U4pZLtbzuNmdbevBNfTjvFlm2T6H2mT1jOwPbFPXW683W87Sk9tvOtuTAOl2Xf61ke5TUPmv3WP92RX21eqv9DL1W80NnW9C7TTcUXu6cT2o7utfYCkV9NVrdcYJerv6Fs81r1em/it/rnA+1z5Jlu28Swv4qRXw7tb7jGD1f/bue27h5/PFdY2c6++2M9e1UxF+lTeGZ+teOu3vG3lR8kvxWRMH26fLYAWdbxFejsL9CZeEj9OSO+3rGXld8qpKtDgU7pskTC7ljvbsUDpSrMjJBj1Y91DP2g8VnKdNqdh438/i5Y+sUDpSpJlqgBysf7xl7RdG5yvXUK9AxWd5YqrMt6m1QZ2CrGqPZ+mvlMz1jLym6QIWeagU6J8obdf+3op4mdQY3qzWWrj9XPNcz9vzCS1XqLVegs0TeaGbX2BZ1BjcqHEvSHype6hl7bsFVOsK3Wf7OCfJF3ZLhmKdNHcENsmy/flP+irPN72/UKdkf0XT/Op4jRslzxONLf+H0J7r8MncVRqC/5s5Gfef5m5zzP3jv/T2VS4+vvVuLtj6tMydfovOmfcjZ1hlp19efu9Y5/91z/qygL8k5/8w79+n5TY/o5NLzdPGMj/bc9peeudI5vf3M3ykt6D4PLdz4sP614e86fvxZunzWJ3rGfv3f16gz2qEvn/ZL5SS7xwn/2fKUnlj3Zx1TeLI+NOczPWPN/pr9vvXkH6kwzf3/e73sOT20+neamT9P18/9sjThLEln6Y4Xb1FNU4mun/xF5bdIdmOl6mpe08uxW5WVNVvvm3O75lXUSk1SZqDB+erv0Qkvq6lulurf/K5OGX+PPpz3F/eKiKRdXV9dPtA2VVubpimy+If61Izf66apu1+fusVsj6Ly6BZfqbZFJ2l8+c91Vspf9d7UPynsbVbE6pQVzZIVS5Ftlpiwwvpu0KctsUKVbP8/HZ/0pM5NvUdh3w7ned0bzZPHeZ63ZKtTP0nq0AY7R6Vld+uY0PPu7fqrFPU0yB/Jkzea7eyHbUX0m6RmrbLSNHHrfToquEgXpv1WEd8ORbz18kVz5O06vjO1cX9IqtdST6ombv2LpgVW6NL0nzuvw1FvrTzRbOf4znb2Qbo3aacWe9JVUvZHTfZu0eXpP+l6Ld4pXyRb/vDuisL7k3foP55UTdj+G5Vau3R1xve7Xour5I1kKhAe79yu81gkVWuhN0njy3+qYjusj2R+RxHfLud1230+3r3C6D9DtXraF1BR5fdVEEnSR7O+pqi3Tp2B7fJG05zX0m7PB+v1iN+nwqpvKzecr//K+mLXa/E2eaMpCvQ8H1v6T6BBDwQ8KtjxVWV2TNEt2Z9R1NuozsAWeWJJCnZM7bndNwJNujcg5Vd/Tumtc/WZnJsV9TSrM7hpwDHbW/4m/TEo5dXcotSW0/TZnI9JnhZ1BN8dcMy2xt+sO4O2cnd9TGnN5+iW7E/J761XR/CdAcds7/qa9fOQrezaa5XRdIE+nvV5JXmrtd45trf6HLNt8zXpRyEpq/4qZTZcphuyblOGt1LtoTXO9aG22bK6HosqX5P+NyRlNlyirPoP6prMbynXt03tIfd4PdR+lCzb65yv9TXqmyFL6Y3nKafuel2dcYeKfBvVlvR219gZzvGG0eSr11dDXqU1n6XcXR/X5ek/Vol/ndrM7VqxPsdsHb5afSHkV0rLycqv+W9dnPZLHRFY4eyv+fvue8xWq8+HfAq1zde46i/p/NTfaXrwDbWH1sm2Ovsds9XrtpAlq+NoFey4Xe9JvVuzg4vUHnxHtqe93zFbo74Riqqzc6YKq76rM1Lu09zQQudxi3laBxyz/U9SWI3hKSqu/KFOTn5YC5Ke7jle73/M9oOkNtVES53niAVJT+rk5Ed7jtf7H7P9JKlZ22MFznPE3NCzOiPlAedY0vwdm/83XyTXHWt16FfJDdpoZzvPEbODL+k9qfeq01+mqK9uwPu6/0uu1VrL/N/fpxnB13Re6h/V6S9X1LdrwPu6PyXt1FtdzxFTA2/rorQ7FfZXKuKr7ve+ztZfkiv1hiet5zniA+k/c57TIv4dA97XPZBc2fMcUWLV6uqMHzi3aW67//u6R5N29nuO+G7Xc0T5gGO2f4Z29XuO+HrP8Xr/Y7aFwTo92uc54ks9x+v9j9kO53PEc+l36KO35I+ZKmTCrmFqbm7umbYYT2pqqtO/azAZGRnyeEb3J3X/WdSs4yObNc/TIvne6fvX09X57Za3YmqPuucvOXeL5tlm7LvuV7+xX3g7orpO9/x7z9mieQEzdpP71W/s7avbVdHqnj/tzM2aF2yRvOZry4Cx/7u+WZu6phkff9oWzQt1j93W9xeypZ9sqtfqHe7F2Sdv1byk7rHbB4y9c1utlpS5F6cs2KZ5yS3OE4hCFQPG3l1erSVdv8b4eWWal9o9tmrA2L/vqNSS9e7FnKO3a15a99gdA8Y+XlOuJe4xgk6bUal5GS2SZcZWDxj7bH2Zlix3Lx43ZafmZXWPfW3A2P80btOSpe7FWaW7NC+7xXQ9iTt2ScuWnrFHFNZrXq4Zq7hjV7Vt7hlblNOkeXmDj93YvntsVnqH5hUMPraic/fYUDCmeUVdY4OvDxhbG929v8a84u6x/Soxbamt39hfFdcrZFtScOmAsbK39hn7o+JaZZntgeUDxq5WWZ+x3yneqSLTLjGwYsDYTdreZ+xXi6s02Y5KgZUD7wero8/YzxVVaKbdKflXS/5+94Pa+oy9+cIyzbPbJP/aAWPbrJY+Yz96/jb3f9m/bsBYY/fYsD7wvu7/e54jRsNzhAm6fD7p1FNSlZe3u18Rxo499rxojWpZxcs9Y7sPkGs6yp3tc8af0HMbbeHWnrHpGelKDrhv9urCO5zt08bN7vPzusempqcoK9nd3hitcbZPyD6iz9gVVa+qLdyipNSgsjLc7c2b65yxeemFfcau3PG66tqqFUj27963siZnbFpSep+xa2uWqKJxq7Lfc4emFx7nbPvn2pDeffpuHV/i15UXZauj45dqaP5ffefRU9TRuFk3TPuqxvsKZbXVqaZ2iRpbHtbEibbed3ySSipzVBser7CnUpbC8kUz5Yn6ZSkqy9OpWP4SeYLuMaWJtOLxWGZSZUwtyctU21KjqqXS3GkNypne6/nBu0NycwJHLKlRDZ3ua830yTWaOGt1r7Hb+hwDeUNNarSTnLGlpTWaOqfX65Zvq/vVxR9qVpM35ozNH1+nqXN7jfW2St6yXn3OmtUSCGvpclvp+fWadvyyfmN3H1ulBFvUEuzU8hURhTIaNOPE13e/rjjHYbtvN93foZakVr21qkMKNWnGKf3HlveMfdEbU0tqg95e06Z2q1Mzz1i8e2y/5+PFHq9aUmu0an2zGjoszTy7/9jd9/cKBdWSWqXV7zYorzFTM8/tP3Znz9j1drJaUsu19rU6pdRENPO813aPdZ6Pa3rGbo2mqiW1TOvfvF6e7bZmvr//2N3HQDsi6WpJ3eCT5fEAAB06SURBVKq65VcqtlmafuHr8nmiXa/Ffcc2do2tX/l+RTdIU857U2n+5p7X7d5jO8MZakndovq1Zyu6VvreuUuVH6yOO9Yb7rrdDScqulL6xtnLVRIs6zV28e7HOOL+bg2bj9HG5dIXT1+hI1Pe2T02+Eav3829zxrKpmnzUunTp6zSzNS3eo1dsvt3iwbUkrpDDZXjtWWpdNOJazUzrdfj0euYLWx71JK6S43VOdq2VPrwces1M73XfdzvmK01tU719ckqWyp9YO4GzczoPbbvMVt7ap0amy1tXyqdP2eTZpb2Htv3mC2cUq/qtk6VL5XOmrVFMyf3GtvvmC2a3KBdDY2qXCqdOH2bZk7rPbbfMVtyo2pbdjrPEcdM3a6ZM3qP7XvM5nWeI3K7niMqNXNWr7G+De5XF3+f54gdmjmn99i+7+tCfZ4jajRzbu+xfd/XpfR5jqjTzON7je33vi6t33PEzBP7j902yHNEo2ae0n/s9iGeI17bi+eI1/biOaL/2B0j4jnii//s1OXXpqu01Lff/bBGAxrUD5NZafGVV15xVl+MV9116qmnqrW1VUuX9ntT3GU0NHkbTsPXhY/ep466tUqxSxVSvrM9qnbVWytlyacd1m2yLfefJzX2d6VorZLtCUqSWzIQVafqrRWy5FG19RVFLffNVYr9kFLtt5VkFytZ7qd5MUVVZ7kHSrusLypiuQfNyfbjSrOXKmQXKEUTeiq7ai33vq+1/lthy606C9nPKMN+TSE7Xyna/bjVWkucTw1qrY8rbLk/L2QvVIb9soJ2rlK1O6mvtZbLVkR11kfVabmf8gXtl5VpL1TAzlaajugZW2etUMz5HT+iDstN5QP2YmXZ/5RfmUq3dyf15j5z77ur1GG5n7D57aXKth+XX2lKt3d/QldvrVZUrWrUJWrzHOts89krlWP/Qz6lKMPe/Qldo7VWYTWrUeerzbPA2ea11yvX/pu8SlKmvfsTukbrHYXVoCbrPWq13Om4Xnuzcu275VVQmfbuqqomvatOq07N1hlqsc50tln2duXbv5clv7LtY3qN3ahOq1Yt1klqttyqK8uuVr79K+exz7bn9Yxt1hZ1WNVqtY5Tk3Whu9Fu0Dj7J87ZHPu43X+DKlO7VaV2HaMGz6XuULtdBfYdzvkse548ckPlFm1Xu1Wpdh2lBo9bPWCMi32za+wx8nQdBbSpUq3WdnVomuo9H+4Zmx/7rixFnPvB3B/u2Cq1WmUKa6JqPbsrFHJj35dXbc79a+5no13VarG2KKLx2uX5WM/YnNiP5VOT87iZx8/oUK2arY2KWgWqsW7uGZtt/0x+u875ezB/F+5Y8zi8q5iyVe3ZXc2QZf9aAXun0uypCsj95C+sRjVa62UrXTs9n+8Zm2H/n0J2hVLtIxSU+ym+83djrZWlZFV5vtwzNt2+S0n2FqXakxSU+8lfRK1qsFbLo4AqPV9ztgWDIQXafq9kvctzxCh6jigqkt5/geU07cbYMpwmtKZa6z9bn3bOnzX50p6w652aFSpr2Oj09ZqS476uRGMRvbjZrUw9fdL75fO4z7Ebd63Wlvr1mpBxhKblzum5bVPFZZxaer4CPre6YkvdOm2sXaOitImakT+3Z+yLmx5T1I7qpJL3KsnvPm9uq9+gDbtWalzqeM0a51btGi9veVLhaKcWjD9bqcEMZ1t542atq16u3OQCzSk8qWfsK1ufUXukVfOLz1BGyH0urGraptU7lygrKU9zi9yKbmNx2b+dVSrNNnOdUd1SoberFjvfa27DuR+itt7c/rwa2up1VN6JygoVKhqTdrXs1Modi+RXumZknK3mZlvNzTGtrX5RDW3Vyg4fI1/HOHW2RxS2q7XZs0qWlaHC2HuVYlcrzd6hBmu5oqpWhj1FSfY4p04qoia9ZaoYrCwVxc5TRmy7cuxNarLWqdPapVR7ojPW2Te1aZlvl1qtLBXH3u+MHWevU5O1UR2qVrJKlGy7x0VRdWiZr0ZNVrrGxy5Vul2hgthqNVtb1K4qJWu8ku3xzlizF8u8Var3ZGh87GKl2btUFFuhVmur2lWhkAqVYpc4+2uO2ZZ7K7TLk63i2IVKsxtUEntTrSpXm1WukD2uzzHbCm+5dnhyVBh7n9Lsdk2Mveb8/BarTCE7RynaXTGxylupCk+2CmLvUZod1aTYK+rQDrVYWwc8H6/x7lCZJ0vjYmcq1fZrSuxFdahGzdbmAc/H6707tMWTpfzYaUqxUzQttrDndbv/8/FGz069681UXuxkJdtZmh571jzrq8naMOD5eItnp9Z7M5UTW6AUu0AzYv9UWE1qtNYNOGYr8+zUGm+msu35zn05I/qUompWg7XGeS3Osnf/b1VY1Vrpy1CWfazz2n1k9F/m2V/11qoBx2xVVrVW+DKUac92jh+mRZ+TpUY1+VYrFo31OWartqq1zJfh/A7md54SfV4+NajOesu5Pts+rquuy7zeVesNX4bS7GnO7zE5+rICqldd1/F6lj1Xnq7EtsGq1mJn7BTnmGti9BUlq067rDcHHLM1W9V6xZehFHuisu25Ko0uVopqVGstk61on2O2Vu3Uf/yZzt9pjn28JsTedP6Paq23ZCusDHuWfL2O2V72pSmkYuXaJ6o4tkwZdoXqrbed/4X+x2z/8YXktwqVFztVhbG3lWVvc+5f8z/W+5jNPPaLfD55rALlx87QuNhq5dibncctopYBx2yv+CzFrHwVxM5Wfmytcu2Nzt+D+bvof8z2mi+qsJXrPEfkxjYo316vRmuDwqofcMz2uq9DbVau8xyRHdukAntNz/F63/d1HXrD16xmy/x/vl+Zsa0qsleqWZvVYdUMeF+3xNugBk+m8xxhnk+K7bfUoq1qt3YqyS5Ssop73tct9dao1pPlPEek2zs1Iba059i+7/s6W8u9Var25PQ8R5TGXlerKrqeI/q+r1vhrVRV13NEut3mPEd0H6/3f1+30lvV5zlicmyR2rVzzDxHNBWeqfe9P1XBoDUmGtQTdg3Tf//3fzurLT700EOaNWv3H1W3Y4891qneevHFF+N+/2j4gxmO0fLHD+DQ4/kBGF34nwXA8wOARA27Rve8ukNo4kS3oideX67q6mqnqitexRcAAAAAAAAOHcKuYTruOHcq1aJFiwZc172tewwAAAAAAAAOD8KuYTrxxBM1YcIEPfnkk1q7dm3PdtOU/re//a38fr8uueSSg/U4AQAAAAAAYBhYjXGYfD6f/ud//kc33XSTPvzhD+uCCy5QSkqK07C+vLxcX/7ylzV+vNukEwAAAAAAAIcHYddeOOGEE/S3v/1Nv/jFL/T0008rEolo2rRp+sIXvqDzzz//4D1KAAAAAAAAGBbCrr109NFH6w9/+MPefhsAAAAAAAAOAXp2AQAAAAAAIGEQdgEAAAAAACBhEHYBAAAAAAAgYRB2AQAAAAAAIGEQdgEAAAAAACBhEHYBAAAAAAAgYRB2AQAAAAAAIGEQdgEAAAAAACBhEHYBAAAAAAAgYRB2AQAAAAAAIGEQdgEAAAAAACBhEHYBAAAAAAAgYRB2AQAAAAAAIGEQdgEAAAAAACBhEHYBAAAAAAAgYRB2AQAAAAAAIGEQdgEAAAAAACBhEHYBAAAAAAAgYRB2AQAAAAAAIGEQdgEAAAAAACBhEHYBAAAAAAAgYRB2AQAAAAAAIGEQdgEAAAAAACBhEHYBAAAAAAAgYRB2AQAAAAAAIGEQdgEAAAAAACBhEHYBAAAAAAAgYRB2AQAAAAAAIGEQdgEAAAAAACBhEHYBAAAAAAAgYRB2AQAAAAAAIGEQdgEAAAAAACBhEHYBAAAAAAAgYRB2AQAAAAAAIGEQdgEAAAAAACBhEHYBAAAAAAAgYRB2AQAAAAAAIGEQdgEAAAAAACBhEHYBAAAAAAAgYRB2AQAAAAAAIGEQdgEAAAAAACBhEHYBAAAAAAAgYRB2AQAAAAAAIGEQdgEAAAAAACBhEHYBAAAAAAAgYRB2AQAAAAAAIGEQdgEAAAAAACBhEHYBAAAAAAAgYRB2AQAAAAAAIGEQdgEAAAAAACBhEHYBAAAAAAAgYRB2AQAAAAAAIGEQdgEAAAAAACBhEHYBAAAAAAAgYRB2AQAAAAAAIGEQdgEAAAAAACBhEHYBAAAAAAAgYRB2AQAAAAAAIGEQdgEAAAAAACBhEHYBAAAAAAAgYRB2AQAAAAAAIGEQdgEAAAAAACBhEHYBAAAAAAAgYRB2AQAAAAAAIGEQdgEAAAAAACBhEHYBAAAAAAAgYRB2AQAAAAAAIGEQdgEAAAAAACBhEHYBAAAAAAAgYRB2AQAAAAAAIGEQdgEAAAAAACBhEHYBAAAAAAAgYRB2AQAAAAAAIGEQdgEAAAAAACBhEHYBAAAAAAAgYRB2AQAAAAAAIGEQdgEAAAAAACBhEHYBAAAAAAAgYRB2AQAAAAAAIGEQdgEAAAAAACBhWLZt24d7JwAAAAAAAIADgcouAAAAAAAAJAzCLgAAAAAAACQMwi4AAAAAAAAkDMIuAAAAAAAAJAzCLgDAQbN9+3YdeeSR+spXvsK9DAAAAOCQ8B2aH4ORyLwBnTRpkp555pnDvSsARkgwdfbZZw855s0331R6evoh2ycAw/ufzc3N1UsvvSSfb+Ch3caNG3X++ec754uLi/X8889ztwJjzG233aaHH35YmZmZ+s9//qNAIHC4dwnAAcLxQHyEXQCAPkpKSnTRRRfFvVeCwSD3FjDCmICrpqbGCbviBdb/+Mc/5PFQzA+MVc3Nzc6H25Zlqb6+Xs8991xPAA4gcXA80BdhFwBgQNj16U9/mnsFGCWOPfZYrVu3Tg899NCAsCsSiejxxx/XSSedpDfeeOOw7SOAw+ef//ynWltb9dGPflR//vOfnQCcsAtIPBwP9MXHfOixY8cO/eIXv9CVV16pE088UbNmzdJZZ52lb33rW9q1a9eAe8r04DFTIcvKynTPPffofe97n/M9Z555pn71q18pFotx7wIJyryxvvXWW3XKKaf0/N9/97vfVV1d3aDfs2HDBv3Xf/2X5s+f77wY33DDDVq1atUh3W8gEZmKS/PG1VR29X+9fvHFF52qrw984AMH9HX/T3/6k/MzzffQkw8Y2Uy4ZSo+brrpJi1YsECvvfaaysvLB4wz///mq7GxUd/4xjd08skna/bs2brkkkv05JNPDhj/y1/+0nlOeP31150pkpdeeqnmzJmja6655hD9ZgAO9fHAF77wBef//u2334575//85z93ro/3nHGoEXahx5IlS3TXXXcpJydHF1xwgfNCNWHCBN1333266qqr1NTUFPfe+tGPfqTf/OY3zpvXq6++uufFz/yhA0g8Cxcu1BVXXOH0/Tn++ON17bXXatq0afrLX/7iPAc0NDQM+B7z5viDH/yg2tvbnVPzAmoOjj/ykY9oxYoVh+X3ABLJ5Zdf7lRxPfbYYwPe5JoePeecc84Be903wfb//d//OQfD1113nfP/D2Bkevfdd/XWW285wZXp7WeCK/OBtAmn4uns7NT111/vVIKalgbmjXFlZaU+//nP69577437PX/84x/17W9/2+kFbJ5H5s6de5B/KwCH63jg6q73+w8++OCA24lGoz29Ac8999zD/iAxjRE9TjjhBC1atEgpKSl97pVHH31UX/7yl503sjfffPOAe2z16tXOFIn8/Hzn8ic/+Um9973vdV4Qb7nlFhpgAqPMtm3bnMC6v1NPPVWlpaX60pe+pKysLOcF0DS77vbUU0/pc5/7nPPJ0O233z7gRdRUdZmD5W7mgNt8yvz1r39dTzzxxEH+rYDEdvTRRzuhkznINFWTRnV1tdOI2gTM8ZpR7+vr/vr16/XII4+oqKjoIP5GAA4E8wbXuPjii53T97znPU4wZZ4rzHF6/35+5nlj4sSJ+vvf/97zvPGJT3zCec3+4Q9/6LyBHTdu3IDFax544AGnmgNAYh8PzJ8/X1OmTHGO+83CF8nJyT3jzc+oqqpyPggbCYtgUNmFHibJ7f8H3v3imJqaqldffTXuvWXCre6gy8jOznZ6hrS0tGjz5s3cw8AoDLvMVOT+X+aTYfMpkWl0a0Kt3kGXYT4JOuqoo5wXv/7MCo7mYLl/eGZKpd955x2mMwIHgKnAMNOFu6slTSBlPt2NN2Vhf173b7zxRoIuYBQIh8PO67b5f+6u5jD/8+Z8RUXFoP/jpk1B7zeqBQUFThW3qfqK9xpvpj4RdAFj53jgqquuct7r938+6K72Ms8JIwGVXejj2Wef1f333+9Ua5n5+qYUsdvOnTvj3lvmzW1/3Z/4DDYFAsDIZfpwmSkJ8Xz2s591Ts08fTM1sb+Ojg6nb1dtba0TfHebMWNG3BdR8+mQ6R2ydu1aZ0oUgH1nphz9+Mc/dhrVm7455lPdmTNnOv9/B/J133xqDGB0tB0wr8dmWlPv1ZRNlZaZlWGqvsxrfm+mt5dpTRLv9dpYs2bNgOt4TgDG1vHAJZdcov/3//6fE26Z1iaG6Qdm+oKZ5w9T+TUSEHahh2k2+4Mf/MB5g2rm9ZtPcUKhkHOdWbnFfDoUj0l7B/xh+dw/rd7/JABGv+5+XH/961+HHNfW1tbnsukTMtgnSQbBOLD/zOu3WSzCfNJqFo0x1dX9pxQfiNf97v9bAKNjCqN5Y9qbqao2H0ybMKy+vt7pr9PNtCnoP7Wx9/+9qe4e7DoAY+N4ID09Xeedd55TMWZmaHRPmzTVYyOlqssg7ILD/GGaJvN5eXlOuXPvFy3btvWHP/yBewpAT7htemztTVNq82lPPN0rvKSlpXHvAgeAqeAwn86aFRJNJcf73//+A/66b1kWjxUwwpmm8q+88opz3iwGMxhT4WWmKHYz1dmmgX3/wKv79Treh9w8JwBj73jg6quvdsIu06/P9N81VWTm+cGEYCMFYRd6XthMZYX5pKf/pzMrV650VlADADNVwbxwmv5dexN2mWmKZm5//6mMpnG9MVRZNYDhM1OSTMWGWUbc9NHLyMiIO47XfSCxmSoLE1rNmzfPWSWxPzP7wrxRNdVfvcMu88Z3+fLlzvfFe702U6EAjHynHOTjgWOOOcbp1Wc+AD/jjDO0ZcsWpwF+UlKSRgrCLjjMH7YpVTRzdM30o+4/UjNl6X/+53+4lwA4TGPLO++8Uz/96U+dOflTp07tc8+Y5w+zUpt5AezNzP3/7W9/22c1RrNii+nXZUIz+nUBB4bX69Wvf/1r5+B2+vTpg47jdR9IXKYaw4RdpuLKTE2aMGFC3HHmzakJtswb2tmzZ/dsN6/xZlpTd5N6s7raPffc41w2b5oBjHzeQ3A8YBrVf+c733FWZTRG0hRGg7ALDlOq/KEPfch5YTOrLpg5vmZO/ssvv+ysuNZ7tUUAY5eZy/+Tn/xEn/nMZ5znCrOi4uTJk50VmsrLy/XGG284IVj/Bvemse19993nrApjgjAz9plnnnFeXAnUgQPLvGnt/cY1Hl73gcS1ePFibd++Xccff/ygQZdx2WWXOWGXqe7qfs4wU5laW1udBtfm/YB58/vPf/7T6e1lpip1L0IFYOSbfZCPB8x40wjfNLA3i9aNtMrPgd0HMSZ0N473+/092z73uc85Sw2bT4H+9re/OUuMXnjhhc6b1t7jAIxtplTZTH249NJLnWWN7733XqeE2QRY5sDZBGH9mYNtE3aZcMs0t3/++eedg3Bz3qwSA+DQ43UfSOzG9OZ1eijnn3++87psmlh3T1Uy1Vt33XWX8xpt+nmZPjymWbVZee2aa645JPsPYHQcD6Smpuqcc84ZkVVdhmWbOleMOdXV1c483gULFjhlyQAAAADGrrPOOss5NR9IAcBwmMb3ppLUtCeJt4DF4URl1xhllho2qKgAAAAAAAB746WXXtI777zjBF4jLegy6Nk1xpgG0WbakZl7n5yc7DSVAwAAAAAA2BMz1dEsXPHggw8qGAzqYx/7mEYiwq4xxsy7Nf26zNKipq/O+PHjD/cuAQAAAACAUeAPf/iDE3ZNmjRJ3/ve94ZcCONwomcXAAAAAAAAEgY9uwAAAAAAAJAwCLsAAAAAAACQMAi7AAAAAAAAkDAIuwAAAAAAAJAwCLsAAAAAAACQMAi7AAAAEsgvf/lLHXnkkXr44YcP964AAAAcFoRdAAAA6GP79u1OYHbNNddwzwAAgFGHsAsAAAAAAAAJg7ALAAAAAAAACcN3uHcAAAAAe2/hwoX63e9+p3Xr1ikUCun444/X5z73ubhj165dqyeeeEKLFy9WRUWFmpubNW7cOJ166qm6+eabnfO9e3796le/cs6/8cYbznTGbpdeeqm+//3v91yur6/XH//4R2dfzNRHv9+vo446Sh/96Ed15pln8rACAIDDgrALAABglLnvvvv0rW99S5Zlaf78+crLy9OKFSt0xRVXxA2ZTCj27LPPOsHVvHnzegIwczvPPfecHnrooZ7Aa8aMGXrve9+rf/3rX8rNzXUCsW7d32ts3rzZCbUqKytVXFysU045RS0tLc5+fOITn9CXvvQl3XjjjYfk/gAAAOjNsm3b7rMFAAAAI1Z5ebnOO+88xWIx3XnnnT1hVDgc1m233eZUcBl33HGHLrvsMue8qeiaMmWKE151M9//m9/8xqnkMuPM+G6mSuvss892qsXuvffeAfsQjUZ1ySWX6J133tEXv/hF3XDDDfJ43O4YW7dudS6bEOzRRx/VtGnTDvp9AgAA0Bs9uwAAAEYRU4XV0dGhCy64oE/VlZlC+LWvfU1JSUkDvueEE07oE3QZJpz61Kc+5VR0Pf/883u1Dy+88IITdJkKsJtuuqkn6DJKS0v1la98xQnEHnjggX36HQEAAPYH0xgBAABGkSVLljin559//oDrsrKydPLJJztTE/urq6tzQq0NGzaosbHRqewyIpGI03vLfGVmZg5rHxYtWuScvuc974l7ffd0x5UrV+7FbwYAAHBgEHYBAACMIjt37nROTZ+seOJtf/LJJ3X77bertbV10Ns1/baGG3aZqZTGF77wBedrMCZgAwAAONQIuwAAABKYCabMtELjq1/9qs444wxn6qJZwdG4+uqrtXz5cu1NG9fuqjAzjbL/9Mj+lWYAAACHGmEXAADAKGJWXjQrIZoQyzSd76+ioqLP5ZdeeslpXm+axl933XUDxpeVle31PhQUFDinZvVH07cLAABgJKFBPQAAwCgyf/585/SZZ54ZcJ3pu/XKK6/02Wb6c/UOqHp78803VVNTM2C7aXbf3c8rHtMXzPj3v/+9T78DAADAwUTYBQAAMIpcdtllCgQCeuKJJ/Tqq6/2bDfVW3fccceAvlwTJ050Th9//PE+1+3YsUPf/OY3B51+aAIvU/VlVlXs79xzz3Wqysw+/PrXv1ZnZ2ef682UyKVLlzpfAAAAh5pl702DBgAAABx2f/3rX/Wd73xHHo/HqfQyUxvfeustp4rL9OQyIZQJvkwwZoIoc2pWYTTj5s6dq46ODr3++uuaPn26c3umZ9fChQs1fvz4np/xiU98Qi+88IKmTp2qmTNnOuGX+d4PfOADzvVbtmzRjTfeqO3btysnJ0dHHnmksrOzneqytWvXateuXbrtttt0/fXXH7b7CQAAjE1UdgEAAIwyH/7wh52KqtmzZ+vtt9/WokWLnODq/vvvV2lpaZ+xpgrMhGMf/OAHnfMmwNq4caM+8pGP6K677uqZstjf//7v/+riiy92wiuzmuM//vEPZ9pj74qxRx99VJ/97GedKZImbDPTGk0/sRkzZugb3/iGLrroooN+XwAAAPRHZRcAAAAAAAASBpVdAAAAAAAASBiEXQAAAAAAAEgYhF0AAAAAAABIGIRdAAAAAAAASBiEXQAAAAAAAEgYhF0AAAAAAABIGIRdAAAAAAAASBiEXQAAAAAAAEgYhF0AAAAAAABIGIRdAAAAAAAASBiEXQAAAAAAAEgYhF0AAAAAAABQovj/wGF54lkNtCMAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1200x700 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "adstock_contribution = allocate(\n",
+    "    social_draws, allocation_weights(theta_draws, adstocked_reach(reach, display_alpha))\n",
+    ")\n",
+    "focus = \"flash_sale_burst\"\n",
+    "focus_adstock = adstock_contribution.sel(campaign=focus)\n",
+    "focus_adstock_bounds = az.hdi(focus_adstock, dim=\"sample\")\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(12, 7), layout=\"constrained\")\n",
+    "ax.fill_between(\n",
+    "    reach.date,\n",
+    "    focus_adstock_bounds.sel(ci_bound=\"lower\").to_numpy(),\n",
+    "    focus_adstock_bounds.sel(ci_bound=\"upper\").to_numpy(),\n",
+    "    color=\"C0\",\n",
+    "    alpha=0.3,\n",
+    "    label=f\"adstocked, {CI_PROB:.0%} HDI\",\n",
+    ")\n",
+    "ax.plot(\n",
+    "    reach.date,\n",
+    "    focus_adstock.mean(\"sample\").to_numpy(),\n",
+    "    color=\"C0\",\n",
+    "    label=f\"adstocked allocation (decay {display_alpha:.1f})\",\n",
+    ")\n",
+    "ax.plot(\n",
+    "    reach.date,\n",
+    "    contribution.sel(campaign=focus).mean(\"sample\").to_numpy(),\n",
+    "    color=\"C2\",\n",
+    "    ls=\":\",\n",
+    "    label=\"raw-reach allocation\",\n",
+    ")\n",
+    "ax.plot(\n",
+    "    data.truth.index, data.truth[focus].to_numpy(), color=\"C1\", ls=\"--\", label=\"true\"\n",
+    ")\n",
+    "ax.set(\n",
+    "    title=f\"Adstocked against raw-reach daily credit for {focus}\",\n",
+    "    xlabel=\"date\",\n",
+    "    ylabel=\"contribution (y units)\",\n",
+    ")\n",
+    "ax.xaxis.set_major_locator(mdates.MonthLocator())\n",
+    "ax.xaxis.set_major_formatter(mdates.DateFormatter(\"%b\"))\n",
+    "ax.margins(y=0.20)\n",
+    "_ = ax.legend(loc=\"upper left\", fontsize=8)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4fc0eb38",
+   "metadata": {},
+   "source": [
+    "> **Fig.** The `flash_sale_burst` daily credit under the adstocked allocation, against the raw-reach allocation and the hidden truth. By construction the adstocked credit decays after the flight ends instead of stopping dead; how well that tail matches the truth is what the sweep table above measures. One boundary artefact is worth knowing about: adstocked reach ramps up from an empty history at the left edge of the window, while the true carryover of the always-on campaigns is already at steady state there, so the first stretch of the window is where this correction is least trustworthy."
    ]
   },
   {
@@ -3500,14 +3959,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 31,
    "id": "080a080e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:37:09.558989Z",
-     "iopub.status.busy": "2026-08-11T12:37:09.558912Z",
-     "iopub.status.idle": "2026-08-11T12:37:16.823892Z",
-     "shell.execute_reply": "2026-08-11T12:37:16.823461Z"
+     "iopub.execute_input": "2026-08-12T10:15:36.736084Z",
+     "iopub.status.busy": "2026-08-12T10:15:36.735971Z",
+     "iopub.status.idle": "2026-08-12T10:15:44.581647Z",
+     "shell.execute_reply": "2026-08-12T10:15:44.581148Z"
     }
    },
    "outputs": [
@@ -3691,7 +4150,7 @@
        "        0.75      0.0252       5.0  "
       ]
      },
-     "execution_count": 28,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3743,14 +4202,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 32,
    "id": "36993e2f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:37:16.825023Z",
-     "iopub.status.busy": "2026-08-11T12:37:16.824946Z",
-     "iopub.status.idle": "2026-08-11T12:37:16.848720Z",
-     "shell.execute_reply": "2026-08-11T12:37:16.848378Z"
+     "iopub.execute_input": "2026-08-12T10:15:44.582954Z",
+     "iopub.status.busy": "2026-08-12T10:15:44.582845Z",
+     "iopub.status.idle": "2026-08-12T10:15:44.620638Z",
+     "shell.execute_reply": "2026-08-12T10:15:44.620163Z"
     }
    },
    "outputs": [
@@ -3817,14 +4276,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 33,
    "id": "f75116b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:37:16.849919Z",
-     "iopub.status.busy": "2026-08-11T12:37:16.849840Z",
-     "iopub.status.idle": "2026-08-11T12:37:23.935212Z",
-     "shell.execute_reply": "2026-08-11T12:37:23.934722Z"
+     "iopub.execute_input": "2026-08-12T10:15:44.621801Z",
+     "iopub.status.busy": "2026-08-12T10:15:44.621681Z",
+     "iopub.status.idle": "2026-08-12T10:15:52.752019Z",
+     "shell.execute_reply": "2026-08-12T10:15:52.751648Z"
     }
    },
    "outputs": [
@@ -4007,7 +4466,7 @@
        "                        7       0.8929  0.0324  0.0248       4.0  "
       ]
      },
-     "execution_count": 30,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4032,14 +4491,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 34,
    "id": "6101b16b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:37:23.936330Z",
-     "iopub.status.busy": "2026-08-11T12:37:23.936243Z",
-     "iopub.status.idle": "2026-08-11T12:37:23.964224Z",
-     "shell.execute_reply": "2026-08-11T12:37:23.963746Z"
+     "iopub.execute_input": "2026-08-12T10:15:52.753590Z",
+     "iopub.status.busy": "2026-08-12T10:15:52.753477Z",
+     "iopub.status.idle": "2026-08-12T10:15:52.797155Z",
+     "shell.execute_reply": "2026-08-12T10:15:52.796492Z"
     }
    },
    "outputs": [
@@ -4120,15 +4579,348 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "1b5205fe",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "### Is ignoring the composition hurting? Two compositional variants\n",
+    "\n",
+    "There is a structural objection to the likelihood, and it deserves a test rather than a shrug. The seven click shares sum to one, so an error on one campaign's share is mechanically absorbed by the others, a built-in negative dependence. The model instead treats the seven $y_c$ as conditionally independent, and it also quietly treats them as seven observations when they carry only six degrees of freedom: $\\sum_c R_c\\,e^{y_c}=T$ holds by construction. Here we fit two variants that take the composition seriously and grade them on the same scoreboard.\n",
+    "\n",
+    "**A compositional twin with the same trust dial.** Suppose each campaign's *unnormalised* log signal is $z_c=\\theta_c+\\varepsilon_c$ with the familiar reach-scaled noise $\\varepsilon_c\\sim\\text{Normal}(0,\\psi_c)$, and the observed click shares are the softmax of the $z$'s. Then the six observable contrasts $y_c-y_{\\text{ref}}$ are multivariate normal with mean $\\theta_c-\\theta_{\\text{ref}}$ and covariance $\\operatorname{diag}(\\psi_{-\\text{ref}})+\\psi_{\\text{ref}}\\mathbf{1}\\mathbf{1}^{\\top}$, and that rank-one term is exactly the induced negative dependence the objection points at. The implementation below never writes that matrix down: conditional on the reference campaign's own noise $\\varepsilon_{\\text{ref}}$, the contrasts are independent Normals sharing the $-\\varepsilon_{\\text{ref}}$ shift, so one extra scalar latent reproduces the covariance exactly. Nothing else changes: same hierarchy, same $\\psi_c=s^2/n^{\\text{rel}}_c$, same dial $Z_c$. The likelihood now only identifies *contrasts* of $\\theta$, so $\\mu$ stays close to its prior, but the daily allocation is invariant to a common shift of $\\theta$ (the softmax eats it), so nothing downstream is lost.\n",
+    "\n",
+    "**The Dirichlet-multinomial the review suggested.** The textbook compositional model for counts goes further: model the click counts themselves, $\\text{clicks}\\sim\\text{DirichletMultinomial}(N,\\kappa\\,p)$ with $p_c\\propto R_c\\,e^{\\theta_c}$ and the same hierarchy on $\\theta$. The catch to watch for is what plays the role of evidence. In this likelihood the noise on a share shrinks with the number of *clicks*, and the concentration $\\kappa$ is asked to learn the overdispersion from a single observed composition. Whether that leaves any room for reach to set the trust is exactly what the comparison below measures."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 35,
+   "id": "c68c76e4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-12T10:15:52.798490Z",
+     "iopub.status.busy": "2026-08-12T10:15:52.798355Z",
+     "iopub.status.idle": "2026-08-12T10:15:55.487366Z",
+     "shell.execute_reply": "2026-08-12T10:15:55.486812Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "NUTS[nutpie]: [mu, log_k, sigma_s, theta_raw, eps_ref]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "NUTS[nutpie]: [mu, log_k, sigma_s, theta_raw, kappa]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>divergences</th>\n",
+       "      <th>spearman</th>\n",
+       "      <th>mae</th>\n",
+       "      <th>crps</th>\n",
+       "      <th>coverage</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>method</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>independent Normal (main)</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0.8929</td>\n",
+       "      <td>0.0347</td>\n",
+       "      <td>0.0254</td>\n",
+       "      <td>5 of 7</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ALR logistic-normal</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0.8929</td>\n",
+       "      <td>0.0343</td>\n",
+       "      <td>0.0251</td>\n",
+       "      <td>4 of 7</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Dirichlet-multinomial</th>\n",
+       "      <td>35</td>\n",
+       "      <td>0.8929</td>\n",
+       "      <td>0.0366</td>\n",
+       "      <td>0.0307</td>\n",
+       "      <td>3 of 7</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                           divergences  spearman     mae    crps coverage\n",
+       "method                                                                   \n",
+       "independent Normal (main)            0    0.8929  0.0347  0.0254   5 of 7\n",
+       "ALR logistic-normal                  0    0.8929  0.0343  0.0251   4 of 7\n",
+       "Dirichlet-multinomial               35    0.8929  0.0366  0.0307   3 of 7"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def build_compositional_model(\n",
+    "    y_direct: pd.Series,\n",
+    "    volume: pd.Series,\n",
+    "    *,\n",
+    "    sigma_s_scale: float = 0.5,\n",
+    "    log_k_sd: float = 0.75,\n",
+    ") -> pm.Model:\n",
+    "    \"\"\"ALR logistic-normal twin of the credibility model, same trust dial.\"\"\"\n",
+    "    campaigns = list(y_direct.index)\n",
+    "    volume_relative = (volume / volume.mean()).reindex(campaigns).to_numpy()\n",
+    "    y_alr = (y_direct.iloc[:-1] - y_direct.iloc[-1]).to_numpy()\n",
+    "    with pm.Model(coords={\"campaign\": campaigns, \"contrast\": campaigns[:-1]}) as model:\n",
+    "        mu = pm.Normal(\"mu\", mu=float(y_direct.mean()), sigma=1.0)\n",
+    "        log_k = pm.Normal(\"log_k\", 0.0, log_k_sd)\n",
+    "        k = pm.Deterministic(\"k\", pm.math.exp(log_k))\n",
+    "        sigma_s = pm.HalfNormal(\"sigma_s\", sigma_s_scale)\n",
+    "        s2 = pm.Deterministic(\"s2\", sigma_s**2)\n",
+    "        pm.Deterministic(\"tau\", pm.math.sqrt(s2 / k))\n",
+    "        psi = s2 / volume_relative\n",
+    "        pm.Deterministic(\"Z\", volume_relative / (volume_relative + k), dims=\"campaign\")\n",
+    "        theta_raw = pm.Normal(\"theta_raw\", 0.0, 1.0, dims=\"campaign\")\n",
+    "        theta = pm.Deterministic(\n",
+    "            \"theta\", mu + pm.math.sqrt(s2 / k) * theta_raw, dims=\"campaign\"\n",
+    "        )\n",
+    "        # the reference campaign's own noise, shared by every contrast: this scalar\n",
+    "        # latent IS the rank-one negative dependence, without writing the matrix down\n",
+    "        eps_ref = pm.Normal(\"eps_ref\", 0.0, pm.math.sqrt(psi[-1]))\n",
+    "        pm.Normal(\n",
+    "            \"y_alr_obs\",\n",
+    "            mu=theta[:-1] - theta[-1] - eps_ref,\n",
+    "            sigma=pm.math.sqrt(psi[:-1]),\n",
+    "            observed=y_alr,\n",
+    "            dims=\"contrast\",\n",
+    "        )\n",
+    "    return model\n",
+    "\n",
+    "\n",
+    "def build_dirichlet_multinomial_model(\n",
+    "    clicks: pd.Series,\n",
+    "    exposure: pd.Series,\n",
+    "    *,\n",
+    "    sigma_s_scale: float = 0.5,\n",
+    "    log_k_sd: float = 0.75,\n",
+    ") -> pm.Model:\n",
+    "    \"\"\"Dirichlet-multinomial on click counts, same hierarchy on theta.\"\"\"\n",
+    "    campaigns = list(clicks.index)\n",
+    "    log_exposure = np.log((exposure / exposure.mean()).reindex(campaigns).to_numpy())\n",
+    "    with pm.Model(coords={\"campaign\": campaigns}) as model:\n",
+    "        mu = pm.Normal(\"mu\", 0.0, 1.0)\n",
+    "        log_k = pm.Normal(\"log_k\", 0.0, log_k_sd)\n",
+    "        k = pm.Deterministic(\"k\", pm.math.exp(log_k))\n",
+    "        sigma_s = pm.HalfNormal(\"sigma_s\", sigma_s_scale)\n",
+    "        s2 = pm.Deterministic(\"s2\", sigma_s**2)\n",
+    "        pm.Deterministic(\"tau\", pm.math.sqrt(s2 / k))\n",
+    "        theta_raw = pm.Normal(\"theta_raw\", 0.0, 1.0, dims=\"campaign\")\n",
+    "        theta = pm.Deterministic(\n",
+    "            \"theta\", mu + pm.math.sqrt(s2 / k) * theta_raw, dims=\"campaign\"\n",
+    "        )\n",
+    "        kappa = pm.LogNormal(\"kappa\", mu=np.log(1_000.0), sigma=2.0)\n",
+    "        p = pm.math.softmax(theta + log_exposure)\n",
+    "        pm.DirichletMultinomial(\n",
+    "            \"clicks_obs\",\n",
+    "            n=int(clicks.sum()),\n",
+    "            a=kappa * p,\n",
+    "            observed=clicks.to_numpy(),\n",
+    "            dims=\"campaign\",\n",
+    "        )\n",
+    "    return model\n",
+    "\n",
+    "\n",
+    "def variant_share(idata: xr.DataTree, *, pair_seed: int) -> xr.DataArray:\n",
+    "    \"\"\"Flight-share draws implied by one fitted variant's theta posterior.\"\"\"\n",
+    "    variant_social, variant_theta = paired_draws(\n",
+    "        data.social, idata.posterior[\"theta\"], pair_seed=pair_seed\n",
+    "    )\n",
+    "    return flight_share(\n",
+    "        allocate(variant_social, allocation_weights(variant_theta, reach))\n",
+    "    ).transpose(\"sample\", \"campaign\")\n",
+    "\n",
+    "\n",
+    "compositional_idata = fit_credibility(\n",
+    "    build_compositional_model(y_direct, unique_reach), progressbar=False\n",
+    ")\n",
+    "compositional_share = variant_share(compositional_idata, pair_seed=seed)\n",
+    "dm_idata = fit_credibility(\n",
+    "    build_dirichlet_multinomial_model(direct[\"clicks\"], direct[\"reach_days\"]),\n",
+    "    progressbar=False,\n",
+    ")\n",
+    "dm_share = variant_share(dm_idata, pair_seed=seed)\n",
+    "\n",
+    "variant_scoreboard = pd.DataFrame(\n",
+    "    [\n",
+    "        {\n",
+    "            \"method\": name,\n",
+    "            \"divergences\": int(fit.sample_stats[\"diverging\"].sum()),\n",
+    "            **score_shares(true_share, draws.to_numpy()),\n",
+    "        }\n",
+    "        for name, fit, draws in [\n",
+    "            (\"independent Normal (main)\", idata, share),\n",
+    "            (\"ALR logistic-normal\", compositional_idata, compositional_share),\n",
+    "            (\"Dirichlet-multinomial\", dm_idata, dm_share),\n",
+    "        ]\n",
+    "    ]\n",
+    ").set_index(\"method\")\n",
+    "variant_scoreboard.assign(\n",
+    "    coverage=lambda df: df[\"coverage\"].map(\"{:.0f} of 7\".format)\n",
+    ").round(4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "7fb6328d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-12T10:15:55.488743Z",
+     "iopub.status.busy": "2026-08-12T10:15:55.488603Z",
+     "iopub.status.idle": "2026-08-12T10:15:55.524897Z",
+     "shell.execute_reply": "2026-08-12T10:15:55.524400Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "Reading the table honestly, in both directions.\n",
+       "\n",
+       "**The compositional twin changes remarkably little here:** the two models are practically the same split: the largest difference in any campaign's mean share is **0.0009**. On the graded scores the twin lands at MAE 0.0343, CRPS 0.0251 and Spearman 0.893 against 0.0347, 0.0254 and 0.893 for the independent likelihood, with 0 and 0 divergences respectively. The negative dependence the objection points at is real, but with seven campaigns and noise this large it barely moves the split. That is a useful negative result: the independent likelihood is not what stands between this method and better accuracy.\n",
+       "\n",
+       "**The Dirichlet-multinomial is the cautionary tale.** Its mean shares end up within **0.0289** of the naive click split, against 0.0422 for the credibility split, so the overdispersion does buy some shrinkage here, though not the reach-scaled kind the credibility model encodes. It scores MAE 0.0366, CRPS 0.0307 and Spearman 0.893, with 35 divergences. The concentration's posterior interquartile range is 4,271 against 3,594 in the prior, so one observed composition leaves it essentially prior-driven: the amount of trust is set by a prior nobody can argue with, not by reach. Click *counts* are the wrong evidence currency for the same reason clicks are a proxy: the noise that matters is the misalignment between clicks and incrementality, and it does not shrink with click volume. Reach does the disciplining in this notebook precisely because it is not the quantity being divided up."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "main_label = \"independent Normal (main)\"\n",
+    "alr_label = \"ALR logistic-normal\"\n",
+    "dm_label = \"Dirichlet-multinomial\"\n",
+    "alr_row = variant_scoreboard.loc[alr_label]\n",
+    "dm_row = variant_scoreboard.loc[dm_label]\n",
+    "main_row = variant_scoreboard.loc[main_label]\n",
+    "\n",
+    "alr_share_gap = float(\n",
+    "    (compositional_share.mean(\"sample\").to_pandas() - share.mean(\"sample\").to_pandas())\n",
+    "    .abs()\n",
+    "    .max()\n",
+    ")\n",
+    "dm_click_gap = float((dm_share.mean(\"sample\").to_pandas() - click_split).abs().max())\n",
+    "main_click_gap = float((share.mean(\"sample\").to_pandas() - click_split).abs().max())\n",
+    "kappa_posterior = dm_idata.posterior[\"kappa\"].to_numpy().ravel()\n",
+    "kappa_prior_iqr = float(\n",
+    "    np.exp(np.log(1_000.0) + 2.0 * 0.6745) - np.exp(np.log(1_000.0) - 2.0 * 0.6745)\n",
+    ")\n",
+    "kappa_posterior_iqr = float(\n",
+    "    np.quantile(kappa_posterior, 0.75) - np.quantile(kappa_posterior, 0.25)\n",
+    ")\n",
+    "kappa_learned = kappa_posterior_iqr < 0.5 * kappa_prior_iqr\n",
+    "\n",
+    "alr_point_verdict = (\n",
+    "    \"the two models are practically the same split: the largest difference in any \"\n",
+    "    f\"campaign's mean share is **{alr_share_gap:.4f}**\"\n",
+    "    if alr_share_gap < 0.01\n",
+    "    else \"the two models disagree more than expected: the largest difference in a \"\n",
+    "    f\"campaign's mean share is **{alr_share_gap:.4f}**\"\n",
+    ")\n",
+    "alr_score_verdict = (\n",
+    "    f\"On the graded scores the twin lands at MAE {alr_row['mae']:.4f}, CRPS \"\n",
+    "    f\"{alr_row['crps']:.4f} and Spearman {alr_row['spearman']:.3f} against \"\n",
+    "    f\"{main_row['mae']:.4f}, {main_row['crps']:.4f} and {main_row['spearman']:.3f} \"\n",
+    "    f\"for the independent likelihood, with {int(alr_row['divergences'])} and \"\n",
+    "    f\"{int(main_row['divergences'])} divergences respectively.\"\n",
+    ")\n",
+    "dm_trust_verdict = (\n",
+    "    f\"It reproduces the click split almost verbatim: its mean shares sit within \"\n",
+    "    f\"**{dm_click_gap:.4f}** of the naive click shares (the credibility split keeps a \"\n",
+    "    f\"distance of {main_click_gap:.4f}), which is the $Z\\\\approx 1$ behaviour the \"\n",
+    "    f\"theory predicts, because thousands of clicks leave the multinomial part of the \"\n",
+    "    f\"likelihood almost no sampling noise to shrink.\"\n",
+    "    if dm_click_gap < 0.005\n",
+    "    else f\"Its mean shares end up within **{dm_click_gap:.4f}** of the naive click \"\n",
+    "    f\"split, against {main_click_gap:.4f} for the credibility split, so the \"\n",
+    "    f\"overdispersion does buy some shrinkage here, though not the reach-scaled kind \"\n",
+    "    f\"the credibility model encodes.\"\n",
+    ")\n",
+    "dm_kappa_verdict = (\n",
+    "    f\"The concentration's posterior interquartile range is \"\n",
+    "    f\"{kappa_posterior_iqr:,.0f} against {kappa_prior_iqr:,.0f} in the prior, so one \"\n",
+    "    \"observed composition does update it\"\n",
+    "    if kappa_learned\n",
+    "    else f\"The concentration's posterior interquartile range is \"\n",
+    "    f\"{kappa_posterior_iqr:,.0f} against {kappa_prior_iqr:,.0f} in the prior, so one \"\n",
+    "    \"observed composition leaves it essentially prior-driven: the amount of trust is \"\n",
+    "    \"set by a prior nobody can argue with, not by reach\"\n",
+    ")\n",
+    "\n",
+    "display(\n",
+    "    Markdown(\n",
+    "        f\"\"\"Reading the table honestly, in both directions.\n",
+    "\n",
+    "**The compositional twin changes remarkably little here:** {alr_point_verdict}. {alr_score_verdict} The negative dependence the objection points at is real, but with seven campaigns and noise this large it barely moves the split. That is a useful negative result: the independent likelihood is not what stands between this method and better accuracy.\n",
+    "\n",
+    "**The Dirichlet-multinomial is the cautionary tale.** {dm_trust_verdict} It scores MAE {dm_row[\"mae\"]:.4f}, CRPS {dm_row[\"crps\"]:.4f} and Spearman {dm_row[\"spearman\"]:.3f}, with {int(dm_row[\"divergences\"])} divergences. {dm_kappa_verdict}. Click *counts* are the wrong evidence currency for the same reason clicks are a proxy: the noise that matters is the misalignment between clicks and incrementality, and it does not shrink with click volume. Reach does the disciplining in this notebook precisely because it is not the quantity being divided up.\"\"\"\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
    "id": "84cc3da2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:37:23.965511Z",
-     "iopub.status.busy": "2026-08-11T12:37:23.965415Z",
-     "iopub.status.idle": "2026-08-11T12:37:23.989080Z",
-     "shell.execute_reply": "2026-08-11T12:37:23.988662Z"
+     "iopub.execute_input": "2026-08-12T10:15:55.526188Z",
+     "iopub.status.busy": "2026-08-12T10:15:55.526052Z",
+     "iopub.status.idle": "2026-08-12T10:15:55.556567Z",
+     "shell.execute_reply": "2026-08-12T10:15:55.556062Z"
     }
    },
    "outputs": [
@@ -4227,9 +5019,9 @@
     "::: {.callout-warning title=\"What it cannot do (read before trusting)\"}\n",
     "- **It cures noise, not bias.** It fixes the \"small campaigns are jumpy\" problem. It does not fix the fact that clicks are not incrementality. `lookalike_conversions` stays under-credited by 0.07 in share and `niche_interest` by 0.03, because **no method that only sees delivery data can recover what delivery data does not contain**.\n",
     "- **On point accuracy it does not beat a delivery split here.** MAE is 0.0347 against 0.0321 for the daily-reach share, and a common dial near 0.20 would have done better still on MAE while getting the ranking wrong. Its measurable gains are ranking, calibration and a defensible trust weight, not a jump in point accuracy.\n",
-    "- **The daily shape is inherited, not estimated.** Within a campaign the day-to-day pattern is its daily reach, which tracks the truth well for five campaigns and badly for `lookalike_conversions` at 0.56 and `niche_interest` at 0.28.\n",
+    "- **The daily shape is inherited, not estimated.** Within a campaign the day-to-day pattern is its daily reach, which tracks the truth well for five campaigns and badly for `lookalike_conversions` at 0.56 and `niche_interest` at 0.28. The adstock extension shows how much of that is repairable by inheriting the MMM's carryover, and a campaign whose true impact simply does not track its delivery stays beyond any reweighting.\n",
     "- **The uncertainty is a lower bound.** Five of seven true shares land inside the 94% HDI, but the interval carries parameter uncertainty only, and the clicks-to-incrementality gap is nowhere in the model.\n",
-    "- **The likelihood ignores that the target is compositional.** The naive rates are modelled as conditionally independent given $\\mu$ and $\\sigma_s$, but the click shares they come from sum to one, so an error on one campaign has to be absorbed by the others. That induced negative dependence is not represented, which is another reason the intervals are optimistic and plausibly contributes to landing at five of seven rather than higher.\n",
+    "- **The likelihood ignores that the target is compositional, so we tested the fix.** The click shares behind the naive rates sum to one, so an error on one campaign is absorbed by the others, a negative dependence the independent likelihood does not represent. The compositional-variants section fits the exact ALR twin of this model, and the split barely moves, so this shortcut is not what limits accuracy here; the same section shows that the Dirichlet-multinomial alternative trades the reach-based dial for a prior-driven one and drifts toward the click split.\n",
     "- **Evidence can be confounded with a truncated flight.** `broad_prospecting` is the only campaign still acquiring new people when the window closes, so its unique reach measures 30 days of growth rather than a saturated audience. It is discounted for being young as much as for being small, and nothing in the model knows the difference.\n",
     "- **Only seven campaigns.** The dial's tuning is itself uncertain, the posterior for $k$ says so, and no single synthetic dataset can settle a comparison against any baseline.\n",
     ":::\n",
@@ -4238,23 +5030,23 @@
     "1. **Pull expanding-window reach** per campaign: fix the report's start date and extend the end date one day at a time. The day-over-day differences are genuinely new people.\n",
     "2. **Build any naive split** of the MMM channel total from what your dashboard already gives you, whether clicks, conversions or last-touch revenue. It is allowed to be bad, that is the point. Express it **per reach-day**, using the same exposure you will allocate over.\n",
     "3. **Fit the model above** and read off each campaign's trust dial $Z_c$. Even before the split, $Z$ alone tells you which campaign numbers deserve to be taken seriously.\n",
-    "4. **Allocate the MMM channel curve daily**, scoring each campaign by its trust-adjusted rate times its daily reach. The pieces sum to the MMM total by construction.\n",
+    "4. **Allocate the MMM channel curve daily**, scoring each campaign by its trust-adjusted rate times its daily reach. Push that daily reach through your MMM's own adstock first, with the channel's fitted decay, so a campaign's credit can outlive its flight the way the MMM says the channel's impact does. The pieces sum to the MMM total by construction either way.\n",
     "5. **Sweep the dial against any ground truth you have**, even one lift test. It is the cheapest check that the answer is not an artefact of one fit.\n",
     ":::\n",
     "\n",
-    "**The bottom line.** This is an uncertainty-aware way to split a channel's MMM credit across campaigns, most valuable exactly where platform numbers are least reliable, on the small and bursty campaigns. Its one hard limit is that delivery data cannot see true incrementality. To break through it, pair the method with a **lift test**: feed a campaign's measured incremental lift in as a prior, and the trust dial will do the rest."
+    "**The bottom line.** This is an uncertainty-aware way to split a channel's MMM credit across campaigns, most valuable exactly where platform numbers are least reliable, on the small and bursty campaigns. Two structural refinements were tested above and are cheap to keep: spending the credit over **adstocked** reach aligns the split's timing with the carryover the MMM already believes in, and the **compositional** likelihood check shows the independence shortcut is not what limits accuracy. Its one hard limit is that delivery data cannot see true incrementality. To break through it, pair the method with a **lift test**: feed a campaign's measured incremental lift in as a prior, and the trust dial will do the rest."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 38,
    "id": "72bda077",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:37:23.990195Z",
-     "iopub.status.busy": "2026-08-11T12:37:23.990131Z",
-     "iopub.status.idle": "2026-08-11T12:37:24.024925Z",
-     "shell.execute_reply": "2026-08-11T12:37:24.024509Z"
+     "iopub.execute_input": "2026-08-12T10:15:55.557918Z",
+     "iopub.status.busy": "2026-08-12T10:15:55.557794Z",
+     "iopub.status.idle": "2026-08-12T10:15:55.601731Z",
+     "shell.execute_reply": "2026-08-12T10:15:55.601083Z"
     }
    },
    "outputs": [
@@ -4262,7 +5054,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Last updated: Tue, 11 Aug 2026\n",
+      "Last updated: Wed, 12 Aug 2026\n",
       "\n",
       "Python implementation: CPython\n",
       "Python version       : 3.14.2\n",
@@ -4284,6 +5076,7 @@
       "pandas        : 2.3.3\n",
       "pymc          : 6.0.1\n",
       "pymc_marketing: 1.0.0\n",
+      "pytensor      : 3.0.7\n",
       "scipy         : 1.18.0\n",
       "seaborn       : 0.13.2\n",
       "xarray        : 2026.4.0\n",


### PR DESCRIPTION
## Description

Implements and validates the suggestions from the review discussion on #2849 ([review thread](https://github.com/pymc-labs/pymc-marketing/pull/2849#discussion_r2273309799)), targeting the notebook branch so the changes land inside the existing PR. The notebook was regenerated end to end (jupytext round-trip, full MCMC execution), all recurring numbers are interpolated from the tables that produce them, and the existing 16-assert guard cell passes unchanged, so the main narrative's numbers are untouched.

### 1. Lack of alignment with the main MMM's structure (@lancechua) — adstock + proxy caveats

**New section "Extension: letting the credit outlive the flight."** Each campaign's daily reach is pushed through `pymc_marketing.mmm.transformers.geometric_adstock` — the same transform the MMM used — before the daily allocation, so a campaign's credit decays after its flight instead of stopping dead. No new MCMC is needed: only the exposure the fitted rates are spent over changes, and the split still reconciles to the MMM draws to `<1e-9`.

The shipped data package carries only the contribution posterior, not the fitted decay, so the notebook sweeps the decay and grades each setting against the hidden truth (same oracle-grading as the existing Z sweep). Measured: mean daily correlation with the truth rises from **0.744** (no carryover) to **0.797** at decay 0.6; the biggest winners are exactly the campaigns the notebook previously flagged as its daily-shape failures, `lookalike_conversions` **0.56 → 0.70** and `niche_interest` **0.28 → 0.41**; `flash_sale_burst` and `spring_promo` give back 0.02/0.01; flight shares move by at most **0.0026**, so it repairs *when* the credit lands, not *who* gets it. The stated production guidance (section + run-it-yourself recipe) is to inherit the channel's `adstock_alpha` posterior from the fitted MMM rather than tune anything — which is what "aligned with the main model" means. The sweep also notes the honest limit: the simulation's true carryover is per-campaign, so a single channel-level decay is an approximation.

**New callout "Clicks are a stand-in, and every click is priced the same."** States the two assumptions the review called out: clicks are one replaceable proxy (conversions, last-touch revenue, lift-informed signals slot into the same $y_c$), and the split prices every click equally — with mixed campaign objectives that is structural bias, and the method cures noise, not bias.

### 2. Small number of campaigns → weakly identified hyperparameters — prose

The weak-identification callout now addresses the time-series idea directly: a weekly-panel likelihood would multiply the observations informing $s^2$ and $k$, but weekly increments of cumulative unique reach are strongly autocorrelated, weekly click shares are still one composition per week, and within-campaign shocks persist across weeks — so the extra rows are far from independent evidence, and the flight-level model plus the prior/seed sensitivity tables is the deliberate compromise (matching @cetagostini's point about autocorrelation).

### 3. Compositional likelihood (Dirichlet suggestion) — tested, both directions reported

**New section "Is ignoring the composition hurting? Two compositional variants."**

- **ALR logistic-normal twin**: the exact compositional version of the model — six ALR contrasts with mean $\theta_c-\theta_{\text{ref}}$ and the induced rank-one covariance $\operatorname{diag}(\psi_{-\text{ref}})+\psi_{\text{ref}}\mathbf{1}\mathbf{1}^{\top}$, implemented as a shared reference-noise scalar latent (no matrix, no extra sampler stress). Same hierarchy, same reach-based dial. Measured: **0 divergences**, largest mean-share difference from the main model **0.0009**, MAE/CRPS 0.0343/0.0251 vs 0.0347/0.0254. A useful negative result, stated as such: the independence shortcut is not what limits accuracy here.
- **Dirichlet-multinomial on click counts** (the review's literal suggestion): drifts toward the click split (within 0.0289 of it vs 0.0422 for the credibility split), its concentration stays essentially prior-driven (posterior IQR ≥ prior IQR from one observed composition), and it samples with 35 divergences. The section explains why: in that likelihood the noise on a share shrinks with click volume, but the noise that matters — the clicks-to-incrementality misalignment — does not, so click counts are the wrong evidence currency and reach keeps the disciplining role.

The honest-part bullets and bottom line were updated to reference the measured outcomes instead of speculating.

## Validation

- `uv run jupyter execute --inplace --kernel_name pymc-mkt-uv` full run: exit 0, **0 error outputs**, guard cell passes ("All 16 hardcoded numbers in the prose still hold").
- New in-notebook asserts: decay-0 sweep row reproduces the main allocation (daily correlations via `np.allclose`, CRPS via `np.isclose`); adstocked reconciliation `<1e-9` at every decay.
- Mock runner (`scripts/run_notebooks/runner.py`) reaches the same pre-existing guard-cell stop as the unmodified notebook, with the *identical* mocked value — confirming the new cells execute cleanly and do not shift the RNG stream. (`mmm/dev` notebooks are outside the CI glob and outside ruff's include, as before.)
- `pre-commit run --all-files` passes. Notebook stays at 2.3 MB. Two cosmetic ipywidgets-related warnings from tqdm/rich in the current uv env are filtered explicitly with a comment, keeping outputs clean.

## Related Issue

- [ ] Closes #
- [x] Related to #2849

## Checklist

- [x] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2863.org.readthedocs.build/en/2863/

<!-- readthedocs-preview pymc-marketing end -->