### PR TITLE
Pin pandas<3 to unblock CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,10 @@ dependencies = [
     # and uv>=0.12 otherwise falls back to a numba pre-release. Lift together with
     # the next pytensor bump that allows numba>=0.67.
     "numpy>=2.0,<2.5",
-    "pandas",
+    # pandas 3.0.5 breaks full-column `.loc` setitem, which mmm.data_conversion and
+    # mmm.builders.yaml rely on to coerce the date column to datetime. Lift once the
+    # pandas 3.0 compatibility work in #2240 lands.
+    "pandas<3.0.5",
     "patsy",
     "preliz>=0.20.0,<1.0",
     "pydantic>=2.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,10 +36,12 @@ dependencies = [
     # and uv>=0.12 otherwise falls back to a numba pre-release. Lift together with
     # the next pytensor bump that allows numba>=0.67.
     "numpy>=2.0,<2.5",
-    # pandas 3.0.5 breaks full-column `.loc` setitem, which mmm.data_conversion and
-    # mmm.builders.yaml rely on to coerce the date column to datetime. Lift once the
+    # pandas 3.0 makes full-column `.loc` setitem strictly in-place, which
+    # mmm.data_conversion and mmm.builders.yaml rely on to coerce the date column to
+    # datetime, and defaults string columns to `str` instead of `object`. Verified by
+    # bisect: 2.3.3 passes, 3.0.0/3.0.3/3.0.5 all fail the same 30 tests. Lift once the
     # pandas 3.0 compatibility work in #2240 lands.
-    "pandas<3.0.5",
+    "pandas<3",
     "patsy",
     "preliz>=0.20.0,<1.0",
     "pydantic>=2.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -4109,7 +4109,7 @@ requires-dist = [
     { name = "osqp", marker = "extra == 'dag'", specifier = ">=0.6.2,<1.0.0" },
     { name = "osqp", marker = "extra == 'docs'", specifier = ">=0.6.2,<1.0.0" },
     { name = "osqp", marker = "extra == 'test'", specifier = ">=0.6.2,<1.0.0" },
-    { name = "pandas", specifier = "<3.0.5" },
+    { name = "pandas", specifier = "<3" },
     { name = "pandas-stubs", marker = "extra == 'lint'" },
     { name = "papermill", marker = "extra == 'test'" },
     { name = "patsy" },

--- a/uv.lock
+++ b/uv.lock
@@ -4109,7 +4109,7 @@ requires-dist = [
     { name = "osqp", marker = "extra == 'dag'", specifier = ">=0.6.2,<1.0.0" },
     { name = "osqp", marker = "extra == 'docs'", specifier = ">=0.6.2,<1.0.0" },
     { name = "osqp", marker = "extra == 'test'", specifier = ">=0.6.2,<1.0.0" },
-    { name = "pandas" },
+    { name = "pandas", specifier = "<3.0.5" },
     { name = "pandas-stubs", marker = "extra == 'lint'" },
     { name = "papermill", marker = "extra == 'test'" },
     { name = "patsy" },


### PR DESCRIPTION
## Problem

pandas 3.0.5 makes full-column `.loc` setitem strictly in-place. `mmm/data_conversion.py` and `mmm/builders/yaml.py` both coerce the date column with `X.loc[:, date_column] = pd.to_datetime(...)`, which now raises `TypeError` instead of upcasting when the column starts out as `str` or `int64`.

CI installs with `uv pip install -e .[test]`, which resolves dependencies fresh from `pyproject.toml` rather than from `uv.lock`, so an unpinned `pandas` picked up 3.0.5 as soon as it was published and test jobs started failing on unrelated PRs.

## Change

Cap the dependency at `pandas<3.0.5` and update the `requires-dist` entry in `uv.lock` to match (`uv lock --check` passes). The resolved version is unchanged at 2.3.3, so this is a constraint-only change.

## Notes

This is a stopgap to get CI green, not a fix. The underlying `.loc` setitem pattern still needs updating (`X = X.assign(**{date_column: pd.to_datetime(X[date_column])})`), and `tests/pie/test_model.py` asserts `dtype == object` for string columns where pandas 3 gives native `str`. Both belong to the pandas 3.0 compatibility work tracked in #2240; the pin should be lifted when that lands.

I have not yet confirmed by test run whether 3.0.0 through 3.0.3 are clean, so it is possible the break predates 3.0.5 and the cap needs to be widened to `<3`. CI on this PR resolves pandas to 3.0.3 under the new constraint, so a green run here is the confirmation that `<3.0.5` is the right boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2951.org.readthedocs.build/en/2951/

<!-- readthedocs-preview pymc-marketing end -->