### PR TITLE
perf: vectorize BetaGeoNBD rng_fn

### DIFF
--- a/pymc_marketing/clv/distributions.py
+++ b/pymc_marketing/clv/distributions.py
@@ -22,6 +22,7 @@ from pymc.distributions.shape_utils import rv_size_is_none
 from pytensor import scan
 from pytensor.graph import vectorize_graph
 from pytensor.tensor.random.op import RandomVariable
+from scipy.special import gammainc, gammaincinv
 
 __all__ = [
     "BetaGeoBetaBinom",
@@ -394,30 +395,43 @@ class BetaGeoNBDRV(RandomVariable):
         alpha = np.broadcast_to(alpha, size)
         T = np.broadcast_to(T, size)
 
-        output = np.zeros(shape=size + (2,))  # noqa:RUF005
-
         lam = rng.gamma(shape=r, scale=1 / alpha, size=size)
         p = rng.beta(a=a, b=b, size=size)
 
-        def sim_data(lam, p, T):
-            t = 0  # recency
-            n = 0  # frequency
+        # rng.geometric requires p in (0, 1], but Beta can underflow to 0.0
+        p_safe = np.clip(p, np.finfo(np.float64).tiny, 1.0)
 
-            churn = 0  # BG/NBD assumes all non-repeat customers are active
-            wait = rng.exponential(scale=1 / lam)
+        # Exact sampling identity for the BG/NBD process: the purchase count is
+        # X = min(K, N_T), where K ~ Geometric(p) is the churn-limited count
+        # and N_T ~ Poisson(lam * T) the time-limited one. The recency is the
+        # arrival time of the X-th purchase, which is:
+        #   * churn-limited (K <= N_T): an Erlang(K, lam) truncated to [0, T),
+        #     sampled exactly by inverse CDF
+        #   * time-limited (K > N_T): the maximum of N_T Uniform(0, T) order
+        #     statistics, i.e. T * Beta(N_T, 1)
+        #   * X == 0 implies recency == 0
+        K = rng.geometric(p_safe, size=size)
+        N_T = rng.poisson(lam * T, size=size)
+        X = np.minimum(K, N_T)
 
-            while t + wait < T and not churn:
-                churn = rng.random() < p
-                n += 1
-                t += wait
-                wait = rng.exponential(scale=1 / lam)
+        u = rng.random(size=size)
+        recency = np.zeros(size, dtype=np.float64)
 
-            return np.array([t, n])
+        churn_limited = (K <= N_T) & (X > 0)
+        if np.any(churn_limited):
+            K_churn = np.maximum(K[churn_limited], 1)
+            cdf_T = gammainc(K_churn, (lam * T)[churn_limited])
+            recency[churn_limited] = (
+                gammaincinv(K_churn, u[churn_limited] * cdf_T) / lam[churn_limited]
+            )
 
-        for index in np.ndindex(*size):
-            output[index] = sim_data(lam[index], p[index], T[index])
+        time_limited = (K > N_T) & (X > 0)
+        if np.any(time_limited):
+            recency[time_limited] = T[time_limited] * rng.beta(
+                np.maximum(N_T[time_limited], 1), 1.0
+            )
 
-        return output
+        return np.stack([recency, X], axis=-1)
 
 
 bg_nbd = BetaGeoNBDRV()

--- a/tests/clv/test_distributions.py
+++ b/tests/clv/test_distributions.py
@@ -16,6 +16,7 @@ import pymc as pm
 import pytensor
 import pytensor.tensor as pt
 import pytest
+import scipy.stats
 from numpy.testing import assert_almost_equal
 from pymc import Model
 from pymc.logprob.utils import ParameterValueError
@@ -26,10 +27,12 @@ from pymc.testing import (
     assert_support_point_is_expected,
     check_selfconsistency_discrete_logcdf,
 )
+from scipy.special import betaln, hyp2f1
 
 from pymc_marketing.clv.distributions import (
     BetaGeoBetaBinom,
     BetaGeoNBD,
+    BetaGeoNBDRV,
     ModifiedBetaGeoNBD,
     ParetoNBD,
     ShiftedBetaGeometric,
@@ -274,6 +277,70 @@ class TestBetaGeoBetaBinom:
         np.testing.assert_allclose(lt_recency_mean, frequency.mean(), rtol=0.9)
 
 
+def _bg_nbd_rng_fn_reference(rng, a, b, r, alpha, T, size):
+    """Pre-vectorization implementation of BetaGeoNBDRV.rng_fn.
+
+    Kept as the statistical oracle for the vectorized sampler: the two must
+    produce identically distributed (recency, frequency) samples.
+    """
+    if size is None:
+        size = np.broadcast_shapes(a.shape, b.shape, r.shape, alpha.shape, T.shape)
+
+    a = np.asarray(a)
+    b = np.asarray(b)
+    r = np.asarray(r)
+    alpha = np.asarray(alpha)
+    T = np.asarray(T)
+
+    if size == ():
+        size = np.broadcast_shapes(a.shape, b.shape, r.shape, alpha.shape, T.shape)
+
+    a = np.broadcast_to(a, size)
+    b = np.broadcast_to(b, size)
+    r = np.broadcast_to(r, size)
+    alpha = np.broadcast_to(alpha, size)
+    T = np.broadcast_to(T, size)
+
+    output = np.zeros(shape=size + (2,))  # noqa:RUF005
+
+    lam = rng.gamma(shape=r, scale=1 / alpha, size=size)
+    p = rng.beta(a=a, b=b, size=size)
+
+    def sim_data(lam, p, T):
+        t = 0  # recency
+        n = 0  # frequency
+
+        churn = 0  # BG/NBD assumes all non-repeat customers are active
+        wait = rng.exponential(scale=1 / lam)
+
+        while t + wait < T and not churn:
+            churn = rng.random() < p
+            n += 1
+            t += wait
+            wait = rng.exponential(scale=1 / lam)
+
+        return np.array([t, n])
+
+    for index in np.ndindex(*size):
+        output[index] = sim_data(lam[index], p[index], T[index])
+
+    return output
+
+
+def _sample_bg_nbd(impl, a, b, r, alpha, T, draws, seed):
+    rng = np.random.default_rng(seed)
+    out = impl(
+        rng,
+        np.float64(a),
+        np.float64(b),
+        np.float64(r),
+        np.float64(alpha),
+        np.float64(T),
+        size=(draws,),
+    )
+    return out[..., 0], out[..., 1]
+
+
 class TestBetaGeoNBD:
     def test_logp_matches_excel(self):
         # Expected logp values can be found in excel file in http://brucehardie.com/notes/004/
@@ -394,6 +461,125 @@ class TestBetaGeoNBD:
             prior = pm.sample_prior_predictive(draws=100)
 
         assert prior["prior"]["bg_nbd"][0].shape == (100, *expected_size)
+
+    @pytest.mark.parametrize(
+        "a, b, r, alpha, T, draws",
+        [
+            (0.793, 2.426, 0.243, 4.414, 78.0, 25_000),  # CDNOW MLE
+            (5.0, 1.0, 1.0, 5.0, 20.0, 25_000),  # high churn
+            (0.5, 10.0, 2.0, 2.0, 50.0, 20_000),  # low churn, long histories
+        ],
+    )
+    def test_rng_fn_matches_reference(self, a, b, r, alpha, T, draws):
+        """The vectorized rng_fn is statistically equivalent to the reference."""
+        rec_ref, x_ref = _sample_bg_nbd(
+            _bg_nbd_rng_fn_reference, a, b, r, alpha, T, draws, seed=20260908
+        )
+        rec_new, x_new = _sample_bg_nbd(
+            BetaGeoNBDRV.rng_fn, a, b, r, alpha, T, draws, seed=919
+        )
+
+        # frequency: chi-square contingency, dropping bins empty in both samples
+        hi = max(int(np.quantile(np.concatenate([x_ref, x_new]), 0.999)), 5)
+        ref_counts = np.bincount(
+            np.minimum(x_ref, hi + 1).astype(int), minlength=hi + 2
+        )
+        new_counts = np.bincount(
+            np.minimum(x_new, hi + 1).astype(int), minlength=hi + 2
+        )
+        table = np.array([ref_counts, new_counts])
+        table = table[:, table.sum(axis=0) > 0]
+        _, p_chi2, _, _ = scipy.stats.chi2_contingency(table)
+        assert p_chi2 > 0.01
+
+        # recency | X > 0: two-sample KS
+        _, p_ks = scipy.stats.ks_2samp(rec_ref[x_ref > 0], rec_new[x_new > 0])
+        assert p_ks > 0.01
+
+        # frequency mean agreement
+        se = np.sqrt(x_ref.var() / draws + x_new.var() / draws)
+        assert abs(x_new.mean() - x_ref.mean()) < 5 * se
+
+    @pytest.mark.parametrize(
+        "a, b, r, alpha, T",
+        [
+            (0.793, 2.426, 0.243, 4.414, 78.0),
+            (5.0, 1.0, 1.0, 5.0, 20.0),
+        ],
+    )
+    def test_rng_fn_zero_purchase_probability(self, a, b, r, alpha, T):
+        """P(X = 0) = (alpha / (alpha + T)) ** r exactly.
+
+        A customer has no repeat purchases iff the Poisson process has no
+        arrivals before T, and the Gamma mixture of that event integrates in
+        closed form.
+        """
+        draws = 100_000
+        _, x_new = _sample_bg_nbd(
+            BetaGeoNBDRV.rng_fn, a, b, r, alpha, T, draws, seed=1234
+        )
+        p_exact = (alpha / (alpha + T)) ** r
+        se = np.sqrt(p_exact * (1 - p_exact) / draws)
+        assert abs((x_new == 0).mean() - p_exact) < 5 * se
+
+    @pytest.mark.parametrize(
+        "a, b, r, alpha, T",
+        [
+            (0.793, 2.426, 0.243, 4.414, 78.0),
+            (5.0, 1.0, 1.0, 5.0, 20.0),
+            (1.0, 1.0, 5.0, 1.0, 10.0),
+        ],
+    )
+    def test_rng_fn_expected_frequency(self, a, b, r, alpha, T):
+        """E[X] against the exact survival sum and the closed-form mean.
+
+        E[X] = sum_k P(K >= k) * P(N_T >= k), where
+        P(K >= k) = B(a, b + k - 1) / B(a, b) is the Beta-Geometric survival
+        and P(N_T >= k) = nbinom.sf(k - 1, r, alpha / (alpha + T)) comes from
+        the Gamma-Poisson mixture. The closed form (valid for a > 1) cross-
+        checks the survival sum.
+        """
+        draws = 100_000
+        _, x_new = _sample_bg_nbd(
+            BetaGeoNBDRV.rng_fn, a, b, r, alpha, T, draws, seed=5678
+        )
+
+        k = np.arange(1, 100_001)
+        surv_k = np.exp(betaln(a, b + k - 1.0) - betaln(a, b))
+        surv_nt = scipy.stats.nbinom.sf(k - 1.0, r, alpha / (alpha + T))
+        expected = float(np.sum(surv_k * surv_nt))
+
+        se = x_new.std() / np.sqrt(draws)
+        assert abs(x_new.mean() - expected) < 6 * se
+
+        if a > 1:
+            closed_form = (
+                (a + b - 1)
+                / (a - 1)
+                * (
+                    1
+                    - (alpha / (alpha + T)) ** r
+                    * hyp2f1(r, b, a + b - 1, T / (alpha + T))
+                )
+            )
+            np.testing.assert_allclose(closed_form, expected, rtol=1e-6)
+
+    @pytest.mark.parametrize(
+        "a, b, r, alpha, T",
+        [
+            (0.793, 2.426, 0.243, 4.414, 78.0),
+            (2.0, 3.0, 1.0, 1.0, 500.0),
+        ],
+    )
+    def test_rng_fn_invariants(self, a, b, r, alpha, T):
+        draws = 50_000
+        rec_new, x_new = _sample_bg_nbd(
+            BetaGeoNBDRV.rng_fn, a, b, r, alpha, T, draws, seed=4321
+        )
+        assert (rec_new >= 0).all()
+        assert (rec_new <= T + 1e-9).all()
+        assert (x_new >= 0).all()
+        np.testing.assert_array_equal(rec_new == 0, x_new == 0)
 
 
 class TestModifiedBetaGeoNBD:


### PR DESCRIPTION
Prior and posterior predictive sampling for the BG/NBD model spent all its time in a per-customer Python simulation loop. This replaces it with an exact vectorized decomposition, so predictive sampling is ~7x faster at CDNOW scale (0.72s -> 0.097s for 100 draws x 2357 customers) and, more importantly, no longer scales with the expected number of purchases: the old cost grows with E[X] (0.72s -> 4.92s on a heavy-purchase parameter set) while the new one stays flat around 0.1-0.2s. Interactive prior predictive workflows (e.g. marimo/modist notebooks that re-sample on every widget drag) go from minutes to sub-second.

The identity is exact, not an approximation: the purchase count is `X = min(K, N_T)` with `K ~ Geometric(p)` and `N_T ~ Poisson(lam * T)`, and the recency is an inverse-CDF sampled truncated Erlang (churn-limited) or a `T * Beta(N_T, 1)` order statistic (time-limited). There is no truncation parameter to get wrong.

Same seed now produces different (but identically distributed) draws since the RNG consumption order changed. No test pinned exact `rng_fn` values. Distributional equivalence was validated against the previous implementation, which is kept as a test oracle in `tests/clv/test_distributions.py`, plus exact analytic checks for `P(X = 0)` and `E[X]`, invariants, broadcasting shapes, and a parameter recovery parity exercise between the two samplers.

While cross-validating the sampler against its own logp, a convention question about the BTYD likelihood surfaced and is reported separately in #2966.

Refs #2966


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2967.org.readthedocs.build/en/2967/

<!-- readthedocs-preview pymc-marketing end -->