### PR TITLE
feat(mmm): wire OriginalScaleIndex into sample_saturation_curve

### DIFF
--- a/pymc_marketing/mmm/mmm.py
+++ b/pymc_marketing/mmm/mmm.py
@@ -234,6 +234,7 @@ from pymc_marketing.mmm.lift_test import (
     scale_lift_measurements,
 )
 from pymc_marketing.mmm.link import LinkFunction, LinkSpec, get_link_spec
+from pymc_marketing.mmm.original_scale_index import OriginalScaleIndex
 from pymc_marketing.mmm.plot import MMMPlotSuite
 from pymc_marketing.mmm.plotting import MMMPlotSuiteFacade
 from pymc_marketing.mmm.plotting.budget import BudgetPlots
@@ -3044,11 +3045,15 @@ class MMM(RegressionModelBuilder):
             Only used when num_samples is not None and less than total available
             samples.
         original_scale : bool, optional
-            Whether to return curve y-values in original scale. If True (default),
-            y-axis values (contribution) are multiplied by target_scale to convert
-            from scaled to original units. If False, values remain in scaled space
-            as used internally by the model. Note that x-axis values always remain
-            in scaled space consistent with the max_value parameter.
+            Whether to return the curve in original scale. If True (default),
+            y-axis values (contribution) are multiplied by ``target_scale`` to
+            convert from scaled to original units, and an
+            :class:`~pymc_marketing.mmm.OriginalScaleIndex` is attached to the
+            returned DataArray so that ``.sel(channel=...)`` automatically
+            replaces the ``x`` coordinate with that channel's original-domain
+            values — ``plot_curve`` picks this up without any extra arguments.
+            If False, both x and y remain in scaled space as used internally
+            by the model.
         idata : xr.DataTree or None, optional
             Optional DataTree to sample from. If None (default), uses
             self.idata. This allows sampling curves from different posterior
@@ -3065,9 +3070,12 @@ class MMM(RegressionModelBuilder):
             When subsampling (``num_samples`` < total posterior draws), the
             ``chain`` dimension has size 1 and ``draw`` has size ``num_samples``.
             When all samples are used, the original chain/draw structure from
-            the posterior is preserved. The "x" coordinate represents spend
-            levels in scaled space (consistent with max_value). Y-values are
-            in original scale when original_scale=True, otherwise in scaled space.
+            the posterior is preserved. The ``"x"`` coordinate stores scaled
+            values consistent with ``max_value``. When ``original_scale=True``,
+            an :class:`~pymc_marketing.mmm.OriginalScaleIndex` is attached so
+            that ``.sel(channel=...)`` transparently converts ``x`` to the
+            channel's original domain. Y-values are in original scale when
+            ``original_scale=True``, otherwise in scaled space.
 
         Raises
         ------
@@ -3091,6 +3099,33 @@ class MMM(RegressionModelBuilder):
         Sample curves in scaled space:
 
         >>> curves_scaled = mmm.sample_saturation_curve(original_scale=False)
+
+        Plot with original-domain x-axis — no extra arguments needed:
+
+        .. code-block:: python
+
+            curve = mmm.sample_saturation_curve(original_scale=True)
+            fig, axes = mmm.saturation.plot_curve(curve)
+            # x-axis shows original spend / impressions per channel
+
+        Inspect original-domain x range per channel:
+
+        .. code-block:: python
+
+            for ch in curve.coords["channel"].values:
+                x_max = float(curve.sel(channel=ch).coords["x"].values[-1])
+                print(f"{ch}: [0, {x_max:.1f}]")
+
+        Geo (panel) model — select both scale dimensions to resolve original-domain x:
+
+        .. code-block:: python
+
+            geo_curve = mmm_geo.sample_saturation_curve(original_scale=True)
+            us_x1 = geo_curve.sel(geo="US", channel="x1")
+            us_x1.coords["x"]  # original-domain x values for US / x1
+            # partial selection keeps the index alive for the remaining dim:
+            us_curve = geo_curve.sel(geo="US")
+            us_curve.xindexes["channel"]  # still an OriginalScaleIndex
 
         Sample curves with custom max value and reproducible sampling:
 
@@ -3148,13 +3183,22 @@ class MMM(RegressionModelBuilder):
 
         # Convert to original scale if requested
         if original_scale:
-            # Scale y values (contribution) to original target units
-            # Note: x coordinates remain in scaled space (same as max_value input)
-            # since converting to original scale would require per-channel scaling
-            # which complicates plotting and interpretation
             target_scale = MMMIDataWrapper(idata).get_target_scale()
-            # Multiply by target_scale since saturation affects target variable
             curve = curve * target_scale
+
+            # Attach OriginalScaleIndex so that .sel(dim=...) automatically
+            # replaces "x" with original-domain values once all scale dims are
+            # resolved. channel_scale may be 1-D ("channel",) for simple models
+            # or multi-D ("country", "channel") for panel models — the index
+            # handles both via xarray broadcasting.
+            channel_scale = MMMIDataWrapper(idata).get_channel_scale()
+            if channel_scale.ndim > 0:
+                scale_dims = list(channel_scale.dims)
+                managed = ["x", *scale_dims]
+                drop_dims = [d for d in managed if d in curve.coords]
+                curve = curve.drop_indexes(drop_dims).set_xindex(
+                    managed, OriginalScaleIndex, channel_scale=channel_scale
+                )
 
         return curve
 

--- a/tests/mmm/test_mmm_saturation_curve.py
+++ b/tests/mmm/test_mmm_saturation_curve.py
@@ -23,7 +23,7 @@ import pytest
 import xarray as xr
 from pydantic import ValidationError
 
-from pymc_marketing.mmm import GeometricAdstock, LogisticSaturation
+from pymc_marketing.mmm import GeometricAdstock, LogisticSaturation, OriginalScaleIndex
 from pymc_marketing.mmm.mmm import MMM
 
 # ============================================================================
@@ -256,33 +256,58 @@ def test_sample_saturation_curve_original_scale_differs_from_scaled(
 
 
 @pytest.mark.parametrize("fitted_mmm", ["simple_fitted_mmm", "panel_fitted_mmm"])
-def test_sample_saturation_curve_x_coords_same_regardless_of_original_scale(
+def test_sample_saturation_curve_x_coords_scaled_when_original_scale_false(
     fitted_mmm, request
 ):
-    """Test that x coordinates remain in scaled space regardless of original_scale.
-
-    Note: x coordinates always remain in scaled space (same as max_value) since
-    converting them would require per-channel scaling which complicates plotting.
-    """
+    """Test that x coordinates remain in scaled space when original_scale=False."""
     mmm = request.getfixturevalue(fitted_mmm)
-    # Arrange
     max_value = 1.0
+    curves = mmm.sample_saturation_curve(max_value=max_value, original_scale=False)
+    x = curves.coords["x"].values
+    assert x[0] == pytest.approx(0.0)
+    assert x[-1] == pytest.approx(max_value)
+    assert not isinstance(curves.xindexes.get("channel"), OriginalScaleIndex)
 
-    # Act
-    curves_scaled = mmm.sample_saturation_curve(
-        max_value=max_value,
-        original_scale=False,
-    )
-    curves_original = mmm.sample_saturation_curve(
-        max_value=max_value,
-        original_scale=True,
-    )
 
-    # Assert - x coordinates should be the same regardless of original_scale
-    x_scaled = curves_scaled.coords["x"].values
-    x_original = curves_original.coords["x"].values
+def test_sample_saturation_curve_original_scale_attaches_original_scale_index(
+    fitted_mmm, request
+):
+    """Test that original_scale=True attaches an OriginalScaleIndex to the curve."""
+    mmm = request.getfixturevalue(fitted_mmm)
+    curve = mmm.sample_saturation_curve(original_scale=True)
+    assert isinstance(curve.xindexes["channel"], OriginalScaleIndex)
 
-    np.testing.assert_array_equal(x_scaled, x_original)
+
+def test_sample_saturation_curve_sel_channel_gives_original_domain_x(
+    fitted_mmm, request
+):
+    """Test that sel(channel=...) returns x in original domain after original_scale=True."""
+    mmm = request.getfixturevalue(fitted_mmm)
+    curve = mmm.sample_saturation_curve(original_scale=True)
+    channel_scale = mmm.data.get_channel_scale()
+    for ch in curve.coords["channel"].values:
+        ch_curve = curve.sel(channel=ch)
+        scale = float(channel_scale.sel(channel=ch))
+        # x[-1] should equal max_value (1.0) * channel_scale
+        assert float(ch_curve.coords["x"].values[-1]) == pytest.approx(scale * 1.0)
+        # x[0] should be 0.0
+        assert float(ch_curve.coords["x"].values[0]) == pytest.approx(0.0)
+
+
+def test_sample_saturation_curve_hdi_sel_channel_gives_original_domain_x(
+    fitted_mmm, request
+):
+    """Test that az.hdi preserves OriginalScaleIndex and sel works on the result."""
+    import arviz as az
+
+    mmm = request.getfixturevalue(fitted_mmm)
+    curve = mmm.sample_saturation_curve(original_scale=True)
+    hdi = az.hdi(curve)
+    channel_scale = mmm.data.get_channel_scale()
+    for ch in curve.coords["channel"].values:
+        ch_hdi = hdi.sel(channel=ch)
+        scale = float(channel_scale.sel(channel=ch))
+        assert float(ch_hdi.coords["x"].values[-1]) == pytest.approx(scale * 1.0)
 
 
 @pytest.mark.parametrize("fitted_mmm", ["simple_fitted_mmm", "panel_fitted_mmm"])

--- a/tests/mmm/test_mmm_saturation_curve.py
+++ b/tests/mmm/test_mmm_saturation_curve.py
@@ -269,6 +269,7 @@ def test_sample_saturation_curve_x_coords_scaled_when_original_scale_false(
     assert not isinstance(curves.xindexes.get("channel"), OriginalScaleIndex)
 
 
+@pytest.mark.parametrize("fitted_mmm", ["simple_fitted_mmm", "panel_fitted_mmm"])
 def test_sample_saturation_curve_original_scale_attaches_original_scale_index(
     fitted_mmm, request
 ):
@@ -278,6 +279,7 @@ def test_sample_saturation_curve_original_scale_attaches_original_scale_index(
     assert isinstance(curve.xindexes["channel"], OriginalScaleIndex)
 
 
+@pytest.mark.parametrize("fitted_mmm", ["simple_fitted_mmm", "panel_fitted_mmm"])
 def test_sample_saturation_curve_sel_channel_gives_original_domain_x(
     fitted_mmm, request
 ):
@@ -294,6 +296,7 @@ def test_sample_saturation_curve_sel_channel_gives_original_domain_x(
         assert float(ch_curve.coords["x"].values[0]) == pytest.approx(0.0)
 
 
+@pytest.mark.parametrize("fitted_mmm", ["simple_fitted_mmm", "panel_fitted_mmm"])
 def test_sample_saturation_curve_hdi_sel_channel_gives_original_domain_x(
     fitted_mmm, request
 ):


### PR DESCRIPTION
## Summary

- `sample_saturation_curve(original_scale=True)` now attaches `OriginalScaleIndex` so the returned DataArray is self-describing: `.sel(channel="TV").coords["x"]` yields original-domain x values
- Works for both simple and geo panel models (multi-dim `channel_scale`)
- Depends on #2910


Plotting on the original domain, now comes for free with `plot_curve`

<details><summary>Setup Code</summary>

```python
import matplotlib.pyplot as plt
import numpy as np
import pandas as pd

from pymc_marketing.mmm import (
    MMM,
    GeometricAdstock,
    LogisticSaturation,
)
from pymc_marketing.mmm.scaling import DataDerivedScaling
from pymc_marketing.paths import data_dir

file_path = data_dir / "mmm_example.csv"
data = pd.read_csv(file_path, parse_dates=["date_week"])

data["x1"] *= 10
data["x2"] *= 6

mmm = MMM(
    adstock=GeometricAdstock(l_max=8),
    saturation=LogisticSaturation(),
    date_column="date_week",
    channel_columns=["x1", "x2"],
    control_columns=["event_1", "event_2", "t"],
    yearly_seasonality=2,
)

X = data.drop("y", axis=1)
y = data["y"]
mmm.fit(X, y)
```

</details>

```python
curve = mmm.sample_saturation_curve(original_scale=True)
fig = mmm.saturation.plot_curve(curve)
fig.suptitle("Simple MMM — original-domain x per channel (x1 ×10, x2 ×6)")
plt.show()
```

<img width="1349" height="717" alt="Screenshot 2026-08-21 at 4 18 21 PM" src="https://github.com/user-attachments/assets/801bbd7f-2ccd-4722-b0f5-ac248f93ece0" />

Custom Index now included on the DataArray which holds the scaling information from the MMM: 

```
Coordinates:
  * chain    (chain) int64 8B 0
  * draw     (draw) int64 4kB 0 1 2 3 4 5 6 7 ... 493 494 495 496 497 498 499
  * channel  (channel) <U2 16B 'x1' 'x2'
  * x        (x) float64 800B 0.0 0.0101 0.0202 0.0303 ... 0.9798 0.9899 1.0
Indexes:
  ┌ x        OriginalScaleIndex
  └ channel
```