### PR TITLE
fix(r2d2): register Fourier coord before the R2D2 decomposition builds

### DIFF
--- a/pymc_marketing/mmm/mmm.py
+++ b/pymc_marketing/mmm/mmm.py
@@ -1811,6 +1811,9 @@ class MMM(RegressionModelBuilder):
             for dim in self.xarray_dataset.coords.dims
         }
 
+        if self.yearly_seasonality is not None:
+            self.model_coords[self.yearly_fourier.prefix] = self.yearly_fourier.nodes
+
         if bool(self.time_varying_intercept) or bool(self.time_varying_media):
             dates = pd.DatetimeIndex(self.xarray_dataset.coords["date"].values)
             self._time_index = xr.DataArray(np.arange(len(dates)), dims=("date",))

--- a/pymc_marketing/r2d2.py
+++ b/pymc_marketing/r2d2.py
@@ -67,6 +67,7 @@ MMM integration:
 >>> mmm = MMM(
 ...     adstock=GeometricAdstock(l_max=8),
 ...     saturation=LogisticSaturation(),
+...     yearly_seasonality=1,
 ...     model_config={
 ...         "likelihood": Prior("Normal", sigma=r2d2.error_sigma),
 ...         "gamma_control": r2d2.split("control"),
@@ -321,6 +322,7 @@ class R2D2:
     >>> mmm = MMM(
     ...     adstock=GeometricAdstock(l_max=8),
     ...     saturation=LogisticSaturation(),
+    ...     yearly_seasonality=1,
     ...     model_config={
     ...         "likelihood": Prior("Normal", sigma=r2d2.error_sigma),
     ...         "gamma_control": r2d2.split("control"),

--- a/pymc_marketing/r2d2.py
+++ b/pymc_marketing/r2d2.py
@@ -67,7 +67,7 @@ MMM integration:
 >>> mmm = MMM(
 ...     adstock=GeometricAdstock(l_max=8),
 ...     saturation=LogisticSaturation(),
-...     yearly_seasonality=1,
+...     yearly_seasonality=4,
 ...     model_config={
 ...         "likelihood": Prior("Normal", sigma=r2d2.error_sigma),
 ...         "gamma_control": r2d2.split("control"),
@@ -322,7 +322,7 @@ class R2D2:
     >>> mmm = MMM(
     ...     adstock=GeometricAdstock(l_max=8),
     ...     saturation=LogisticSaturation(),
-    ...     yearly_seasonality=1,
+    ...     yearly_seasonality=4,
     ...     model_config={
     ...         "likelihood": Prior("Normal", sigma=r2d2.error_sigma),
     ...         "gamma_control": r2d2.split("control"),

--- a/tests/test_r2d2.py
+++ b/tests/test_r2d2.py
@@ -647,6 +647,44 @@ class TestR2D2WithMMM:
         # Verify the decomposition was built
         assert r2d2.built
 
+    def test_r2d2_with_mmm_control_and_fourier_build_model(self, mmm_data):
+        """R2D2 should build when sharing budget across control and Fourier."""
+        from pymc_marketing.mmm import MMM
+        from pymc_marketing.mmm.components.adstock import GeometricAdstock
+        from pymc_marketing.mmm.components.saturation import LogisticSaturation
+
+        r2d2 = R2D2(
+            r2=Prior("Beta", mu=0.8, sigma=0.2),
+            total_sigma=Prior("LogNormal", mu=0, sigma=1),
+            dims={"control": "control", "fourier": "fourier_mode"},
+        )
+        mmm = MMM(
+            date_column="date_week",
+            channel_columns=["x1", "x2"],
+            control_columns=["event_1", "event_2", "t"],
+            target_column="y",
+            adstock=GeometricAdstock(l_max=8),
+            saturation=LogisticSaturation(),
+            yearly_seasonality=1,
+            model_config={
+                "likelihood": Prior("Normal", sigma=r2d2.error_sigma, dims="date"),
+                "gamma_control": r2d2.split("control"),
+                "gamma_fourier": r2d2.split("fourier"),
+            },
+        )
+
+        X = mmm_data.drop("y", axis=1)
+        y = mmm_data["y"]
+
+        mmm.build_model(X, y)
+
+        expected_split = ["event_1", "event_2", "t", "sin_1", "cos_1"]
+        assert list(mmm.model.coords["r2d2_split"]) == expected_split
+        free_rv_names = {v.name for v in mmm.model.free_RVs}
+        assert "gamma_control" in free_rv_names
+        assert "gamma_fourier" in free_rv_names
+        assert mmm.model.dim_lengths["fourier_mode"].eval() == 2
+
     def test_r2d2_with_mmm_contribution_names(self, mmm_data):
         """R2D2 should produce variables that work with MMM contribution plotting."""
         from pymc_marketing.mmm import MMM


### PR DESCRIPTION
Closes #2927

## Summary

`R2D2` advertises sharing one variance budget between an MMM's control block and its yearly Fourier seasonality, via `dims={"control": "control", "fourier": "fourier_mode"}`. That configuration could not be built — it raised `KeyError: 'fourier_mode'`.

`R2D2.create_variable` needs every component's dim length up front, because the Dirichlet spans all components at once. It fires lazily on the first `split(...).create_variable(...)` call, which in `MMM.build_model` is `gamma_control`. But the `fourier_mode` coord was only registered later, by `FourierBase.apply`. So the coord did not exist yet when the decomposition asked for its length.

The fix registers the coord alongside the others in `_generate_and_preprocess_model_data`:

```python
if self.yearly_seasonality is not None:
    self.model_coords[self.yearly_fourier.prefix] = self.yearly_fourier.nodes
```

This is safe because `pm.Model.add_coord` returns early when the coord already exists with equal values, so the later `apply` call becomes a no-op. `fourier_mode` already ended up in `model.coords` before this change — it is now simply available earlier, before `gamma_control` is created. `self.model_coords` is read in only four places in `mmm.py` (the `pm.Model(coords=...)` call, the `dayofyear` lookup, date-overlap validation, and the time index), none of which iterate it or are sensitive to an extra key.

Also fixed: both copies of the MMM integration example in the `R2D2` docstrings omitted `yearly_seasonality`, so even after the coord fix they would create no Fourier term and leave `gamma_fourier` unused.

## Test plan

- [x] New regression test `test_r2d2_with_mmm_control_and_fourier_build_model` asserts the shared Dirichlet spans every coefficient across both components, in order: `["event_1", "event_2", "t", "sin_1", "cos_1"]`. It also checks both `gamma_control` and `gamma_fourier` are free random variables and that `fourier_mode` has length 2.
- [x] Confirmed the test fails without the fix, with `KeyError: 'fourier_mode'` from the `dim_sizes` lookup in `r2d2.py`, and passes with it.
- [x] `uv run pytest tests/test_r2d2.py` — 29 passed
- [x] `uv run pytest tests/mmm/test_mmm.py` — 247 passed. This is the important one for the default path: it covers `yearly_seasonality` of `None` and `4` crossed with the TVP settings over single-dim and multi-dim fixtures, plus `test_fourier_contribution`, `test_yearly_seasonality_contribution` and `test_with_controls_and_seasonality`. A user who just passes a number and no custom prior sees no behavioural change.
- [x] `uv run pytest tests` — 4469 passed, 52 skipped. The 9 failures in `tests/test_mlflow.py` are pre-existing and environmental: they were reproduced identically on clean `main`, and are caused by the Graphviz `dot` binary being absent from the local machine, so `model_graph.pdf` is never logged. CI installs `graphviz` explicitly.
- [x] `uv run pre-commit run --files ...` — all hooks pass, including mypy.

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2929.org.readthedocs.build/en/2929/

<!-- readthedocs-preview pymc-marketing end -->