### PR TITLE
ci: run notebook tests on mmm notebook changes

### DIFF
--- a/.github/workflows/test_notebook.yml
+++ b/.github/workflows/test_notebook.yml
@@ -10,7 +10,6 @@ on:
      - ".github/workflows/test_notebook.yml"
      - "scripts/run_notebooks/**.py"
      - "docs/source/notebooks/**.ipynb"
-     - "!docs/source/notebooks/mmm/**.ipynb"
      - "!docs/source/notebooks/*/dev/**.ipynb"
   push:
     branches: [main, v1.0.0]
@@ -21,7 +20,6 @@ on:
      - ".github/workflows/test_notebook.yml"
      - "scripts/run_notebooks/**.py"
      - "docs/source/notebooks/**.ipynb"
-     - "!docs/source/notebooks/mmm/**.ipynb"
      - "!docs/source/notebooks/*/dev/**.ipynb"
 
 concurrency:


### PR DESCRIPTION
Closes #2939.

## The exclusion is orphaned, not a policy

The issue frames this as a choice between including mmm notebooks in the trigger paths and documenting the exclusion. The history says it is neither: the exclusion lost its reason eleven months ago and nobody removed it.

- #1986 (`41c53e29`) renamed this workflow to "Test Other Notebooks", added a sibling `.github/workflows/test_notebook_mmm.yml`, and added `!docs/source/notebooks/mmm/**.ipynb` here so the two workflows would not run the same notebooks twice.
- #1989 (`9af7f676`), one day later, deleted `test_notebook_mmm.yml`, renamed this workflow back to "Test Notebooks", and folded the mmm runs into its own matrix:

```yaml
- "--notebooks mmm --end-idx 10"
- "--notebooks mmm --start-idx 10"
```

The path exclusion was left behind. Since then this workflow has run every mmm notebook without ever being triggered by a change to one.

## What this does not cost

The mmm splits already run on every PR that touches `pymc_marketing/**`, `tests/**.py`, `pyproject.toml`, `scripts/run_notebooks/**.py`, or this workflow file. Removing the exclusion does not add a job to those runs. It only adds coverage for the case the issue describes: a PR that changes an mmm notebook and nothing else, which today is gated solely by whoever remembers to run `scripts/run_notebooks/runner.py` locally.

`!docs/source/notebooks/*/dev/**.ipynb` is untouched. Dev notebooks stay excluded.

## Verification

GitHub path filters cannot be dry-run locally, so this is not verified end to end here. `.github/workflows/test_notebook.yml` is itself in the trigger paths, so this PR runs the full matrix and shows the workflow still works after the edit. The behaviour this fixes is only observable on the next PR that changes an mmm notebook and nothing else.

No release note: the issue carries `no releasenotes`.


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2971.org.readthedocs.build/en/2971/

<!-- readthedocs-preview pymc-marketing end -->