### PR TITLE
feat(mmm): co-optimize monetary spend variables with the media budgets

### DIFF
--- a/pymc_marketing/mmm/budget_optimizer.py
+++ b/pymc_marketing/mmm/budget_optimizer.py
@@ -318,9 +318,13 @@ class BudgetOptimizationResult:
         The raw scipy optimization result (solver diagnostics, ``x``, ``fun``,
         convergence status).
     optimized_vars : dict[str, xarray.DataArray]
-        Optimal values of any non-media decision variables co-optimized
-        alongside the media budgets. Empty until such variables are declared
-        (see https://github.com/pymc-labs/pymc-marketing/pull/2621).
+        Optimal values of every decision variable other than the media budgets,
+        by name: ``optimizable_vars`` levers in their own units, and
+        ``spend_vars`` monetary variables in money. Empty when neither is
+        declared. Note that a monetary entry here and ``budgets`` are the same
+        kind of quantity, drawn from the same total -- ``budgets`` is singled
+        out because it is the allocation most callers want, not because it is
+        the only spend.
     callback_info : list[OptimizationIterationInfo] or None
         Per-iteration diagnostics (``x``, ``fun``, ``jac``, constraint values)
         when ``allocate_budget(callback=True)``; ``None`` otherwise.

--- a/pymc_marketing/mmm/budget_optimizer.py
+++ b/pymc_marketing/mmm/budget_optimizer.py
@@ -325,6 +325,10 @@ class BudgetOptimizationResult:
         kind of quantity, drawn from the same total -- ``budgets`` is singled
         out because it is the allocation most callers want, not because it is
         the only spend.
+    spend_var_names : list[str]
+        Which ``optimized_vars`` entries are monetary, i.e. the declared
+        ``spend_vars``. Recorded so the result can say on its own which of its
+        allocations draw from the budget; see :attr:`spend_var_allocations`.
     callback_info : list[OptimizationIterationInfo] or None
         Per-iteration diagnostics (``x``, ``fun``, ``jac``, constraint values)
         when ``allocate_budget(callback=True)``; ``None`` otherwise.
@@ -333,7 +337,35 @@ class BudgetOptimizationResult:
     budgets: DataArray
     scipy_result: OptimizeResult
     optimized_vars: dict[str, DataArray] = field(default_factory=dict)
+    spend_var_names: list[str] = field(default_factory=list)
     callback_info: list[OptimizationIterationInfo] | None = None
+
+    @property
+    def spend_var_allocations(self) -> dict[str, DataArray]:
+        """The ``optimized_vars`` entries that are money rather than levers.
+
+        ``optimized_vars`` holds both kinds, and telling them apart matters:
+        these are drawn from the same total as :attr:`budgets`, so they are
+        what a caller sums against a budget, while a lever's units are its own
+        and adding them to money means nothing.
+
+        Returns
+        -------
+        dict[str, xarray.DataArray]
+            One entry per declared ``spend_vars`` name.
+
+        Examples
+        --------
+        Check that the plan spends the budget and no more:
+
+        .. code-block:: python
+
+            spent = float(result.budgets.sum()) + sum(
+                float(allocation.sum())
+                for allocation in result.spend_var_allocations.values()
+            )
+        """
+        return {name: self.optimized_vars[name] for name in self.spend_var_names}
 
     def __iter__(self):
         """Yield ``(budgets, scipy_result)`` for two-element unpacking."""
@@ -2243,6 +2275,7 @@ class BudgetOptimizer(BaseModel):
                 budgets=optimal_budgets,
                 scipy_result=result,
                 optimized_vars=unpacked,
+                spend_var_names=list(self.spend_vars),
                 callback_info=callback_info if callback else None,
             )
 

--- a/pymc_marketing/mmm/budget_optimizer.py
+++ b/pymc_marketing/mmm/budget_optimizer.py
@@ -1313,6 +1313,17 @@ class BudgetOptimizer(BaseModel):
         ),
     )
 
+    spend_var_scales: dict[str, float | Sequence[float]] = Field(
+        default_factory=dict,
+        description=(
+            "Per-spend-variable scale factors converting monetary amounts into "
+            "the node's stored units, keyed by name. Omit a name to declare its "
+            "node stored in raw money. Mirrors channel_scales for the media "
+            "variable: a node stored scaled and left at the default 1.0 is "
+            "optimized in the wrong units, silently."
+        ),
+    )
+
     optimizable_vars: dict[str, Sequence[tuple[float | None, float | None]] | None] = (
         Field(
             default_factory=dict,
@@ -1681,13 +1692,24 @@ class BudgetOptimizer(BaseModel):
                 f"spend_vars may not name channel_data_var "
                 f"({self.channel_data_var!r}); it is already optimized."
             )
+        unknown = set(self.spend_var_scales) - set(self.spend_vars)
+        if unknown:
+            raise ValueError(
+                f"spend_var_scales names {sorted(unknown)}, which are not in "
+                f"spend_vars {list(self.spend_vars)}. A scale on a name that is "
+                "not optimized has no effect, so it is more likely a typo than "
+                "an intention."
+            )
         spends = [
             MediaVariable.from_model(
                 self.model,
                 name,
                 num_periods=self.num_periods,
                 adstock_periods=self.adstock_periods,
-                carry_in_values=carry_in_for(name),
+                carry_in_periods=self.carry_in_periods,
+                scales=np.asarray(self.spend_var_scales[name])
+                if name in self.spend_var_scales
+                else 1.0,
                 date_dim=self.date_dim,
             )
             for name in self.spend_vars

--- a/pymc_marketing/mmm/budget_optimizer.py
+++ b/pymc_marketing/mmm/budget_optimizer.py
@@ -1264,6 +1264,19 @@ class BudgetOptimizer(BaseModel):
         ),
     )
 
+    spend_vars: Sequence[str] = Field(
+        default_factory=tuple,
+        description=(
+            "Names of additional monetary pm.Data variables to co-optimize with "
+            "the media budgets. Each must vary over the date dimension and is "
+            "decided over its remaining dims, in money, so it competes with "
+            "media for the same total through the default budget-sum "
+            "constraint. Use optimizable_vars instead for a quantity that is "
+            "not money -- a discount depth, a frequency -- which is optimized "
+            "in its own units and stays outside that constraint."
+        ),
+    )
+
     optimizable_vars: dict[str, Sequence[tuple[float | None, float | None]] | None] = (
         Field(
             default_factory=dict,
@@ -1603,11 +1616,12 @@ class BudgetOptimizer(BaseModel):
         # model graph. One do() call over every variable keeps gradients joint.
         # Read from the model we were handed: it already carries the spend that
         # preceded the window, so nothing here needs to know where history lives.
-        carry_in_values = None
-        if self.carry_in_periods:
-            carry_in_values = np.asarray(self.model[self.channel_data_var].get_value())[
-                : self.carry_in_periods
-            ]
+        def carry_in_for(name: str) -> np.ndarray | None:
+            if not self.carry_in_periods:
+                return None
+            return np.asarray(self.model[name].get_value())[: self.carry_in_periods]
+
+        carry_in_values = carry_in_for(self.channel_data_var)
 
         media_variable = MediaVariable(
             name=self.channel_data_var,
@@ -1621,6 +1635,28 @@ class BudgetOptimizer(BaseModel):
             budget_distribution_over_period_tensor=self._budget_distribution_over_period_tensor,
             cost_per_unit_tensor=self._cost_per_unit_tensor,
         )
+        # Additional monetary variables are media-path variables over a
+        # different node: same money, same window, so their spend joins the
+        # budget-sum constraint through budget_contribution without
+        # constraints.py knowing they exist.
+        duplicated = [name for name in self.spend_vars if name == self.channel_data_var]
+        if duplicated:
+            raise ValueError(
+                f"spend_vars may not name channel_data_var "
+                f"({self.channel_data_var!r}); it is already optimized."
+            )
+        spends = [
+            MediaVariable.from_model(
+                self.model,
+                name,
+                num_periods=self.num_periods,
+                adstock_periods=self.adstock_periods,
+                carry_in_values=carry_in_for(name),
+                date_dim=self.date_dim,
+            )
+            for name in self.spend_vars
+        ]
+
         # Optimizable vars become lever variables appended after media. They
         # are optimized in their own units and stay out of the budget-sum
         # constraint, which sums the media tensor alone.
@@ -1631,7 +1667,7 @@ class BudgetOptimizer(BaseModel):
             for lever_name, lever_bounds in self.optimizable_vars.items()
         ]
 
-        self._variables = OptimizationVariables([media_variable, *levers])
+        self._variables = OptimizationVariables([media_variable, *spends, *levers])
         self._budgets_flat = self._variables.flat
         self._budgets = media_variable.scattered(
             self._variables.variable_slice(self.channel_data_var)
@@ -1656,20 +1692,31 @@ class BudgetOptimizer(BaseModel):
         # the objective cannot reach has an identically zero gradient, so the
         # solver would return its warm-start value and report it as optimal.
         # Graph reachability answers this exactly, before anything is compiled.
-        if self.optimizable_vars:
+        # A spend variable the objective cannot reach is worse than a lever
+        # that cannot: it still draws from the budget, so the solver funds it
+        # from media and gets nothing back.
+        if self.optimizable_vars or self.spend_vars:
             reachable = set(ancestors([self._pymc_model[self.response_variable]]))
-            unreachable = [
-                name
-                for name in self.optimizable_vars
-                if self._pymc_model[name] not in reachable
+
+            def unreachable(names) -> list[str]:
+                return [
+                    name for name in names if self._pymc_model[name] not in reachable
+                ]
+
+            parts = [
+                f"{label} {names}"
+                for label, names in (
+                    ("optimizable_vars", unreachable(self.optimizable_vars)),
+                    ("spend_vars", unreachable(self.spend_vars)),
+                )
+                if names
             ]
-            if unreachable:
+            if parts:
                 raise ValueError(
                     f"response_variable={self.response_variable!r} does not "
-                    f"depend on optimizable_vars {unreachable}, so their "
-                    "gradient is identically zero and they cannot be "
-                    "optimized. Pass a response variable that includes their "
-                    "contribution."
+                    f"depend on {' or '.join(parts)}, so their gradient is "
+                    "identically zero and they cannot be optimized. Pass a "
+                    "response variable that includes their contribution."
                 )
 
         # 9. Compile objective & gradient

--- a/pymc_marketing/mmm/mmm.py
+++ b/pymc_marketing/mmm/mmm.py
@@ -2659,6 +2659,13 @@ class MMM(RegressionModelBuilder):
     ) -> _WindowLayout:
         """Split an optimization model's date axis into its three blocks.
 
+        Only the date axis is read off *pymc_model*; the carry-over comes from
+        this MMM's own adstock and effects. The two therefore have to describe
+        the same window -- pass the model
+        :meth:`create_optimization_model` returned for *start_date*, not one
+        built from different parameters, or the three blocks will not add up to
+        the axis and ``BudgetOptimizer`` will refuse them.
+
         Derived in one place so the three numbers cannot drift apart: the
         leading dates are whatever
         :func:`~pymc_marketing.mmm.utils.create_zero_dataset` was able to

--- a/pymc_marketing/mmm/mmm.py
+++ b/pymc_marketing/mmm/mmm.py
@@ -184,7 +184,7 @@ import json
 import warnings
 from collections.abc import Callable, Sequence
 from copy import deepcopy
-from typing import TYPE_CHECKING, Annotated, Any, Literal, Self, cast
+from typing import TYPE_CHECKING, Annotated, Any, Literal, NamedTuple, Self, cast
 
 import arviz as az
 import numpy as np
@@ -278,6 +278,22 @@ def _deserialize_cost_per_unit(json_str: str) -> pd.DataFrame:
         if hasattr(dt_accessor, "tz") and dt_accessor.tz is not None:
             df["date"] = dt_accessor.tz_localize(None)
     return df
+
+
+class _WindowLayout(NamedTuple):
+    """The three blocks an optimization model's date axis divides into.
+
+    Only ``decisions`` is optimized.  ``carry_in`` holds spend already made
+    before the window, so the adstock does not start cold, and ``carry_over``
+    the zero-spend periods that catch the tail the decisions produce after the
+    window closes.  The three must together cover the axis exactly; that is the
+    invariant :class:`~pymc_marketing.mmm.budget_optimizer.BudgetOptimizer`
+    re-checks for callers who set the three numbers by hand.
+    """
+
+    carry_in: int
+    decisions: int
+    carry_over: int
 
 
 class MMM(RegressionModelBuilder):
@@ -2611,13 +2627,11 @@ class MMM(RegressionModelBuilder):
         declares nothing contributes nothing, which reproduces the previous
         behaviour rather than guessing on its behalf.
 
-        An effect that has not implemented ``incrementality_spec`` is skipped,
-        and so is one that returns ``None`` to opt out. Any *other* exception
-        from an effect's ``incrementality_spec`` propagates deliberately: it
-        means the effect cannot answer a question about itself, and sizing the
-        window from a silently swallowed error would truncate the tail exactly
-        as before, with nothing to show why. Catch it at the effect if it is
-        expected there.
+        An effect that returns ``None`` to opt out is skipped. Anything an
+        effect's ``incrementality_spec`` raises propagates: it means the effect
+        cannot answer a question about itself, and sizing the window from a
+        swallowed error would truncate the tail exactly as before, with nothing
+        to show why.
 
         Returns
         -------
@@ -2627,21 +2641,74 @@ class MMM(RegressionModelBuilder):
         """
         declared = 0
         for effect in self.mu_effects:
-            spec_of = getattr(effect, "incrementality_spec", None)
-            if spec_of is None:
-                continue
-            try:
-                spec = spec_of()
-            except NotImplementedError:
-                continue
+            spec = effect.incrementality_spec()
             if spec is None:
                 # Opted out. Skip this effect only: another effect's declaration
                 # must still widen the window.
                 continue
-            lags = getattr(spec, "additional_carryover_lags", None)
+            lags = spec.additional_carryover_lags
             if lags:
                 declared = max(declared, int(lags))
         return int(getattr(self.adstock, "l_max", 0)) + declared
+
+    def _window_layout(
+        self,
+        pymc_model: pm.Model,
+        start_date: str | pd.Timestamp,
+        date_dim: str = "date",
+    ) -> _WindowLayout:
+        """Split an optimization model's date axis into its three blocks.
+
+        Derived in one place so the three numbers cannot drift apart: the
+        leading dates are whatever
+        :func:`~pymc_marketing.mmm.utils.create_zero_dataset` was able to
+        prepend -- it clips against the training index, so asking is the only
+        way to know -- and the trailing block is
+        :meth:`effective_carryover_lags`, leaving the decisions in between.
+
+        Parameters
+        ----------
+        pymc_model : pymc.Model
+            A model built by :meth:`create_optimization_model`.
+        start_date : str or pd.Timestamp
+            First date of the decision window, as passed to that method.
+        date_dim : str, default "date"
+            Name of the model's date dimension.
+
+        Returns
+        -------
+        _WindowLayout
+            Carry-in, decision and carry-over period counts.
+
+        Raises
+        ------
+        ValueError
+            If the model has no *date_dim* coordinate, or the window leaves no
+            room for a decision once both flanking blocks are taken out.
+        """
+        if date_dim not in pymc_model.coords:
+            raise ValueError(
+                f"The optimization model has no {date_dim!r} coordinate, so "
+                "num_periods cannot be inferred. Pass date_dim= naming the model's "
+                "date dimension, or build the BudgetOptimizer directly with an "
+                "explicit num_periods."
+            )
+        model_dates = pd.DatetimeIndex(list(pymc_model.coords[date_dim]))
+        # Leading dates hold spend that already happened, so they are neither
+        # decisions nor carry-over. Counting them as either would spread the
+        # budget over history.
+        carry_in = int((model_dates < pd.Timestamp(start_date)).sum())
+        carry_over = self.effective_carryover_lags()
+        decisions = len(model_dates) - carry_in - carry_over
+        if decisions <= 0:
+            raise ValueError(
+                f"The optimization window covers {len(model_dates) - carry_in} "
+                f"periods, which does not exceed the carry-over of {carry_over} "
+                "periods. Widen the window between start_date and end_date."
+            )
+        return _WindowLayout(
+            carry_in=carry_in, decisions=decisions, carry_over=carry_over
+        )
 
     def create_optimization_model(
         self,
@@ -2799,31 +2866,10 @@ class MMM(RegressionModelBuilder):
 
         pymc_model = self.create_optimization_model(start_date, end_date)
 
-        adstock_lag = self.effective_carryover_lags()
         # Honour a caller-supplied date_dim rather than assuming "date": this is
         # the method that feeds BudgetOptimizer's configurable date_dim field.
         date_dim = kwargs.get("date_dim", "date")
-        if date_dim not in pymc_model.coords:
-            raise ValueError(
-                f"The optimization model has no {date_dim!r} coordinate, so "
-                "num_periods cannot be inferred. Pass date_dim= naming the model's "
-                "date dimension, or build the BudgetOptimizer directly with an "
-                "explicit num_periods."
-            )
-        n_dates = len(pymc_model.coords[date_dim])
-        # Leading dates hold spend that already happened, so they are neither
-        # decisions nor carry-over. Counting them as either would spread the
-        # budget over history.
-        model_dates = pd.DatetimeIndex(list(pymc_model.coords[date_dim]))
-        carry_in_periods = int((model_dates < pd.Timestamp(start_date)).sum())
-        decision_and_tail = n_dates - carry_in_periods
-        if decision_and_tail <= adstock_lag:
-            raise ValueError(
-                f"The optimization window covers {decision_and_tail} periods, "
-                f"which does not exceed the adstock carry-over of {adstock_lag} "
-                "periods. Widen the window between start_date and end_date."
-            )
-        num_periods = decision_and_tail - adstock_lag
+        layout = self._window_layout(pymc_model, start_date, date_dim=date_dim)
 
         # budgets_to_optimize is intentionally passed through untouched. When it is
         # None, BudgetOptimizer auto-detects the optimizable cells from the posterior;
@@ -2841,9 +2887,9 @@ class MMM(RegressionModelBuilder):
         return BudgetOptimizer(
             model=pymc_model,
             idata=self.idata,
-            num_periods=num_periods,
-            adstock_periods=adstock_lag,
-            carry_in_periods=carry_in_periods,
+            num_periods=layout.decisions,
+            adstock_periods=layout.carry_over,
+            carry_in_periods=layout.carry_in,
             channel_scales=getattr(self, "_channel_scales", 1.0),
             budgets_to_optimize=budgets_to_optimize,
             cost_per_unit=cost_per_unit,

--- a/pymc_marketing/mmm/optimization_variables.py
+++ b/pymc_marketing/mmm/optimization_variables.py
@@ -279,6 +279,7 @@ class MediaVariable(OptimizationVariable):
         adstock_periods: int,
         channel_scales: float | np.ndarray,
         dtype: str,
+        scales_dims: tuple[str, ...] = ("channel",),
         date_dim: str = "date",
         budget_distribution_over_period_tensor: XTensorVariable | None = None,
         cost_per_unit_tensor: XTensorVariable | None = None,
@@ -296,6 +297,7 @@ class MediaVariable(OptimizationVariable):
         self.num_periods = num_periods
         self.adstock_periods = adstock_periods
         self.channel_scales = channel_scales
+        self.scales_dims = tuple(scales_dims)
         self.dtype = dtype
         self.date_dim = date_dim
         self.budget_distribution_over_period_tensor = (
@@ -334,11 +336,104 @@ class MediaVariable(OptimizationVariable):
         """Shape of the full (unmasked) budget tensor."""
         return self._bool_mask.shape
 
+    @classmethod
+    def from_model(
+        cls,
+        model: Model,
+        name: str,
+        *,
+        num_periods: int,
+        adstock_periods: int,
+        mask: DataArray | None = None,
+        carry_in_values: np.ndarray | None = None,
+        scales: float | np.ndarray = 1.0,
+        date_dim: str = "date",
+        **kwargs,
+    ) -> "MediaVariable":
+        """Build a monetary variable by reading a named node's dims off a model.
+
+        The media budgets are one instance of a monetary decision; a
+        lower-funnel spend, or the reach an impression budget buys, is another.
+        What distinguishes them is which node they substitute and over which
+        dims they are decided, and both already live in the model, so callers
+        name the node and this reads the rest.
+
+        Parameters
+        ----------
+        model : Model
+            The model holding the node.
+        name : str
+            Name of the monetary node to optimize. Must carry named dims,
+            including *date_dim*.
+        num_periods, adstock_periods : int
+            Decision and carry-over period counts for the window.
+        mask : DataArray or None
+            Which cells to optimize, over the node's non-date dims. Defaults to
+            all of them.
+        carry_in_values : np.ndarray or None
+            Spend already made before the window, one leading period per row.
+        scales : float or np.ndarray
+            Scale factors converting monetary amounts into the node's units.
+        date_dim : str
+            The model's date dimension, which the node must vary over.
+        **kwargs
+            Passed through to the constructor.
+
+        Returns
+        -------
+        MediaVariable
+            A monetary variable over ``name``.
+
+        Raises
+        ------
+        ValueError
+            If ``name`` has no named dims, or does not vary over *date_dim*.
+        """
+        if name not in model.named_vars_to_dims:
+            raise ValueError(
+                f"spend variable '{name}' is not a variable with named dims in "
+                "the model, so the cells to optimize cannot be determined."
+            )
+        dims = tuple(model.named_vars_to_dims[name])
+        if date_dim not in dims:
+            raise ValueError(
+                f"spend variable '{name}' has dims {dims}, which do not include "
+                f"{date_dim!r}. A budget is spent over time; a quantity that "
+                "does not vary by date is a lever, not a spend."
+            )
+        cell_dims = tuple(dim for dim in dims if dim != date_dim)
+        if mask is None:
+            shape = tuple(len(model.coords[dim]) for dim in cell_dims)
+            mask = DataArray(
+                np.ones(shape, dtype=bool),
+                dims=cell_dims,
+                coords={dim: list(model.coords[dim]) for dim in cell_dims},
+            )
+        return cls(
+            name=name,
+            mask=mask,
+            num_periods=num_periods,
+            adstock_periods=adstock_periods,
+            carry_in_values=carry_in_values,
+            channel_scales=scales,
+            dtype=model[name].dtype,
+            scales_dims=cell_dims,
+            date_dim=date_dim,
+            **kwargs,
+        )
+
     def scattered(self, z: XTensorVariable) -> XTensorVariable:
         """Scatter the flat slice into the full budget-dims tensor.
 
         Non-optimized cells are zero. Values remain in monetary units.
         """
+        if not self.dims:
+            # One budget, decided over nothing but date -- a single national
+            # spend. There are no cells to scatter into, the mask is 0-d, and
+            # pytensor cannot index with a scalar boolean. The constructor has
+            # already refused a mask that selects nothing, so the one cell here
+            # is always optimized and reshaping is the whole of the scatter.
+            return as_xtensor(z.values.reshape(()), dims=())
         budgets_zeros = pt.zeros(self.shape)
         budgets_zeros.name = "budgets_zeros"
         return as_xtensor(
@@ -387,7 +482,7 @@ class MediaVariable(OptimizationVariable):
 
         repeated_budgets = repeated_budgets / as_xtensor(
             self.channel_scales,
-            dims=() if np.ndim(self.channel_scales) == 0 else ("channel",),
+            dims=() if np.ndim(self.channel_scales) == 0 else self.scales_dims,
         )
 
         # Convert from monetary units to original units using date-specific
@@ -779,10 +874,48 @@ class OptimizationVariables:
             for variable in self.variables
         }
 
+    def spending_variables(self) -> list[OptimizationVariable]:
+        """Return the variables that draw from the shared budget.
+
+        Read off ``budget_contribution`` rather than a second flag, so there is
+        one answer to "does this spend?" and it cannot disagree with itself.
+        Building the contribution is symbolic and cheap; nothing is evaluated.
+        """
+        return [
+            variable
+            for variable in self.variables
+            if variable.budget_contribution(self.variable_slice(variable.name))
+            is not None
+        ]
+
     def x0(self, total_budget: float) -> np.ndarray:
-        """Default initial guess: each variable's ``default_x0`` concatenated."""
+        """Default initial guess: each variable's ``default_x0`` concatenated.
+
+        The budget is shared out across the *cells* of every spending variable,
+        so the guess sums to ``total_budget`` however many of them there are and
+        every spending cell starts at the same amount. With one spender this is
+        exactly ``default_x0(total_budget)``; with two, splitting matters --
+        giving each the whole budget would start the solver at twice it, outside
+        the equality constraint before the first step.
+
+        A variable that does not spend is handed the total untouched: it is in
+        its own units, and its default ignores the figure anyway.
+        """
+        spenders = self.spending_variables()
+        cells = sum(variable.size for variable in spenders)
+        shares = (
+            {
+                variable.name: total_budget * variable.size / cells
+                for variable in spenders
+            }
+            if cells
+            else {}
+        )
         return np.concatenate(
-            [variable.default_x0(total_budget) for variable in self.variables]
+            [
+                variable.default_x0(shares.get(variable.name, total_budget))
+                for variable in self.variables
+            ]
         )
 
     def bounds(

--- a/pymc_marketing/mmm/optimization_variables.py
+++ b/pymc_marketing/mmm/optimization_variables.py
@@ -346,6 +346,7 @@ class MediaVariable(OptimizationVariable):
         adstock_periods: int,
         mask: DataArray | None = None,
         carry_in_values: np.ndarray | None = None,
+        carry_in_periods: int = 0,
         scales: float | np.ndarray = 1.0,
         date_dim: str = "date",
         **kwargs,
@@ -372,6 +373,10 @@ class MediaVariable(OptimizationVariable):
             all of them.
         carry_in_values : np.ndarray or None
             Spend already made before the window, one leading period per row.
+        carry_in_periods : int
+            Read that many leading periods off the node itself when
+            *carry_in_values* is not given. Read after the name is validated,
+            so a typo is reported as a typo.
         scales : float or np.ndarray
             Scale factors converting monetary amounts into the node's units.
         date_dim : str
@@ -401,6 +406,16 @@ class MediaVariable(OptimizationVariable):
                 f"{date_dim!r}. A budget is spent over time; a quantity that "
                 "does not vary by date is a lever, not a spend."
             )
+        if carry_in_periods and carry_in_values is None:
+            node = model[name]
+            if not hasattr(node, "get_value"):
+                raise ValueError(
+                    f"spend variable '{name}' is not a shared variable, so the "
+                    "spend made before the window cannot be read from it. "
+                    "Spend variables must be pm.Data nodes."
+                )
+            carry_in_values = np.asarray(node.get_value())[:carry_in_periods]
+
         cell_dims = tuple(dim for dim in dims if dim != date_dim)
         if mask is None:
             shape = tuple(len(model.coords[dim]) for dim in cell_dims)

--- a/pymc_marketing/mmm/optimization_variables.py
+++ b/pymc_marketing/mmm/optimization_variables.py
@@ -795,6 +795,17 @@ class OptimizationVariables:
             flat_name, shape=(self.size,), dims=(flat_dim,)
         )
 
+        # Which variables spend is fixed once the layout is, and answering it
+        # builds a throwaway symbolic tensor per variable. Settled here so
+        # repeated `x0` calls -- a warm start, a sweep over budgets -- do not
+        # rebuild the same graphs to reach the same answer.
+        self._spending: tuple[OptimizationVariable, ...] = tuple(
+            variable
+            for variable in self.variables
+            if variable.budget_contribution(self.variable_slice(variable.name))
+            is not None
+        )
+
     def variable_slice(self, name: str) -> XTensorVariable:
         """Return the symbolic slice of the flat vector for variable ``name``.
 
@@ -879,14 +890,10 @@ class OptimizationVariables:
 
         Read off ``budget_contribution`` rather than a second flag, so there is
         one answer to "does this spend?" and it cannot disagree with itself.
-        Building the contribution is symbolic and cheap; nothing is evaluated.
+        Settled once at construction, since the layout it depends on is fixed
+        there too.
         """
-        return [
-            variable
-            for variable in self.variables
-            if variable.budget_contribution(self.variable_slice(variable.name))
-            is not None
-        ]
+        return list(self._spending)
 
     def x0(self, total_budget: float) -> np.ndarray:
         """Default initial guess: each variable's ``default_x0`` concatenated.

--- a/tests/mmm/test_budget_optimizer.py
+++ b/tests/mmm/test_budget_optimizer.py
@@ -24,6 +24,7 @@ import pytest
 import xarray as xr
 from pydantic import ValidationError
 from pytensor.graph.traversal import ancestors
+from scipy.optimize import OptimizeResult
 from xarray import DataArray
 
 import pymc_marketing.mmm.budget_optimizer as budget_optimizer_module
@@ -1512,3 +1513,26 @@ def test_custom_constraint_can_bind_a_lever(mock_pymc_sample):
     assert float(result.optimized_vars["promo_data"].sum()) <= cap + 1e-6
     # And the budget constraint is still honoured alongside it.
     np.testing.assert_allclose(float(result.budgets.sum()), 100.0, rtol=1e-6)
+
+
+def test_spend_var_allocations_excludes_levers():
+    """Only money is reported as money.
+
+    ``optimized_vars`` carries both kinds, and a lever's units are its own: a
+    discount depth added to a budget means nothing. Asserted on a result built
+    by hand, because the discriminating case needs a lever *and* a spend
+    variable present at once -- with only one kind present, returning
+    everything would look correct.
+    """
+    result = BudgetOptimizationResult(
+        budgets=xr.DataArray([1.0, 2.0], dims=("channel",)),
+        scipy_result=OptimizeResult(success=True),
+        optimized_vars={
+            "lf_budget": xr.DataArray(7.0),
+            "discount_depth": xr.DataArray(0.2),
+        },
+        spend_var_names=["lf_budget"],
+    )
+
+    assert set(result.spend_var_allocations) == {"lf_budget"}
+    assert float(result.spend_var_allocations["lf_budget"]) == 7.0

--- a/tests/mmm/test_budget_optimizer_mmm.py
+++ b/tests/mmm/test_budget_optimizer_mmm.py
@@ -2171,3 +2171,102 @@ class TestMonetarySpendVariables:
         """Naming it twice would give the media budget two disjoint slices."""
         with pytest.raises(ValueError, match="already optimized"):
             self._optimizer(funnel_identity_fitted_mmm, spend_vars=["channel_data"])
+
+    @staticmethod
+    def _variable(optimizer, name):
+        return next(
+            variable
+            for variable in optimizer.optimization_variables.variables
+            if variable.name == name
+        )
+
+    def test_a_misspelled_spend_variable_says_so(self, funnel_identity_fitted_mmm):
+        """Carry-in is on for this path, so the name used to be read first.
+
+        The node was dereferenced while building the argument list, before
+        `from_model` validated anything, so a typo surfaced as a bare
+        `KeyError` naming nothing the caller could act on.
+        """
+        with pytest.raises(ValueError, match="not a variable with named dims"):
+            self._optimizer(funnel_identity_fitted_mmm, spend_vars=["lf_bugdet"])
+
+    def test_a_spend_variable_must_be_a_data_node(self, funnel_identity_fitted_mmm):
+        """A dimensioned node with no stored value cannot carry prior spend."""
+        with pytest.raises(ValueError, match="not a shared variable"):
+            self._optimizer(
+                funnel_identity_fitted_mmm, spend_vars=["channel_contribution"]
+            )
+
+    def test_the_default_spend_var_scale_is_one(self, funnel_identity_fitted_mmm):
+        """Declaring no scale means the node is read as raw money."""
+        optimizer = self._optimizer(funnel_identity_fitted_mmm, spend_vars=["lf_budget"])
+
+        scales = self._variable(optimizer, "lf_budget").channel_scales
+        assert float(np.asarray(scales)) == 1.0
+
+    def test_a_declared_scale_reaches_the_variable(self, funnel_identity_fitted_mmm):
+        """A node stored in scaled units has to be told its scale.
+
+        `channel_scales` exists on the media variable because `channel_data` is
+        stored scaled; a second monetary node can be stored the same way. Left
+        pinned at 1.0 with no way to set it, the optimizer treats one stored
+        unit as one dollar and the allocation is wrong with nothing raised.
+        """
+        optimizer = self._optimizer(
+            funnel_identity_fitted_mmm,
+            spend_vars=["lf_budget"],
+            spend_var_scales={"lf_budget": 1000.0},
+        )
+
+        scales = self._variable(optimizer, "lf_budget").channel_scales
+        assert float(np.asarray(scales)) == 1000.0
+
+    def test_a_scale_for_an_undeclared_name_is_refused(
+        self, funnel_identity_fitted_mmm
+    ):
+        """Dropping the key silently is the failure the scale exists to prevent.
+
+        A scale keyed on a name that is not optimized has no effect, so the run
+        succeeds and answers in the wrong units.
+        """
+        with pytest.raises(ValueError, match="not in spend_vars"):
+            self._optimizer(
+                funnel_identity_fitted_mmm,
+                spend_vars=["lf_budget"],
+                spend_var_scales={"lf_bugdet": 1000.0},
+            )
+
+    def test_the_budget_is_still_shared_in_money_when_scaled(
+        self, funnel_identity_fitted_mmm
+    ):
+        """The constraint stays in money whatever the storage units are.
+
+        The scale converts money into the node's units inside `to_model`. If it
+        leaked into `budget_contribution`, the sum constraint would total
+        dollars against stored units and the split would be meaningless.
+        """
+        optimizer = self._optimizer(
+            funnel_identity_fitted_mmm,
+            spend_vars=["lf_budget"],
+            spend_var_scales={"lf_budget": 1000.0},
+        )
+
+        result = optimizer.allocate_budget(total_budget=self.TOTAL)
+
+        assert result.scipy_result.success, result.scipy_result.message
+        spent = float(result.budgets.sum()) + sum(
+            float(allocation.sum())
+            for allocation in result.spend_var_allocations.values()
+        )
+        np.testing.assert_allclose(spent, self.TOTAL, rtol=1e-6)
+
+    def test_a_bare_string_is_not_read_character_by_character(
+        self, funnel_identity_fitted_mmm
+    ):
+        """`spend_vars="lf_budget"` must not be read as ["l", "f", "_", ...]."""
+        with pytest.raises((ValueError, TypeError)) as info:
+            self._optimizer(funnel_identity_fitted_mmm, spend_vars="lf_budget")
+
+        assert "'l'" not in str(info.value), (
+            "a bare string was iterated character by character"
+        )

--- a/tests/mmm/test_budget_optimizer_mmm.py
+++ b/tests/mmm/test_budget_optimizer_mmm.py
@@ -2073,9 +2073,14 @@ class TestMonetarySpendVariables:
         result = optimizer.allocate_budget(total_budget=self.TOTAL)
 
         assert result.scipy_result.success, result.scipy_result.message
-        media = float(result.budgets.sum())
-        lower_funnel = float(np.asarray(result.optimized_vars["lf_budget"]))
-        np.testing.assert_allclose(media + lower_funnel, self.TOTAL, rtol=1e-6)
+        # Summed off the result alone: it records which of its allocations are
+        # money, so the check does not depend on the test knowing which keys of
+        # `optimized_vars` are spend rather than levers.
+        spent = float(result.budgets.sum()) + sum(
+            float(allocation.sum())
+            for allocation in result.spend_var_allocations.values()
+        )
+        np.testing.assert_allclose(spent, self.TOTAL, rtol=1e-6)
 
     def test_the_split_is_interior(self, funnel_identity_fitted_mmm):
         """Both are funded, so the two are genuinely traded off.
@@ -2090,8 +2095,22 @@ class TestMonetarySpendVariables:
 
         result = optimizer.allocate_budget(total_budget=self.TOTAL)
 
-        assert float(np.asarray(result.optimized_vars["lf_budget"])) > 0.0
+        allocations = result.spend_var_allocations
+        assert set(allocations) == {"lf_budget"}
+        assert float(allocations["lf_budget"].sum()) > 0.0
         assert (result.budgets > 0).all()
+
+    def test_declaring_no_spend_variables_reports_none(
+        self, funnel_identity_fitted_mmm
+    ):
+        """The media budgets alone are not reported as a spend variable."""
+        optimizer = self._optimizer(funnel_identity_fitted_mmm, spend_vars=[])
+
+        result = optimizer.allocate_budget(total_budget=self.TOTAL)
+
+        assert result.spend_var_names == []
+        assert result.spend_var_allocations == {}
+        np.testing.assert_allclose(float(result.budgets.sum()), self.TOTAL, rtol=1e-6)
 
     def test_a_spend_variable_the_objective_cannot_see_is_refused(
         self, funnel_identity_fitted_mmm

--- a/tests/mmm/test_budget_optimizer_mmm.py
+++ b/tests/mmm/test_budget_optimizer_mmm.py
@@ -2109,6 +2109,43 @@ class TestMonetarySpendVariables:
                 response_variable="total_media_contribution_original_scale",
             )
 
+    def test_a_repeated_spend_variable_is_refused(self, funnel_identity_fitted_mmm):
+        """Two variables of one name would share a slot in the flat vector.
+
+        `variable_slice` looks up by name, so the second would read the first's
+        segment and the budget allocated to it would go nowhere. The container
+        refuses the layout before it is built; this pins that, because the
+        failure it prevents is silent.
+        """
+        with pytest.raises(ValueError, match="Duplicate variable names"):
+            self._optimizer(
+                funnel_identity_fitted_mmm, spend_vars=["lf_budget", "lf_budget"]
+            )
+
+    def test_a_spend_variable_opens_on_its_own_prior_spend(
+        self, funnel_identity_fitted_mmm
+    ):
+        """Carry-in is per variable, read from each node's own history.
+
+        The leading block for a spend variable comes from that variable's data,
+        not the channel variable's, so a spend decided over different dims than
+        media still gets a correctly shaped warm start rather than a shape
+        error at substitution time.
+        """
+        mmm = funnel_identity_fitted_mmm
+        optimizer = self._optimizer(mmm, spend_vars=["lf_budget"])
+
+        assert optimizer.carry_in_periods == mmm.effective_carryover_lags()
+        spend = next(
+            variable
+            for variable in optimizer.optimization_variables.variables
+            if variable.name == "lf_budget"
+        )
+        expected = np.asarray(mmm.model["lf_budget"].get_value())[
+            -optimizer.carry_in_periods :
+        ]
+        np.testing.assert_allclose(spend.carry_in_values, expected)
+
     def test_spend_vars_may_not_name_the_media_variable(
         self, funnel_identity_fitted_mmm
     ):

--- a/tests/mmm/test_budget_optimizer_mmm.py
+++ b/tests/mmm/test_budget_optimizer_mmm.py
@@ -21,6 +21,7 @@ import pymc.dims as pmd
 import pytest
 import xarray as xr
 from pytensor import function
+from pytensor.compile.mode import Mode
 from pytensor.xtensor import as_xtensor
 
 from pymc_marketing.mmm import GeometricAdstock, LogisticSaturation
@@ -2024,3 +2025,93 @@ class TestLegacyWrapperNumPeriods:
                 response_variable="total_media_contribution_original_scale",
             )
         assert "BudgetOptimizerWrapper" in str(info.value)
+
+
+class TestMonetarySpendVariables:
+    """A second money tensor competes with media for the same budget.
+
+    A funnel's lower-funnel spend is a decision, not an input: it is money, so
+    it belongs in the same pot as the media budgets rather than beside them.
+    `LeverVariable` cannot carry it -- a lever is optimized in its own units and
+    deliberately sits outside the budget-sum constraint -- so it rides the media
+    path over a different node instead.
+
+    `cvm` because numba cannot compile the gradient of this effect's second,
+    sample-batched adstock (pytensor#2360), which is upstream and unrelated.
+    """
+
+    # Large enough that media has saturated and the lower funnel is worth
+    # funding. At a small budget media wins outright and the split is a corner,
+    # which would not tell us the two are being traded off at all.
+    TOTAL = 200.0
+
+    def _optimizer(self, mmm, **kwargs):
+        dates = pd.DatetimeIndex(mmm.xarray_dataset.coords["date"].values)
+        t0 = dates[-1]
+        kwargs.setdefault("response_variable", "total_response_original_scale")
+        return mmm.budget_optimizer(
+            start_date=t0 + pd.Timedelta(weeks=1),
+            end_date=t0 + pd.Timedelta(weeks=8),
+            compile_kwargs={"mode": Mode(linker="cvm")},
+            **kwargs,
+        )
+
+    def test_the_budget_is_shared_with_the_media_spend(
+        self, funnel_identity_fitted_mmm
+    ):
+        """The claim: one pot, split between media and the lower funnel.
+
+        `constraints.py` is untouched by this feature. The default sum
+        constraint totals every variable that reports a `budget_contribution`,
+        so a second monetary variable joins it by being one -- which is what
+        that seam was built for.
+        """
+        optimizer = self._optimizer(
+            funnel_identity_fitted_mmm, spend_vars=["lf_budget"]
+        )
+
+        result = optimizer.allocate_budget(total_budget=self.TOTAL)
+
+        assert result.scipy_result.success, result.scipy_result.message
+        media = float(result.budgets.sum())
+        lower_funnel = float(np.asarray(result.optimized_vars["lf_budget"]))
+        np.testing.assert_allclose(media + lower_funnel, self.TOTAL, rtol=1e-6)
+
+    def test_the_split_is_interior(self, funnel_identity_fitted_mmm):
+        """Both are funded, so the two are genuinely traded off.
+
+        A corner solution would satisfy the sum constraint just as well while
+        telling us nothing about whether the second variable moves the
+        objective at all.
+        """
+        optimizer = self._optimizer(
+            funnel_identity_fitted_mmm, spend_vars=["lf_budget"]
+        )
+
+        result = optimizer.allocate_budget(total_budget=self.TOTAL)
+
+        assert float(np.asarray(result.optimized_vars["lf_budget"])) > 0.0
+        assert (result.budgets > 0).all()
+
+    def test_a_spend_variable_the_objective_cannot_see_is_refused(
+        self, funnel_identity_fitted_mmm
+    ):
+        """Worse than an unreachable lever: it spends and returns nothing.
+
+        The default objective counts the direct path only, so the mediated
+        lower-funnel spend is invisible to it. Left to run, the solver would
+        fund it out of the media budget and get no response back.
+        """
+        with pytest.raises(ValueError, match=r"spend_vars \['lf_budget'\]"):
+            self._optimizer(
+                funnel_identity_fitted_mmm,
+                spend_vars=["lf_budget"],
+                response_variable="total_media_contribution_original_scale",
+            )
+
+    def test_spend_vars_may_not_name_the_media_variable(
+        self, funnel_identity_fitted_mmm
+    ):
+        """Naming it twice would give the media budget two disjoint slices."""
+        with pytest.raises(ValueError, match="already optimized"):
+            self._optimizer(funnel_identity_fitted_mmm, spend_vars=["channel_data"])

--- a/tests/mmm/test_budget_optimizer_mmm.py
+++ b/tests/mmm/test_budget_optimizer_mmm.py
@@ -2199,7 +2199,9 @@ class TestMonetarySpendVariables:
 
     def test_the_default_spend_var_scale_is_one(self, funnel_identity_fitted_mmm):
         """Declaring no scale means the node is read as raw money."""
-        optimizer = self._optimizer(funnel_identity_fitted_mmm, spend_vars=["lf_budget"])
+        optimizer = self._optimizer(
+            funnel_identity_fitted_mmm, spend_vars=["lf_budget"]
+        )
 
         scales = self._variable(optimizer, "lf_budget").channel_scales
         assert float(np.asarray(scales)) == 1.0

--- a/tests/mmm/test_optimization_variables.py
+++ b/tests/mmm/test_optimization_variables.py
@@ -561,3 +561,77 @@ def test_from_model_leaves_bounds_optional(lever_model):
 def test_from_model_rejects_nodes_that_cannot_be_levers(lever_model, name, match):
     with pytest.raises(ValueError, match=match):
         LeverVariable.from_model(lever_model, name, date_dim="date")
+
+
+def _money(name, sizes=(3,), dims=("channel",)):
+    coords = {
+        dim: [f"{dim}_{i}" for i in range(size)]
+        for dim, size in zip(dims, sizes, strict=True)
+    }
+    mask = xr.DataArray(np.ones(sizes, dtype=bool), dims=dims, coords=coords)
+    return MediaVariable(
+        name=name,
+        mask=mask,
+        num_periods=4,
+        adstock_periods=2,
+        channel_scales=1.0,
+        dtype="float64",
+    )
+
+
+def test_x0_shares_one_budget_across_every_spending_variable():
+    """Two money variables must not each start at the whole budget.
+
+    The default sum constraint is an equality, so an initial guess totalling
+    twice the budget starts the solver outside the feasible set. SLSQP will
+    often recover, which is exactly why this is asserted on the guess itself
+    rather than left to be noticed in an optimum.
+    """
+    variables = OptimizationVariables([_money("channel_data"), _money("lf_budget")])
+
+    x0 = variables.x0(total_budget=100.0)
+
+    np.testing.assert_allclose(x0.sum(), 100.0)
+    # Uniform across every spending cell, not merely equal per variable.
+    np.testing.assert_allclose(x0, np.full(6, 100.0 / 6))
+
+
+def test_x0_is_unchanged_with_a_single_spending_variable():
+    """The share degenerates to the previous behaviour when there is one pot."""
+    variables = OptimizationVariables([_money("channel_data")])
+
+    np.testing.assert_allclose(variables.x0(total_budget=100.0), np.full(3, 100.0 / 3))
+
+
+def test_a_lever_does_not_take_a_share_of_the_budget():
+    """Levers are optimized in their own units and stay out of the pot."""
+    money = _money("channel_data")
+    variables = OptimizationVariables([money])
+
+    assert [v.name for v in variables.spending_variables()] == ["channel_data"]
+
+
+def test_a_national_spend_has_no_cells_to_scatter_into():
+    """A budget decided over date alone is one number, not a masked tensor.
+
+    The mask is then 0-dimensional, which pytensor cannot index with, so the
+    scatter has to recognise it. A single national lower-funnel budget is an
+    ordinary thing to optimize.
+    """
+    mask = xr.DataArray(np.array(True), dims=(), coords={})
+    variable = MediaVariable(
+        name="lf_budget",
+        mask=mask,
+        num_periods=4,
+        adstock_periods=2,
+        channel_scales=1.0,
+        dtype="float64",
+    )
+
+    z = ptx.as_xtensor(pt.as_tensor_variable(np.array([7.0])), dims=(FLAT_DIM,))
+    built = variable.to_model(z).values.eval()
+
+    assert variable.size == 1
+    assert built.shape == (6,)
+    np.testing.assert_allclose(built[:4], 7.0)
+    np.testing.assert_allclose(built[4:], 0.0)

--- a/tests/mmm/test_optimization_variables.py
+++ b/tests/mmm/test_optimization_variables.py
@@ -685,3 +685,102 @@ def test_from_model_refuses_a_node_that_does_not_vary_over_date():
         MediaVariable.from_model(
             model, "discount_depth", num_periods=4, adstock_periods=2
         )
+
+
+def _dated_money_model(values=None):
+    """A dated money node, plus a dimensioned node that stores no value."""
+    if values is None:
+        values = np.arange(30, dtype=float).reshape(10, 3)
+    coords = {"date": range(values.shape[0]), "geo": ["north", "south", "west"]}
+    with pm.Model(coords=coords) as model:
+        data = pmd.Data("lf_budget", values, dims=("date", "geo"))
+        pmd.Deterministic("lf_effect", data * 2.0)
+    return model
+
+
+def test_from_model_names_a_misspelled_spend_before_reading_its_history():
+    """The name is validated before the node is dereferenced.
+
+    ``carry_in_periods`` makes ``from_model`` read the node's own leading
+    periods. Read before the name is checked, a typo comes back as a bare
+    ``KeyError`` from the model and the message written here never fires.
+    """
+    with pytest.raises(ValueError, match="not a variable with named dims"):
+        MediaVariable.from_model(
+            _dated_money_model(),
+            "lf_bugdet",
+            num_periods=4,
+            adstock_periods=2,
+            carry_in_periods=3,
+        )
+
+
+def test_from_model_refuses_a_spend_it_cannot_read_prior_spend_from():
+    """A node with dims but no stored value is refused with a reason.
+
+    Same ordering, different symptom: an ``AttributeError`` on ``.get_value()``
+    says nothing about which node is wrong or what to pass instead.
+    """
+    with pytest.raises(ValueError, match="not a shared variable"):
+        MediaVariable.from_model(
+            _dated_money_model(),
+            "lf_effect",
+            num_periods=4,
+            adstock_periods=2,
+            carry_in_periods=3,
+        )
+
+
+def test_from_model_reads_carry_in_off_the_node_when_given_periods():
+    """Passing the count is equivalent to passing the values it would read."""
+    values = np.arange(30, dtype=float).reshape(10, 3)
+    variable = MediaVariable.from_model(
+        _dated_money_model(values),
+        "lf_budget",
+        num_periods=4,
+        adstock_periods=2,
+        carry_in_periods=3,
+    )
+
+    np.testing.assert_allclose(variable.carry_in_values, values[:3])
+
+
+def test_explicit_carry_in_values_win_over_the_node():
+    """The caller's values are kept, so the media variable's path is unchanged."""
+    given = np.full((3, 3), 5.0)
+    variable = MediaVariable.from_model(
+        _dated_money_model(),
+        "lf_budget",
+        num_periods=4,
+        adstock_periods=2,
+        carry_in_values=given,
+        carry_in_periods=3,
+    )
+
+    np.testing.assert_allclose(variable.carry_in_values, given)
+
+
+def test_the_scale_divides_the_substituted_spend():
+    """The point of a scale: money in, the node's stored units out.
+
+    ``to_model`` divides the monetary decision by ``channel_scales``, so the
+    tensor substituted for a 1000x-scaled variable is 1000x smaller for the
+    same money. Checked numerically rather than by reading the attribute back,
+    because the attribute arriving is not the same claim as it being applied.
+    """
+    model = _dated_money_model()
+
+    def substituted(scales):
+        variable = MediaVariable.from_model(
+            model, "lf_budget", num_periods=4, adstock_periods=2, scales=scales
+        )
+        z = ptx.as_xtensor(
+            pt.as_tensor_variable(np.full(variable.size, 120.0)), dims=(FLAT_DIM,)
+        )
+        return variable.to_model(z).values.eval()
+
+    plain = substituted(1.0)
+    scaled = substituted(1000.0)
+
+    np.testing.assert_allclose(plain, scaled * 1000.0, rtol=1e-6)
+    assert float(plain.max()) > 0.0

--- a/tests/mmm/test_optimization_variables.py
+++ b/tests/mmm/test_optimization_variables.py
@@ -13,6 +13,7 @@
 #   limitations under the License.
 import numpy as np
 import pymc as pm
+import pymc.dims as pmd
 import pytensor.tensor as pt
 import pytensor.xtensor as ptx
 import pytest
@@ -635,3 +636,52 @@ def test_a_national_spend_has_no_cells_to_scatter_into():
     assert built.shape == (6,)
     np.testing.assert_allclose(built[:4], 7.0)
     np.testing.assert_allclose(built[4:], 0.0)
+
+
+def test_from_model_reads_a_geo_dimensioned_spend_off_the_model():
+    """The shape a funnel actually has: one budget per geo, spent over dates.
+
+    ``from_model`` has to drop the date dim to find the cells and keep the rest
+    with their coords, so the decision is per geo and the substituted tensor is
+    the window's three blocks stacked over it.
+    """
+    coords = {"date": range(10), "geo": ["north", "south", "west"]}
+    with pm.Model(coords=coords) as model:
+        pmd.Data(
+            "lf_budget",
+            np.arange(30, dtype=float).reshape(10, 3),
+            dims=("date", "geo"),
+        )
+
+    variable = MediaVariable.from_model(
+        model,
+        "lf_budget",
+        num_periods=4,
+        adstock_periods=2,
+        carry_in_values=np.full((3, 3), 5.0),
+    )
+
+    assert variable.dims == ("geo",)
+    assert variable.size == 3
+    assert [str(g) for g in variable.coords["geo"]] == ["north", "south", "west"]
+
+    z = ptx.as_xtensor(
+        pt.as_tensor_variable(np.array([1.0, 2.0, 3.0])), dims=(FLAT_DIM,)
+    )
+    built = variable.to_model(z).values.eval()
+
+    assert built.shape == (9, 3)  # 3 carry-in + 4 decided + 2 carry-over
+    np.testing.assert_allclose(built[:3], 5.0)
+    np.testing.assert_allclose(built[3:7], np.array([[1.0, 2.0, 3.0]] * 4))
+    np.testing.assert_allclose(built[7:], 0.0)
+
+
+def test_from_model_refuses_a_node_that_does_not_vary_over_date():
+    """A quantity with no date dim is a lever, not a spend."""
+    with pm.Model(coords={"geo": ["north", "south"]}) as model:
+        pmd.Data("discount_depth", np.array([0.1, 0.2]), dims=("geo",))
+
+    with pytest.raises(ValueError, match="is a lever, not a spend"):
+        MediaVariable.from_model(
+            model, "discount_depth", num_periods=4, adstock_periods=2
+        )

--- a/tests/mmm/test_utils.py
+++ b/tests/mmm/test_utils.py
@@ -936,14 +936,24 @@ class TestBuildContributions:
 class _StubEffect:
     """A mu effect that reads *data_vars* and nothing else.
 
-    `create_zero_dataset` only ever asks an effect which variables it reads, so
-    the branches below need a name and a list -- not a fitted funnel.
+    `create_zero_dataset` only ever asks an effect which variables it reads and
+    what carryover it declares, so the branches below need a name, a list and an
+    opt-out -- not a fitted funnel.
     ``set_data`` mirrors ``DataVarMuEffect``: it sets what the dataset carries,
     which is what lets ``create_optimization_model`` run the stub end to end.
     """
 
     def __init__(self, data_vars):
         self.data_vars = list(data_vars)
+
+    def incrementality_spec(self):
+        """Opt out, as ``MuEffect``'s own default does.
+
+        The stub stands in for a real effect, so it has to answer the questions
+        the ABC says every effect answers. Leaving it off would make production
+        code tolerate a shape no registered effect can have.
+        """
+        return None
 
     def set_data(self, mmm, model, X):
         for var_name in self.data_vars:


### PR DESCRIPTION
## Description

**Lower-funnel spend becomes a decision rather than an input.** It is money, so it belongs in the same pot as the media budgets — but `LeverVariable` (#2884) cannot carry it: a lever is optimized in its own units and deliberately sits *outside* the budget-sum constraint. This adds a second variable on the media path over a different node.

```python
optimizer = mmm.budget_optimizer(
    start_date=..., end_date=...,
    response_variable="total_response_original_scale",
    spend_vars=["lf_budget"],
)
result = optimizer.allocate_budget(total_budget=200_000)

result.budgets                  # media, per channel
result.spend_var_allocations    # {"lf_budget": ...}, the other money
```

**`constraints.py` is untouched.** The default sum constraint already totals every variable that reports a `budget_contribution`, with a comment written in anticipation of exactly this. That seam shipped in #2884 with one implementor; this is the second, and the first evidence it was designed right.

## Commits

**1 — one owner for the window's three blocks.** `MMM.budget_optimizer` derived carry-in, decisions and carry-over inline from the date axis, three lines from the `BudgetOptimizer` guard that re-checks the same arithmetic. `_window_layout` names the split once; the guard stays, because it protects callers who set the three by hand.

Also drops dead defensiveness in `effective_carryover_lags`: `incrementality_spec` is concrete on the `MuEffect` ABC (`additive_effect.py:477`, returning `None`) and `mmm.py` already imports `MuEffect`, so neither the `getattr` nor the `NotImplementedError` branch could fire. They *could* fire for a duck-typed object that is not a `MuEffect` subclass — which is what removing them exposed in a test double, so the double now opts out the way the ABC's own default does. Production code tolerating a shape no registered effect can have is the wrong way round. **Flagging it as the one intentional narrowing here**, since `add_mu_effect` is annotated `MuEffect` but does not enforce it at runtime.

**2 — the spend variables.** `spend_vars` names additional monetary `pm.Data` nodes. Each becomes a `MediaVariable` over its own non-date dims, inheriting the window's three blocks, cost-per-unit conversion and mask scatter, and joins the budget constraint by reporting its spend. Three things it needed:

- **`scales_dims`**, so a scales array over `("geo",)` broadcasts. The hardcoded `("channel",)` only ever applied to *array* scales, which is why a scalar-scaled spend variable worked without it — smaller than expected.
- **`MediaVariable.from_model`**, reading dims, coords and dtype off the model as `LeverVariable.from_model` already does, so `budget_optimizer.py` gains no model introspection of its own.
- **A scatter that recognises a 0-dimensional mask.** A budget decided over date alone — a single national spend — has no cells, and pytensor cannot index with a scalar boolean. Found by running it, not by planning.

**`x0` now shares one budget** across the cells of every spending variable instead of handing each the whole of it, which would start the solver at twice the budget, outside an equality constraint. Unchanged with one spender.

**An unreachable spend variable is refused** like an unreachable lever, for a sharper reason: it still draws from the budget, so the solver funds it out of media and gets nothing back.

**3 — review fixes.** The spender set is settled once at construction rather than rebuilding throwaway symbolic tensors on every `x0` call; `_window_layout` documents that only the date axis comes from the model it is handed and the carry-over from `self`; `optimized_vars` stops calling itself "non-media".

**4 — `spend_var_allocations`.** `optimized_vars` carries levers and money alike, and a caller summing against a budget must not add a discount depth to it. `spend_var_names` records which is which and the property reads it back, so the budget check is self-contained in the result. Two accessors rather than one merged `monetary_allocations`: `budgets` is per-channel and a spend variable is per-spend-var, so merging needs either the media variable's name in the result or a heterogeneous mix. Uglier, honest about the structure.

## Measured

Media and lower-funnel spend reach a joint interior optimum on the funnel fixture, and the split is exact:

| total | media | `lf_budget` | sum |
|---|---|---|---|
| 10 | 10.000 | 0.000 | 10.000 |
| 50 | 36.514 | 13.486 | 50.000 |
| 200 | 123.204 | 76.796 | 200.000 |
| 1000 | 640.279 | 359.721 | 1000.000 |

At a small budget media wins outright; as it saturates the lower funnel becomes worth funding. The interior split is what shows the two are genuinely traded off — a corner solution would satisfy the sum constraint just as well while saying nothing about whether the second variable moves the objective.

## Verification

712 passed, 6 skipped across `test_utils.py`, `test_budget_optimizer.py`, `test_budget_optimizer_mmm.py`, `test_optimization_variables.py`, `test_mmm.py`, `test_additive_effect.py`, `test_cost_per_unit.py`, `test_incrementality.py`. Lint and mypy clean.

Mutation-verified, each failing the test that asserts its guarantee:

| mutation | caught by |
|---|---|
| spend variable stops reporting its spend | budget no longer sums to the total |
| `x0` hands each spender the whole budget | the guess sums to 2× |
| 0-d scatter special case removed | `NotImplementedError: Boolean scalar indexing` |
| duplicate-name guard removed | `DID NOT RAISE ValueError` |
| carry-in read from the channel node, not the variable's own | three tests |
| `spend_var_names` left unpopulated | two tests |
| `spend_var_allocations` returns every `optimized_vars` entry | the lever-exclusion unit test |

Two of these are worth calling out, because in both cases no end-to-end optimization would have caught the bug:

- **The `x0` fix.** SLSQP recovered from the infeasible start on this fixture, so every optimization test passed with it broken. It is asserted on the guess itself.
- **The lever-exclusion test.** As first written it declared `spend_vars=[]` and contained no lever, so it asserted the empty case and would have passed whatever the property returned. The distinction is only observable with a lever *and* a spend variable present at once, which the funnel fixture cannot produce (`lf_budget` is date-only, so it cannot be a lever), so it is now a unit test on a result built by hand.

## Not in this PR

- **Per-spend-variable configuration.** Scales, `cost_per_unit` and a cell mask all default; the plumbing accepts them but they are not exposed per entry. Bounds already work through the existing `bounds_overrides`, keyed by variable name.
- **`requires_full_axis`** — an effect declaring `evaluation_mode="full"` cannot be reproduced by any window, and `effective_carryover_lags` still sizes one anyway.
- **Carry-in dates inflating the reported objective.** Argmax is unaffected; the quoted value is not.

## Related

- Retires "it does not co-optimize the lower funnel" from #2890's caveats.
- Same machinery freq/reach needs: reach is bought with money, and `cost_per_unit_tensor` already exists to fold `assumed_frequency` into the rate (#1968).
- Builds on #2884 (the `budget_contribution` seam), #2895 (the objective that sees the mediated path) and #2898 (the window).

## Type of change

- [x] New feature (`spend_vars` defaults to empty; `x0` unchanged with a single spending variable; `spend_var_names` defaults to empty)
- [x] Minor breaking change: an effect that is not a `MuEffect` subclass and lacks `incrementality_spec` now raises instead of being skipped (see commit 1)
