### PR TITLE
Fold notebook code cells by default in the docs

### DIFF
--- a/docs/source/_static/fold-code-cells.css
+++ b/docs/source/_static/fold-code-cells.css
@@ -1,0 +1,69 @@
+/* Styling for the folded notebook code cells added by fold-code-cells.js
+   (#2926). Uses pydata-sphinx-theme CSS variables so it follows the
+   light/dark theme. */
+
+details.code-fold {
+  margin-bottom: 1rem;
+}
+
+details.code-fold > summary.code-fold__summary {
+  display: inline-block;
+  cursor: pointer;
+  list-style: none;
+  padding: 0.15rem 0.75rem;
+  font-size: 0.8rem;
+  font-family: var(--pst-font-family-base);
+  color: var(--pst-color-text-muted);
+  background-color: var(--pst-color-surface);
+  border: 1px solid var(--pst-color-border);
+  border-radius: 0.75rem;
+  user-select: none;
+}
+
+details.code-fold > summary.code-fold__summary::-webkit-details-marker {
+  display: none;
+}
+
+details.code-fold > summary.code-fold__summary::before {
+  content: "\25B8"; /* small right-pointing triangle */
+  display: inline-block;
+  margin-right: 0.4rem;
+  transition: transform 0.15s ease;
+}
+
+details.code-fold[open] > summary.code-fold__summary::before {
+  transform: rotate(90deg);
+}
+
+details.code-fold > summary.code-fold__summary:hover {
+  color: var(--pst-color-primary);
+  border-color: var(--pst-color-primary);
+}
+
+details.code-fold[open] > summary.code-fold__summary {
+  margin-bottom: 0.35rem;
+}
+
+/* The wrapped cell_input keeps its own bottom margin; drop the doubled-up
+   spacing inside the details element. */
+details.code-fold > div.cell_input {
+  margin-bottom: 0;
+}
+
+button.code-fold__toggle-all {
+  display: block;
+  margin: 0 0 1rem auto;
+  padding: 0.25rem 0.9rem;
+  font-size: 0.8rem;
+  font-family: var(--pst-font-family-base);
+  color: var(--pst-color-text-muted);
+  background-color: var(--pst-color-surface);
+  border: 1px solid var(--pst-color-border);
+  border-radius: 0.75rem;
+  cursor: pointer;
+}
+
+button.code-fold__toggle-all:hover {
+  color: var(--pst-color-primary);
+  border-color: var(--pst-color-primary);
+}

--- a/docs/source/_static/fold-code-cells.js
+++ b/docs/source/_static/fold-code-cells.js
@@ -1,0 +1,74 @@
+// Fold notebook code cells by default (#2926).
+//
+// myst-nb renders every notebook code cell as
+//   <div class="cell"><div class="cell_input">...</div><div class="cell_output">...</div></div>
+// This script wraps each cell_input in a <details> element that starts
+// collapsed, so readers see the narrative and the outputs first and can
+// expand the code they care about. A per-page "Show all code" toggle is
+// added above the first folded cell.
+
+(function () {
+  "use strict";
+
+  var LABELS = {
+    en: { show: "Show code", hide: "Hide code", showAll: "Show all code", hideAll: "Hide all code" },
+    es: { show: "Mostrar código", hide: "Ocultar código", showAll: "Mostrar todo el código", hideAll: "Ocultar todo el código" },
+  };
+
+  function labels() {
+    var lang = (document.documentElement.lang || "en").split("-")[0];
+    return LABELS[lang] || LABELS.en;
+  }
+
+  function foldCell(input, t) {
+    var details = document.createElement("details");
+    details.className = "code-fold";
+
+    var summary = document.createElement("summary");
+    summary.className = "code-fold__summary";
+    summary.dataset.show = t.show;
+    summary.dataset.hide = t.hide;
+    summary.textContent = t.show;
+    details.appendChild(summary);
+
+    details.addEventListener("toggle", function () {
+      summary.textContent = details.open ? summary.dataset.hide : summary.dataset.show;
+    });
+
+    input.parentNode.insertBefore(details, input);
+    details.appendChild(input);
+    return details;
+  }
+
+  function addGlobalToggle(firstCell, folds, t) {
+    var button = document.createElement("button");
+    button.type = "button";
+    button.className = "code-fold__toggle-all";
+    button.textContent = t.showAll;
+
+    button.addEventListener("click", function () {
+      var expand = button.textContent === t.showAll;
+      folds.forEach(function (details) {
+        details.open = expand;
+      });
+      button.textContent = expand ? t.hideAll : t.showAll;
+    });
+
+    firstCell.parentNode.insertBefore(button, firstCell);
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    var t = labels();
+    var inputs = document.querySelectorAll("div.cell > div.cell_input");
+    if (inputs.length === 0) {
+      return;
+    }
+
+    var folds = [];
+    inputs.forEach(function (input) {
+      folds.push(foldCell(input, t));
+    });
+
+    addGlobalToggle(folds[0].closest("div.cell"), folds, t);
+  });
+})();

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -290,7 +290,10 @@ html_context = {
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static/"]
-html_css_files = ["custom.css"]
+html_css_files = ["custom.css", "fold-code-cells.css"]
+# Folds notebook code cells by default so example pages lead with narrative
+# and outputs instead of walls of code (#2926).
+html_js_files = ["fold-code-cells.js"]
 
 # -- Options for LaTeX output ---------------------------------------------
 


### PR DESCRIPTION
## Description

Notebook pages in the docs lead with walls of code, which makes the examples feel daunting (#2926). This PR folds all notebook code cells by default so pages lead with narrative and outputs:

- Each code cell input is wrapped in a collapsed `<details>` element with a **Show code** toggle pill.
- Every page with code cells gets a **Show all code / Hide all code** button above the first cell.
- Cell **outputs stay visible** — tables, plots, and printed results are unaffected.
- Toggle labels are localized (English/Spanish) based on the page language.
- Progressive enhancement: without JavaScript the cells simply render expanded as before, and no notebook files needed to be touched.

Implemented as a small static JS/CSS pair (`fold-code-cells.js` / `fold-code-cells.css`) registered in `conf.py`; the styling uses pydata-sphinx-theme CSS variables so it follows the light/dark theme.

Verified on a local Sphinx build of `adstock_functions_guide.ipynb`: all 23 code cells fold/unfold correctly, sphinx-copybutton keeps working (the whole `cell_input` subtree is moved, copy buttons included), and folded code is confirmed invisible until expanded.

The second part of the issue (a better display theme overall) is left as follow-up work.

Closes #2926

## Type of change
- [ ] Bug fix
- [x] New feature / enhancement (docs)
- [ ] Breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2932.org.readthedocs.build/en/2932/

<!-- readthedocs-preview pymc-marketing end -->