### PR TITLE
feat(mmm): add OriginalScaleIndex and fix drop_scalar_coords for custom xarray indexes

### DIFF
--- a/pymc_marketing/mmm/__init__.py
+++ b/pymc_marketing/mmm/__init__.py
@@ -77,6 +77,7 @@ from pymc_marketing.mmm.optimization_variables import (
     OptimizationVariable,
     OptimizationVariables,
 )
+from pymc_marketing.mmm.original_scale_index import OriginalScaleIndex
 from pymc_marketing.mmm.plotting import MMMPlotSuiteFacade
 from pymc_marketing.mmm.preprocessing import (
     preprocessing_method_X,
@@ -133,6 +134,7 @@ __all__ = [
     "NoSaturation",
     "OptimizationVariable",
     "OptimizationVariables",
+    "OriginalScaleIndex",
     "PeriodicCovFunc",
     "RootSaturation",
     "SaturationTransformation",

--- a/pymc_marketing/mmm/original_scale_index.py
+++ b/pymc_marketing/mmm/original_scale_index.py
@@ -1,0 +1,234 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Custom xarray Index for saturation curve x coordinates in original scale."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+from xarray import Index
+from xarray.core.indexing import IndexSelResult
+from xarray.indexes import PandasIndex
+
+
+class OriginalScaleIndex(Index):
+    """Custom xarray Index that maps scaled x coordinates to original domain on selection.
+
+    Stores ``x_original = x_scaled * channel_scale`` as a pre-computed DataArray
+    via xarray broadcasting. Selecting on any scale dimension (e.g. ``"channel"``,
+    ``"geo"``) reduces the array; once all scale dimensions are resolved, the
+    ``"x"`` coordinate is replaced with original-domain values backed by a plain
+    :class:`~xarray.indexes.PandasIndex`. Partial selections return a new
+    ``OriginalScaleIndex`` over the remaining scale dimensions.
+
+    ``da.xindexes["x"]`` and ``da.xindexes["channel"]`` return the same
+    ``OriginalScaleIndex`` instance.
+
+    Parameters
+    ----------
+    x_original : xr.DataArray
+        Pre-computed original-domain x values. Must have ``"x"`` as one dimension;
+        all other dimensions are treated as scale dimensions (e.g. ``("x", "channel")``
+        or ``("x", "geo", "channel")``). The ``"x"`` coordinate holds the scaled
+        linspace values; the DataArray values are ``x_scaled * channel_scale``.
+
+    Examples
+    --------
+    Attach directly to a DataArray via :func:`~xarray.DataArray.set_xindex`:
+
+    .. code-block:: python
+
+        channel_scale = xr.DataArray(
+            [5000.0, 1200.0],
+            dims=["channel"],
+            coords={"channel": ["TV", "Radio"]},
+        )
+        # da has dims (chain, draw, channel, x) with x in [0, 1]
+        curve = da.drop_indexes(["x", "channel"]).set_xindex(
+            ["x", "channel"], OriginalScaleIndex, channel_scale=channel_scale
+        )
+        curve.sel(channel="TV").coords["x"]  # TV's original-domain x values
+
+    See :meth:`~pymc_marketing.mmm.MMM.sample_saturation_curve` for the primary
+    use-case where this index is attached automatically.
+    """
+
+    def __init__(self, x_original: xr.DataArray) -> None:
+        self.x_original = x_original
+
+    @property
+    def _scale_dims(self) -> tuple[str, ...]:
+        return tuple(d for d in self.x_original.dims if d != "x")
+
+    @classmethod
+    def _from_x_and_scale(
+        cls,
+        x_values: np.ndarray,
+        channel_scale: xr.DataArray,
+    ) -> OriginalScaleIndex:
+        x_da = xr.DataArray(x_values, dims=["x"], coords={"x": x_values})
+        return cls(x_original=x_da * channel_scale)
+
+    @classmethod
+    def from_variables(
+        cls,
+        variables: dict[str, xr.Variable],
+        *,
+        options: dict | None = None,
+    ) -> OriginalScaleIndex:
+        """Create an OriginalScaleIndex from coordinate variables.
+
+        Called by xarray when ``set_xindex([...], OriginalScaleIndex, channel_scale=da)``
+        is invoked.
+
+        Parameters
+        ----------
+        variables : dict[str, xr.Variable]
+            Must contain an ``"x"`` variable (scaled x linspace). Scale dimension
+            variables are derived from ``options["channel_scale"]``.
+        options : dict, optional
+            Must contain ``"channel_scale"``: an ``xr.DataArray`` with the per-channel
+            scale factors and whatever dims apply.
+
+        Returns
+        -------
+        OriginalScaleIndex
+        """
+        options = options or {}
+        x_var = variables.get("x")
+        channel_scale = options.get("channel_scale")
+        if x_var is None:
+            raise ValueError(
+                f"OriginalScaleIndex requires an 'x' variable. Got: {list(variables)}"
+            )
+        if channel_scale is None:
+            raise ValueError(
+                "OriginalScaleIndex requires 'channel_scale' in options. "
+                "Pass it via set_xindex(..., channel_scale=da)."
+            )
+        return cls._from_x_and_scale(x_var.values, channel_scale)
+
+    def create_variables(
+        self,
+        variables: dict | None = None,
+    ) -> dict[str, xr.Variable]:
+        """Return the coordinate variables managed by this index."""
+        result: dict[str, xr.Variable] = {
+            "x": xr.Variable("x", self.x_original.coords["x"].values)
+        }
+        for dim in self._scale_dims:
+            result[dim] = xr.Variable(dim, self.x_original.coords[dim].values)
+        return result
+
+    def sel(
+        self,
+        labels: dict,
+        method: str | None = None,
+        tolerance: float | None = None,
+    ) -> IndexSelResult:
+        """Handle label-based selection.
+
+        Selects on scale dimensions by indexing into the pre-computed ``x_original``
+        DataArray. When all scale dimensions are resolved the ``x`` coordinate is
+        replaced with original-domain values. Partial selections return a new
+        ``OriginalScaleIndex`` over the remaining dimensions.
+
+        Parameters
+        ----------
+        labels : dict
+            Selection labels. Keys may be any subset of the managed scale
+            dimension names or ``"x"``.
+        method : str, optional
+            Passed through to PandasIndex for ``"x"`` selection.
+        tolerance : float, optional
+            Passed through to PandasIndex for ``"x"`` selection.
+
+        Returns
+        -------
+        IndexSelResult
+        """
+        scale_labels = {k: v for k, v in labels.items() if k in self._scale_dims}
+        x_labels = {k: v for k, v in labels.items() if k == "x"}
+
+        if scale_labels:
+            dim_indexers: dict[str, int] = {}
+            for dim, val in scale_labels.items():
+                arr = self.x_original.coords[dim].values
+                matches = np.where(arr == val)[0]
+                if not len(matches):
+                    raise KeyError(f"{dim}={val!r} not found. Available: {list(arr)}")
+                dim_indexers[dim] = int(matches[0])
+
+            selected = self.x_original.sel(scale_labels)
+            remaining = [d for d in self._scale_dims if d not in scale_labels]
+
+            if not remaining:
+                x_natural = selected.values  # shape (n_x,) — already in original domain
+                return IndexSelResult(
+                    dim_indexers=dim_indexers,
+                    variables={"x": xr.Variable("x", x_natural)},
+                    indexes={"x": PandasIndex(pd.Index(x_natural), "x")},
+                )
+            else:
+                new_idx = OriginalScaleIndex(selected)
+                return IndexSelResult(
+                    dim_indexers=dim_indexers,
+                    indexes={"x": new_idx, **{d: new_idx for d in remaining}},
+                )
+
+        if x_labels:
+            x_scaled = self.x_original.coords["x"].values
+            return PandasIndex(pd.Index(x_scaled), "x").sel(
+                {"x": x_labels["x"]}, method=method, tolerance=tolerance
+            )
+
+        raise NotImplementedError(
+            f"OriginalScaleIndex.sel does not support labels: {list(labels)}"
+        )
+
+    def isel(self, indexers: dict) -> OriginalScaleIndex | PandasIndex:
+        """Handle integer-based selection.
+
+        Parameters
+        ----------
+        indexers : dict
+            Integer indexers for ``"x"`` and/or any scale dimensions.
+
+        Returns
+        -------
+        OriginalScaleIndex | PandasIndex
+            Returns a ``PandasIndex`` on original-domain x values once all scale
+            dimensions are reduced; otherwise returns a new ``OriginalScaleIndex``.
+        """
+        x_idx = indexers.get("x", slice(None))
+        scale_indexers = {d: indexers[d] for d in self._scale_dims if d in indexers}
+        selected = self.x_original.isel({"x": x_idx, **scale_indexers})
+
+        remaining = [d for d in self._scale_dims if d not in scale_indexers]
+        if not remaining:
+            return PandasIndex(pd.Index(selected.values), "x")
+        return OriginalScaleIndex(selected)
+
+    def equals(self, other: object) -> bool:
+        """Check equality with another index."""
+        return isinstance(other, OriginalScaleIndex) and self.x_original.equals(
+            other.x_original
+        )
+
+    def __repr__(self) -> str:  # noqa: D105
+        return (
+            f"OriginalScaleIndex(scale_dims={list(self._scale_dims)}, "
+            f"n_x={self.x_original.sizes['x']})"
+        )

--- a/pymc_marketing/mmm/original_scale_index.py
+++ b/pymc_marketing/mmm/original_scale_index.py
@@ -50,16 +50,26 @@ class OriginalScaleIndex(Index):
 
     .. code-block:: python
 
+        import numpy as np
+        import xarray as xr
+
+        channels = ["TV", "Radio"]
+        x = np.linspace(0, 1, 100)
         channel_scale = xr.DataArray(
             [5000.0, 1200.0],
             dims=["channel"],
-            coords={"channel": ["TV", "Radio"]},
+            coords={"channel": channels},
         )
-        # da has dims (chain, draw, channel, x) with x in [0, 1]
+        # y = x (linear / "infinite returns" saturation)
+        da = xr.DataArray(
+            np.broadcast_to(x, (len(channels), len(x))).copy(),
+            dims=["channel", "x"],
+            coords={"channel": channels, "x": x},
+        )
         curve = da.drop_indexes(["x", "channel"]).set_xindex(
             ["x", "channel"], OriginalScaleIndex, channel_scale=channel_scale
         )
-        curve.sel(channel="TV").coords["x"]  # TV's original-domain x values
+        curve.sel(channel="TV").coords["x"]  # TV's original-domain x values [0, 5000]
 
     See :meth:`~pymc_marketing.mmm.MMM.sample_saturation_curve` for the primary
     use-case where this index is attached automatically.

--- a/pymc_marketing/mmm/original_scale_index.py
+++ b/pymc_marketing/mmm/original_scale_index.py
@@ -15,12 +15,26 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 import pandas as pd
 import xarray as xr
 from xarray import Index
 from xarray.core.indexing import IndexSelResult
 from xarray.indexes import PandasIndex
+
+
+def _is_scalar_indexer(idx: Any) -> bool:
+    """Check whether an integer indexer reduces its dimension to a scalar."""
+    if isinstance(idx, slice | xr.Variable):
+        return False
+    return np.ndim(idx) == 0
+
+
+def _is_scalar_label(label: Any) -> bool:
+    """Check whether a label-based indexer selects a single position."""
+    return not isinstance(label, slice) and np.ndim(label) == 0
 
 
 class OriginalScaleIndex(Index):
@@ -35,6 +49,43 @@ class OriginalScaleIndex(Index):
 
     ``da.xindexes["x"]`` and ``da.xindexes["channel"]`` return the same
     ``OriginalScaleIndex`` instance.
+
+    Selection semantics
+    -------------------
+    ``"x"`` labels are always interpreted in the **original (spend) domain**, and
+    they can only be resolved once every scale dimension has been reduced to a
+    scalar, because a single spend value maps to a different position on each
+    channel's axis. Select TV's curve at a spend of 2500 with
+
+    .. code-block:: python
+
+        curve.sel(channel="TV").sel(x=2500)
+
+    ``"x"`` **slices and lists** may be combined with scale labels in a single
+    call — the scale dimensions are resolved first and the ``"x"`` label is
+    applied to the resolved spend axis:
+
+    .. code-block:: python
+
+        curve.sel(channel="TV", x=slice(0, 2500))
+
+    A **scalar** ``"x"`` label cannot be combined with scale labels in one call
+    (the result would silently fall back to a scaled-domain coordinate), and no
+    ``"x"`` label can be used while any scale dimension is unresolved — both
+    raise :class:`NotImplementedError` with guidance. Positional ``.isel`` is
+    unaffected. Scale dimension labels accept scalars, lists and slices and are
+    resolved through a :class:`~xarray.indexes.PandasIndex` per dimension.
+
+    Known limitations
+    -----------------
+    - :meth:`~xarray.DataArray.groupby` over a scale dimension keeps **scaled**
+      ``x`` on each group: groupby reduces via a one-element list, so the index
+      never reaches its fully-resolved branch. Use ``.sel`` per group for
+      original-domain ``x``.
+    - Selecting a **list** on a scale dimension keeps the remaining curve in the
+      scaled domain (the original domain is a different axis per channel).
+    - To operate on the raw scaled coordinate, drop the index first:
+      ``curve.drop_indexes(["channel", "x"])``.
 
     Parameters
     ----------
@@ -70,13 +121,19 @@ class OriginalScaleIndex(Index):
             ["x", "channel"], OriginalScaleIndex, channel_scale=channel_scale
         )
         curve.sel(channel="TV").coords["x"]  # TV's original-domain x values [0, 5000]
+        curve.sel(channel="TV", x=slice(0, 2500))  # TV's curve up to a spend of 2500
 
-    See :meth:`~pymc_marketing.mmm.MMM.sample_saturation_curve` for the primary
-    use-case where this index is attached automatically.
+    Intended use-case: attaching original-domain x coordinates to MMM saturation
+    curves automatically, e.g. from ``MMM.sample_saturation_curve``
+    (`#2740 <https://github.com/pymc-labs/pymc-marketing/issues/2740>`__).
     """
 
     def __init__(self, x_original: xr.DataArray) -> None:
         self.x_original = x_original
+        self._scale_indexes: dict[str, PandasIndex] = {
+            dim: PandasIndex(pd.Index(x_original.coords[dim].values), dim)
+            for dim in self._scale_dims
+        }
 
     @property
     def _scale_dims(self) -> tuple[str, ...]:
@@ -134,12 +191,30 @@ class OriginalScaleIndex(Index):
         self,
         variables: dict | None = None,
     ) -> dict[str, xr.Variable]:
-        """Return the coordinate variables managed by this index."""
-        result: dict[str, xr.Variable] = {
-            "x": xr.Variable("x", self.x_original.coords["x"].values)
-        }
-        for dim in self._scale_dims:
-            result[dim] = xr.Variable(dim, self.x_original.coords[dim].values)
+        """Return the coordinate variables managed by this index.
+
+        Parameters
+        ----------
+        variables : dict, optional
+            Variables already created by the caller. Entries for the dimensions
+            managed by this index are passed through unchanged, preserving any
+            ``attrs`` or dtype; missing entries are rebuilt from the underlying
+            coordinates.
+
+        Returns
+        -------
+        dict[str, xr.Variable]
+        """
+        result: dict[str, xr.Variable] = {}
+        if "x" in self.x_original.coords:
+            names = ["x", *self._scale_dims]
+        else:
+            names = list(self._scale_dims)
+        for name in names:
+            if variables is not None and name in variables:
+                result[name] = variables[name]
+            else:
+                result[name] = xr.Variable(name, self.x_original.coords[name].values)
         return result
 
     def sel(
@@ -150,10 +225,17 @@ class OriginalScaleIndex(Index):
     ) -> IndexSelResult:
         """Handle label-based selection.
 
-        Selects on scale dimensions by indexing into the pre-computed ``x_original``
-        DataArray. When all scale dimensions are resolved the ``x`` coordinate is
-        replaced with original-domain values. Partial selections return a new
-        ``OriginalScaleIndex`` over the remaining dimensions.
+        Scale dimension labels (scalars, lists and slices) are resolved to
+        positions through a :class:`~xarray.indexes.PandasIndex` per dimension.
+        Once every scale dimension is reduced to a scalar, the ``"x"`` coordinate
+        is replaced with original-domain values backed by a
+        :class:`~xarray.indexes.PandasIndex`.
+
+        ``"x"`` labels are in the original (spend) domain. They are accepted
+        alongside scale labels as slices or lists, in which case the scale
+        dimensions are resolved first and the ``"x"`` label is applied to the
+        resolved axis. A scalar ``"x"`` label, or any ``"x"`` label with a scale
+        dimension still unresolved, raises :class:`NotImplementedError`.
 
         Parameters
         ----------
@@ -161,54 +243,87 @@ class OriginalScaleIndex(Index):
             Selection labels. Keys may be any subset of the managed scale
             dimension names or ``"x"``.
         method : str, optional
-            Passed through to PandasIndex for ``"x"`` selection.
+            Look-up method for scalar labels, e.g. ``"nearest"``.
         tolerance : float, optional
-            Passed through to PandasIndex for ``"x"`` selection.
+            Maximum distance between the label and the matched coordinate for
+            inexact look-ups.
 
         Returns
         -------
         IndexSelResult
         """
-        scale_labels = {k: v for k, v in labels.items() if k in self._scale_dims}
+        scale_labels = {k: v for k, v in labels.items() if k in self._scale_indexes}
         x_labels = {k: v for k, v in labels.items() if k == "x"}
-
-        if scale_labels:
-            dim_indexers: dict[str, int] = {}
-            for dim, val in scale_labels.items():
-                arr = self.x_original.coords[dim].values
-                matches = np.where(arr == val)[0]
-                if not len(matches):
-                    raise KeyError(f"{dim}={val!r} not found. Available: {list(arr)}")
-                dim_indexers[dim] = int(matches[0])
-
-            selected = self.x_original.sel(scale_labels)
-            remaining = [d for d in self._scale_dims if d not in scale_labels]
-
-            if not remaining:
-                x_natural = selected.values  # shape (n_x,) — already in original domain
-                return IndexSelResult(
-                    dim_indexers=dim_indexers,
-                    variables={"x": xr.Variable("x", x_natural)},
-                    indexes={"x": PandasIndex(pd.Index(x_natural), "x")},
-                )
-            else:
-                new_idx = OriginalScaleIndex(selected)
-                return IndexSelResult(
-                    dim_indexers=dim_indexers,
-                    indexes={"x": new_idx, **{d: new_idx for d in remaining}},
-                )
-
-        if x_labels:
-            x_scaled = self.x_original.coords["x"].values
-            return PandasIndex(pd.Index(x_scaled), "x").sel(
-                {"x": x_labels["x"]}, method=method, tolerance=tolerance
+        unknown = set(labels) - set(scale_labels) - {"x"}
+        if unknown:
+            raise NotImplementedError(
+                f"OriginalScaleIndex does not support labels: {sorted(unknown)}"
             )
 
-        raise NotImplementedError(
-            f"OriginalScaleIndex.sel does not support labels: {list(labels)}"
+        if x_labels:
+            if not scale_labels:
+                raise NotImplementedError(
+                    "OriginalScaleIndex cannot resolve an 'x' label while the "
+                    f"scale dimensions {list(self._scale_dims)} are unresolved: "
+                    "'x' labels are in the original (spend) domain, which differs "
+                    "per channel. Select the scale dimensions first, e.g. "
+                    ".sel(channel=...).sel(x=...) or .sel(channel=..., x=...)."
+                )
+            if any(_is_scalar_label(val) for val in x_labels.values()):
+                # A scalar 'x' label would reduce every managed dimension in one
+                # call; xarray then drops the index and the original-domain x
+                # coordinate cannot be carried over (it would silently fall back
+                # to the scaled value).
+                raise NotImplementedError(
+                    "OriginalScaleIndex cannot apply a scalar 'x' label in the "
+                    "same .sel() call as scale dimensions. Chain the selection "
+                    "instead: .sel(channel=...).sel(x=...) — or select an 'x' "
+                    "slice or list, which keeps the 'x' dimension."
+                )
+
+        dim_indexers: dict = {}
+        if scale_labels:
+            for dim, val in scale_labels.items():
+                res = self._scale_indexes[dim].sel(
+                    {dim: val}, method=method, tolerance=tolerance
+                )
+                dim_indexers[dim] = res.dim_indexers[dim]
+
+            selected = self.x_original.isel(dim_indexers)
+            remaining = [d for d in self._scale_dims if d in selected.dims]
+
+            if remaining:
+                return IndexSelResult(
+                    dim_indexers=dim_indexers,
+                    indexes={
+                        "x": OriginalScaleIndex(selected),
+                        **{d: OriginalScaleIndex(selected) for d in remaining},
+                    },
+                )
+        else:
+            selected = self.x_original
+
+        # All scale dims resolved: selected is 1-D over the original-domain axis
+        spend = np.asarray(selected.values)
+        spend_index = PandasIndex(pd.Index(spend), "x")
+
+        if x_labels:
+            x_res = spend_index.sel(x_labels, method=method, tolerance=tolerance)
+            x_pos = x_res.dim_indexers["x"]
+            dim_indexers["x"] = x_pos
+            return IndexSelResult(
+                dim_indexers=dim_indexers,
+                variables={"x": xr.Variable("x", spend[x_pos])},
+                indexes={"x": PandasIndex(pd.Index(spend[x_pos]), "x")},
+            )
+
+        return IndexSelResult(
+            dim_indexers=dim_indexers,
+            variables={"x": xr.Variable("x", spend)},
+            indexes={"x": spend_index},
         )
 
-    def isel(self, indexers: dict) -> OriginalScaleIndex | PandasIndex:
+    def isel(self, indexers: dict) -> OriginalScaleIndex | PandasIndex | None:
         """Handle integer-based selection.
 
         Parameters
@@ -218,17 +333,34 @@ class OriginalScaleIndex(Index):
 
         Returns
         -------
-        OriginalScaleIndex | PandasIndex
+        OriginalScaleIndex | PandasIndex | None
             Returns a ``PandasIndex`` on original-domain x values once all scale
             dimensions are reduced; otherwise returns a new ``OriginalScaleIndex``.
+            Returns ``None`` when every managed dimension is reduced to a scalar,
+            matching :meth:`~xarray.indexes.PandasIndex.isel` semantics for
+            scalar selection.
         """
         x_idx = indexers.get("x", slice(None))
         scale_indexers = {d: indexers[d] for d in self._scale_dims if d in indexers}
-        selected = self.x_original.isel({"x": x_idx, **scale_indexers})
+        all_indexers = {"x": x_idx, **scale_indexers}
 
-        remaining = [d for d in self._scale_dims if d not in scale_indexers]
+        for dim, idx in all_indexers.items():
+            if isinstance(idx, xr.Variable) and idx.dims != (dim,):
+                # An indexer introducing new dimensions prevents preserving the
+                # index, matching PandasIndex behaviour.
+                return None
+
+        selected = self.x_original.isel(all_indexers)
+
+        remaining = [d for d in self._scale_dims if d in selected.dims]
         if not remaining:
-            return PandasIndex(pd.Index(selected.values), "x")
+            if "x" in selected.dims:
+                return PandasIndex(pd.Index(selected.values), "x")
+            return None
+        if _is_scalar_indexer(x_idx):
+            # 'x' reduced to a scalar position: keep managing only the scale
+            # dims; the scalar x coordinate is carried by positional indexing.
+            selected = selected.drop_vars("x")
         return OriginalScaleIndex(selected)
 
     def equals(self, other: object) -> bool:

--- a/pymc_marketing/plot.py
+++ b/pymc_marketing/plot.py
@@ -79,7 +79,7 @@ def drop_scalar_coords(curve: xr.DataArray) -> xr.DataArray:
     """
     scalar_coords_to_drop = []
     for coord, values in curve.coords.items():
-        if values.size == 1 and coord not in curve.indexes:
+        if values.size == 1 and coord not in curve.xindexes:
             scalar_coords_to_drop.append(coord)
 
     return curve.reset_coords(scalar_coords_to_drop, drop=True)

--- a/tests/mmm/test_original_scale_index.py
+++ b/tests/mmm/test_original_scale_index.py
@@ -1,0 +1,219 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Unit tests for OriginalScaleIndex."""
+
+import numpy as np
+import pytest
+import xarray as xr
+from xarray.indexes import PandasIndex
+
+from pymc_marketing.mmm.original_scale_index import OriginalScaleIndex
+
+
+@pytest.fixture()
+def x() -> np.ndarray:
+    return np.linspace(0, 1, 5)
+
+
+@pytest.fixture()
+def channels() -> np.ndarray:
+    return np.array(["TV", "Radio"])
+
+
+@pytest.fixture()
+def channel_scale(channels) -> xr.DataArray:
+    return xr.DataArray(
+        [5000.0, 1200.0],
+        dims=["channel"],
+        coords={"channel": channels},
+    )
+
+
+@pytest.fixture()
+def curve(x, channels, channel_scale) -> xr.DataArray:
+    rng = np.random.default_rng(0)
+    data = rng.normal(size=(1, 20, len(channels), len(x)))
+    da = xr.DataArray(
+        data,
+        dims=["chain", "draw", "channel", "x"],
+        coords={"chain": [0], "draw": np.arange(20), "channel": channels, "x": x},
+    )
+    return da.drop_indexes(["x", "channel"]).set_xindex(
+        ["x", "channel"], OriginalScaleIndex, channel_scale=channel_scale
+    )
+
+
+def test_set_xindex_creates_original_scale_index(curve) -> None:
+    assert isinstance(curve.xindexes["channel"], OriginalScaleIndex)
+    assert isinstance(curve.xindexes["x"], OriginalScaleIndex)
+    assert curve.xindexes["x"] is curve.xindexes["channel"]
+
+
+def test_x_original_property(curve, x, channel_scale) -> None:
+    idx = curve.xindexes["channel"]
+    # x_original should have dims (x, channel) with original-domain values
+    xo = idx.x_original
+    assert set(xo.dims) == {"x", "channel"}
+    np.testing.assert_allclose(xo.sel(channel="TV").values, x * 5000.0)
+    np.testing.assert_allclose(xo.sel(channel="Radio").values, x * 1200.0)
+
+
+@pytest.mark.parametrize("channel,expected_scale", [("TV", 5000.0), ("Radio", 1200.0)])
+def test_sel_channel_returns_original_domain_x(
+    curve, x, channel, expected_scale
+) -> None:
+    result = curve.sel(channel=channel)
+    np.testing.assert_allclose(result.coords["x"].values, x * expected_scale)
+
+
+def test_sel_channel_removes_channel_dim(curve) -> None:
+    result = curve.sel(channel="TV")
+    assert "channel" not in result.dims
+
+
+def test_sel_channel_x_index_is_pandas_index_after_selection(curve) -> None:
+    result = curve.sel(channel="TV")
+    assert isinstance(result.xindexes["x"], PandasIndex)
+
+
+def test_sel_unknown_channel_raises(curve) -> None:
+    with pytest.raises(KeyError, match="not found"):
+        curve.sel(channel="Unknown")
+
+
+def test_isel_x_slice_returns_new_original_scale_index(curve) -> None:
+    result = curve.isel(x=slice(0, 3))
+    assert isinstance(result.xindexes["channel"], OriginalScaleIndex)
+    assert result.sizes["x"] == 3
+
+
+def test_isel_channel_scalar_returns_pandas_index(curve, x) -> None:
+    result = curve.isel(channel=0)
+    assert "channel" not in result.dims
+    expected_x = x * 5000.0  # TV is index 0
+    np.testing.assert_allclose(result.coords["x"].values, expected_x)
+
+
+def test_equals_same_index(x, channel_scale) -> None:
+    idx1 = OriginalScaleIndex._from_x_and_scale(x, channel_scale)
+    idx2 = OriginalScaleIndex._from_x_and_scale(x.copy(), channel_scale.copy())
+    assert idx1.equals(idx2)
+
+
+def test_equals_different_scales(x, channels) -> None:
+    scale1 = xr.DataArray(
+        [5000.0, 1200.0], dims=["channel"], coords={"channel": channels}
+    )
+    scale2 = xr.DataArray(
+        [9999.0, 1200.0], dims=["channel"], coords={"channel": channels}
+    )
+    idx1 = OriginalScaleIndex._from_x_and_scale(x, scale1)
+    idx2 = OriginalScaleIndex._from_x_and_scale(x, scale2)
+    assert not idx1.equals(idx2)
+
+
+def test_repr_contains_dims_and_n_x(curve) -> None:
+    r = repr(curve.xindexes["channel"])
+    assert "channel" in r
+    assert "5" in r  # n_x=5
+
+
+def test_az_hdi_preserves_original_scale_index(curve) -> None:
+    az = pytest.importorskip("arviz")
+    hdi = az.hdi(curve)
+    assert isinstance(hdi.xindexes["channel"], OriginalScaleIndex)
+
+
+def test_az_hdi_sel_channel_gives_original_domain_x(curve, x) -> None:
+    az = pytest.importorskip("arviz")
+    hdi = az.hdi(curve)
+    scales = {"TV": 5000.0, "Radio": 1200.0}
+    for ch, scale in scales.items():
+        hdi_ch = hdi.sel(channel=ch)
+        np.testing.assert_allclose(hdi_ch.coords["x"].values, x * scale)
+
+
+def test_to_series_uses_original_domain_x(curve, x) -> None:
+    tv = curve.isel(chain=0).sel(channel="TV")
+    series = tv.to_series()
+    x_in_series = series.index.get_level_values("x")
+    expected = x * 5000.0
+    np.testing.assert_allclose(np.sort(np.unique(x_in_series)), np.sort(expected))
+
+
+def test_from_variables_raises_without_x(channels, channel_scale) -> None:
+    variables = {"channel": xr.Variable("channel", channels)}
+    with pytest.raises(ValueError, match="requires an 'x' variable"):
+        OriginalScaleIndex.from_variables(
+            variables, options={"channel_scale": channel_scale}
+        )
+
+
+def test_from_variables_raises_without_channel_scale(x) -> None:
+    variables = {"x": xr.Variable("x", x)}
+    with pytest.raises(ValueError, match="requires 'channel_scale'"):
+        OriginalScaleIndex.from_variables(variables, options={})
+
+
+def test_panel_2d_scale_sel_both_dims_gives_original_domain_x(x) -> None:
+    """Panel model: channel_scale has dims ('country', 'channel')."""
+    countries = np.array(["US", "UK"])
+    channels = np.array(["TV", "Radio"])
+    scale_data = np.array([[5000.0, 1200.0], [3000.0, 800.0]])
+    channel_scale = xr.DataArray(
+        scale_data,
+        dims=["country", "channel"],
+        coords={"country": countries, "channel": channels},
+    )
+    da = xr.DataArray(
+        np.ones((len(countries), len(channels), len(x))),
+        dims=["country", "channel", "x"],
+        coords={"country": countries, "channel": channels, "x": x},
+    )
+    da = da.drop_indexes(["x", "channel", "country"]).set_xindex(
+        ["x", "channel", "country"], OriginalScaleIndex, channel_scale=channel_scale
+    )
+
+    result = da.sel(channel="TV", country="US")
+    np.testing.assert_allclose(result.coords["x"].values, x * 5000.0)
+
+    result_uk_radio = da.sel(channel="Radio", country="UK")
+    np.testing.assert_allclose(result_uk_radio.coords["x"].values, x * 800.0)
+
+
+def test_panel_2d_scale_partial_sel_returns_original_scale_index(x) -> None:
+    """Selecting only one dim of a 2-D scale preserves the index for the remaining dim."""
+    countries = np.array(["US", "UK"])
+    channels = np.array(["TV", "Radio"])
+    scale_data = np.array([[5000.0, 1200.0], [3000.0, 800.0]])
+    channel_scale = xr.DataArray(
+        scale_data,
+        dims=["country", "channel"],
+        coords={"country": countries, "channel": channels},
+    )
+    da = xr.DataArray(
+        np.ones((len(countries), len(channels), len(x))),
+        dims=["country", "channel", "x"],
+        coords={"country": countries, "channel": channels, "x": x},
+    )
+    da = da.drop_indexes(["x", "channel", "country"]).set_xindex(
+        ["x", "channel", "country"], OriginalScaleIndex, channel_scale=channel_scale
+    )
+
+    partial = da.sel(channel="TV")
+    assert "country" in partial.dims
+    assert isinstance(partial.xindexes.get("x"), OriginalScaleIndex)
+
+    result = partial.sel(country="US")
+    np.testing.assert_allclose(result.coords["x"].values, x * 5000.0)

--- a/tests/mmm/test_original_scale_index.py
+++ b/tests/mmm/test_original_scale_index.py
@@ -88,7 +88,7 @@ def test_sel_channel_x_index_is_pandas_index_after_selection(curve) -> None:
 
 
 def test_sel_unknown_channel_raises(curve) -> None:
-    with pytest.raises(KeyError, match="not found"):
+    with pytest.raises(KeyError, match="not all values found"):
         curve.sel(channel="Unknown")
 
 
@@ -123,10 +123,10 @@ def test_equals_different_scales(x, channels) -> None:
     assert not idx1.equals(idx2)
 
 
-def test_repr_contains_dims_and_n_x(curve) -> None:
-    r = repr(curve.xindexes["channel"])
-    assert "channel" in r
-    assert "5" in r  # n_x=5
+def test_repr_pins_exact_format(curve) -> None:
+    assert repr(curve.xindexes["channel"]) == (
+        "OriginalScaleIndex(scale_dims=['channel'], n_x=5)"
+    )
 
 
 def test_az_hdi_preserves_original_scale_index(curve) -> None:
@@ -217,3 +217,136 @@ def test_panel_2d_scale_partial_sel_returns_original_scale_index(x) -> None:
 
     result = partial.sel(country="US")
     np.testing.assert_allclose(result.coords["x"].values, x * 5000.0)
+
+
+def test_sel_channel_list_keeps_original_scale_index(curve) -> None:
+    result = curve.sel(channel=["TV", "Radio"])
+    assert result.sizes["channel"] == 2
+    assert isinstance(result.xindexes["channel"], OriginalScaleIndex)
+    # List selection keeps the scaled domain: the original domain is a
+    # different axis per channel.
+    np.testing.assert_allclose(result.coords["x"].values, np.linspace(0, 1, 5))
+
+
+def test_sel_channel_slice_works(curve) -> None:
+    """Slices on scale dims resolve through PandasIndex (monotonic labels)."""
+    channels_sorted = np.array(["Radio", "TV"])
+    channel_scale = xr.DataArray(
+        [1200.0, 5000.0], dims=["channel"], coords={"channel": channels_sorted}
+    )
+    da = xr.DataArray(
+        np.ones((2, 5)),
+        dims=["channel", "x"],
+        coords={"channel": channels_sorted, "x": np.linspace(0, 1, 5)},
+    )
+    curve_sorted = da.drop_indexes(["x", "channel"]).set_xindex(
+        ["x", "channel"], OriginalScaleIndex, channel_scale=channel_scale
+    )
+    result = curve_sorted.sel(channel=slice("Radio", "TV"))
+    assert list(result.coords["channel"].values) == ["Radio", "TV"]
+    assert isinstance(result.xindexes["channel"], OriginalScaleIndex)
+
+
+def test_isel_channel_list_keeps_original_scale_index(curve) -> None:
+    result = curve.isel(channel=[0, 1])
+    assert result.sizes["channel"] == 2
+    assert isinstance(result.xindexes["channel"], OriginalScaleIndex)
+
+
+def test_isel_channel_slice_keeps_original_scale_index(curve) -> None:
+    result = curve.isel(channel=slice(0, 2))
+    assert result.sizes["channel"] == 2
+    assert isinstance(result.xindexes["channel"], OriginalScaleIndex)
+
+
+def test_isel_x_scalar_keeps_scale_index(curve) -> None:
+    result = curve.isel(x=2)
+    assert "channel" in result.dims
+    assert "x" not in result.dims
+    assert isinstance(result.xindexes["channel"], OriginalScaleIndex)
+    # x falls back to its scaled scalar value, as with a dropped index
+    np.testing.assert_allclose(result.coords["x"].values, 0.5)
+
+
+def test_isel_fully_reduced_returns_scalar(curve) -> None:
+    result = curve.isel(channel=0, x=2)
+    assert "channel" not in result.dims
+    assert "x" not in result.dims
+    np.testing.assert_allclose(result.coords["x"].values, 0.5)
+
+
+def test_groupby_channel_works(curve) -> None:
+    groups = dict(list(curve.groupby("channel")))
+    assert set(groups) == {"TV", "Radio"}
+    # NOTE: groups keep scaled x because groupby reduces via a one-element
+    # list; see the "Known limitations" section of OriginalScaleIndex.
+    np.testing.assert_allclose(groups["TV"].coords["x"].values, np.linspace(0, 1, 5))
+
+
+def test_sel_combined_x_slice_is_spend_domain(curve, x) -> None:
+    combined = curve.sel(channel="TV", x=slice(0, 2500))
+    chained = curve.sel(channel="TV").sel(x=slice(0, 2500))
+    np.testing.assert_allclose(combined.coords["x"].values, [0.0, 1250.0, 2500.0])
+    np.testing.assert_allclose(combined.values, chained.values)
+    assert isinstance(combined.xindexes["x"], PandasIndex)
+
+
+def test_sel_combined_x_list_is_spend_domain(curve) -> None:
+    result = curve.sel(channel="TV", x=[1250.0, 5000.0])
+    np.testing.assert_allclose(result.coords["x"].values, [1250.0, 5000.0])
+    assert isinstance(result.xindexes["x"], PandasIndex)
+
+
+def test_sel_combined_x_slice_nearest_method(curve) -> None:
+    result = curve.sel(channel="TV", x=slice(1000, None))
+    np.testing.assert_allclose(
+        result.coords["x"].values, [1250.0, 2500.0, 3750.0, 5000.0]
+    )
+
+
+def test_sel_combined_scalar_x_raises(curve) -> None:
+    with pytest.raises(NotImplementedError, match="Chain the selection"):
+        curve.sel(channel="TV", x=2500.0)
+
+
+def test_sel_x_scalar_without_scale_dims_raises(curve) -> None:
+    with pytest.raises(NotImplementedError, match="scale dimensions"):
+        curve.sel(x=2500.0)
+
+
+def test_sel_x_slice_without_scale_dims_raises(curve) -> None:
+    with pytest.raises(NotImplementedError, match="scale dimensions"):
+        curve.sel(x=slice(0, 2500))
+
+
+def test_sel_x_with_partially_resolved_scale_dims_raises(curve) -> None:
+    with pytest.raises(NotImplementedError, match="Chain the selection"):
+        curve.sel(channel=["TV", "Radio"], x=2500.0)
+
+
+def test_sel_x_scalar_after_scale_dims_is_spend_domain(curve, x) -> None:
+    tv = curve.sel(channel="TV")
+    result = tv.sel(x=2500.0)
+    np.testing.assert_allclose(result.coords["x"].values, 2500.0)
+    np.testing.assert_allclose(result.values, tv.isel(x=2).values)
+
+
+def test_sel_x_nearest_after_scale_dims(curve) -> None:
+    tv = curve.sel(channel="TV")
+    result = tv.sel(x=2600.0, method="nearest")
+    np.testing.assert_allclose(result.coords["x"].values, 2500.0)
+
+
+def test_drop_indexes_escape_hatch(curve) -> None:
+    raw = curve.drop_indexes(["channel", "x"])
+    result = raw.sel(x=0.5)
+    np.testing.assert_allclose(result.coords["x"].values, 0.5)
+
+
+def test_create_variables_preserves_passed_variables(curve) -> None:
+    idx = curve.xindexes["channel"]
+    passed = {"x": xr.Variable("x", np.linspace(0, 1, 5), attrs={"units": "scaled"})}
+    result = idx.create_variables(passed)
+    assert result["x"] is passed["x"]
+    assert result["x"].attrs == {"units": "scaled"}
+    assert "channel" in result

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -19,6 +19,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 
+from pymc_marketing.mmm.original_scale_index import OriginalScaleIndex
 from pymc_marketing.plot import (
     drop_scalar_coords,
     plot_curve,
@@ -399,6 +400,81 @@ def test_drop_scalar_coords(mock_curve_with_scalars) -> None:
 
     # Ensure the original DataArray was not modified
     xr.testing.assert_identical(mock_curve_with_scalars, original_curve)
+
+
+@pytest.fixture
+def curve_with_original_scale_index() -> xr.DataArray:
+    """Curve with OriginalScaleIndex attached, mimicking sample_saturation_curve(original_scale=True)."""
+    channels = np.array(["x1", "x2"])
+    x = np.linspace(0, 1, 10)
+    channel_scale = xr.DataArray(
+        [5000.0, 1200.0], dims=["channel"], coords={"channel": channels}
+    )
+    rng = np.random.default_rng(42)
+    data = rng.normal(size=(2, 50, len(channels), len(x)))
+    da = xr.DataArray(
+        data,
+        dims=["chain", "draw", "channel", "x"],
+        coords={"chain": [0, 1], "draw": np.arange(50), "channel": channels, "x": x},
+    )
+    return da.drop_indexes(["x", "channel"]).set_xindex(
+        ["x", "channel"], OriginalScaleIndex, channel_scale=channel_scale
+    )
+
+
+def test_drop_scalar_coords_with_original_scale_index(
+    curve_with_original_scale_index,
+) -> None:
+    """drop_scalar_coords must not crash or drop x/channel when OriginalScaleIndex is present."""
+    curve = drop_scalar_coords(curve_with_original_scale_index)
+    assert "x" in curve.coords
+    assert "channel" in curve.coords
+    assert isinstance(curve.xindexes["channel"], OriginalScaleIndex)
+
+
+def test_plot_curve_with_original_scale_index(
+    curve_with_original_scale_index, auto_close_figures
+) -> None:
+    """plot_curve uses original-domain x values when OriginalScaleIndex is present."""
+    x_scaled = np.linspace(0, 1, 10)
+    channel_scales = {"x1": 5000.0, "x2": 1200.0}
+    fig, axes = plot_curve(curve_with_original_scale_index, non_grid_names={"x"})
+    assert isinstance(fig, plt.Figure)
+    assert axes.size == curve_with_original_scale_index.sizes["channel"]
+    # Channels appear in coordinate order: x1, x2
+    for ax, (ch, scale) in zip(axes.flat, channel_scales.items(), strict=True):
+        lines = ax.get_lines()
+        assert len(lines) > 0, f"No lines plotted for channel {ch}"
+        np.testing.assert_allclose(
+            lines[0].get_xdata(),
+            x_scaled * scale,
+            err_msg=f"channel {ch}: x data should be original-domain (scaled by {scale})",
+        )
+    plt.close(fig)
+
+
+def test_plot_curve_without_original_scale_index(auto_close_figures) -> None:
+    """plot_curve shows scaled 0-1 x values when no OriginalScaleIndex is attached."""
+    channels = np.array(["x1", "x2"])
+    x = np.linspace(0, 1, 10)
+    rng = np.random.default_rng(42)
+    data = rng.normal(size=(2, 50, len(channels), len(x)))
+    curve = xr.DataArray(
+        data,
+        dims=["chain", "draw", "channel", "x"],
+        coords={"chain": [0, 1], "draw": np.arange(50), "channel": channels, "x": x},
+    )
+    fig, axes = plot_curve(curve, non_grid_names={"x"})
+    assert isinstance(fig, plt.Figure)
+    for ax in axes.flat:
+        lines = ax.get_lines()
+        assert len(lines) > 0
+        np.testing.assert_allclose(
+            lines[0].get_xdata(),
+            x,
+            err_msg="x data should be scaled 0-1 when no OriginalScaleIndex is attached",
+        )
+    plt.close(fig)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Adds `OriginalScaleIndex`: a custom xarray `Index` that maps scaled `x` coordinates to original domain on `.sel()`, with support for multi-dim scale (e.g. geo × channel panel models)
- Fixes a latent bug in `plot.drop_scalar_coords` where `curve.indexes` triggered `to_pandas_indexes()`, failing for any custom xarray index — changed to `curve.xindexes`
- Exports `OriginalScaleIndex` from `pymc_marketing.mmm`