### PR TITLE
ci: skip the LLM PR labeler on every fork PR

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -25,8 +25,10 @@ jobs:
 
       # Eligibility runs before any expensive setup so skipped PRs cost
       # seconds, not minutes. Skipped: drafts, bot authors (already labeled
-      # by the Bot PRs workflow), and fork PRs from unaffiliated authors
-      # (GitHub withholds secrets/read-write tokens for those anyway).
+      # by the Bot PRs workflow), and every fork PR. GitHub withholds
+      # secrets from pull_request runs on forks regardless of the author's
+      # association, so ANTHROPIC_API_KEY is empty there and the labeler
+      # step cannot run. Maintainers label fork PRs by hand.
       - name: Check eligibility
         id: eligibility
         env:
@@ -39,10 +41,8 @@ jobs:
           skip=""
           if [[ "$PR_DRAFT" == "true" ]]; then
             skip="draft PR"
-          elif [[ "$ASSOCIATION" == "OWNER" || "$ASSOCIATION" == "MEMBER" || "$ASSOCIATION" == "COLLABORATOR" || "$ASSOCIATION" == "CONTRIBUTOR" ]]; then
-            :
           elif [[ "$FROM_FORK" == "true" ]]; then
-            skip="fork PR from unaffiliated author ($ASSOCIATION)"
+            skip="fork PR ($ASSOCIATION); secrets are unavailable to pull_request runs from forks"
           fi
 
           if [ -z "$skip" ]; then


### PR DESCRIPTION
The `label` job added in #2914 fails on every fork PR whose author has a previously merged PR. It is failing right now on #2969 (@anevolbap) and #2971 (mine), and it will fail on the next one too.

## What happens

The eligibility gate checks the author association *before* it checks whether the PR comes from a fork:

```bash
if [[ "$PR_DRAFT" == "true" ]]; then
  skip="draft PR"
elif [[ "$ASSOCIATION" == "OWNER" || "$ASSOCIATION" == "MEMBER" || "$ASSOCIATION" == "COLLABORATOR" || "$ASSOCIATION" == "CONTRIBUTOR" ]]; then
  :
elif [[ "$FROM_FORK" == "true" ]]; then
  skip="fork PR from unaffiliated author ($ASSOCIATION)"
fi
```

A fork PR from a `CONTRIBUTOR` therefore takes the allowlist branch, never reaches the fork branch, and runs the labeler step. GitHub withholds secrets from `pull_request` runs on forks regardless of author association, so `ANTHROPIC_API_KEY` is empty and the step exits 1:

```
env:
  ANTHROPIC_API_KEY:
  GH_TOKEN: ***
Not logged in · Please run /login
##[error]Process completed with exit code 1.
```

The blank value next to `GH_TOKEN: ***` in that log is the tell: a populated secret is masked, an unset one prints empty.

The gate's comment says fork PRs from unaffiliated authors are skipped "(GitHub withholds secrets/read-write tokens for those anyway)". The withholding is not conditional on affiliation, which is where the inversion comes from.

## Observed today

| PR | author | fork | association | `label` |
|---|---|---|---|---|
| #2971 | @shivamlalakiya | yes | CONTRIBUTOR | FAILURE |
| #2969 | @anevolbap | yes | CONTRIBUTOR | FAILURE |
| #2949 | @Golopmoui3 | yes | NONE | SUCCESS (skipped) |
| #2967 | @williambdean | no | CONTRIBUTOR | SUCCESS |
| #2957 | @juanitorduz | no | COLLABORATOR | SUCCESS |

The check currently passes on fork PRs from people the gate does not recognise and fails on fork PRs from repeat contributors.

## The change

Check the fork condition first and drop the allowlist. The allowlist only ever mattered for fork PRs: a same-repo branch requires write access, so a same-repo PR can never have an unaffiliated author, and every non-fork PR reaches the labeler either way. Behaviour for same-repo PRs is unchanged; every fork PR now skips instead of failing.

## Verification

I extracted the gate from the workflow and ran it against both versions with the eight combinations that matter:

```console
$ bash t.sh gate_old.sh       # gate on main
FAIL fork + CONTRIBUTOR (#2971): got skip=false want skip=true
FAIL fork + COLLABORATOR: got skip=false want skip=true
exit=1

$ bash t.sh gate.sh           # gate on this branch
all 8 cases pass
```

The two failures are exactly the cases failing in production. The other six (fork + NONE, same-repo COLLABORATOR, same-repo CONTRIBUTOR, draft, same-repo bot, same-repo copilot-swe-agent) behave identically before and after.

I did not check the harness in. It is forty lines of bash for a four-line gate, and there is no workflow-test infrastructure here to hang it on. Happy to add it if you would rather have it.

This PR is itself a fork PR from a `CONTRIBUTOR`, so its own `label` check is the live test: `pull_request` runs use the workflow from the merge ref, so it should report skipped rather than failing.

## What this does not do

It does not make the labeler work on fork PRs. Doing that means moving to `pull_request_target`, which would hand `ANTHROPIC_API_KEY` and a read-write token to a job that feeds untrusted PR titles, bodies and diffs into `claude -p --dangerously-skip-permissions`. That is a deliberate maintainer decision about prompt injection, not a CI cleanup, so this PR only stops the false red. Fork PRs get labelled by hand, as they effectively are today.

Note for #2971: the `label` trigger is `[opened, ready_for_review]`, so once this merges, that PR needs a draft/ready toggle (or a rebase and the same toggle) to clear its red check. Re-running the failed job alone will not do it.


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2972.org.readthedocs.build/en/2972/

<!-- readthedocs-preview pymc-marketing end -->