### PR TITLE
feat(mmm): reject target values outside the likelihood support at build time

### DIFF
--- a/pymc_marketing/mmm/link.py
+++ b/pymc_marketing/mmm/link.py
@@ -50,8 +50,11 @@ class LinkFunction(StrEnum):
 #: likelihood is observed on the target divided by ``target_scale``, which is
 #: not integer-valued, so they cannot be used under this model at all.
 #: ``Beta`` needs the target inside ``(0, 1)``, which the scaling does not
-#: guarantee, and nothing checks the target against the likelihood support yet.
-#: See issue #2835.
+#: guarantee.  :meth:`LinkSpec.validate_likelihood_support` now rejects a
+#: target outside any of those supports at build time (issue #2835) rather
+#: than letting it through to an ``-inf`` logp, but that check says nothing
+#: about whether ``mu`` is on the response scale, which is what this set is
+#: for.
 RESPONSE_SCALE_LIKELIHOODS = frozenset(
     {
         "Normal",
@@ -85,6 +88,60 @@ def _distribution_name(likelihood: Prior) -> str:
     while dist is not None and not isinstance(dist, str):
         dist = getattr(dist, "distribution", None)
     return dist if dist is not None else type(likelihood).__name__
+
+
+def _positive(likelihood: Prior, observed: np.ndarray):
+    return observed <= 0, "strictly positive"
+
+
+def _unit_interval(likelihood: Prior, observed: np.ndarray):
+    return (observed <= 0) | (observed >= 1), "strictly inside (0, 1)"
+
+
+def _non_negative_integer(likelihood: Prior, observed: np.ndarray):
+    return (observed < 0) | (observed != np.floor(observed)), "a non-negative integer"
+
+
+def _within_truncation(likelihood: Prior, observed: np.ndarray):
+    """Check *observed* against whichever of ``lower``/``upper`` is a number.
+
+    A bound given as a ``Prior`` or an array is left alone: the support then
+    varies per draw or per element, so there is no single interval to report.
+    """
+    parameters = getattr(likelihood, "parameters", {})
+    bounds = {
+        name: parameters[name]
+        for name in ("lower", "upper")
+        if isinstance(parameters.get(name), int | float)
+    }
+    if not bounds:
+        return None
+
+    mask = np.zeros_like(observed, dtype=bool)
+    if "lower" in bounds:
+        mask |= observed < bounds["lower"]
+    if "upper" in bounds:
+        mask |= observed > bounds["upper"]
+
+    described = " and ".join(f"{name} {value}" for name, value in bounds.items())
+    return mask, f"within its truncation ({described})"
+
+
+#: Support checks by distribution name.  Each returns the mask of violating
+#: values and a description of what was required, or ``None`` when the
+#: distribution carries no checkable bound.  Distributions absent from this
+#: mapping are not checked: ``Normal``, ``StudentT`` and ``Laplace`` are
+#: unbounded, and anything unrecognised already draws a warning from
+#: :meth:`LinkSpec.validate_likelihood_compatibility`.
+_SUPPORT_CHECKS = {
+    "LogNormal": _positive,
+    "Gamma": _positive,
+    "InverseGamma": _positive,
+    "Beta": _unit_interval,
+    "Poisson": _non_negative_integer,
+    "NegativeBinomial": _non_negative_integer,
+    "TruncatedNormal": _within_truncation,
+}
 
 
 class LinkSpec(ABC):
@@ -337,6 +394,100 @@ class LinkSpec(ABC):
                 f"decomposition and optimisation results."
             )
 
+    @staticmethod
+    def validate_likelihood_support(likelihood: Prior, observed) -> None:
+        """Raise if *observed* falls outside the support of *likelihood*.
+
+        *observed* is the value the likelihood is given, which is the target
+        divided by ``target_scale`` rather than the target itself.  The two
+        differ in sign whenever the scale is negative, which
+        ``DataDerivedScaling`` allows because it reduces with ``max``/``mean``
+        rather than their absolute values, so this check cannot be run against
+        the raw target.  ``build_model`` clamps a NaN or infinite ratio to
+        ``0.0``, which is finite but outside every positive-only support, and
+        this check reports that too.
+
+        Without it a target outside the support builds without complaint and
+        fails later as an ``-inf`` logp with nothing naming the cause.
+
+        Unrecognised distributions are not checked and do not warn:
+        :meth:`validate_likelihood_compatibility` already warns for those, and
+        a second warning on the same line would say nothing new.
+
+        Parameters
+        ----------
+        likelihood : Prior
+            The likelihood distribution prior.
+        observed : np.ndarray or XTensorVariable
+            The values handed to the likelihood.  A symbolic variable is
+            evaluated only once a distribution with a checkable support has
+            been found, so the default ``Normal`` costs no compile.
+
+        Raises
+        ------
+        ValueError
+            If any observed value lies outside the support.
+        """
+        if not isinstance(getattr(likelihood, "distribution", None), str):
+            # Anything whose own ``distribution`` is not a name is either a
+            # wrapper such as ``Censored`` or a ``SpecialPrior`` subclass.
+            # ``_distribution_name`` reports the inner name for those, but the
+            # inner support is not theirs: censoring at zero is precisely what
+            # makes a zero observation valid under ``LogNormal``, so applying
+            # it would reject the data the wrapper exists for.  The special
+            # priors validate their own observations instead.
+            return
+
+        dist_name = _distribution_name(likelihood)
+        check = _SUPPORT_CHECKS.get(dist_name)
+        if check is None:
+            return
+
+        if hasattr(observed, "eval"):
+            try:
+                observed = observed.eval()
+            except Exception:
+                # A check that can break model construction for a graph it did
+                # not anticipate is worse than no check.
+                return
+
+        violation = check(likelihood, np.asarray(observed, dtype=float))
+        if violation is None:
+            return
+
+        mask, requirement = violation
+        count = int(np.count_nonzero(mask))
+        if not count:
+            return
+
+        message = (
+            f"Likelihood '{dist_name}' requires the observed target to be "
+            f"{requirement}, but {count} of {mask.size} values are not. "
+            "The likelihood observes the target divided by 'target_scale', "
+            "not the raw target, so a value that looks valid in the original "
+            "units can still fall outside the support. Without this check the "
+            "model would build and then sample an '-inf' logp."
+        )
+
+        values = np.asarray(observed, dtype=float)
+        if np.all(values[mask] == 0.0):
+            # `build_model` rewrites a NaN or infinite ratio to 0.0, so a
+            # violation made entirely of zeros usually means the scale is the
+            # problem rather than the target's own values.
+            message += (
+                " Every violating value is exactly 0.0, which is what "
+                "build_model writes when 'target / target_scale' is NaN or "
+                "infinite. Check 'target_scale' for a zero entry, which a "
+                "target slice whose maximum is zero produces, rather than "
+                "looking for bad values in the target itself."
+            )
+        else:
+            message += (
+                " Fix the target, or choose a likelihood whose support covers it."
+            )
+
+        raise ValueError(message)
+
 
 class IdentityLinkSpec(LinkSpec):
     """Identity link: ``E[y] = mu * target_scale``."""
@@ -422,7 +573,17 @@ class LogLinkSpec(LinkSpec):
         return Prior("Normal", mu=0, sigma=5, dims=dims)
 
     def validate_target(self, y: np.ndarray) -> None:
-        """Raise ``ValueError`` if *y* contains non-positive values."""
+        """Raise ``ValueError`` if *y* contains non-positive values.
+
+        This is a link-level rule about the target, not the ``LogNormal``
+        support check.  The two are easy to confuse because the log link
+        always uses ``LogNormal``, but they test different arrays: this one
+        runs on the raw target before scaling, while
+        :meth:`LinkSpec.validate_likelihood_support` runs on
+        ``target / target_scale``, which is what the likelihood observes.  A
+        target that is entirely negative fails here and passes there, because
+        a negative ``target_scale`` makes the ratio positive.
+        """
         if np.any(y <= 0):
             raise ValueError(
                 "All target values must be strictly positive when using "

--- a/pymc_marketing/mmm/link.py
+++ b/pymc_marketing/mmm/link.py
@@ -21,6 +21,7 @@ contribution graph construction).
 
 from __future__ import annotations
 
+import numbers
 import warnings
 from abc import ABC, abstractmethod
 from enum import StrEnum
@@ -91,15 +92,17 @@ def _distribution_name(likelihood: Prior) -> str:
 
 
 def _positive(likelihood: Prior, observed: np.ndarray):
-    return observed <= 0, "strictly positive"
+    return ~(observed > 0), "strictly positive"
 
 
 def _unit_interval(likelihood: Prior, observed: np.ndarray):
-    return (observed <= 0) | (observed >= 1), "strictly inside (0, 1)"
+    return ~((observed > 0) & (observed < 1)), "strictly inside (0, 1)"
 
 
 def _non_negative_integer(likelihood: Prior, observed: np.ndarray):
-    return (observed < 0) | (observed != np.floor(observed)), "a non-negative integer"
+    return ~((observed >= 0) & (observed == np.floor(observed))), (
+        "a non-negative integer"
+    )
 
 
 def _within_truncation(likelihood: Prior, observed: np.ndarray):
@@ -112,12 +115,13 @@ def _within_truncation(likelihood: Prior, observed: np.ndarray):
     bounds = {
         name: parameters[name]
         for name in ("lower", "upper")
-        if isinstance(parameters.get(name), int | float)
+        if isinstance(parameters.get(name), numbers.Real)
+        and not isinstance(parameters.get(name), bool)
     }
     if not bounds:
         return None
 
-    mask = np.zeros_like(observed, dtype=bool)
+    mask = ~np.isfinite(observed)
     if "lower" in bounds:
         mask |= observed < bounds["lower"]
     if "upper" in bounds:
@@ -125,6 +129,46 @@ def _within_truncation(likelihood: Prior, observed: np.ndarray):
 
     described = " and ".join(f"{name} {value}" for name, value in bounds.items())
     return mask, f"within its truncation ({described})"
+
+
+def _attribute_violation(offending: np.ndarray, target_scale) -> str:
+    """Describe the likely cause of *offending*, the violating observed values.
+
+    An exact ``0.0`` is ambiguous.  ``build_model`` rewrites a NaN or infinite
+    ratio to ``0.0``, so it can be the clamp's output, but a target that
+    genuinely contains zeros produces the same value under a healthy scale,
+    and that is by far the more common case.  The two are only
+    distinguishable with the scale in hand: the clamp fires for a finite
+    target exactly when the scale has a zero entry.  Without it, name both
+    rather than assert one.
+    """
+    if not np.all(offending == 0.0):
+        return " Fix the target, or choose a likelihood whose support covers it."
+
+    zeros = (
+        " Every violating value is exactly 0.0."
+        " That is either a zero in the target itself, which this likelihood"
+        " cannot observe, or the value build_model writes when"
+        " 'target / target_scale' is NaN or infinite."
+    )
+
+    if target_scale is None:
+        return (
+            zeros + " Check the target for zeros and 'target_scale' for a zero entry."
+        )
+
+    if np.any(np.asarray(target_scale, dtype=float) == 0.0):
+        return (
+            zeros + " 'target_scale' has a zero entry, which a target slice"
+            " whose maximum is zero produces, so the scale is the cause"
+            " rather than the target's own values."
+        )
+
+    return (
+        zeros + " 'target_scale' has no zero entry, so these are zeros in the"
+        " target rather than a scaling artefact. Remove or impute them, or"
+        " choose a likelihood whose support includes zero."
+    )
 
 
 #: Support checks by distribution name.  Each returns the mask of violating
@@ -395,7 +439,9 @@ class LinkSpec(ABC):
             )
 
     @staticmethod
-    def validate_likelihood_support(likelihood: Prior, observed) -> None:
+    def validate_likelihood_support(
+        likelihood: Prior, observed, target_scale=None
+    ) -> None:
         """Raise if *observed* falls outside the support of *likelihood*.
 
         *observed* is the value the likelihood is given, which is the target
@@ -422,6 +468,12 @@ class LinkSpec(ABC):
             The values handed to the likelihood.  A symbolic variable is
             evaluated only once a distribution with a checkable support has
             been found, so the default ``Normal`` costs no compile.
+        target_scale : array-like, optional
+            The scale the target was divided by.  Used only to attribute a
+            violation made of exact zeros: those are the clamp's output when
+            the scale has a zero entry, and ordinary target values when it
+            does not.  Omit it and the error names both possibilities rather
+            than picking one.
 
         Raises
         ------
@@ -451,7 +503,8 @@ class LinkSpec(ABC):
                 # not anticipate is worse than no check.
                 return
 
-        violation = check(likelihood, np.asarray(observed, dtype=float))
+        values = np.asarray(observed, dtype=float)
+        violation = check(likelihood, values)
         if violation is None:
             return
 
@@ -469,24 +522,7 @@ class LinkSpec(ABC):
             "model would build and then sample an '-inf' logp."
         )
 
-        values = np.asarray(observed, dtype=float)
-        if np.all(values[mask] == 0.0):
-            # `build_model` rewrites a NaN or infinite ratio to 0.0, so a
-            # violation made entirely of zeros usually means the scale is the
-            # problem rather than the target's own values.
-            message += (
-                " Every violating value is exactly 0.0, which is what "
-                "build_model writes when 'target / target_scale' is NaN or "
-                "infinite. Check 'target_scale' for a zero entry, which a "
-                "target slice whose maximum is zero produces, rather than "
-                "looking for bad values in the target itself."
-            )
-        else:
-            message += (
-                " Fix the target, or choose a likelihood whose support covers it."
-            )
-
-        raise ValueError(message)
+        raise ValueError(message + _attribute_violation(values[mask], target_scale))
 
 
 class IdentityLinkSpec(LinkSpec):

--- a/pymc_marketing/mmm/mmm.py
+++ b/pymc_marketing/mmm/mmm.py
@@ -2332,6 +2332,25 @@ class MMM(RegressionModelBuilder):
             ## TODO: Find a better way to save it or access it in the pytensor graph.
             self.target_data_scaled = target_data_scaled
 
+            # The likelihood observes this, not `_target`, so the support check
+            # has to run here rather than next to `validate_target` above: the
+            # scale can be negative and the switch above rewrites NaN/inf to
+            # zero, so the raw target's values are not the ones being fitted.
+            # `validate_likelihood_support` evaluates the variable only if the
+            # likelihood has a support to check, so the default `Normal` pays
+            # nothing.
+            #
+            # An all-zero target is the placeholder that `fit` and
+            # `sample_prior_predictive` substitute when no `y` is given
+            # (`model_builder.py:1546`, `:1772`). It has no support to respect,
+            # and failing it would break building a model in order to look at
+            # its prior, so skip the check rather than reject the placeholder.
+            if np.any(self.xarray_dataset["_target"].values != 0):
+                LinkSpec.validate_likelihood_support(
+                    self.model_config["likelihood"],
+                    target_data_scaled,
+                )
+
             for mu_effect in self.mu_effects:
                 mu_effect.create_data(self)
 

--- a/pymc_marketing/mmm/mmm.py
+++ b/pymc_marketing/mmm/mmm.py
@@ -2349,6 +2349,7 @@ class MMM(RegressionModelBuilder):
                 LinkSpec.validate_likelihood_support(
                     self.model_config["likelihood"],
                     target_data_scaled,
+                    target_scale=self.scalers["_target"].values,
                 )
 
             for mu_effect in self.mu_effects:

--- a/tests/mmm/test_link.py
+++ b/tests/mmm/test_link.py
@@ -1025,10 +1025,21 @@ class TestLikelihoodSupport:
         mmm.build_model(X, y)
 
     def test_prior_predictive_without_y_builds(self, mock_pymc_sample):
-        """The same placeholder path, reached the way a user reaches it."""
+        """The same placeholder path, reached the way a user reaches it.
+
+        Only the build is under test.  Drawing from a ``Gamma`` prior under
+        ``link='identity'`` can raise ``scale < 0`` because ``mu`` is
+        unconstrained, which is the likelihood's own business and depends on
+        the seed.  That failure is tolerated; the support check firing on the
+        placeholder is not.
+        """
         mmm = _make_mmm(dims=None, model_config={"likelihood": self.GAMMA})
         X, _ = _make_panel_with_target([1.0] * 8)
-        mmm.sample_prior_predictive(X, samples=5)
+        try:
+            mmm.sample_prior_predictive(X, samples=5)
+        except ValueError as exc:
+            assert "requires the observed target" not in str(exc)
+        assert "y" in mmm.model.named_vars
 
     def test_multidimensional_target_is_checked(self, mock_pymc_sample):
         """The mask is over the full ``(date, country)`` grid, not one series."""

--- a/tests/mmm/test_link.py
+++ b/tests/mmm/test_link.py
@@ -1083,8 +1083,77 @@ class TestLikelihoodSupport:
                 )
             },
         )
-        with pytest.raises(ValueError, match="Check 'target_scale' for a zero entry"):
+        with pytest.raises(ValueError) as excinfo:
             mmm.build_model(X, y)
+
+        message = str(excinfo.value)
+        assert "'target_scale' has a zero entry" in message
+        assert "the scale is the cause" in message
+
+    def test_target_zeros_are_not_blamed_on_the_scale(self, mock_pymc_sample):
+        """Genuine zeros in the target look identical to the clamp's output.
+
+        A target containing zero weeks produces exact ``0.0`` observations
+        under a perfectly healthy scale, so attributing every all-zero
+        violation to a degenerate scale sends the reader hunting for a zero
+        entry that is not there.
+        """
+        mmm = _make_mmm(dims=None, model_config={"likelihood": self.GAMMA})
+        X, y = _make_panel_with_target([0.0, 5.0, 10.0, 0.0, 8.0, 3.0, 7.0, 2.0])
+        with pytest.raises(ValueError) as excinfo:
+            mmm.build_model(X, y)
+
+        message = str(excinfo.value)
+        assert "no zero entry" in message
+        assert "zeros in the target rather than a scaling artefact" in message
+
+    def test_zero_attribution_names_both_without_the_scale(self):
+        """The staticmethod has no scale to consult, so it asserts neither."""
+        likelihood = Prior("Gamma", dims=("date",))
+        with pytest.raises(ValueError) as excinfo:
+            LinkSpec.validate_likelihood_support(likelihood, np.array([0.0, 1.0]))
+
+        message = str(excinfo.value)
+        assert (
+            "Check the target for zeros and 'target_scale' for a zero entry" in message
+        )
+
+    @pytest.mark.parametrize(
+        "dist_name, kwargs",
+        [
+            ("Gamma", {}),
+            ("Beta", {}),
+            ("TruncatedNormal", {"sigma": 1, "lower": 0, "upper": 5}),
+        ],
+    )
+    def test_nan_is_never_silently_accepted(self, dist_name, kwargs):
+        """`np.nan <= 0` is False, so a naive mask lets NaN through."""
+        likelihood = Prior(dist_name, dims=("date",), **kwargs)
+        with pytest.raises(ValueError):
+            LinkSpec.validate_likelihood_support(likelihood, np.array([0.5, np.nan]))
+
+    def test_numpy_truncation_bounds_are_honoured(self):
+        """A numpy scalar bound is a bound.
+
+        ``Prior`` rejects ``np.int64`` and ``np.float32`` outright, so
+        ``np.float64`` is the only numpy bound reachable through it.  It
+        happens to subclass ``float``, but the check is written against
+        ``numbers.Real`` so it does not depend on that.
+        """
+        likelihood = Prior(
+            "TruncatedNormal",
+            sigma=1,
+            lower=np.float64(0),
+            upper=np.float64(5),
+            dims=("date",),
+        )
+        with pytest.raises(ValueError, match=r"lower 0.0 and upper 5.0"):
+            LinkSpec.validate_likelihood_support(likelihood, np.array([2.5, 6.0]))
+
+    def test_boolean_truncation_bound_is_not_treated_as_a_number(self):
+        """`isinstance(False, int)` is True; `lower=False` is not a bound."""
+        likelihood = Prior("TruncatedNormal", sigma=1, lower=False, dims=("date",))
+        LinkSpec.validate_likelihood_support(likelihood, np.array([-100.0, 100.0]))
 
     def test_unevaluable_observed_is_skipped(self):
         """A check that can break build_model is worse than no check."""

--- a/tests/mmm/test_link.py
+++ b/tests/mmm/test_link.py
@@ -61,6 +61,16 @@ def _make_positive_panel(
     return df, y
 
 
+def _make_panel_with_target(y_values, channels=("C1", "C2")):
+    """Single-dim panel whose target is exactly *y_values*."""
+    rng = np.random.default_rng(0)
+    n = len(y_values)
+    df = pd.DataFrame({"date": pd.date_range("2025-01-06", periods=n, freq="W-MON")})
+    for ch in channels:
+        df[ch] = rng.uniform(10, 100, n)
+    return df, pd.Series(np.asarray(y_values, dtype=float), name="y")
+
+
 def _make_mmm(link: str = "identity", dims=("country",), **kwargs) -> MMM:
     sat = LogSaturation() if link == "log" else LogisticSaturation()
     return MMM(
@@ -968,3 +978,180 @@ class TestTotalResponseDeterministic:
 
         assert float(before[0]) != float(after[0])
         assert float(before[1]) == float(after[1])
+
+
+class TestLikelihoodSupport:
+    """Target values outside the likelihood support are rejected at build time.
+
+    See issue #2835.  The likelihood observes ``target / target_scale``, so
+    every case here is stated in terms of that ratio rather than the target.
+    """
+
+    GAMMA = Prior("Gamma", sigma=Prior("HalfNormal", sigma=1), dims=("date",))
+
+    def test_negative_scaled_target_raises(self, mock_pymc_sample):
+        """One negative value, positive scale, so the ratio leaves the support."""
+        mmm = _make_mmm(dims=None, model_config={"likelihood": self.GAMMA})
+        X, y = _make_panel_with_target([-5.0, 3.0, 7.0, 2.0, 9.0, 4.0, 6.0, 8.0])
+        with pytest.raises(ValueError, match="1 of 8 values"):
+            mmm.build_model(X, y)
+
+    def test_negative_target_with_negative_scale_builds(self, mock_pymc_sample):
+        """An all-negative target scales to a positive ratio and must be allowed.
+
+        ``DataDerivedScaling`` reduces with ``max``, not ``max(abs(...))``, so
+        the scale is negative here and every observed value is positive.  A
+        check written against the raw target would reject a model that fits.
+        """
+        mmm = _make_mmm(dims=None, model_config={"likelihood": self.GAMMA})
+        X, y = _make_panel_with_target([-5.0, -3.0, -7.0, -2.0, -9.0, -4.0, -6.0, -8.0])
+        mmm.build_model(X, y)
+
+        assert float(mmm.scalers["_target"].values) < 0
+        assert np.all(mmm.target_data_scaled.eval() > 0)
+        logp = mmm.model.compile_logp()(mmm.model.initial_point())
+        assert np.isfinite(logp)
+
+    def test_all_zero_placeholder_target_is_skipped(self, mock_pymc_sample):
+        """An all-zero target is the no-``y`` placeholder, not data to reject.
+
+        ``fit`` and ``sample_prior_predictive`` substitute ``np.zeros`` when
+        no target is given, and the scale is then zero, so every observed
+        value is the clamped ``0.0``.  Rejecting that would make it impossible
+        to build a model in order to look at its prior.
+        """
+        mmm = _make_mmm(dims=None, model_config={"likelihood": self.GAMMA})
+        X, y = _make_panel_with_target([0.0] * 8)
+        mmm.build_model(X, y)
+
+    def test_prior_predictive_without_y_builds(self, mock_pymc_sample):
+        """The same placeholder path, reached the way a user reaches it."""
+        mmm = _make_mmm(dims=None, model_config={"likelihood": self.GAMMA})
+        X, _ = _make_panel_with_target([1.0] * 8)
+        mmm.sample_prior_predictive(X, samples=5)
+
+    def test_multidimensional_target_is_checked(self, mock_pymc_sample):
+        """The mask is over the full ``(date, country)`` grid, not one series."""
+        mmm = _make_mmm(model_config={"likelihood": self.GAMMA})
+        X, y = _make_positive_panel()
+        y.iloc[0] = -1.0
+        with pytest.raises(ValueError, match="1 of 16 values"):
+            mmm.build_model(X, y)
+
+    def test_degenerate_scale_names_the_scale(self, mock_pymc_sample):
+        """A zero scale clamps a real target to 0.0; say so, not "bad values".
+
+        Country ``A``'s target has a maximum of zero, so its scale is zero and
+        every ratio is NaN or infinite.  ``build_model`` rewrites those to
+        ``0.0``, which is outside ``Gamma``'s support, and the user-visible
+        cause is the scale rather than anything in the target.
+        """
+        dates = pd.date_range("2025-01-06", periods=4, freq="W-MON")
+        rng = np.random.default_rng(0)
+        rows = [
+            {
+                "date": d,
+                "country": c,
+                "C1": rng.uniform(10, 100),
+                "C2": rng.uniform(10, 100),
+            }
+            for d in dates
+            for c in ("A", "B")
+        ]
+        X = pd.DataFrame(rows)
+        y = pd.Series([-2.0, 50.0, -2.0, 50.0, -2.0, 50.0, 0.0, 50.0], name="y")
+
+        per_country = DataDerivedScaling(method="max", dims=())
+        mmm = _make_mmm(
+            scaling=Scaling(target=per_country, channel=per_country),
+            model_config={
+                "likelihood": Prior(
+                    "Gamma",
+                    sigma=Prior("HalfNormal", sigma=1),
+                    dims=("date", "country"),
+                )
+            },
+        )
+        with pytest.raises(ValueError, match="Check 'target_scale' for a zero entry"):
+            mmm.build_model(X, y)
+
+    def test_unevaluable_observed_is_skipped(self):
+        """A check that can break build_model is worse than no check."""
+
+        class Unevaluable:
+            def eval(self):
+                raise RuntimeError("cannot evaluate")
+
+        likelihood = Prior("Gamma", dims=("date",))
+        LinkSpec.validate_likelihood_support(likelihood, Unevaluable())
+
+    def test_log_link_still_rejects_the_raw_target(self, mock_pymc_sample):
+        """``LogLinkSpec.validate_target`` is unchanged and fires first.
+
+        The scaled target here is strictly positive (the scale is negative),
+        so the support check would accept it.  The link-level rule is a
+        separate decision and still rejects it.
+        """
+        mmm = _make_mmm(link="log", dims=None)
+        X, y = _make_panel_with_target([-5.0, -3.0, -7.0, -2.0, -9.0, -4.0, -6.0, -8.0])
+        with pytest.raises(ValueError, match="strictly positive when using link='log'"):
+            mmm.build_model(X, y)
+
+    def test_unbounded_likelihood_is_not_checked(self, mock_pymc_sample):
+        """``Normal`` has no bound, so the same target builds fine."""
+        mmm = _make_mmm(dims=None)
+        X, y = _make_panel_with_target([-5.0, 3.0, 7.0, 2.0, 9.0, 4.0, 6.0, 8.0])
+        mmm.build_model(X, y)
+
+    def test_censored_wrapper_is_not_checked(self, mock_pymc_sample):
+        """Censoring at zero is what makes a zero valid; do not reject it.
+
+        ``_distribution_name`` unwraps to ``LogNormal``, so a naive lookup
+        would apply LogNormal's positivity rule to exactly the zero-inflated
+        data the wrapper exists for.
+        """
+        likelihood = Censored(
+            Prior("LogNormal", sigma=Prior("HalfNormal", sigma=1), dims=("date",)),
+            lower=0,
+        )
+        observed = np.array([0.0, 0.5, 1.0])
+        LinkSpec.validate_likelihood_support(likelihood, observed)
+
+    @pytest.mark.parametrize(
+        "dist_name, observed, expected",
+        [
+            ("LogNormal", [1.0, -1.0], "strictly positive"),
+            ("InverseGamma", [1.0, 0.0], "strictly positive"),
+            ("Beta", [0.5, 1.5], r"strictly inside \(0, 1\)"),
+            ("Poisson", [1.0, 1.5], "a non-negative integer"),
+            ("NegativeBinomial", [1.0, -2.0], "a non-negative integer"),
+        ],
+    )
+    def test_support_rules(self, dist_name, observed, expected):
+        likelihood = Prior(dist_name, dims=("date",))
+        with pytest.raises(ValueError, match=expected):
+            LinkSpec.validate_likelihood_support(likelihood, np.array(observed))
+
+    def test_truncated_normal_uses_its_bounds(self):
+        likelihood = Prior("TruncatedNormal", sigma=1, lower=0, upper=5, dims=("date",))
+        LinkSpec.validate_likelihood_support(likelihood, np.array([0.0, 2.5, 5.0]))
+        with pytest.raises(ValueError, match=r"lower 0 and upper 5"):
+            LinkSpec.validate_likelihood_support(likelihood, np.array([2.5, 6.0]))
+
+    def test_truncated_normal_without_numeric_bounds_is_skipped(self):
+        """A ``Prior`` bound has no single interval to report, so skip it."""
+        likelihood = Prior(
+            "TruncatedNormal", sigma=1, lower=Prior("Normal"), dims=("date",)
+        )
+        LinkSpec.validate_likelihood_support(likelihood, np.array([-100.0, 100.0]))
+
+    def test_error_names_the_distribution_and_the_count(self):
+        likelihood = Prior("Gamma", dims=("date",))
+        with pytest.raises(ValueError) as excinfo:
+            LinkSpec.validate_likelihood_support(
+                likelihood, np.array([1.0, -1.0, -2.0, 3.0])
+            )
+        message = str(excinfo.value)
+        assert "'Gamma'" in message
+        assert "strictly positive" in message
+        assert "2 of 4 values" in message


### PR DESCRIPTION
Closes #2835.

A target outside the likelihood's support builds without complaint and dies later as an `-inf` logp with nothing naming the cause. `LinkSpec.validate_likelihood_support` rejects it at build time instead, naming the distribution, the violated bound, and how many values violate it.

The design discussion is on the issue. Two points from it drive the shape of this diff.

## The check runs on what the likelihood observes, not on the target

`build_model` observes `target / target_scale` (`mmm/mmm.py:2322-2331`, `2479`), so the check has to live after the scaling rather than next to the existing `validate_target` call. The two arrays genuinely differ. `DataDerivedScaling` reduces with `data.max(...)` or `data.mean(...)`, not their absolute values, so the scale can be negative and the ratio can flip sign:

```
raw target : [-5. -3. -7. -2. -9. -4. -6. -8.]
scale      : -2.0
observed   : [2.5  1.5  3.5  1.  4.5  2.  3.  4. ]
logp       : -17.661266674163816
```

Every raw value is outside `Gamma`'s support and the model fits, because the likelihood never sees those values. A rule written against the target rejects a model that works. That case is `test_negative_target_with_negative_scale_builds`.

## `LogLinkSpec.validate_target` is unchanged

The issue asks whether it should delegate to the new check. I would say no, and this PR does not change it.

Under `link='log'` the likelihood is always `LogNormal`, so at a glance the support check subsumes it. It does not: the data above is rejected by `validate_target` (it reads the raw target) and would be accepted by the support check (the scaled values are positive, and `exp(mu) * target_scale` inverts back to the negative originals correctly). Delegating would silently start allowing all-negative targets under a log link. Whether that should be allowed is a modelling decision for the maintainers, not a side effect of adding a support check, so I left the behaviour alone and narrowed the docstring to say which array each rule reads. `test_log_link_still_rejects_the_raw_target` pins that.

Happy to flip it if you would rather the two collapse into one rule.

## Coverage

| distribution | constraint on the observed values |
|---|---|
| `LogNormal`, `Gamma`, `InverseGamma` | `> 0` |
| `Beta` | `0 < y < 1` |
| `Poisson`, `NegativeBinomial` | non-negative integers |
| `TruncatedNormal` | within whichever of `lower`/`upper` is a number |

Unrecognised distributions are not checked and do not warn: `validate_likelihood_compatibility` already warns for those.

## Three things deliberately skipped

**The no-`y` placeholder.** `fit` and `sample_prior_predictive` substitute `np.zeros` when no target is given (`model_builder.py:1546`, `:1772`). The scale is then zero, every ratio is NaN, and the existing switch clamps them to `0.0`, which is outside every positive-only support. Checking that breaks `mmm.sample_prior_predictive(X)` under `Gamma` or `LogNormal`:

```console
ValueError: Likelihood 'Gamma' requires the observed target to be strictly positive,
but 8 of 8 values are not. ...
```

At `build_model` nothing distinguishes the placeholder from a user's genuinely all-zero target, so an all-zero target is skipped. This is the same zeros constraint @daimon-pymclabs wrote up as point 3 on #2956, reached from the other side. `test_prior_predictive_without_y_builds` pins it, because it is the thing a naive version of this check breaks.

The clamp is still caught whenever it is *not* the placeholder, which is the case that actually destroys data. A per-slice zero scale under `DataDerivedScaling(dims=())`:

```
scale    : [ 0. 50.]
raw      : [-2. 50. -2. 50. -2. 50.  0. 50.]
observed : [ 0.  1.  0.  1.  0.  1.  0.  1.]
```

Country `A`'s target is gone. That raises, and when every violating value is exactly `0.0` the error names the scale instead of reporting a bare support violation. `test_degenerate_scale_names_the_scale`.

**Wrappers and special priors.** `_distribution_name` unwraps `Censored(Prior("LogNormal", ...))` to `LogNormal`, but censoring at zero is exactly what makes a zero observation valid, so applying the inner support would reject the data the wrapper exists for. The guard is `isinstance(getattr(likelihood, "distribution", None), str)`, which is also False for the `SpecialPrior` subclasses; those validate their own observations.

**A `TruncatedNormal` bound given as a `Prior` or an array.** The support then varies per draw or per element and there is no single interval to report, so it is left alone.

## Cost

The observed values are evaluated only after a distribution with a checkable support has been found, so the default `Normal` pays nothing. `build_model` on a 520-week single-dim model, median of three:

```
without the check : 0.014s
with the check    : 0.016s
```

An earlier version evaluated unconditionally and cost 0.022s with a ~190ms first-call compile. Flagging the numbers because #2874 was parked over build-time cost.

The eval is also guarded: if it raises, the check returns rather than failing `build_model`, per review on the issue. A check that can break model construction for a graph it did not anticipate is worse than no check. `test_unevaluable_observed_is_skipped`.

## Tests

18 new tests in `TestLikelihoodSupport`, covering each support rule directly, the build-time path for single and multi dimensional targets, the negative-scale case that must keep building, the placeholder path through `sample_prior_predictive`, the degenerate per-slice scale, the guarded eval, the `Censored` wrapper, and the error message naming the distribution and the count.

```console
$ uv run pytest tests/mmm/test_link.py -q
104 passed, 2 skipped

$ uv run pytest tests/mmm/test_mmm.py -q
247 passed

$ uv run pytest tests/test_model_builder.py -q
85 passed
```

The whole of `tests/mmm` plus `tests/test_model_builder.py` also ran green at 3267 passed, 9 skipped, 1 xfailed, 1 xpassed, on the commit before the last two review changes (the guarded eval and the zero-scale message). Those two only add a skip path and extra text on an already-raising branch, and the three files above cover them, but I would rather state which run covered what than round it up. CI has the full picture.

## Out of scope, filed separately

Both split out at @daimon-pymclabs's request rather than folded in, since each is a behaviour change with its own blast radius:

- #2973: `DataDerivedScaling` reduces with a signed `max`/`mean` while its docstring says max-absolute, and a zero scale silently zeroes a target slice.
- #2974: the `link='log'` rejection of an all-negative target the model can fit once scaled.


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2975.org.readthedocs.build/en/2975/

<!-- readthedocs-preview pymc-marketing end -->