### PR TITLE
fix(clv): broadcast x in BetaGeoBetaBinom.logp so short values don't truncate the scan

### DIFF
--- a/pymc_marketing/clv/distributions.py
+++ b/pymc_marketing/clv/distributions.py
@@ -310,8 +310,13 @@ class BetaGeoBetaBinom(Discrete):
         # Broadcast all the parameters so they are sequences.
         # Potentially inefficient, but otherwise ugly logic needed to unpack arguments in the scan function,
         # since sequences always precede non-sequences.
-        t_x, alpha, beta, gamma, delta, T = pt.broadcast_arrays(
-            t_x, alpha, beta, gamma, delta, T
+        # `x` must be broadcast too: it comes from `value`, whose length may
+        # differ from the parameter batch. If it keeps a shorter length (e.g. a
+        # single customer against a batch of parameter draws), `scan` truncates
+        # to the shortest sequence and the logp silently computes over a
+        # prefix of the data (see #2919).
+        t_x, x, alpha, beta, gamma, delta, T = pt.broadcast_arrays(
+            t_x, x, alpha, beta, gamma, delta, T
         )
 
         def logp_customer_died(t_x_i, x_i, alpha_i, beta_i, gamma_i, delta_i, T_i):

--- a/tests/clv/test_distributions.py
+++ b/tests/clv/test_distributions.py
@@ -197,6 +197,39 @@ class TestBetaGeoBetaBinom:
             rtol=1e-3,
         )
 
+    def test_logp_length_one_value_broadcasts_to_parameter_batch(self):
+        # Regression test for #2919: with a length-1 value against a batched
+        # parameter set, `x` was not broadcast to the batch length, so `scan`
+        # truncated to a single step and the data-dependent term was computed
+        # once (effectively for draw 0) and reused for every draw, collapsing
+        # the posterior variation of everything flowing through `_logp`.
+        alpha = np.full(6, 1.204)
+        beta = np.full(6, 0.750)
+        gamma = np.full(6, 0.657)
+        delta = np.full(6, 2.783)
+        T = np.full(6, 6)
+
+        # Single customer: t_x=3, x=2
+        value_one = np.array([[3.0, 2.0]])
+        value_tiled = np.repeat(value_one, 6, axis=0)
+
+        dist = BetaGeoBetaBinom.dist(
+            alpha=alpha, beta=beta, gamma=gamma, delta=delta, T=T
+        )
+        logp_one = pm.logp(dist, value_one).eval()
+        logp_tiled = pm.logp(dist, value_tiled).eval()
+
+        # A length-1 value must broadcast to the full parameter batch.
+        assert logp_one.shape == (6,)
+        np.testing.assert_allclose(logp_one, logp_tiled, rtol=1e-10)
+
+        # And it must agree with the scalar-parameter logp of that customer.
+        dist_scalar = BetaGeoBetaBinom.dist(
+            alpha=1.204, beta=0.750, gamma=0.657, delta=2.783, T=6
+        )
+        expected_first = pm.logp(dist_scalar, value_one[0]).eval()
+        np.testing.assert_allclose(logp_tiled[0], expected_first, rtol=1e-8)
+
     def test_invalid_value_logp(self):
         beta_geo_beta_binom = BetaGeoBetaBinom.dist(
             alpha=1.20, beta=0.75, gamma=0.66, delta=2.78, T=6


### PR DESCRIPTION
Fixes #2919

## Problem

`x` was missing from the `pt.broadcast_arrays` call in `BetaGeoBetaBinom.logp`:

```python
t_x, alpha, beta, gamma, delta, T = pt.broadcast_arrays(
    t_x, alpha, beta, gamma, delta, T
)
...
unnorm_logp = scan(
    fn=logp_customer_died,
    outputs_info=[None],
    sequences=[t_x, x, alpha, beta, gamma, delta, T],
    return_updates=False,
)
```

Since `x` (like `t_x`) comes from `value`, a length-1 value against a longer parameter batch kept its length while the other scan sequences were broadcast to the batch length. `scan` truncates `n_steps` to the shortest sequence, so the data-dependent term was computed once — effectively for draw 0 — and reused for every other draw, with only the `-betaln(alpha, beta) - betaln(gamma, delta)` normalizer varying. The output shape stayed correct, so nothing warned.

`BetaGeoBetaBinomModel._logp` passes exactly such a length-1 dummy value, so everything flowing through `_logp` was affected: `expected_purchases`, `expected_probability_alive`, `expected_purchase_probability` — posterior means looked fine while posterior *variation* was collapsed, making the credible intervals meaningless.

## Fix

Add `x` to the `broadcast_arrays` call (one line + comment).

## Testing

New regression test `test_logp_length_one_value_broadcasts_to_parameter_batch` (6 parameter draws, one customer `t_x=3, x=2`):

- length-1 value now broadcasts to the full batch: shape `(6,)`, identical to the tiled-value logp (rtol 1e-10),
- agrees with the scalar-parameter logp of the same customer (~9e-10 rel. diff, asserted at 1e-8).

Full `tests/clv/test_distributions.py` suite: **51 passed** in docker (python:3.12), including `test_logp_matches_excel` against the Bruce Hardie reference values. (The MCMC-heavy `tests/clv/models/test_beta_geo_beta_binom.py` suite wasn't run locally to completion — left for CI.)

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2949.org.readthedocs.build/en/2949/

<!-- readthedocs-preview pymc-marketing end -->