### PR TITLE
docs: clarify Streamlit local setup

### DIFF
--- a/streamlit/mmm-explainer/README.md
+++ b/streamlit/mmm-explainer/README.md
@@ -3,30 +3,43 @@
 ## Overview
 
 This Streamlit application is designed to provide a dynamic and interactive visualization of key Marketing Mix Modeling (MMM) concepts, including adstock, saturation, and the use of Bayesian priors. It aims to help marketers, data scientists, and anyone interested in understanding MMM more deeply. Through this application, users can explore how different parameters affect adstock, saturation, and Bayesian priors.
+
 ## Run Locally
 
 You may wish to run the app locally rather than relying on the [deployment](https://pymc-marketing-app.streamlit.app/).
 
-To run the app, you need a Python environment with **Python 3.11 or newer**.
+Run the following commands from the repository root. The app supports **Python 3.12 or newer**. A dedicated virtual environment keeps the app's pinned dependencies separate from the package development environment.
 
-1. **Set up the environment:**
+1. **Create and activate the environment:**
+
    ```bash
-   uv pip install pymc-marketing streamlit
+   uv venv --python 3.12 .venv-streamlit
+   source .venv-streamlit/bin/activate
    ```
-   Or with pip:
+
+   On Windows PowerShell, activate it with:
+
+   ```powershell
+   .venv-streamlit\Scripts\Activate.ps1
+   ```
+
+2. **Install the app dependencies:**
+
    ```bash
-   pip install pymc-marketing streamlit
+   uv pip install -r streamlit/mmm-explainer/requirements.txt
    ```
-2. **Install App Dependencies:**
 
-The Streamlit app has additional dependencies listed in `streamlit/mmm-explainer/requirements.txt`.
-Install them using:
+   The requirements install the released `pymc-marketing` version used by the deployed app. If you are testing changes to the package itself, replace it with the current checkout:
 
-```bash
-pip install -r streamlit/mmm-explainer/requirements.txt
-```
-3. **Launch the App:**
-    streamlit run Visualise_Priors.py
+   ```bash
+   uv pip install --editable .
+   ```
+
+3. **Launch the app:**
+
+   ```bash
+   streamlit run streamlit/mmm-explainer/Visualise_Priors.py
+   ```
 
 ## Features
 


### PR DESCRIPTION
## Description

Clarifies how to run the Streamlit MMM explainer from a fresh Python 3.12 virtual environment. It also distinguishes the pinned deployed package from an editable checkout and fixes the launch path when commands are run from the repository root.

## Related Issue

- [x] Closes #1392
- [ ] Related to #

## Checklist

- [x] Checked that the pre-commit linting/style checks pass.
- [ ] Included tests that prove the fix is effective or that the new feature works (documentation-only change).
- [x] Added necessary documentation.
- [x] Each commit corresponds to a relevant logical change.

AI assistance: Codex helped draft and validate this documentation change.


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2947.org.readthedocs.build/en/2947/

<!-- readthedocs-preview pymc-marketing end -->