### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/pymc_marketing/version.py
+++ b/pymc_marketing/version.py
@@ -13,4 +13,4 @@
 #   limitations under the License.
 """Version of the package."""
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"


### PR DESCRIPTION
Prepares the next minor release, needed for the JOSS review (openjournals/joss-reviews#10805): the editor requires a tagged release with a matching Zenodo archive.

Minor bump since several `feat` commits have landed on main since 1.0.0.

After merge: publish a GitHub Release with tag `1.1.0` on `main` to trigger PyPI publishing and archiving.

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2917.org.readthedocs.build/en/2917/

<!-- readthedocs-preview pymc-marketing end -->