### PR TITLE
feat(mmm): co-optimize named pm.Data levers alongside the media budgets

### DIFF
--- a/pymc_marketing/mmm/budget_optimizer.py
+++ b/pymc_marketing/mmm/budget_optimizer.py
@@ -1551,30 +1551,12 @@ class BudgetOptimizer(BaseModel):
         # Optimizable vars become lever variables appended after media. They
         # are optimized in their own units and stay out of the budget-sum
         # constraint, which sums the media tensor alone.
-        levers = []
-        for lever_name, lever_bounds in self.optimizable_vars.items():
-            if lever_name not in self.model.named_vars_to_dims:
-                raise ValueError(
-                    f"optimizable_vars entry '{lever_name}' is not a variable "
-                    "with named dims in the model."
-                )
-            lever_dims = list(self.model.named_vars_to_dims[lever_name])
-            if len(lever_dims) != 1 or lever_dims[0] == self.date_dim:
-                raise ValueError(
-                    f"optimizable_vars entry '{lever_name}' must have exactly "
-                    f"one dim, and not the {self.date_dim!r} dim; got "
-                    f"{tuple(lever_dims)}. Date-varying optimizable variables "
-                    "are not supported."
-                )
-            levers.append(
-                LeverVariable(
-                    name=lever_name,
-                    dim=lever_dims[0],
-                    coords=list(self.model.coords[lever_dims[0]]),
-                    bounds=lever_bounds,
-                    initial_value=self.model[lever_name].get_value(),
-                )
+        levers = [
+            LeverVariable.from_model(
+                self.model, lever_name, lever_bounds, date_dim=self.date_dim
             )
+            for lever_name, lever_bounds in self.optimizable_vars.items()
+        ]
 
         self._variables = OptimizationVariables([media_variable, *levers])
         self._budgets_flat = self._variables.flat

--- a/pymc_marketing/mmm/budget_optimizer.py
+++ b/pymc_marketing/mmm/budget_optimizer.py
@@ -251,6 +251,7 @@ from pymc.model.transform.optimization import freeze_dims_and_data
 from pytensor import function
 from pytensor.compile.sharedvalue import SharedVariable, shared
 from pytensor.graph import rewrite_graph
+from pytensor.graph.traversal import ancestors
 from pytensor.xtensor.type import XTensorVariable
 from scipy.optimize import OptimizeResult, minimize
 from xarray import DataArray, DataTree
@@ -262,6 +263,7 @@ from pymc_marketing.mmm.constraints import (
 )
 from pymc_marketing.mmm.optimization_variables import (
     FLAT_DIM,
+    LeverVariable,
     MediaVariable,
     OptimizationVariables,
     align_to_model_coords,
@@ -1223,6 +1225,23 @@ class BudgetOptimizer(BaseModel):
         ),
     )
 
+    optimizable_vars: dict[str, Sequence[tuple[float | None, float | None]] | None] = (
+        Field(
+            default_factory=dict,
+            description=(
+                "Additional pm.Data variables to co-optimize alongside "
+                "`channel_data_var`, keyed by variable name. Each value gives the "
+                "native (low, high) bounds per entry in the variable's coordinate "
+                "order, or None for unbounded. Each variable must have exactly one "
+                "dim, which must not be the date dim, since date-varying variables "
+                "are not supported. Optimal values are returned in "
+                "`result.optimized_vars`. These variables are optimized in their "
+                "own units and do not participate in the default budget-sum "
+                "constraint, which sums the media budgets alone."
+            ),
+        )
+    )
+
     response_variable: str = Field(
         default="total_media_contribution_original_scale",
         description="The response variable to optimize.",
@@ -1529,7 +1548,35 @@ class BudgetOptimizer(BaseModel):
             budget_distribution_over_period_tensor=self._budget_distribution_over_period_tensor,
             cost_per_unit_tensor=self._cost_per_unit_tensor,
         )
-        self._variables = OptimizationVariables([media_variable])
+        # Optimizable vars become lever variables appended after media. They
+        # are optimized in their own units and stay out of the budget-sum
+        # constraint, which sums the media tensor alone.
+        levers = []
+        for lever_name, lever_bounds in self.optimizable_vars.items():
+            if lever_name not in self.model.named_vars_to_dims:
+                raise ValueError(
+                    f"optimizable_vars entry '{lever_name}' is not a variable "
+                    "with named dims in the model."
+                )
+            lever_dims = list(self.model.named_vars_to_dims[lever_name])
+            if len(lever_dims) != 1 or lever_dims[0] == self.date_dim:
+                raise ValueError(
+                    f"optimizable_vars entry '{lever_name}' must have exactly "
+                    f"one dim, and not the {self.date_dim!r} dim; got "
+                    f"{tuple(lever_dims)}. Date-varying optimizable variables "
+                    "are not supported."
+                )
+            levers.append(
+                LeverVariable(
+                    name=lever_name,
+                    dim=lever_dims[0],
+                    coords=list(self.model.coords[lever_dims[0]]),
+                    bounds=lever_bounds,
+                    initial_value=self.model[lever_name].get_value(),
+                )
+            )
+
+        self._variables = OptimizationVariables([media_variable, *levers])
         self._budgets_flat = self._variables.flat
         self._budgets = media_variable.scattered(
             self._variables.variable_slice(self.channel_data_var)
@@ -1550,12 +1597,52 @@ class BudgetOptimizer(BaseModel):
                 "Pass an explicit response_variable to BudgetOptimizer."
             )
 
+        # 8b. Every lever must be able to move the response variable. A lever
+        # the objective cannot reach has an identically zero gradient, so the
+        # solver would return its warm-start value and report it as optimal.
+        # Graph reachability answers this exactly, before anything is compiled.
+        if self.optimizable_vars:
+            reachable = set(ancestors([self._pymc_model[self.response_variable]]))
+            unreachable = [
+                name
+                for name in self.optimizable_vars
+                if self._pymc_model[name] not in reachable
+            ]
+            if unreachable:
+                raise ValueError(
+                    f"response_variable={self.response_variable!r} does not "
+                    f"depend on optimizable_vars {unreachable}, so their "
+                    "gradient is identically zero and they cannot be "
+                    "optimized. Pass a response variable that includes their "
+                    "contribution."
+                )
+
         # 9. Compile objective & gradient
         self._compile_objective_and_grad()
 
         # 10. Build constraints
         self._constraints = {}
         self.set_constraints(constraints=self.constraints)
+
+    @property
+    def optimization_variables(self) -> OptimizationVariables:
+        """The decision vector's variables: media, plus any ``optimizable_vars``.
+
+        Exposed so a custom
+        :class:`~pymc_marketing.mmm.constraints.Constraint` can reach a
+        variable's segment of the flat vector, which is what constraining
+        anything other than the media budgets requires. For example, capping
+        the total of a lever named ``promo_data``::
+
+            Constraint(
+                key="max_total_discount",
+                constraint_type="ineq",
+                constraint_fun=lambda budgets, total, opt: (
+                    1.0 - opt.optimization_variables.variable_slice("promo_data").sum()
+                ),
+            )
+        """
+        return self._variables
 
     def set_constraints(self, constraints: Sequence[Constraint]) -> None:
         """Set constraints for the optimizer.

--- a/pymc_marketing/mmm/constraints.py
+++ b/pymc_marketing/mmm/constraints.py
@@ -54,7 +54,14 @@ def build_default_sum_constraint(key: str = "default") -> Constraint:
     def _constraint_fun(
         budgets_sym: XTensorVariable, total_budget_sym: XTensorVariable, optimizer
     ) -> XTensorVariable:
-        return budgets_sym.sum() - total_budget_sym
+        # Total every variable that spends from the pot, not the media tensor
+        # alone, so a second monetary variable shares the budget rather than
+        # being optimized for free.
+        contributions = optimizer.optimization_variables.budget_contributions()
+        total = contributions[0].sum()
+        for contribution in contributions[1:]:
+            total = total + contribution.sum()
+        return total - total_budget_sym
 
     return Constraint(
         key=key,

--- a/pymc_marketing/mmm/optimization_variables.py
+++ b/pymc_marketing/mmm/optimization_variables.py
@@ -31,7 +31,7 @@ variable each segment substitutes, how a segment maps to model-space tensors
 """
 
 from abc import ABC, abstractmethod
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 
 import numpy as np
 import pytensor.tensor as pt
@@ -42,6 +42,7 @@ from xarray import DataArray
 
 __all__ = [
     "FLAT_DIM",
+    "LeverVariable",
     "MediaVariable",
     "OptimizationVariable",
     "OptimizationVariables",
@@ -419,6 +420,108 @@ class MediaVariable(OptimizationVariable):
     ) -> list[tuple[float | None, float | None]]:
         """Default ``[0, total_budget]`` bounds per optimized cell."""
         return [(0.0, float(total_budget))] * self.size
+
+
+class LeverVariable(OptimizationVariable):
+    """A non-media decision variable: one ``pm.Data`` node in native units.
+
+    Where :class:`MediaVariable` converts monetary budgets into channel data,
+    a lever is optimized directly in whatever units the model already uses for
+    it (a discount fraction, a price index), so the forward map is the identity
+    up to relabelling the flat dimension.
+
+    Levers do not participate in the default budget-sum constraint, which sums
+    the media tensor alone: a discount depth is not money drawn from a shared
+    pool. To constrain one, write a custom
+    :class:`~pymc_marketing.mmm.constraints.Constraint` and reach its segment
+    of the flat vector through
+    ``optimizer.optimization_variables.variable_slice(name)``.
+
+    Parameters
+    ----------
+    name : str
+        Name of the model's ``pm.Data`` node this lever substitutes.
+    dim : str
+        The node's single dimension, which must not be the date dim.
+    coords : list
+        Coordinates of ``dim``, in the model's order.
+    bounds : Sequence[tuple] or None
+        Declared ``(low, high)`` bounds per entry in the lever's native units,
+        or None to leave it unbounded.
+    initial_value : np.ndarray
+        The node's current value in the model, used as the warm start.
+    flat_dim : str
+        Name of the flat decision vector's dimension.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        dim: str,
+        coords: list,
+        bounds: Sequence[tuple[float | None, float | None]] | None,
+        initial_value: np.ndarray,
+        flat_dim: str = FLAT_DIM,
+    ) -> None:
+        self.name = name
+        self.dim = dim
+        self.dims = (dim,)
+        self.coords = {dim: list(coords)}
+        self.bounds = list(bounds) if bounds is not None else None
+        self.initial_value = np.ravel(np.asarray(initial_value, dtype=float))
+        self.flat_dim = flat_dim
+        if self.initial_value.shape != (self.size,):
+            raise ValueError(
+                f"{name}: initial value has {self.initial_value.size} entries, "
+                f"expected {self.size} (the length of dim {dim!r})"
+            )
+        if self.bounds is not None and len(self.bounds) != self.size:
+            raise ValueError(
+                f"{name}: {len(self.bounds)} bounds pairs for {self.size} "
+                f"entries of dim {dim!r}"
+            )
+
+    @property
+    def size(self) -> int:
+        """Number of lever entries, the length of its dim."""
+        return len(self.coords[self.dim])
+
+    def to_model(self, z: XTensorVariable) -> XTensorVariable:
+        """Relabel the flat slice with the lever's own dim."""
+        return z.rename({self.flat_dim: self.dim})
+
+    def unpack(self, x: np.ndarray) -> DataArray:
+        """Label a flat solution slice with the lever's dim and coords."""
+        return DataArray(np.asarray(x, dtype=float), dims=self.dims, coords=self.coords)
+
+    def pack(self, da: DataArray) -> np.ndarray:
+        """Flatten labelled lever values into flat-vector order."""
+        if set(da.dims) != set(self.dims):
+            raise ValueError(
+                f"{self.name}: expected dims {list(self.dims)}, got {list(da.dims)}"
+            )
+        return (
+            align_to_model_coords(da, self.coords, label=self.name)
+            .transpose(*self.dims)
+            .values
+        )
+
+    def default_x0(self, total_budget: float) -> np.ndarray:
+        """Warm start at the lever's current model value, clipped to bounds."""
+        x0 = self.initial_value.copy()
+        if self.bounds is not None:
+            lows = np.array([-np.inf if lo is None else lo for lo, _ in self.bounds])
+            highs = np.array([np.inf if hi is None else hi for _, hi in self.bounds])
+            x0 = np.clip(x0, lows, highs)
+        return x0
+
+    def default_bounds(
+        self, total_budget: float
+    ) -> list[tuple[float | None, float | None]]:
+        """Return the declared native-unit bounds, or unbounded."""
+        if self.bounds is not None:
+            return list(self.bounds)
+        return [(None, None)] * self.size
 
 
 class OptimizationVariables:

--- a/pymc_marketing/mmm/optimization_variables.py
+++ b/pymc_marketing/mmm/optimization_variables.py
@@ -212,6 +212,20 @@ class OptimizationVariable(ABC):
     ) -> list[tuple[float | None, float | None]]:
         """Default ``(low, high)`` bounds per flat entry."""
 
+    def budget_contribution(self, z: XTensorVariable) -> XTensorVariable | None:
+        """Monetary amount this variable draws from the shared budget.
+
+        Returns None by default, for a variable optimized in its own units: a
+        discount depth is not money. A variable that spends from the pot
+        returns that spend, and the default budget-sum constraint totals every
+        such contribution.
+
+        The amount must follow the same convention as the media budgets, which
+        are per-period rates rather than totals over the horizon, since the
+        constraint sums the contributions directly.
+        """
+        return None
+
 
 class MediaVariable(OptimizationVariable):
     """The media-budget decision variable.
@@ -382,6 +396,10 @@ class MediaVariable(OptimizationVariable):
         )
         repeated_budgets_with_carry_over.name = "repeated_budgets_with_carry_over"
         return repeated_budgets_with_carry_over
+
+    def budget_contribution(self, z: XTensorVariable) -> XTensorVariable:
+        """Media spends its whole slice, already in monetary units."""
+        return self.scattered(z)
 
     def unpack(self, x: np.ndarray) -> DataArray:
         """Scatter a flat solution back into a labelled monetary ``DataArray``."""
@@ -594,6 +612,17 @@ class OptimizationVariables:
         if flat_slice == slice(0, self.size):
             return self.flat
         return self.flat.isel({self.flat_dim: flat_slice})
+
+    def budget_contributions(self) -> list[XTensorVariable]:
+        """Monetary contributions of every variable that spends from the pot."""
+        contributions = []
+        for variable in self.variables:
+            contribution = variable.budget_contribution(
+                self.variable_slice(variable.name)
+            )
+            if contribution is not None:
+                contributions.append(contribution)
+        return contributions
 
     def substitutions(self) -> dict[str, XTensorVariable]:
         """Model substitution dict: one entry per variable, one joint graph."""

--- a/pymc_marketing/mmm/optimization_variables.py
+++ b/pymc_marketing/mmm/optimization_variables.py
@@ -36,6 +36,7 @@ from collections.abc import Mapping, Sequence
 import numpy as np
 import pytensor.tensor as pt
 import pytensor.xtensor as ptx
+from pymc import Model
 from pytensor.xtensor import as_xtensor
 from pytensor.xtensor.type import XTensorVariable
 from xarray import DataArray
@@ -467,7 +468,12 @@ class LeverVariable(OptimizationVariable):
         Declared ``(low, high)`` bounds per entry in the lever's native units,
         or None to leave it unbounded.
     initial_value : np.ndarray
-        The node's current value in the model, used as the warm start.
+        The node's current value in the model, used as the warm start. It is
+        read once, when the optimizer is constructed, which matches the rest of
+        the optimizer: the objective graph is built and frozen at construction
+        too, and this node is substituted out of it entirely. Updating the
+        ``pm.Data`` node afterwards therefore changes neither the objective nor
+        the warm start; rebuild the optimizer to pick up a new value.
     flat_dim : str
         Name of the flat decision vector's dimension.
     """
@@ -524,6 +530,68 @@ class LeverVariable(OptimizationVariable):
             .values
         )
 
+    @classmethod
+    def from_model(
+        cls,
+        model: Model,
+        name: str,
+        bounds: Sequence[tuple[float | None, float | None]] | None = None,
+        *,
+        date_dim: str = "date",
+        flat_dim: str = FLAT_DIM,
+    ) -> "LeverVariable":
+        """Build a lever by reading a named node's dim, coords and value off a model.
+
+        Everything a lever needs besides its bounds already lives in the model,
+        so callers name the node and this reads the rest, raising if the node
+        cannot serve as a lever.
+
+        Parameters
+        ----------
+        model : Model
+            The model holding the node.
+        name : str
+            Name of the node to optimize. Must carry named dims.
+        bounds : Sequence[tuple] or None
+            Declared ``(low, high)`` bounds per entry, in native units.
+        date_dim : str
+            The model's date dimension, which a lever may not vary over.
+        flat_dim : str
+            Name of the flat decision vector's dimension.
+
+        Returns
+        -------
+        LeverVariable
+            A lever over ``name``.
+
+        Raises
+        ------
+        ValueError
+            If ``name`` has no named dims in the model, or does not have
+            exactly one dim other than ``date_dim``.
+        """
+        if name not in model.named_vars_to_dims:
+            raise ValueError(
+                f"optimizable_vars entry '{name}' is not a variable "
+                "with named dims in the model."
+            )
+        dims = tuple(model.named_vars_to_dims[name])
+        if len(dims) != 1 or dims[0] == date_dim:
+            raise ValueError(
+                f"optimizable_vars entry '{name}' must have exactly "
+                f"one dim, and not the {date_dim!r} dim; got "
+                f"{dims}. Date-varying optimizable variables "
+                "are not supported."
+            )
+        return cls(
+            name=name,
+            dim=dims[0],
+            coords=list(model.coords[dims[0]]),
+            bounds=bounds,
+            initial_value=model[name].get_value(),
+            flat_dim=flat_dim,
+        )
+
     def default_x0(self, total_budget: float) -> np.ndarray:
         """Warm start at the lever's current model value, clipped to bounds."""
         x0 = self.initial_value.copy()
@@ -571,7 +639,10 @@ class OptimizationVariables:
         names = [variable.name for variable in variables]
         if len(set(names)) != len(names):
             raise ValueError(f"Duplicate variable names: {names}")
-        self.variables = list(variables)
+        # A tuple, not a list: the slice layout is computed once below, so a
+        # variable appended later would silently desynchronise it from the
+        # flat input. The container is exposed publicly for constraints.
+        self.variables: tuple[OptimizationVariable, ...] = tuple(variables)
         self.flat_dim = flat_dim
         # Reject a variable naming a different flat dimension rather than
         # realigning it: a variable whose own tensors are keyed on its name is

--- a/tests/mmm/test_budget_optimizer.py
+++ b/tests/mmm/test_budget_optimizer.py
@@ -11,6 +11,8 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+import ast
+import inspect
 from unittest.mock import patch
 
 import numpy as np
@@ -21,9 +23,12 @@ import pytensor
 import pytest
 import xarray as xr
 from pydantic import ValidationError
+from pytensor.graph.traversal import ancestors
 from xarray import DataArray
 
+import pymc_marketing.mmm.budget_optimizer as budget_optimizer_module
 from pymc_marketing.mmm import MMM
+from pymc_marketing.mmm.additive_effect import MuEffect
 from pymc_marketing.mmm.budget_optimizer import (
     BudgetOptimizationResult,
     BudgetOptimizer,
@@ -33,7 +38,7 @@ from pymc_marketing.mmm.budget_optimizer import (
 )
 from pymc_marketing.mmm.components.adstock import GeometricAdstock
 from pymc_marketing.mmm.components.saturation import LogisticSaturation
-from pymc_marketing.mmm.constraints import Constraint
+from pymc_marketing.mmm.constraints import Constraint, build_default_sum_constraint
 from pymc_marketing.mmm.utility import _check_samples_dimensionality
 
 
@@ -1233,4 +1238,200 @@ def test_default_bounds_come_from_the_media_variable(mmm_wrapper):
     with pytest.warns(UserWarning, match="No budget bounds provided"):
         result = optimizer.allocate_budget(total_budget=100.0)
     assert result.scipy_result.success
+    np.testing.assert_allclose(float(result.budgets.sum()), 100.0, rtol=1e-6)
+
+
+class _LeverEffect(MuEffect):
+    """Test-only effect registering an optimizable pm.Data node.
+
+    Deliberately a plain MuEffect: this PR wires levers by variable *name*, so
+    the optimizer needs no knowledge of effect classes.
+    """
+
+    prefix: str = "promo"
+
+    def create_data(self, mmm) -> None:
+        model = mmm.model
+        model.add_coord(self.prefix, ["evt1", "evt2"])
+        pmd.Data(f"{self.prefix}_data", np.full(2, 0.10), dims=self.prefix)
+
+    def create_effect(self, mmm):
+        model = mmm.model
+        data = model[f"{self.prefix}_data"]
+        coef = pmd.HalfNormal(f"{self.prefix}_coef", sigma=1.0, dims=self.prefix)
+        contribution = pmd.Deterministic(
+            f"{self.prefix}_effect_contribution", data * coef, dims=self.prefix
+        )
+        # An objective that sees both blocks. The stock media objective is
+        # media only, so a lever declared against it is (correctly) rejected by
+        # the reachability guard.
+        pmd.Deterministic(
+            "joint_objective",
+            model["channel_contribution"].sum() + contribution.sum(),
+        )
+        return contribution.sum(dim=self.prefix)
+
+    def set_data(self, mmm, model, X) -> None:
+        pass
+
+
+def _fit_mmm_with_lever(mock_pymc_sample):
+    date_range = pd.date_range("2023-01-01", periods=14, freq="W")
+    rng = np.random.default_rng(0)
+    X = pd.DataFrame(
+        {
+            "date": date_range,
+            "ch1": rng.uniform(100, 500, size=len(date_range)),
+            "ch2": rng.uniform(100, 500, size=len(date_range)),
+        }
+    )
+    y = pd.Series(rng.uniform(500, 1500, size=len(date_range)), name="target")
+    mmm = MMM(
+        date_column="date",
+        channel_columns=["ch1", "ch2"],
+        target_column="target",
+        adstock=GeometricAdstock(l_max=2),
+        saturation=LogisticSaturation(),
+    ).add_mu_effect(_LeverEffect())
+    mmm.fit(X, y, random_seed=0)
+    return mmm, date_range
+
+
+def test_optimizable_vars_co_optimized_with_media(mock_pymc_sample):
+    """A named pm.Data node is optimized alongside the budgets, in one solve."""
+    mmm, date_range = _fit_mmm_with_lever(mock_pymc_sample)
+    optimizer = mmm.budget_optimizer(
+        start_date=date_range[-1] + pd.Timedelta(weeks=1),
+        end_date=date_range[-1] + pd.Timedelta(weeks=4),
+        optimizable_vars={"promo_data": [(0.0, 1.0), (0.0, 1.0)]},
+        response_variable="joint_objective",
+    )
+    # One joint flat vector: media entries first, then the lever.
+    assert optimizer._variables.slices["promo_data"] == slice(
+        optimizer.budgets_to_optimize.sum().item(),
+        optimizer.budgets_to_optimize.sum().item() + 2,
+    )
+    # The lever really is wired into the graph the objective is built from.
+    assert optimizer._budgets_flat in ancestors([optimizer._pymc_model["promo_data"]])
+
+    result = optimizer.allocate_budget(total_budget=100.0)
+    assert result.scipy_result.success
+    # Media still sums to the budget: the lever does not draw from the pot.
+    np.testing.assert_allclose(float(result.budgets.sum()), 100.0, rtol=1e-6)
+    # The lever's optimum comes back labelled.
+    promo = result.optimized_vars["promo_data"]
+    assert list(promo.coords["promo"].values) == ["evt1", "evt2"]
+    assert ((promo.values >= 0.0) & (promo.values <= 1.0)).all()
+
+
+def test_optimizable_vars_warm_start_at_current_value(mock_pymc_sample):
+    """With maxiter=0 the solver returns x0, exposing the seeding convention."""
+    mmm, date_range = _fit_mmm_with_lever(mock_pymc_sample)
+    optimizer = mmm.budget_optimizer(
+        start_date=date_range[-1] + pd.Timedelta(weeks=1),
+        end_date=date_range[-1] + pd.Timedelta(weeks=4),
+        optimizable_vars={"promo_data": [(0.0, 1.0), (0.0, 1.0)]},
+        response_variable="joint_objective",
+    )
+    result = optimizer.allocate_budget(
+        total_budget=100.0,
+        minimize_kwargs={"options": {"maxiter": 0}},
+        return_if_fail=True,
+    )
+    # Media spreads the budget uniformly; the lever starts at its model value.
+    np.testing.assert_allclose(result.scipy_result.x[:2], [50.0, 50.0])
+    np.testing.assert_allclose(result.scipy_result.x[2:], 0.10)
+
+
+def test_optimizable_vars_unreachable_response_raises(mock_pymc_sample):
+    """A lever the response variable cannot reach is rejected at construction."""
+    mmm, date_range = _fit_mmm_with_lever(mock_pymc_sample)
+    with pytest.raises(ValidationError, match="does not depend on optimizable_vars"):
+        mmm.budget_optimizer(
+            start_date=date_range[-1] + pd.Timedelta(weeks=1),
+            end_date=date_range[-1] + pd.Timedelta(weeks=4),
+            optimizable_vars={"promo_data": None},
+            # channel_contribution is media only, so it cannot reach the lever.
+            response_variable="channel_contribution",
+        )
+
+
+@pytest.mark.parametrize(
+    "entry, match",
+    [
+        ({"not_a_variable": None}, "not a variable with named dims"),
+        ({"promo_data": [(0.0, 1.0)]}, "bounds pairs"),
+    ],
+    ids=["unknown_name", "bounds_length_mismatch"],
+)
+def test_optimizable_vars_validation_raises(mock_pymc_sample, entry, match):
+    mmm, date_range = _fit_mmm_with_lever(mock_pymc_sample)
+    with pytest.raises(ValidationError, match=match):
+        mmm.budget_optimizer(
+            start_date=date_range[-1] + pd.Timedelta(weeks=1),
+            end_date=date_range[-1] + pd.Timedelta(weeks=4),
+            optimizable_vars=entry,
+            response_variable="joint_objective",
+        )
+
+
+def test_optimized_vars_empty_without_optimizable_vars(mmm_wrapper):
+    """Backward compatible: a plain optimization returns no extra variables."""
+    optimizer = BudgetOptimizer(
+        model=mmm_wrapper,
+        num_periods=30,
+        response_variable="total_media_contribution_original_scale",
+    )
+    with pytest.warns(UserWarning, match="No budget bounds provided"):
+        result = optimizer.allocate_budget(total_budget=100.0)
+    assert result.optimized_vars == {}
+
+
+def test_budget_optimizer_has_no_marketing_imports():
+    """The optimizer stays a graph-level tool: levers are wired by name only."""
+    banned = ("pymc_marketing.mmm.additive_effect", "pymc_marketing.mmm.mmm")
+    tree = ast.parse(inspect.getsource(budget_optimizer_module))
+    imported: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.append(node.module)
+    offenders = [m for m in imported if any(m.startswith(b) for b in banned)]
+    assert not offenders, (
+        f"budget_optimizer must not import marketing modules: {offenders}"
+    )
+
+
+def test_custom_constraint_can_bind_a_lever(mock_pymc_sample):
+    """A lever is constrainable through the public variables accessor.
+
+    Levers stay out of the default budget-sum constraint, so the only way to
+    bound one jointly is a custom constraint reaching its segment of the flat
+    vector. That has to be possible without private attributes.
+    """
+    mmm, date_range = _fit_mmm_with_lever(mock_pymc_sample)
+    cap = 0.4
+
+    total_lever_cap = Constraint(
+        key="max_total_lever",
+        constraint_type="ineq",
+        constraint_fun=lambda budgets_sym, total_budget_sym, optimizer: (
+            cap - optimizer.optimization_variables.variable_slice("promo_data").sum()
+        ),
+    )
+
+    optimizer = mmm.budget_optimizer(
+        start_date=date_range[-1] + pd.Timedelta(weeks=1),
+        end_date=date_range[-1] + pd.Timedelta(weeks=4),
+        optimizable_vars={"promo_data": [(0.0, 1.0), (0.0, 1.0)]},
+        response_variable="joint_objective",
+        constraints=[total_lever_cap, build_default_sum_constraint()],
+    )
+    result = optimizer.allocate_budget(total_budget=100.0)
+
+    assert result.scipy_result.success
+    # The lever cap binds: unconstrained, both entries would climb to 1.0.
+    assert float(result.optimized_vars["promo_data"].sum()) <= cap + 1e-6
+    # And the budget constraint is still honoured alongside it.
     np.testing.assert_allclose(float(result.budgets.sum()), 100.0, rtol=1e-6)

--- a/tests/mmm/test_optimization_variables.py
+++ b/tests/mmm/test_optimization_variables.py
@@ -17,6 +17,7 @@ import xarray as xr
 
 from pymc_marketing.mmm.optimization_variables import (
     FLAT_DIM,
+    LeverVariable,
     MediaVariable,
     OptimizationVariables,
 )
@@ -282,3 +283,108 @@ def test_channel_scales_applied_on_both_spreading_paths(with_distribution):
     # divided by that channel's scale. A uniform distribution reproduces the
     # default spreading exactly, so both paths must agree.
     np.testing.assert_allclose(out[0], spend / scales)
+
+
+def make_lever_variable(
+    bounds=((0.05, 0.45), (0.05, 0.45)),
+    initial=(0.30, 0.20),
+    name: str = "promo_data",
+) -> LeverVariable:
+    return LeverVariable(
+        name=name,
+        dim="promo",
+        coords=["spring", "fall"],
+        bounds=list(bounds) if bounds is not None else None,
+        initial_value=np.asarray(initial),
+    )
+
+
+def test_lever_pack_unpack_round_trip():
+    lever = make_lever_variable()
+    x = np.array([0.11, 0.42])
+    da = lever.unpack(x)
+    assert da.dims == ("promo",)
+    np.testing.assert_array_equal(lever.pack(da), x)
+    # order invariant: packing follows the lever's coords, not the input's
+    np.testing.assert_array_equal(lever.pack(da.sel(promo=["fall", "spring"])), x)
+
+
+def test_lever_warm_start_clipped_to_bounds():
+    np.testing.assert_allclose(
+        make_lever_variable(initial=(0.80, 0.01)).default_x0(100.0), [0.45, 0.05]
+    )
+    # an unbounded lever starts at its raw model value
+    np.testing.assert_allclose(
+        make_lever_variable(bounds=None, initial=(0.80, 0.01)).default_x0(100.0),
+        [0.80, 0.01],
+    )
+
+
+def test_lever_default_bounds():
+    assert make_lever_variable().default_bounds(100.0) == [(0.05, 0.45)] * 2
+    assert make_lever_variable(bounds=None).default_bounds(100.0) == [(None, None)] * 2
+
+
+@pytest.mark.parametrize(
+    "kwargs, match",
+    [
+        ({"bounds": [(0.0, 1.0)]}, "bounds pairs"),
+        ({"initial": (0.3,)}, "expected 2"),
+    ],
+    ids=["bounds_length", "initial_length"],
+)
+def test_lever_validation_raises(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        make_lever_variable(**kwargs)
+
+
+def test_lever_pack_rejects_unknown_coords():
+    lever = make_lever_variable()
+    da = xr.DataArray(
+        np.zeros(2), dims=("promo",), coords={"promo": ["spring", "typo"]}
+    )
+    with pytest.raises(ValueError, match="coordinates the model does not have"):
+        lever.pack(da)
+
+
+def test_media_and_lever_layout_exercises_the_isel_path():
+    """Two variables: the isel branch of variable_slice runs and stays correct.
+
+    With a single variable the slice covers the whole flat vector and
+    ``variable_slice`` short-circuits to ``self.flat``, so the ``isel`` branch
+    every additional variable depends on never executes.
+    """
+    from pytensor import function
+
+    rng = np.random.default_rng(11)
+    media = make_media_variable(rng, sizes=(3,))
+    lever = make_lever_variable()
+    opt_vars = OptimizationVariables([media, lever])
+
+    assert opt_vars.slices == {
+        "channel_data": slice(0, 3),
+        "promo_data": slice(3, 5),
+    }
+    assert opt_vars.size == 5
+
+    media_slice = opt_vars.variable_slice("channel_data")
+    lever_slice = opt_vars.variable_slice("promo_data")
+    assert media_slice is not opt_vars.flat  # no short-circuit with two variables
+    assert lever_slice.type.shape == (2,)
+
+    # to_model on the isel'd slice reads the lever's own entries.
+    x = np.array([10.0, 20.0, 30.0, 0.25, 0.75])
+    got = function(
+        [opt_vars.flat], lever.to_model(lever_slice).values, on_unused_input="ignore"
+    )(x)
+    np.testing.assert_allclose(got, [0.25, 0.75])
+
+    # x0 and bounds concatenate in variable order.
+    np.testing.assert_allclose(opt_vars.x0(90.0), [30.0, 30.0, 30.0, 0.30, 0.20])
+    assert opt_vars.bounds(90.0) == [(0.0, 90.0)] * 3 + [(0.05, 0.45)] * 2
+
+    # pack/unpack round-trips across both variables.
+    unpacked = opt_vars.unpack(x)
+    assert set(unpacked) == {"channel_data", "promo_data"}
+    np.testing.assert_array_equal(opt_vars.pack(unpacked), x)
+    assert set(opt_vars.substitutions()) == {"channel_data", "promo_data"}

--- a/tests/mmm/test_optimization_variables.py
+++ b/tests/mmm/test_optimization_variables.py
@@ -12,6 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 import numpy as np
+import pymc as pm
 import pytest
 import xarray as xr
 
@@ -462,3 +463,45 @@ def test_a_second_monetary_variable_shares_the_budget():
         np.array([30.0, 20.0, 50.0])
     )
     np.testing.assert_allclose(got, 100.0)
+
+
+@pytest.fixture(scope="module")
+def lever_model() -> pm.Model:
+    """A model with a one-dim lever node, a date-varying node and an unnamed one."""
+    coords = {"promo": ["p1", "p2"], "date": [0, 1, 2]}
+    with pm.Model(coords=coords) as model:
+        pm.Data("promo_data", np.array([0.1, 0.2]), dims="promo")
+        pm.Data("daily_data", np.zeros(3), dims="date")
+        pm.Data("both_data", np.zeros((3, 2)), dims=("date", "promo"))
+    return model
+
+
+def test_from_model_reads_dim_coords_and_value(lever_model):
+    """The factory needs only a name: the rest is already in the model."""
+    lever = LeverVariable.from_model(lever_model, "promo_data", [(0.0, 0.5)] * 2)
+
+    assert lever.name == "promo_data"
+    assert lever.dim == "promo"
+    assert lever.coords == {"promo": ["p1", "p2"]}
+    assert lever.size == 2
+    np.testing.assert_allclose(lever.initial_value, [0.1, 0.2])
+    assert lever.default_bounds(total_budget=1.0) == [(0.0, 0.5)] * 2
+
+
+def test_from_model_leaves_bounds_optional(lever_model):
+    lever = LeverVariable.from_model(lever_model, "promo_data")
+    assert lever.default_bounds(total_budget=1.0) == [(None, None)] * 2
+
+
+@pytest.mark.parametrize(
+    "name, match",
+    [
+        ("not_a_node", "not a variable with named dims"),
+        ("daily_data", "must have exactly one dim"),
+        ("both_data", "must have exactly one dim"),
+    ],
+    ids=["unknown", "date_varying", "multidim"],
+)
+def test_from_model_rejects_nodes_that_cannot_be_levers(lever_model, name, match):
+    with pytest.raises(ValueError, match=match):
+        LeverVariable.from_model(lever_model, name, date_dim="date")

--- a/tests/mmm/test_optimization_variables.py
+++ b/tests/mmm/test_optimization_variables.py
@@ -19,6 +19,7 @@ from pymc_marketing.mmm.optimization_variables import (
     FLAT_DIM,
     LeverVariable,
     MediaVariable,
+    OptimizationVariable,
     OptimizationVariables,
 )
 
@@ -388,3 +389,76 @@ def test_media_and_lever_layout_exercises_the_isel_path():
     assert set(unpacked) == {"channel_data", "promo_data"}
     np.testing.assert_array_equal(opt_vars.pack(unpacked), x)
     assert set(opt_vars.substitutions()) == {"channel_data", "promo_data"}
+
+
+class _SpendVariable(OptimizationVariable):
+    """Test-only stand-in for a second monetary variable.
+
+    Reach-and-frequency budgets and funnel spend are money, so unlike a lever
+    they have to come out of the shared pot. This is the minimum such variable:
+    a per-entry spend spread over the periods.
+    """
+
+    def __init__(self, name: str, coords: list, num_periods: int):
+        self.name = name
+        self.dims = ("rf_channel",)
+        self.coords = {"rf_channel": list(coords)}
+        self.num_periods = num_periods
+        self.flat_dim = FLAT_DIM
+
+    @property
+    def size(self) -> int:
+        return len(self.coords["rf_channel"])
+
+    def to_model(self, z):
+        return z.rename({self.flat_dim: "rf_channel"}).expand_dims(
+            date=self.num_periods
+        )
+
+    def unpack(self, x):
+        return xr.DataArray(
+            np.asarray(x, dtype=float), dims=self.dims, coords=self.coords
+        )
+
+    def pack(self, da):
+        return da.reindex(self.coords).transpose(*self.dims).values
+
+    def default_x0(self, total_budget):
+        return np.full(self.size, total_budget / self.size)
+
+    def default_bounds(self, total_budget):
+        return [(0.0, float(total_budget))] * self.size
+
+    def budget_contribution(self, z):
+        """Unlike a lever, this one spends from the pot."""
+        return z.rename({self.flat_dim: "rf_channel"})
+
+
+def test_media_is_the_only_budget_contributor_by_default():
+    rng = np.random.default_rng(20)
+    opt_vars = OptimizationVariables(
+        [make_media_variable(rng, sizes=(3,)), make_lever_variable()]
+    )
+    # A lever is optimized in its own units, so it never draws from the pot.
+    assert len(opt_vars.budget_contributions()) == 1
+
+
+def test_a_second_monetary_variable_shares_the_budget():
+    """Two spending variables total together, which is what the sum constraint uses."""
+    from pytensor import function
+
+    rng = np.random.default_rng(21)
+    media = make_media_variable(rng, sizes=(2,))
+    spend = _SpendVariable("rf_data", ["rf1"], num_periods=media.num_periods)
+    opt_vars = OptimizationVariables([media, spend])
+
+    contributions = opt_vars.budget_contributions()
+    assert len(contributions) == 2
+
+    total = contributions[0].sum()
+    for contribution in contributions[1:]:
+        total = total + contribution.sum()
+    got = function([opt_vars.flat], total.values, on_unused_input="ignore")(
+        np.array([30.0, 20.0, 50.0])
+    )
+    np.testing.assert_allclose(got, 100.0)


### PR DESCRIPTION
## Description

**Lets the budget optimizer solve for things that aren't media budgets, jointly with the media budgets.**

Today the decision vector is exclusively the media grid, so the optimizer can only answer "how do I split this budget across channels and periods." This PR lets you name any one-dimensional `pm.Data` node in the model, give it bounds, and have scipy solve for it and the spend allocation together:

```python
optimizer = mmm.budget_optimizer(
    ...,
    optimizable_vars={"promo_data": [(0.05, 0.45)]},   # native units
    response_variable="total_response_original_scale",  # must reach the lever
)
result = optimizer.allocate_budget(total_budget=100_000)
result.optimized_vars["promo_data"]  # labelled optimum
```

**Why jointly, rather than one and then the other.** The optimal discount depth depends on how much media is pushing the promoted product, and the optimal media split depends on how deep the discount is. Both segments live in one flat vector and go through a single `pymc.do()` substitution, so the Jacobian covers media and levers together and the cross-partials between them are real derivatives rather than an artifact of alternating two separate solves. That is the technical point of the PR; the rest is bookkeeping.

Discounts are the motivating application, but nothing here knows what a promotion is. The optimizer sees "a one-dim node with bounds," which is what keeps the marketing concepts in the follow-up and this PR reviewable as pure optimizer mechanics. An AST guard test enforces that no marketing module is imported.

### What it costs

`LeverVariable` implements the existing protocol in ~90 lines: the forward map is the identity up to relabelling the flat dim, the warm start is the node's current model value clipped to its bounds, and `default_bounds` are the declared native-unit bounds. `LeverVariable.from_model` reads a node's dim, coords and current value straight off the model and rejects anything that cannot serve as a lever, so the optimizer keeps a comprehension rather than an introspection loop. Everything else comes from the abstraction already in `main`, and `result.optimized_vars` was already populated, so the result path needed no change.

The equivalent in #2621 was roughly 400 lines of optimizer diff. This is the abstraction from #2879 paying rent.

Levers are optimized in their own units and **do not** enter the default budget-sum constraint, which sums the media tensor alone: a discount depth is not money drawn from a shared pool.

### Two guards, both exact

- **Construction-time reachability.** A lever the response variable cannot reach has an identically zero gradient, so the solver would return its warm start and report it as optimal. Graph ancestry settles this before anything is compiled. It fires in practice: writing the end-to-end test against the stock media-only objective was rejected, which is how it should behave, so the test effect registers an objective seeing both blocks.
- **Bounds and dim validation** in `LeverVariable.__init__`, so a wrong-length bounds list, a date-varying node or a multi-dim node fails at construction with a message naming the variable, rather than as a shape error from scipy at solve time.

Deliberately *not* included: the inert-variable probe (tracked in #2807) and the `f(x0)` finiteness check. A non-finite objective already fails loudly through scipy, so that check only improved a message, and the case it was written for is caught earlier at effect build time. The "levers scored against the media-contribution objective" warning is also held back: it pattern-matches an MMM variable name, so it belongs at the adaptor layer, in the follow-up.

### `optimization_variables` is now public

Constraining anything other than the media budgets means reaching a variable's segment of the flat vector, which was previously only possible through private attributes (raised by @daimon-pymclabs during #2621: levers optimizable but not constrainable through public API). The accessor closes that, with a docstring example and a test that caps a lever through a custom `Constraint` using only public API while the budget constraint still binds.

The container is exposed for reading, not for injection: it is built inside `model_post_init` and reached through a getter-only property, so "media comes first" stays structural rather than conventional.

### Budget participation seam (added after a spike)

The default sum constraint totalled the media tensor alone, so a second *monetary* variable would have been optimized for free. Variables now declare what they spend via `budget_contribution`, which defaults to `None`:

```python
def budget_contribution(self, z) -> XTensorVariable | None:
    return None            # a lever is not money
    # MediaVariable returns self.scattered(z), the tensor it already builds
```

Behaviour is unchanged, media is still the only contributor, but this is the piece reach-and-frequency budgets (#1968) and funnel spend both need, and including it means neither has to change the protocol later. A spike measured the cost at 30 lines across two files with no regressions, which is why it is folded in here rather than deferred.

A method rather than a flag, because the constraint cannot reconstruct a variable's monetary amount generically: media applies `channel_scales`, R&F would apply `cost_per_unit`. Only the variable knows what its slice costs. The contract follows the media convention of per-period rates rather than horizon totals, since the constraint sums contributions directly.

Tested with a stand-in spend variable: two monetary variables total together, and a lever stays out.

### Also closes a coverage gap from #2879

No test there built `OptimizationVariables` with two variables, so the container's `variable_slice` `isel` branch, which every additional variable depends on, never ran in CI. A lever is the first genuine second variable: the slice layout, the `isel` path, and the concatenation of `x0` and bounds across variables are all now exercised.

## Verification

160 tests green across `test_budget_optimizer.py`, `test_optimization_variables.py`, `test_budget_optimizer_mmm.py`, `test_cost_per_unit.py`. Lint and mypy clean.

## Scope

This generalizes the *decision vector*. It does not change what the objective counts, so mediated effects (funnel) are unaffected here: those need the response variable generalized, which lands with the effect protocol in the follow-up.

## Related

- Follow-up: `OptimizableMuEffect` plus the `MMM`/`link` wiring (second half of the closed #2804), then `DiscountedEventEffect` with its notebook
- Builds on #2879 · supersedes half of #2804 · probe redesign tracked in #2807
- Also unblocks #1968 (frequency/reach), though note R&F budgets are *spend* and so want a variable that participates in the sum constraint, unlike a lever

## Type of change

- [x] New feature (backward compatible: no `optimizable_vars` means behaviour is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2884.org.readthedocs.build/en/2884/

<!-- readthedocs-preview pymc-marketing end -->
