### PR TITLE
docs: fix stale external links and prefer intersphinx roles over hard-coded URLs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -188,6 +188,26 @@ intersphinx_mapping = {
     "xarray": ("https://docs.xarray.dev/en/stable/", None),
 }
 
+# Prefer cross-reference roles over hard-coded URLs when pointing at an API of
+# any project listed above, e.g. {func}`pymc.sample` instead of a literal link
+# to the pymc docs. Renamed or moved objects then surface as a warning, which
+# the docs build turns into an error (-W), instead of silently rotting into a
+# 404 on the published site.
+
+# `sphinx-build docs/source docs/build -b linkcheck` catches the hard-coded
+# links that remain. Anchors are not checked: many targets render them client
+# side, which produces false positives.
+linkcheck_anchors = False
+linkcheck_timeout = 30
+linkcheck_retries = 2
+linkcheck_ignore = [
+    # Rate-limits or blocks CI traffic.
+    r"https://(www\.)?linkedin\.com/.*",
+    r"https://(twitter|x)\.com/.*",
+    r"https://calendly\.com/.*",
+    r"https://discord\.(gg|com)/.*",
+]
+
 
 # linkcode extension (links of [source] pointing to github)
 def linkcode_resolve(domain, info):

--- a/docs/source/guide/benefits/model_deployment.ipynb
+++ b/docs/source/guide/benefits/model_deployment.ipynb
@@ -8682,7 +8682,7 @@
    "id": "84d5ab97d17b4c38ab41a2b065bbd0c0",
    "metadata": {},
    "source": [
-    "All the data passed to the model on initialization is stored in `idata.attrs`. This will be used later in the `save()` method to convert both this data and all the fit data into the netCDF format. You can read more about this format [here](https://python.arviz.org/en/stable/getting_started/XarrayforArviZ.html)."
+    "All the data passed to the model on initialization is stored in `idata.attrs`. This will be used later in the `save()` method to convert both this data and all the fit data into the netCDF format. You can read more about this format [here](https://python.arviz.org/en/stable/schema/schema.html)."
    ]
   },
   {

--- a/docs/source/guide/mmm/data_export.md
+++ b/docs/source/guide/mmm/data_export.md
@@ -42,7 +42,7 @@ Common parameters across methods:
 - **`frequency`** — time aggregation (`"weekly"`, `"monthly"`, `"yearly"`, etc.)
 - **`dims`** — dimension filters, e.g. `{"geo": ["CA"]}`
 
-See the full API: [`MMMSummaryFactory`](https://www.pymc-marketing.io/en/stable/api/generated/pymc_marketing.mmm.summary.MMMSummaryFactory.html).
+See the full API: {class}`~pymc_marketing.mmm.summary.factory.MMMSummaryFactory`.
 
 ### Methods overview
 

--- a/docs/source/notebooks/general/model_configuration.ipynb
+++ b/docs/source/notebooks/general/model_configuration.ipynb
@@ -1044,7 +1044,7 @@
    "id": "007646bd-61f4-4a2d-8400-14c36e08f289",
    "metadata": {},
    "source": [
-    "For more complicated distributions, consider using the `sample_prior` method in order to access the prior. Or PreliZ's functions like [predictive explorer](https://preliz.readthedocs.io/en/latest/examples/observed_space_examples.html#predictive-explorer).\n",
+    "For more complicated distributions, consider using the `sample_prior` method in order to access the prior. Or PreliZ's functions like [predictive explorer](https://preliz.readthedocs.io/en/latest/examples/gallery/predictive_explorer.html).\n",
     "\n",
     "\n",
     "```{note}\n",

--- a/docs/source/notebooks/general/other_nuts_samplers.ipynb
+++ b/docs/source/notebooks/general/other_nuts_samplers.ipynb
@@ -75,7 +75,7 @@
    "id": "f1ce2819",
    "metadata": {},
    "source": [
-    "We can pass the keyword argument `nuts_sampler` to the `fit` method of the `CLV` model to specify the NUTS sampler to use. In addition, we can pass additional keyword arguments which will be passed to the [`pymc.sample`](https://www.pymc.io/projects/docs/en/stable/api/generated/pymc.sampling.mcmc.sample.html#pymc.sampling.mcmc.sample) method via the model builder layer.  For example, we can use the `numpyro` sampler as:"
+    "We can pass the keyword argument `nuts_sampler` to the `fit` method of the `CLV` model to specify the NUTS sampler to use. In addition, we can pass additional keyword arguments which will be passed to the {func}`pymc.sample` method via the model builder layer.  For example, we can use the `numpyro` sampler as:"
    ]
   },
   {

--- a/docs/source/notebooks/mmm/mmm_data_generator.ipynb
+++ b/docs/source/notebooks/mmm/mmm_data_generator.ipynb
@@ -14,7 +14,7 @@
     "\n",
     "1. **Generate correlated channel spend covariates** using a multivariate normal model with an LKJ prior on the correlation structure.\n",
     "2. **Fix known \"true\" parameter values** for adstock, saturation, seasonality, and noise.\n",
-    "3. **Forward-sample through the MMM** using PyMC's [`do`](https://www.pymc.io/projects/docs/en/stable/api/model/generated/pymc.model.transform.conditioning.do.html) operator to produce a synthetic observed target variable.\n",
+    "3. **Forward-sample through the MMM** using PyMC's {func}`~pymc.model.transform.do` operator to produce a synthetic observed target variable.\n",
     "4. **Fit the MMM** on the synthetic data using the same model specification.\n",
     "5. **Verify recovery** by comparing posterior distributions against the ground-truth values.\n",
     "\n",

--- a/docs/source/notebooks/mmm/mmm_funnel_mueffect.ipynb
+++ b/docs/source/notebooks/mmm/mmm_funnel_mueffect.ipynb
@@ -487,7 +487,7 @@
    "source": [
     "## Data generating process\n",
     "\n",
-    "We follow the same recipe as the {ref}`mmm_data_generator` notebook: build a PyMC model, clamp the parameters to known ground-truth values with the [`do`](https://www.pymc.io/projects/docs/en/stable/api/model/generated/pymc.model.transform.conditioning.do.html) operator, and forward-sample. The twist here is that the generative model **is** the funnel MMM (base `MMM` + `FunnelEffect`), so a single forward pass produces **both** the observed lower-funnel spend and the target.\n"
+    "We follow the same recipe as the {ref}`mmm_data_generator` notebook: build a PyMC model, clamp the parameters to known ground-truth values with the {func}`~pymc.model.transform.do` operator, and forward-sample. The twist here is that the generative model **is** the funnel MMM (base `MMM` + `FunnelEffect`), so a single forward pass produces **both** the observed lower-funnel spend and the target.\n"
    ]
   },
   {

--- a/docs/source/notebooks/mmm/mmm_funnel_mueffect_advanced.ipynb
+++ b/docs/source/notebooks/mmm/mmm_funnel_mueffect_advanced.ipynb
@@ -853,7 +853,7 @@
    "source": [
     "## Data generating process\n",
     "\n",
-    "As in {ref}`mmm_data_generator`, we build a model, clamp every parameter to a known value with the [`do`](https://www.pymc.io/projects/docs/en/stable/api/model/generated/pymc.model.transform.conditioning.do.html) operator, and forward-sample. The generative model **is** the funnel MMM, so one forward pass produces the target and both demand proxies at once."
+    "As in {ref}`mmm_data_generator`, we build a model, clamp every parameter to a known value with the {func}`~pymc.model.transform.do` operator, and forward-sample. The generative model **is** the funnel MMM, so one forward pass produces the target and both demand proxies at once."
    ]
   },
   {


### PR DESCRIPTION
Closes #2933.

## What was wrong

`pm.sample` in [other_nuts_samplers](https://www.pymc-marketing.io/en/latest/notebooks/general/other_nuts_samplers.html) linked to `pymc.sampling.mcmc.sample`, which 404s: upstream now documents it as `pymc.sample`.

Since the issue also asks about other stale references, I extracted every external documentation URL under `docs/source` (275 unique) and status-checked the ones pointing at PyMC-ecosystem and scientific-Python docs. Four more were dead:

| Stale target | Now |
| --- | --- |
| `pymc.sampling.mcmc.sample` | `pymc.sample` |
| `pymc.model.transform.conditioning.do` (3 notebooks) | `pymc.model.transform.do` |
| preliz `examples/observed_space_examples.html#predictive-explorer` | `examples/gallery/predictive_explorer.html` |
| arviz `getting_started/XarrayforArviZ.html` | `schema/schema.html` |
| `pymc_marketing.mmm.summary.MMMSummaryFactory` | `pymc_marketing.mmm.summary.factory.MMMSummaryFactory` |

Every replacement was verified to return 200.

## The structural fix

Hard-coding a URL to another project's API is what let these rot silently. Where the target is a project already in `intersphinx_mapping`, the link is now a cross-reference role instead:

- `` {func}`pymc.sample` ``
- `` {func}`~pymc.model.transform.do` ``
- `` {class}`~pymc_marketing.mmm.summary.factory.MMMSummaryFactory` ``

An unresolvable role is a Sphinx warning, and the docs build already runs with `-W`, so the next upstream rename fails CI at the source rather than turning into a 404 on the published site. `conf.py` now states that convention in a comment next to `intersphinx_mapping`.

preliz is not in `intersphinx_mapping`, so that one stays a plain URL. Adding preliz to the mapping would be a reasonable follow-up.

For the hard-coded links that remain (blog posts, papers, sites with no inventory), `conf.py` gains `linkcheck_*` settings so `sphinx-build docs/source docs/build -b linkcheck` is usable. Anchor checking is off: too many targets render anchors client side and produce false positives. I did not wire this into CI, because `broken-link-checker.yml` already crawls the deployed site weekly; the difference is that `linkcheck` runs against source, so it can be run on a branch before merge.

## Notes

Docs-only change. No code touched, no notebook outputs re-executed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2934.org.readthedocs.build/en/2934/

<!-- readthedocs-preview pymc-marketing end -->