### PR TITLE
test(clv): fix flaky GammaGammaModel convergence test

### DIFF
--- a/tests/clv/models/test_gamma_gamma.py
+++ b/tests/clv/models/test_gamma_gamma.py
@@ -170,11 +170,24 @@ class TestGammaGammaModel(BaseTestGammaGammaModel):
         model = GammaGammaModel(model_config=model_config)
         model.fit(data=self.data, chains=2, progressbar=False, random_seed=rng)
         fit = model.idata.posterior
+
+        # The aggregated likelihood (Eq 1a) pins down q and the population mean
+        # spend p * v / (q - 1), but only weakly constrains p and v separately:
+        # the posterior runs along a p-v ridge, and under the default HalfFlat
+        # priors it is not identified at all. So assert point recovery on the
+        # identified quantities, and interval coverage on p and v.
+        np.testing.assert_allclose(fit["q"].mean(), self.q_true, rtol=0.15)
         np.testing.assert_allclose(
-            [fit["p"].mean(), fit["q"].mean(), fit["v"].mean()],
-            [self.p_true, self.q_true, self.v_true],
-            rtol=0.3,
+            (fit["p"] * fit["v"] / (fit["q"] - 1)).mean(),
+            self.p_true * self.v_true / (self.q_true - 1),
+            rtol=0.1,
         )
+        for name, true_value in (("p", self.p_true), ("v", self.v_true)):
+            low, high = np.percentile(fit[name].values, [3, 97])
+            assert low <= true_value <= high, (
+                f"94% credible interval for {name} "
+                f"[{low:.3f}, {high:.3f}] excludes {true_value}"
+            )
 
     @pytest.mark.parametrize("distribution", (True, False))
     def test_spend(self, distribution):


### PR DESCRIPTION
## Problem

`TestGammaGammaModel::test_model_convergence` fails intermittently on the posterior mean of `p`:

```
Not equal to tolerance rtol=0.3, atol=0
Mismatch at index [0]: 8.115318525372663 (ACTUAL), 6.0 (DESIRED)
Max relative difference among violations: 0.35255309
 ACTUAL: array([ 8.115319,  3.7727  , 12.035771])
 DESIRED: array([ 6.,  4., 15.])
```

## Diagnosis

Not sampler noise. The aggregated Gamma-Gamma likelihood (Eq 1a, the `Potential` in `build_model`) constrains `q` and the population mean spend `p * v / (q - 1)`, but not `p` and `v` separately, so the posterior runs along a `p`-`v` ridge.

Under the model's default `HalfFlat` priors the parameters are not identified at all. Re-running the same fit with `HalfFlat` instead of the test's `HalfNormal(sigma=10)`, `p` runs off to ~1e13 with r-hat up to 6.0. The only thing bounding `p` in this test is the prior the test itself sets, so the assertion was testing the prior, not parameter recovery.

Measured over 15 seeds on the aggregated model (2 chains, N=1000, `HalfNormal(sigma=10)` as in the test):

| quantity | mean rel. err | max rel. err | fails `rtol=0.3` |
|---|---|---|---|
| `p` | 0.259 | 0.318 | 1 / 15 seeds |
| `q` | 0.052 | 0.057 | 0 / 15 |
| `v` | 0.156 | 0.177 | 0 / 15 |
| `p * v / (q - 1)` | 0.009 | 0.011 | 0 / 15 |

The old assertion sat right on its own tolerance boundary, so seed and backend jitter tipped it over. For reference, the 94% credible interval for `p` spans roughly `[3.7, 16.2]` against a truth of `6.0`.

## Fix

Assert point recovery on the quantities the likelihood actually identifies, and interval coverage on the two that it does not:

- `q` at `rtol=0.15` (observed max 0.057)
- `p * v / (q - 1)` at `rtol=0.1` (observed max 0.011)
- the 94% credible interval for `p` and for `v` contains the true value (held 15 / 15 seeds)

Both point tolerances keep roughly 10x margin over the observed spread, so this is a stronger recovery check than before where the model is identified and an honest one where it is not.

## Verification

Ran on a clean checkout of `main` (pymc 6.0.1 / pytensor 3.0.7 / nutpie 0.16.10, nutpie-numba backend, matching the failing CI job).

- The rewritten test passed **10 / 10** consecutive runs with `--run-slow`.
- Full `tests/clv/models/test_gamma_gamma.py` passes.
- `ruff format` and `ruff check` clean.

`TestGammaGammaModelIndividual::test_model_convergence` is deliberately left unchanged. That model conditions on individual transactions, which identifies `p` directly (rel. err 0.017 over 6 seeds), so it is nowhere near its tolerance and is not flaky.

Failing job for reference: https://github.com/pymc-labs/pymc-marketing/actions/runs/32522577133/job/96897887951

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2913.org.readthedocs.build/en/2913/

<!-- readthedocs-preview pymc-marketing end -->