### PR TITLE
feat: allow for Transformation call after apply method

### DIFF
--- a/pymc_marketing/mmm/components/base.py
+++ b/pymc_marketing/mmm/components/base.py
@@ -685,6 +685,82 @@ class Transformation:
         kwargs = self._create_distributions(idx=idx)
         return self.function(x, dim=core_dim, **kwargs)
 
+    def __call__(
+        self,
+        x: XTensorLike,
+        *,
+        core_dim: str | None = None,
+    ) -> XTensorVariable:
+        """Apply the transformation, reusing variables from an active model context.
+
+        If called inside a ``pm.Model`` context that already contains this
+        transformation's variables (e.g. after :meth:`apply` has been called
+        during ``build_model``), the existing ``XTensorVariable``s are reused
+        rather than creating new ones.  Otherwise falls back to
+        :meth:`apply` behaviour (creates new distributions).
+
+        Parameters
+        ----------
+        x : XTensorLike
+            The data to transform.
+        core_dim : str, optional
+            The dimension along which to apply the transformation.
+
+        Returns
+        -------
+        XTensorVariable
+            The transformed data.
+
+        Examples
+        --------
+        Evaluate the saturation curve at a grid of points inside the fitted
+        model so that posterior uncertainty is propagated automatically:
+
+        .. code-block:: python
+
+            import numpy as np
+            import pytensor.xtensor as ptx
+
+            x_vals = np.linspace(0, 1, 200)
+            x_curve = ptx.as_xtensor(x_vals, dims=("saturation_x",))
+
+            with mmm.model:
+                mmm.model.add_coord("saturation_x", x_vals)
+                curve = mmm.saturation(x_curve, core_dim="saturation_x")
+                pmd.Deterministic("saturation_curve_contribution", curve)
+
+        To also obtain the curve in original (unscaled) target units, pass the
+        deterministic name to :meth:`~pymc_marketing.mmm.MMM.add_original_scale_contribution_variable`:
+
+        .. code-block:: python
+
+            import numpy as np
+            import pytensor.xtensor as ptx
+
+            x_vals = np.linspace(0, 1, 200)
+            x_curve = ptx.as_xtensor(x_vals, dims=("saturation_x",))
+
+            with mmm.model:
+                mmm.model.add_coord("saturation_x", x_vals)
+                curve = mmm.saturation(x_curve, core_dim="saturation_x")
+                pmd.Deterministic("saturation_curve_contribution", curve)
+
+            mmm.add_original_scale_contribution_variable(["saturation_curve_contribution"])
+            # → adds "saturation_curve_contribution_original_scale" to the model
+
+        """
+        model = pm.Model.get_context(error_if_none=False)
+        if model is not None and all(
+            v in model.named_vars for v in self.variable_mapping.values()
+        ):
+            kwargs = {
+                param: model.named_vars[var]
+                for param, var in self.variable_mapping.items()
+            }
+        else:
+            kwargs = self._create_distributions()
+        return self.function(x, dim=core_dim, **kwargs)
+
 
 def _serialize_value(value: Any) -> Any:
     if hasattr(value, "to_dict"):

--- a/pymc_marketing/mmm/components/base.py
+++ b/pymc_marketing/mmm/components/base.py
@@ -745,7 +745,9 @@ class Transformation:
                 curve = mmm.saturation(x_curve, core_dim="saturation_x")
                 pmd.Deterministic("saturation_curve_contribution", curve)
 
-            mmm.add_original_scale_contribution_variable(["saturation_curve_contribution"])
+            mmm.add_original_scale_contribution_variable(
+                ["saturation_curve_contribution"]
+            )
             # → adds "saturation_curve_contribution_original_scale" to the model
 
         """

--- a/tests/mmm/components/test_base.py
+++ b/tests/mmm/components/test_base.py
@@ -671,3 +671,26 @@ def test_exposed_priors_property() -> None:
     priors = {"x": dist}
     tfm = DummyTransformation(priors=priors)
     assert tfm.priors == {"x": dist}
+
+
+def test_call_reuses_existing_vars(new_transformation) -> None:
+    x = as_xtensor(np.array([1, 2, 3]), dims=("time",))
+    with pm.Model() as model:
+        new_transformation.apply(x)
+        n_vars_before = len(model.named_vars)
+        new_transformation(x)
+        assert len(model.named_vars) == n_vars_before
+
+
+def test_call_fallback_creates_distributions(new_transformation) -> None:
+    x = as_xtensor(np.array([1, 2, 3]), dims=("time",))
+    expected = np.array([6, 12, 18])
+    with pm.Model() as generative_model:
+        pm.Deterministic("y", new_transformation(x))
+    fixed = pm.do(generative_model, {"new_a": 2, "new_b": 3})
+    np.testing.assert_allclose(fixed["y"].eval(), expected)
+
+
+def test_call_outside_model_raises(new_transformation) -> None:
+    with pytest.raises(TypeError, match=r"on context stack"):
+        new_transformation(as_xtensor(np.array([1, 2, 3]), dims=("time",)))


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

<details><summary>Setup</summary>

```python
import numpy as np
import pymc.dims as pmd
import pytensor.xtensor as ptx

import pandas as pd
from pymc_marketing.mmm import (
    MMM,
    GeometricAdstock,
    HillSaturation,
)
from pymc_marketing.paths import data_dir

file_path = data_dir / "mmm_example.csv"
data = pd.read_csv(file_path, parse_dates=["date_week"])

mmm = MMM(
    adstock=GeometricAdstock(l_max=8),
    saturation=HillSaturation(),
    date_column="date_week",
    channel_columns=["x1", "x2"],
    control_columns=[
        "event_1",
        "event_2",
        "t",
    ],
    yearly_seasonality=2,
)

X = data.drop("y", axis=1)
y = data["y"]
mmm.build_model(X, y)
```

</details>

Allows calling saturation / adstock after build for Determinsitics in the larger / built MMM graph:

```python
def bolt_saturation_curve(mmm: MMM) -> None:
    x_vals = np.linspace(0, 1, 200)
    x_curve = ptx.as_xtensor(x_vals, dims=("saturation_x",))

    saturation = mmm.saturation
    prefix = saturation.prefix

    with mmm.model:
        mmm.model.add_coord(f"{prefix}_x", x_vals)
        curve = mmm.saturation(x_curve, core_dim=f"{saturation}_x")
        pmd.Deterministic(f"{prefix}_curve_contribution", curve)

bolt_saturation_curve(mmm)
```

[`modist`](https://github.com/williambdean/modist) plug:

```python
ui = md.pymc.create_priors(mmm.model)

ui
```

```python
idata = ui.sample_prior_predictive()
fig, axes = plot_curve(idata["prior"].saturation_curve_contribution, "saturation_x")
fig.set_figwidth(12)
fig.set_figheight(4)

fig
```

<img width="815" height="653" alt="Bolted saturation" src="https://github.com/user-attachments/assets/f6f475be-3ea2-4704-8bd1-0e2b1f55de9d" />


## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://www.pymc-marketing.io/en/latest/contributing/index.html). Feel free to comment [`pre-commit.ci autofix` to auto-fix](https://pre-commit.ci/#configuration-autofix_prs).
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks) using [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2942.org.readthedocs.build/en/2942/

<!-- readthedocs-preview pymc-marketing end -->