### PR TITLE
SEO/AEO: fix canonicals, prune sitemap, meta descriptions, llms.txt, retitle top pages

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,0 +1,35 @@
+{%- extends "!layout.html" %}
+{#- Adds JSON-LD structured data on top of the theme's canonical/hreflang tags.
+    The "!" prefix resolves to the active theme's layout.html, so the theme's
+    own extrahead block is preserved via super(). #}
+{%- block extrahead %}
+  {{ super() }}
+  {%- if pagename == "index" %}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "PyMC-Marketing",
+    "description": "Open-source Python library for Bayesian Marketing Mix Modeling (MMM), Customer Lifetime Value (CLV), and media budget optimization, built on PyMC.",
+    "url": "https://www.pymc-marketing.io/",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Windows, macOS, Linux",
+    "license": "https://www.apache.org/licenses/LICENSE-2.0",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "sameAs": [
+      "https://github.com/pymc-labs/pymc-marketing",
+      "https://pypi.org/project/pymc-marketing/"
+    ],
+    "author": {
+      "@type": "Organization",
+      "name": "PyMC Labs",
+      "url": "https://www.pymc-labs.com"
+    }
+  }
+  </script>
+  {%- endif %}
+{%- endblock %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,7 +17,9 @@ import pymc_marketing  # isort:skip
 project = "PyMC-Marketing"
 author = "PyMC Labs"
 copyright = f"2022-%Y, {author}"
-html_title = "PyMC-Marketing — Open Source Bayesian MMM & CLV Library for Python"
+# Keep the <title> suffix short: Google truncates titles around 60 characters,
+# so a long suffix pushes each page's own keywords out of the visible snippet.
+html_title = "PyMC-Marketing"
 
 # The master toctree document.
 master_doc = "index"
@@ -245,12 +247,23 @@ notfound_urls_prefix = "/en/latest/"
 ogp_site_url = "https://www.pymc-marketing.io/en/stable/"
 ogp_canonical_url = "https://www.pymc-marketing.io/en/stable/"
 ogp_image = "https://www.pymc-marketing.io/en/stable/_images/marketing-logo-light.jpg"
-ogp_enable_meta_description = False
+# Auto-generate <meta name="description"> from the first paragraph of each
+# page. Pages that declare their own description (e.g. index.md) are skipped.
+ogp_enable_meta_description = True
 
 
 # sitemap extension configuration
 site_url = "https://www.pymc-marketing.io/"
 sitemap_url_scheme = f"{{lang}}{rtd_version}/{{link}}"
+# Keep thin auto-generated pages out of the sitemap so crawl budget goes to
+# real content. The classmethods stubs alone are ~80% of all pages and sit in
+# Search Console as "Crawled - currently not indexed".
+sitemap_excludes = [
+    "search.html",
+    "genindex.html",
+    "py-modindex.html",
+    "api/generated/classmethods/*",
+]
 
 
 # -- Options for HTML output ----------------------------------------------
@@ -258,7 +271,7 @@ sitemap_url_scheme = f"{{lang}}{rtd_version}/{{link}}"
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 html_theme = "labs_sphinx_theme"
-html_extra_path = ["robots.txt"]
+html_extra_path = ["robots.txt", "llms.txt"]
 html_copy_source = (
     False  # don't include rst source files as _sources/...txt in the build
 )

--- a/docs/source/llms.txt
+++ b/docs/source/llms.txt
@@ -1,0 +1,40 @@
+# PyMC-Marketing
+
+> PyMC-Marketing is an open-source Python library for Bayesian marketing analytics, built and maintained by PyMC Labs. It provides production-ready implementations of Media Mix Modeling (MMM) — including adstock and saturation transformations, time-varying parameters, lift-test calibration, and budget optimization — and Customer Lifetime Value (CLV) models such as BG/NBD, Pareto/NBD, Gamma-Gamma, and shifted Beta-Geometric, all with full Bayesian uncertainty quantification via PyMC.
+
+Install with `pip install pymc-marketing`. Source code: https://github.com/pymc-labs/pymc-marketing (Apache 2.0 license).
+
+## Getting started
+
+- [Installation and quickstart](https://www.pymc-marketing.io/en/stable/getting_started/index.html): How to install PyMC-Marketing and fit a first model.
+
+## Media Mix Modeling (MMM)
+
+- [Introduction to Media Mix Modeling](https://www.pymc-marketing.io/en/stable/guide/mmm/mmm_intro.html): Conceptual introduction — adstock, saturation, and why Bayesian MMM.
+- [MMM end-to-end example](https://www.pymc-marketing.io/en/stable/notebooks/mmm/mmm_example.html): Complete worked example of building, fitting, and interpreting an MMM in Python.
+- [Multidimensional MMM](https://www.pymc-marketing.io/en/stable/notebooks/mmm/mmm_multidimensional_example.html): Modeling multiple geographies/markets in one hierarchical MMM.
+- [Budget allocation](https://www.pymc-marketing.io/en/stable/notebooks/mmm/mmm_budget_allocation_example.html): Optimizing media spend allocation from a fitted MMM.
+- [Lift-test calibration](https://www.pymc-marketing.io/en/stable/notebooks/mmm/mmm_lift_test.html): Calibrating an MMM with experimental lift-test results.
+- [Causal identification in MMM](https://www.pymc-marketing.io/en/stable/notebooks/mmm/mmm_causal_identification.html): Using causal DAGs to justify MMM control variables.
+- [How PyMC-Marketing compares](https://www.pymc-marketing.io/en/stable/guide/mmm/comparison.html): Feature comparison with Robyn, Meridian, and Orbit.
+
+## Customer Lifetime Value (CLV)
+
+- [Introduction to CLV](https://www.pymc-marketing.io/en/stable/guide/clv/clv_intro.html): Conceptual introduction to probabilistic CLV modeling.
+- [CLV quickstart](https://www.pymc-marketing.io/en/stable/notebooks/clv/clv_quickstart.html): Fitting BG/NBD and Gamma-Gamma models on transaction data.
+- [BG/NBD model](https://www.pymc-marketing.io/en/stable/notebooks/clv/bg_nbd.html): Purchase-frequency modeling for non-contractual settings.
+- [Pareto/NBD model](https://www.pymc-marketing.io/en/stable/notebooks/clv/pareto_nbd.html): Classic continuous-time purchase and churn model.
+- [Gamma-Gamma model](https://www.pymc-marketing.io/en/stable/notebooks/clv/gamma_gamma.html): Modeling monetary value per transaction.
+
+## Other models
+
+- [Bass diffusion model](https://www.pymc-marketing.io/en/stable/notebooks/bass/bass_example.html): Forecasting adoption of new products.
+
+## API reference
+
+- [API documentation](https://www.pymc-marketing.io/en/stable/api/index.html): Full API reference for all modules.
+
+## Optional
+
+- [PyMC Labs](https://www.pymc-labs.com): The company behind PyMC-Marketing; offers consulting for custom marketing analytics.
+- [PyMC](https://www.pymc.io): The probabilistic programming framework PyMC-Marketing is built on.

--- a/docs/source/notebooks/bass/bass_example.ipynb
+++ b/docs/source/notebooks/bass/bass_example.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "(bass_example)=\n",
-    "# Introduction to the Bass Diffusion Model\n",
+    "# The Bass Diffusion Model: Formula, Intuition, and Implementation in Python\n",
     "\n",
     "## What is the Bass Model?\n",
     "\n",

--- a/docs/source/notebooks/clv/bg_nbd.ipynb
+++ b/docs/source/notebooks/clv/bg_nbd.ipynb
@@ -5,7 +5,7 @@
    "id": "51e3591e",
    "metadata": {},
    "source": [
-    "# BG/NBD Model\n",
+    "# The BG/NBD Model for Customer Lifetime Value\n",
     "\n",
     "In this notebook we show how to fit a BG/NBD model in PyMC-Marketing. The model is presented in the paper: Fader, P. S., Hardie, B. G., & Lee, K. L. (2005). [“Counting your customers” the easy way: An alternative to the Pareto/NBD model. Marketing science, 24(2), 275-284.](http://www.brucehardie.com/papers/bgnbd_2004-04-20.pdf)"
    ]

--- a/docs/source/notebooks/clv/clv_quickstart.ipynb
+++ b/docs/source/notebooks/clv/clv_quickstart.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "(clv_quickstart)=\n",
-    "# CLV Quickstart"
+    "# Customer Lifetime Value (CLV) in Python: Quickstart"
    ]
   },
   {

--- a/docs/source/notebooks/clv/pareto_nbd.ipynb
+++ b/docs/source/notebooks/clv/pareto_nbd.ipynb
@@ -5,7 +5,7 @@
    "id": "d2d0bc87",
    "metadata": {},
    "source": [
-    "# Pareto/NBD Model\n",
+    "# The Pareto/NBD Model for Customer Lifetime Value\n",
     "The Pareto/Negative-Binomial Distribution model was the first Buy-Till-You-Die (BTYD) model for estimating non-contractual customer activity over a continuous time period. First introduced by Schmittlein, et. al. in 1987 and developed further by Bruce Hardie and Peter Fader, it is frequently used as a benchmark in CLV research due to its robust performance and wide range of functionality. For detailed derivations of this model please refer to\n",
     "[\"A Note on Deriving the Pareto/NBD Model and Related Expressions.\"](https://www.brucehardie.com/notes/009/pareto_nbd_derivations_2005-11-05.pdf)\n",
     "\n",

--- a/docs/source/notebooks/mmm/mmm_example.ipynb
+++ b/docs/source/notebooks/mmm/mmm_example.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "(mmm_example)=\n",
-    "# MMM Example Notebook\n",
+    "# Media Mix Modeling (MMM) in Python: End-to-End Example\n",
     "\n",
     "In this notebook we work out a simulated example to showcase the Media Mix Model (MMM) API from `pymc-marketing`. This package provides a `pymc` implementation of the MMM presented in the paper [Jin, Yuxue, et al. “Bayesian methods for media mix modeling with carryover and shape effects.” (2017)](https://research.google/pubs/pub46001/). We work with synthetic data as we want to do *parameter recovery* to better understand the model assumptions. That is, we explicitly set values for our adstock and saturation parameters (see model specification below) and recover them back from the model. The data generation process is an adaptation of the blog post [\"Media Effect Estimation with PyMC: Adstock, Saturation & Diminishing Returns\"](https://juanitorduz.github.io/pymc_mmm/) by [Juan Orduz](https://juanitorduz.github.io/).\n",
     "\n",

--- a/docs/source/robots.txt
+++ b/docs/source/robots.txt
@@ -8,5 +8,16 @@
 # * Our guide about SEO techniques: https://docs.readthedocs.com/platform/stable/guides/technical-docs-seo-guide.html
 
 User-agent: *
+# Old numbered versions have no canonical tags and compete with /en/stable/
+# for the same queries, splitting ranking signals across versions.
+Disallow: /en/0.
+Disallow: /es/0.
+# Thin auto-generated per-method stub pages: ~80% of all pages, none of them
+# indexable content. Keeping crawlers out spends crawl budget on real pages.
+Disallow: /en/stable/api/generated/classmethods/
+Disallow: /en/latest/api/generated/classmethods/
+Disallow: /es/stable/api/generated/classmethods/
+Disallow: /es/latest/api/generated/classmethods/
 
 Sitemap: https://www.pymc-marketing.io/en/stable/sitemap.xml
+Sitemap: https://www.pymc-marketing.io/es/stable/sitemap.xml

--- a/docs/source/robots.txt
+++ b/docs/source/robots.txt
@@ -8,10 +8,39 @@
 # * Our guide about SEO techniques: https://docs.readthedocs.com/platform/stable/guides/technical-docs-seo-guide.html
 
 User-agent: *
-# Old numbered versions have no canonical tags and compete with /en/stable/
-# for the same queries, splitting ranking signals across versions.
-Disallow: /en/0.
-Disallow: /es/0.
+# Versions 0.17.x and older were built before canonical tags existed (#2119)
+# and compete with /en/stable/ for the same queries, splitting ranking
+# signals. Versions 0.18+ carry canonicals pointing at stable and stay
+# crawlable so Google can consolidate them itself. Minor versions are listed
+# explicitly because a "/en/0.1" prefix would also match 0.18 and 0.19.
+Disallow: /en/0.4
+Disallow: /en/0.5
+Disallow: /en/0.6
+Disallow: /en/0.7
+Disallow: /en/0.8
+Disallow: /en/0.9
+Disallow: /en/0.10
+Disallow: /en/0.11
+Disallow: /en/0.12
+Disallow: /en/0.13
+Disallow: /en/0.14
+Disallow: /en/0.15
+Disallow: /en/0.16
+Disallow: /en/0.17
+Disallow: /es/0.4
+Disallow: /es/0.5
+Disallow: /es/0.6
+Disallow: /es/0.7
+Disallow: /es/0.8
+Disallow: /es/0.9
+Disallow: /es/0.10
+Disallow: /es/0.11
+Disallow: /es/0.12
+Disallow: /es/0.13
+Disallow: /es/0.14
+Disallow: /es/0.15
+Disallow: /es/0.16
+Disallow: /es/0.17
 # Thin auto-generated per-method stub pages: ~80% of all pages, none of them
 # indexable content. Keeping crawlers out spends crawl budget on real pages.
 Disallow: /en/stable/api/generated/classmethods/


### PR DESCRIPTION
## What & why

A GSC export (last 16 months) for pymc-marketing.io shows we leave a lot of search traffic on the table. This PR fixes the technical-SEO issues that are addressable from the repo and adds AEO (answer-engine optimization) assets. Follows up on #2119; rebased on #2931 (which landed the canonical double-slash fix separately).

### What the Search Console data shows

- **Version fragmentation**: `mmm_intro` ranks three times for the same queries — `/en/0.15.1/` (pos 12, 1,436 clicks), `/en/stable/` (pos 14), `/en/latest/` (pos 19). Versions ≤0.17 carry **no canonical tags** (built before #2119), so Google treats them as independent duplicates. Coverage report: 2,151 "Duplicate without user-selected canonical", 6,610 404s (mostly dead old-version URLs).
- **Crawl budget waste**: 2,113 of 2,674 sitemap URLs (79%) are auto-generated `classmethods/*` stub pages. GSC: 11,043 pages "Crawled – currently not indexed".
- **Missing meta descriptions**: notebook pages (incl. the top traffic pages) have none — `ogp_enable_meta_description` was explicitly disabled.
- **Weak titles on high-impression pages**: e.g. `bass_example.html` has **207k impressions** at position ~4.9 but only 0.61% CTR; `mmm_example.html` is titled "MMM Example Notebook" while the query space is "media mix modeling python", "pymc mmm example", etc. Every `<title>` also drags a 66-char suffix ("— PyMC-Marketing — Open Source Bayesian MMM & CLV Library for Python") that eats the ~60 visible SERP characters.

### Changes

1. **Enable auto meta descriptions** (`ogp_enable_meta_description = True`) — sphinxext-opengraph skips pages that already declare one (e.g. `index.md`), so no duplicates.
2. **Prune sitemap** — exclude `api/generated/classmethods/*`, `search.html`, `genindex.html`, `py-modindex.html` via `sitemap_excludes` (fnmatch patterns, supported by sphinx-sitemap).
3. **robots.txt** — disallow versions 0.4–0.17 (no canonical tags; listed per minor version so the prefix doesn't catch 0.18/0.19) and the classmethods stubs; add the `es` sitemap. Versions 0.18+ declare stable as canonical and stay crawlable so Google can consolidate them itself; in the RTD dashboard they are visible again, ≤0.17 are hidden.
4. **Shorten `html_title`** to "PyMC-Marketing" so page titles read "Introduction to Media Mix Modeling — PyMC-Marketing".
5. **Add `llms.txt`** (served at `/en/stable/llms.txt`) — curated map of the docs for LLMs/answer engines.
6. **Add `SoftwareApplication` JSON-LD** on the landing page via a project `layout.html` that extends the theme template (canonical/hreflang blocks preserved via `super()`).
7. **Retitle 5 top-traffic notebooks** to match search intent (H1-only change; MyST labels untouched):
   - "MMM Example Notebook" → "Media Mix Modeling (MMM) in Python: End-to-End Example"
   - "CLV Quickstart" → "Customer Lifetime Value (CLV) in Python: Quickstart"
   - "BG/NBD Model" → "The BG/NBD Model for Customer Lifetime Value"
   - "Pareto/NBD Model" → "The Pareto/NBD Model for Customer Lifetime Value"
   - "Introduction to the Bass Diffusion Model" → "The Bass Diffusion Model: Formula, Intuition, and Implementation in Python"

### Follow-ups after merge

- **Search Console**: resubmit the sitemap and validate the "Duplicate without user-selected canonical" issue to speed up reprocessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
