### PR TITLE
test(mmm): assert every adstock logp is differentiable

### DIFF
--- a/tests/mmm/components/test_adstock.py
+++ b/tests/mmm/components/test_adstock.py
@@ -84,6 +84,29 @@ def test_apply(model, adstock: AdstockTransformation, x, dims) -> None:
     "adstock",
     adstocks(),
 )
+def test_adstock_logp_is_differentiable(adstock: AdstockTransformation) -> None:
+    """Every adstock parameter must admit a gradient of the model logp.
+
+    ``pm.sample`` silently demotes a variable to Metropolis when ``grad`` raises,
+    so a non-differentiable Op inside an adstock graph surfaces much later as an
+    unrelated sampler error rather than as a transformation failure.
+    """
+    data = as_xtensor(np.broadcast_to(x, (3, 20)).T.copy(), dims=("time", "channel"))
+
+    with pm.Model(coords={"channel": ["a", "b", "c"], "time": range(20)}) as model:
+        y = adstock.apply(data, core_dim="time")
+        mu = y.transpose("time", "channel").values
+        pm.Normal("obs", mu=mu, sigma=1, observed=np.zeros((20, 3)))
+
+    logp = model.logp()
+    for value_var in model.continuous_value_vars:
+        pt.grad(logp, value_var)
+
+
+@pytest.mark.parametrize(
+    "adstock",
+    adstocks(),
+)
 def test_default_prefix(adstock: AdstockTransformation) -> None:
     assert adstock.prefix == "adstock"
     for value in adstock.variable_mapping.values():


### PR DESCRIPTION
Add test to assert every adstock logp is differentiable.

The bug was fixed upstream.

<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
Using this WeibullPDFAdstock throws a verbatim TypeError when computing the min-max normalization because Min has no pullback however, Max does (invisible at tensor level since pt.min is -max(-x)). The result is that PyMC's gradient check fails and falls back to Metropolis, which can't handle a dims model.

This adstock has never actually been NUTS-sampled, previously published results may be affected, worth a release-note mention.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #2877 https://github.com/pymc-labs/pymc-marketing/issues/2877
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2881.org.readthedocs.build/en/2881/

<!-- readthedocs-preview pymc-marketing end -->