### PR TITLE
Signpost the advanced funnel notebook: full model names and section takeaways

### DIFF
--- a/docs/source/notebooks/mmm/mmm_funnel_mueffect_advanced.ipynb
+++ b/docs/source/notebooks/mmm/mmm_funnel_mueffect_advanced.ipynb
@@ -531,14 +531,14 @@
     "\n",
     "| Model | Beyond the two upper channels | How it treats the funnel | Question it can answer |\n",
     "|---|---|---|---|\n",
-    "| `Naive A` | adds `lower_spend` as a third **channel** | conditions on the mediator, which blocks the indirect path | approximately the **direct** effect of the upper channels |\n",
-    "| `Naive B` | nothing | ignores the mediator entirely | targets the **total** effect, but a backdoor through the shared market driver stays open |\n",
-    "| `Naive B+` | adds `category_demand` as a **control column** | still ignores the mediator, but blocks that backdoor through the observed demand index | the **total** effect: formally valid |\n",
-    "| `Naive B++` | adds the growth trend `t` as a **control column** | blocks only the trend strand of the backdoor; the drivers' shared noise stays open | the **total** effect: valid only conditionally |\n",
-    "| `Naive C` | adds `search_volume` as a third **channel** | conditions on a *symptom* of demand, partially blocking the indirect path | neither effect cleanly |\n",
+    "| `Naive A (mediator as channel)` | adds `lower_spend` as a third **channel** | conditions on the mediator, which blocks the indirect path | approximately the **direct** effect of the upper channels |\n",
+    "| `Naive B (mediator omitted)` | nothing | ignores the mediator entirely | targets the **total** effect, but a backdoor through the shared market driver stays open |\n",
+    "| `Naive B+ (demand as control)` | adds `category_demand` as a **control column** | still ignores the mediator, but blocks that backdoor through the observed demand index | the **total** effect: formally valid |\n",
+    "| `Naive B++ (trend as control)` | adds the growth trend `t` as a **control column** | blocks only the trend strand of the backdoor; the drivers' shared noise stays open | the **total** effect: valid only conditionally |\n",
+    "| `Naive C (indicator as channel)` | adds `search_volume` as a third **channel** | conditions on a *symptom* of demand, partially blocking the indirect path | neither effect cleanly |\n",
     "| `Funnel` | the `FunnelEffect`: `lower_spend` and `search_volume` as extra likelihoods, `category_demand` and `lf_budget` as inputs | models the mediation explicitly | **direct, indirect and total**, separately |\n",
     "\n",
-    "These names stick throughout the notebook. The d-separation section below *computes* the causal verdicts sketched in the last column, and the fitting section then tests them against the known ground truth."
+    "These are the labels every table and figure below prints, verbatim, and the prose uses the full form whenever a model is (re)introduced, so a name never has to be held in memory across sections. The short forms `Naive A`, `Naive B`, `Naive B+`, `Naive B++` and `Naive C` are used only as shorthand inside a discussion that has already named the model in full. The d-separation section below *computes* the causal verdicts sketched in the last column, and the fitting section then tests them against the known ground truth."
    ]
   },
   {
@@ -4312,9 +4312,9 @@
    "id": "e84f1dba",
    "metadata": {},
    "source": [
-    "### Naive A: mediator as an ordinary channel\n",
+    "### `Naive A (mediator as channel)`: the mediator as an ordinary channel\n",
     "\n",
-    "This is what most production MMMs do when they have upper- and lower-funnel spend in the same table: list them side by side. It is not an unreasonable model: in this DAG lower-funnel spend really does drive the target, so the coefficient it estimates is a real thing. But as the d-separation table showed, conditioning on the mediator **blocks the indirect path**: the upper channels are credited with at most their direct effect, and the lower-funnel channel keeps the credit for demand they created. Naive A is not a broken model so much as a model that silently answers a different question (the *direct* effect), and we will benchmark it against that quantity as well as against the total."
+    "This is what most production MMMs do when they have upper- and lower-funnel spend in the same table: list them side by side. It is not an unreasonable model: in this DAG lower-funnel spend really does drive the target, so the coefficient it estimates is a real thing. But as the d-separation table showed, conditioning on the mediator **blocks the indirect path**: the upper channels are credited with at most their direct effect, and the lower-funnel channel keeps the credit for demand they created. `Naive A (mediator as channel)` is not a broken model so much as a model that silently answers a different question (the *direct* effect), and we will benchmark it against that quantity as well as against the total."
    ]
   },
   {
@@ -4430,9 +4430,9 @@
    "id": "1026772a",
    "metadata": {},
    "source": [
-    "### Naive B: mediator omitted\n",
+    "### `Naive B (mediator omitted)`\n",
     "\n",
-    "Here the two upper channels are the only media. Causally this is the **right estimand**: not conditioning on the mediator is exactly what makes a total effect a total effect. Naive B has two distinct problems, and they will land on different channels. The first is the one the graph isolated: the open backdoor through the shared growth trend, which the residual-correlation table showed is material for TV and absent for social. The second the graph is silent about: with the mediator omitted, each response curve also has to absorb the demand its channel creates downstream, mediated through a saturating pool the model does not represent. Where each part lands, we will let the results say."
+    "Here the two upper channels are the only media. Causally this is the **right estimand**: not conditioning on the mediator is exactly what makes a total effect a total effect. `Naive B (mediator omitted)` has two distinct problems, and they will land on different channels. The first is the one the graph isolated: the open backdoor through the shared growth trend, which the residual-correlation table showed is material for TV and absent for social. The second the graph is silent about: with the mediator omitted, each response curve also has to absorb the demand its channel creates downstream, mediated through a saturating pool the model does not represent. Where each part lands, we will let the results say."
    ]
   },
   {
@@ -4548,7 +4548,7 @@
    "id": "671ad93d",
    "metadata": {},
    "source": [
-    "### Naive B+: mediator omitted, category demand as a control\n",
+    "### `Naive B+ (demand as control)`: mediator omitted, category demand as a control\n",
     "\n",
     "This is the adjustment the d-separation analysis nominated: block the remaining backdoors with the observed category index, which sits downstream of *both* forks in the shared driver. `MMM` takes it as an ordinary **control column** (a linear term with a per-geo coefficient, no adstock or saturation), which is one argument and no new machinery:"
    ]
@@ -4676,9 +4676,9 @@
    "id": "6adc4cfb",
    "metadata": {},
    "source": [
-    "### Naive B++: mediator omitted, the trend as a control\n",
+    "### `Naive B++ (trend as control)`: mediator omitted, the trend as a control\n",
     "\n",
-    "The second candidate is the cheapest specification available here: no extra data series at all, since the regressor is a function of the calendar, just one more control column with a per-geo coefficient. On the graph it is valid only under the extra assumption that the drivers' shared noise is negligible, which is the kind of assumption trend controls usually rest on and which we sized above rather than waved at. The same functional-form caveat applies as for Naive B+: the trend reaches the target through softplus-rectified plans and a saturating conversion, and a linear term stands in for all of it."
+    "The second candidate is the cheapest specification available here: no extra data series at all, since the regressor is a function of the calendar, just one more control column with a per-geo coefficient. On the graph it is valid only under the extra assumption that the drivers' shared noise is negligible, which is the kind of assumption trend controls usually rest on and which we sized above rather than waved at. The same functional-form caveat applies as for `Naive B+ (demand as control)`: the trend reaches the target through softplus-rectified plans and a saturating conversion, and a linear term stands in for all of it."
    ]
   },
   {
@@ -4794,7 +4794,7 @@
    "id": "e5d36c13",
    "metadata": {},
    "source": [
-    "### Naive C: the indicator as a channel\n",
+    "### `Naive C (indicator as channel)`: the indicator as a channel\n",
     "\n",
     "Branded search volume is the most tempting variable in the whole dataset. It correlates beautifully with sales, it is free, and it arrives weekly. So it ends up in the channel list.\n",
     "\n",
@@ -5324,6 +5324,10 @@
    "metadata": {},
    "source": [
     "## Parameter recovery\n",
+    "\n",
+    "```{important}\n",
+    "**Where this lands.** The funnel model recovers the ground truth, but the direct and demand paths are only weakly identified *apart*: in all six channel-geo cells the two amplitudes miss in opposite directions. That seesaw is a property of two paths originating at the same spend, not six independent misses, and the total effects further down survive it. `west` is the hardest geo, by construction.\n",
+    "```\n",
     "\n",
     "Because we generated the data we can check the funnel model against the truth. One subtlety carries over from the basic notebook and gets slightly more involved here: the `MMM` fits on an internally scaled target, so every parameter that acts on the **scale of the target mean** (the intercept, the two saturation amplitudes and the Fourier coefficients) must be multiplied by `target_scale` before comparing with the ground truth. With `dims=()` scaling that factor is **per geo**, and `xarray` applies it by label for us. Parameters acting on the *inputs* (adstock decays, saturation curvatures) or on the *mediator* scale (everything in the demand equation) are scale-free and compare directly."
    ]
@@ -6291,9 +6295,13 @@
    "source": [
     "## Head-to-head: the bias from ignoring the funnel\n",
     "\n",
+    "```{important}\n",
+    "**Where this lands.** Every mediator-blind model pays for the funnel it cannot see, and the bill differs by channel. `Naive B (mediator omitted)` overstates TV through the shared growth trend. `Naive B++ (trend as control)` repairs TV and misallocates onto social instead. `Naive A (mediator as channel)` is not so much wrong as answering the *direct*-effect question, so it is scored against both benchmarks below.\n",
+    "```\n",
+    "\n",
     "Finally we compare the six models on the quantity a budget decision actually turns on: the **total contribution of each upper-funnel channel**. For the naive models the channel contribution is already the counterfactual versus zero spend. For the funnel model we use direct plus the counterfactual indirect effect.\n",
     "\n",
-    "The rows are grouped **by estimand**, following the d-separation analysis: the models above the separator answer (or claim to answer) the total-effect question; `Naive A` sits below it with the funnel model's direct path, because the direct effect is the question it actually answers. Every bias annotation names its benchmark.\n",
+    "The rows are grouped **by estimand**, following the d-separation analysis: the models above the separator answer (or claim to answer) the total-effect question; `Naive A (mediator as channel)` sits below it with the funnel model's direct path, because the direct effect is the question it actually answers. Every bias annotation names its benchmark.\n",
     "\n",
     "The figure is a forest plot of means and intervals against the true values, and the ROAS comparison further down wants exactly the same panel, so we write it once:"
    ]
@@ -6483,9 +6491,9 @@
    "source": [
     "Each verdict from the d-separation table now has an empirical face, and the two channels put two different failure mechanisms on display.\n",
     "\n",
-    "**Naive B overstates TV, and the trend is why.** TV, the channel whose residual correlation with category demand survived the seasonal projection at +0.63 to +0.67, comes out overstated in every geo (+15.9% to +30.8%). This is textbook confounding: trending category demand, routed through the mediator into the target, credited to the one regressor that also trends.\n",
+    "**`Naive B (mediator omitted)` overstates TV, and the trend is why.** TV, the channel whose residual correlation with category demand survived the seasonal projection at +0.63 to +0.67, comes out overstated in every geo (+15.9% to +30.8%). This is textbook confounding: trending category demand, routed through the mediator into the target, credited to the one regressor that also trends.\n",
     "\n",
-    "**Both candidate fixes do repair TV, and the graph's ranking of them is inverted.** `Naive B++` conditions on the trend itself, exactly where the graph put one of the two forks, and its TV estimates land within a few points of the truth, just past it on the other side (-7.4% to -2.5%). `Naive B+` conditions downstream on the category index (the specification the graph nominated, because it blocks the noise fork too) and recovers only part of the same correction (TV at +7.7% to +19.9%, and in `west` it nudges TV slightly further out rather than back).\n",
+    "**Both candidate fixes do repair TV, and the graph's ranking of them is inverted.** `Naive B++ (trend as control)` conditions on the trend itself, exactly where the graph put one of the two forks, and its TV estimates land within a few points of the truth, just past it on the other side (-7.4% to -2.5%). `Naive B+ (demand as control)` conditions downstream on the category index (the specification the graph nominated, because it blocks the noise fork too) and recovers only part of the same correction (TV at +7.7% to +19.9%, and in `west` it nudges TV slightly further out rather than back).\n",
     "\n",
     "So the adjustment set with the *weaker* formal credential does the better empirical job here: its linear control competes with the flexible response curves for the same variance, and, as the arithmetic below shows, a trend the curves cannot mimic is won more decisively than a category index they can. Graph validity ranks specifications only up to functional form; it never promised more.\n",
     "\n",
@@ -6743,6 +6751,10 @@
    "metadata": {},
    "source": [
     "## ROAS, nationally and per geo\n",
+    "\n",
+    "```{important}\n",
+    "**Where this lands.** The ROAS ordering reproduces the contribution ordering above; what is new here is the **denominator**. Upper-funnel activity induces lower-funnel spend that someone has to authorise, and only a model that sees the funnel can price it, so `Funnel (total)` and the induced-spend row answer two different budget questions.\n",
+    "```\n",
     "\n",
     "Budget decisions key off return on ad spend, so let us express the same comparison that way. All estimates use the **same** definition (contribution summed over the observed weeks, divided by spend over those same weeks) so that any difference between them is structural rather than definitional.\n",
     "\n",
@@ -7493,7 +7505,7 @@
    "id": "a2113fb3",
    "metadata": {},
    "source": [
-    "The bias table judges every column against the **true total**. For five of the six that is their own estimand; `Naive A` is included on the same yardstick deliberately, because \"mediator as a channel\" is how it gets used in practice: its column shows the cost of *misreading* it as a total-effect estimate, and its own estimand is scored separately below.\n",
+    "The bias table judges every column against the **true total**. For five of the six that is their own estimand; `Naive A (mediator as channel)` is included on the same yardstick deliberately, because \"mediator as a channel\" is how it gets used in practice: its column shows the cost of *misreading* it as a total-effect estimate, and its own estimand is scored separately below.\n",
     "\n",
     "Read `Naive A`'s summary row with one caution, though: a percentage bias divides by the estimand it is scored against, and the true direct effect is about two thirds of the true total (the indirect shares above run 33.7% to 37.7%). The same absolute error therefore prints *smaller* against the total than against the direct effect, which is most of the distance between A's mean |error| in this table and the roughly 34% it scores against its own estimand.\n",
     "\n",
@@ -8278,7 +8290,7 @@
    "id": "4ddbc4d7",
    "metadata": {},
    "source": [
-    "The denominators are not the story. In truth the two channels contribute almost the same amount (162 against 146: social buys less spend but converts it better), so a percentage comparison between them was close to fair already, and the absolute table repeats the percentage table's verdict without the escape hatch. `Naive B` misallocates about **half again** as much contribution onto social as onto TV (+56.5 against +38.9); `Naive B++`, the model that *fixes* TV, misallocates about **nine times** as much, 72.9 against 8.5 on the uncancelled row. (Here the two readings agree for B++: its three TV cells run -3.3, -4.0 and -1.1, all the same sign, so nothing cancels.) The likelihood really does prefer social; it is not an artifact of dividing by a smaller number.\n",
+    "The denominators are not the story. In truth the two channels contribute almost the same amount (162 against 146: social buys less spend but converts it better), so a percentage comparison between them was close to fair already, and the absolute table repeats the percentage table's verdict without the escape hatch. `Naive B (mediator omitted)` misallocates about **half again** as much contribution onto social as onto TV (+56.5 against +38.9); `Naive B++ (trend as control)`, the model that *fixes* TV, misallocates about **nine times** as much, 72.9 against 8.5 on the uncancelled row. (Here the two readings agree for B++: its three TV cells run -3.3, -4.0 and -1.1, all the same sign, so nothing cancels.) The likelihood really does prefer social; it is not an artifact of dividing by a smaller number.\n",
     "\n",
     "One caution about the by-channel row itself, before reading it: summing signed biases over geos lets a model's cells cancel. The funnel model is the clearest case here. Its social column nets to +2.0, close enough to zero to look like a model that gets social exactly right, while its three social cells (-6.2, +9.4 and -1.3) misstate 16.9 units between them. `Naive C`'s social column tells the same story more loudly: +32.2 signed against 54.4 uncancelled, because its cells run -11.1, +33.6 and +9.7. Neither reading changes the ranking on this draw, but the signed row understates both models, and by different amounts.\n",
     "\n",


### PR DESCRIPTION
Follow-up to @jamespooley's two review comments on #2813, which landed after the merge.

**1. Consistent, informative model names.** The notebook already has canonical labels that every table and figure prints verbatim (`Naive A (mediator as channel)`, `Naive B (mediator omitted)`, `Naive B+ (demand as control)`, `Naive B++ (trend as control)`, `Naive C (indicator as channel)`), but the prose mostly used the bare letters. Rather than introduce a third naming scheme, this reuses those exact strings in:

- the *Model structures we will study* table
- the five fitting-section headings
- the first mention of each model in the head-to-head, bias, and absolute-bias discussions

The short forms survive only as shorthand inside a discussion that has already named the model in full, which keeps the denser paragraphs readable. The table's closing sentence now states that rule explicitly.

**2. Reorientation boxes at the top of the major sections.** Added an `{important}` box opening Parameter recovery, Head-to-head, and ROAS, each stating that section's finding before the detail: the amplitude seesaw and that the totals survive it; that the bill for ignoring the funnel differs by channel and that `Naive A` answers the direct-effect question; and that the ROAS section's new information is the denominator. The existing mid-section boxes are untouched.

Markdown cells only. No code, outputs, or numbers changed, so nothing needed a re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2880.org.readthedocs.build/en/2880/

<!-- readthedocs-preview pymc-marketing end -->