### PR TITLE
Remove trailing slash from docs baseurl to fix broken canonical URLs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -281,7 +281,10 @@ html_context = {
     "github_version": "main",
     "doc_path": "docs/source/",
     "default_mode": "light",
-    "baseurl": "https://www.pymc-marketing.io/",
+    # No trailing slash: the theme's layout.html builds the canonical URL as
+    # "{baseurl}/{language}/stable/{pagename}.html". A trailing slash here
+    # produced broken canonicals ("https://www.pymc-marketing.io//en/...").
+    "baseurl": "https://www.pymc-marketing.io",
     "rtd_version": rtd_version,
     "translations": ["en", "es"],
 }


### PR DESCRIPTION
## Problem

Every page of the docs currently emits a double-slash canonical:

```
$ curl -s https://www.pymc-marketing.io/en/stable/ | grep canonical
<link rel="canonical" href="https://www.pymc-marketing.io//en/stable/index.html">
```

labs-sphinx-theme's `layout.html` builds the canonical as `{baseurl}/{language}/stable/{pagename}.html`, and our `conf.py` sets `html_context["baseurl"]` with a trailing slash. Search engines treat the resulting URLs as broken/duplicate canonicals — GSC coverage for pymc-marketing.io shows **549 pages "crawled - currently not indexed"**. CausalPy had the identical issue and fixed it the same way.

## Fix

Drop the trailing slash from `baseurl` in `docs/source/conf.py`, with a comment documenting the contract so it doesn't regress.

The theme itself is also being fixed to normalize the trailing slash (pymc-labs/labs-sphinx-theme#8), but this repo needs the workaround until a theme release is out and pinned here.

After merge, the fix takes effect on the next stable docs deploy; canonicals should then read `https://www.pymc-marketing.io/en/stable/<page>.html`, and re-indexing can be requested in GSC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2931.org.readthedocs.build/en/2931/

<!-- readthedocs-preview pymc-marketing end -->