### PR TITLE
feat: compose BG/NBD parameters as terms outside the model

### DIFF
--- a/pymc_marketing/clv/models/basic.py
+++ b/pymc_marketing/clv/models/basic.py
@@ -122,7 +122,7 @@ class CLVModel(ModelBuilder):
         else:
             return f"{self._model_type}\n{self.model.str_repr()}"
 
-    def _prepare_fit(self, data: pd.DataFrame | None = None) -> None:
+    def _prepare_fit(self, data: pd.DataFrame | xr.Dataset | None = None) -> None:
         """Build the model on first fit, and reject a second fit on different data.
 
         CLV models bake the training data into the model graph, so refitting a built
@@ -135,11 +135,17 @@ class CLVModel(ModelBuilder):
                     "or call `build_model(data)` first."
                 )
             self.build_model(data)  # type: ignore[call-arg]
-        elif data is not None and not self.data.equals(data):  # type: ignore[attr-defined]
-            raise ValueError(
-                "The model was built with different data. "
-                "Create a new model instance to fit new data."
-            )
+        elif data is not None:
+            if isinstance(data, xr.Dataset):
+                modeling_data = getattr(self, "_modeling_data", None)
+                same = modeling_data is not None and bool(data.equals(modeling_data))
+            else:
+                same = bool(self.data.equals(data))  # type: ignore[attr-defined]
+            if not same:
+                raise ValueError(
+                    "The model was built with different data. "
+                    "Create a new model instance to fit new data."
+                )
 
     @classmethod
     def build_from_idata(cls, idata: xr.DataTree) -> None:
@@ -148,9 +154,18 @@ class CLVModel(ModelBuilder):
         model = cls(**kwargs)
 
         model.idata = idata
-        model.data = idata.fit_data.dataset.to_dataframe()
+        fit_data = idata.fit_data.dataset
+        if "customer_id" in fit_data.coords:
+            # New-shape fit_data: the modeling dataset (recipes may bind
+            # arbitrary data variables). The Dataset path validates and
+            # reconstructs the customer-level DataFrame.
+            model.build_model(fit_data)  # type: ignore[call-arg]
+        else:
+            # Old-shape fit_data: a plain DataFrame dump (customer_id as a
+            # variable on the "index" dimension).
+            model.data = fit_data.to_dataframe()  # type: ignore[attr-defined]
+            model.build_model(model.data)  # type: ignore[call-arg,attr-defined]
 
-        model.build_model(model.data)  # type: ignore
         if model.id != idata.attrs["id"]:
             msg = (
                 "The model id in the DataTree does not match the model id. "
@@ -159,7 +174,7 @@ class CLVModel(ModelBuilder):
                 "Investigate if the model structure or configuration has changed."
             )
             raise DifferentModelError(msg)
-        return model
+        return model  # type: ignore[return-value]
 
     def thin_fit_result(self, keep_every: int):
         """Return a copy of the model with a thinned fit result.
@@ -200,6 +215,20 @@ class CLVModel(ModelBuilder):
     @property
     def _serializable_model_config(self) -> dict:
         return self.model_config
+
+    def create_fit_data_group(self) -> xr.Dataset | None:
+        """Build the ``fit_data`` group stored alongside the posterior.
+
+        When the model persisted a modeling dataset (``_modeling_data`` set
+        during ``build_model``), it is merged with the customer-level
+        DataFrame so every recipe-bound data variable survives
+        serialization. Otherwise the base implementation is used.
+        """
+        modeling_data = getattr(self, "_modeling_data", None)
+        if modeling_data is None or getattr(self, "data", None) is None:
+            return super().create_fit_data_group()
+        customer_part = self.data.set_index("customer_id").to_xarray()  # type: ignore[attr-defined]
+        return xr.merge([customer_part, modeling_data], compat="no_conflicts")
 
     def fit_summary(self, **kwargs):
         """Compute the summary of the fit result."""

--- a/pymc_marketing/clv/models/beta_geo.py
+++ b/pymc_marketing/clv/models/beta_geo.py
@@ -435,6 +435,15 @@ def _dataset_to_dataframe(
         *[(col, "dropout_data", "dropout_covariate") for col in dropout_cols],
     ]:
         data[col] = np.asarray(ds[var].sel({dim: col}))
+    # Carry over remaining customer-level variables (e.g. extra user
+    # columns such as dates) so the round-trip preserves them.
+    for name in map(str, ds.data_vars):
+        if name in data:
+            continue
+        values = np.asarray(ds[name])
+        if values.ndim != 1:
+            continue
+        data[name] = values
     return pd.DataFrame(data)
 
 
@@ -723,6 +732,12 @@ class BetaGeoModel(CLVModel):
             dot.var_name for term in spec.values() for dot in _iter_dots(term)
         }
 
+        spec = self._parameter_spec
+        terms = collect_terms(list(spec.values()))
+        data_bound = {
+            dot.var_name for term in spec.values() for dot in _iter_dots(term)
+        }
+
         if isinstance(data, xarray.Dataset):
             ds = data
             _validate_modeling_dataset(
@@ -746,6 +761,9 @@ class BetaGeoModel(CLVModel):
                 purchase_cols=self.purchase_covariate_cols,
                 dropout_cols=self.dropout_covariate_cols,
             )
+        # Persist the dataset the recipes actually bound so it survives
+        # serialization (see ``create_fit_data_group``).
+        self._modeling_data = ds
 
         coords = {
             "purchase_covariate": self.purchase_covariate_cols,
@@ -775,24 +793,24 @@ class BetaGeoModel(CLVModel):
             )
 
     def _check_dataframe_recipe_support(self, data_bound: set[str]) -> None:
-        """Raise for custom recipes the DataFrame path cannot data-bind.
+        """Raise for recipes the DataFrame path cannot data-bind.
 
-        Recipes that bind data variables need discoverable columns: either
-        the columns embedded by the covariate helpers, the deprecated
-        config keys, or an ``xr.Dataset`` passed to ``build_model``.
+        The DataFrame path can construct exactly two data variables: from
+        the purchase covariate columns (``purchase_data``) and the dropout
+        covariate columns (``dropout_data``). Any other recipe-bound
+        variable requires an ``xr.Dataset`` passed to ``build_model``.
         """
-        expected = {
-            "purchase_data": self.purchase_covariate_cols,
-            "dropout_data": self.dropout_covariate_cols,
+        can_provide = {
+            "purchase_data": bool(self.purchase_covariate_cols),
+            "dropout_data": bool(self.dropout_covariate_cols),
         }
-        for var_name, cols in expected.items():
-            if var_name in data_bound and not cols:
+        for var_name in sorted(data_bound):
+            if not can_provide.get(var_name, False):
                 raise ValueError(
-                    f"A recipe binds the data variable {var_name!r} but no "
-                    "covariate columns are configured. Pass columns via "
-                    "create_purchase_covariates / create_dropout_covariates, "
-                    "the deprecated config keys, or pass an xr.Dataset to "
-                    "build_model."
+                    f"A recipe binds the data variable {var_name!r} which cannot "
+                    "be constructed from a DataFrame. Pass the covariate columns "
+                    "(create_purchase_covariates / create_dropout_covariates), or "
+                    "an xr.Dataset to build_model."
                 )
 
     def _check_recipes_predictable(self) -> None:

--- a/pymc_marketing/clv/models/beta_geo.py
+++ b/pymc_marketing/clv/models/beta_geo.py
@@ -13,21 +13,429 @@
 #   limitations under the License.
 """Beta-Geometric Negative Binomial Distribution (BG/NBD) model for a non-contractual customer population across continuous time."""  # noqa: E501
 
+from __future__ import annotations
+
+import warnings
 from collections.abc import Sequence
-from typing import Literal
+from dataclasses import dataclass
+from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
 import pymc as pm
+import pytensor.xtensor as ptx
 import xarray
 from pymc.util import RandomState
-from pymc_extras.prior import Prior
+from pymc_extras.prior import Prior, VariableFactory
 from scipy.special import betaln, expit, hyp2f1
 
 from pymc_marketing.clv.distributions import BetaGeoNBD
 from pymc_marketing.clv.models.basic import CLVModel
 from pymc_marketing.clv.utils import to_xarray
 from pymc_marketing.model_config import ModelConfig
+from pymc_marketing.serialization import serialization
+from pymc_marketing.terms import (
+    Dot,
+    ModelTerm,
+    Named,
+    Parameter,
+    Product,
+    Ref,
+    Sum,
+    Transform,
+    _as_plain_tensor,
+    _deserialize_child,
+    build_param,
+    collect_coords,
+    collect_terms,
+    register_data,
+)
+
+
+@serialization.register
+@dataclass
+class _Covariates(Named):
+    """A covariate recipe carrying the DataFrame columns it consumes."""
+
+    cols: Sequence[str] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the named recipe with its columns."""
+        return {**super().to_dict(), "cols": list(self.cols)}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> _Covariates:
+        """Reconstruct a covariate recipe from its serialized form."""
+        return cls(
+            name=data["name"],
+            expr=_deserialize_child(data["expr"]),
+            dims=data.get("dims"),
+            cols=data.get("cols", ()),
+        )
+
+
+def _covariate_dataset(
+    data: pd.DataFrame,
+    *,
+    purchase_cols: Sequence[str],
+    dropout_cols: Sequence[str],
+) -> xarray.Dataset:
+    """Build the single dataset all covariate terms share."""
+    data_vars = {}
+    if purchase_cols:
+        data_vars["purchase_data"] = (
+            ("customer_id", "purchase_covariate"),
+            data[purchase_cols].to_numpy(),
+        )
+    if dropout_cols:
+        data_vars["dropout_data"] = (
+            ("customer_id", "dropout_covariate"),
+            data[dropout_cols].to_numpy(),
+        )
+    return xarray.Dataset(
+        data_vars,
+        coords={
+            "customer_id": data["customer_id"].to_numpy(),
+            "purchase_covariate": list(purchase_cols),
+            "dropout_covariate": list(dropout_cols),
+        },
+    )
+
+
+def create_purchase_covariates(
+    purchase_covariate_cols: Sequence[str],
+    *,
+    scale_prior: VariableFactory | None = None,
+    coefficient_prior: VariableFactory | None = None,
+) -> _Covariates:
+    """Create the standard BG/NBD purchase-rate covariate recipe.
+
+    Composes ``alpha = alpha_scale * exp(-X @ beta)`` outside the model.
+    The columns become part of the returned term, so passing this recipe
+    replaces the deprecated ``purchase_covariate_cols`` config key.
+
+    Parameters
+    ----------
+    purchase_covariate_cols : sequence of str
+        DataFrame columns for the covariates.
+    scale_prior : VariableFactory, optional
+        Prior for ``alpha_scale``. Defaults to ``Prior("Weibull", alpha=2, beta=10)``.
+    coefficient_prior : VariableFactory, optional
+        Prior for the coefficients. Defaults to ``Prior("Normal", mu=0, sigma=1)``
+        with ``dims="purchase_covariate"``.
+
+    Returns
+    -------
+    _Covariates
+        The ``alpha`` recipe with the columns embedded.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from pymc_marketing.clv.models.beta_geo import create_purchase_covariates
+
+        alpha = create_purchase_covariates(["income", "age"])
+        model = BetaGeoModel(model_config={"alpha": alpha})
+    """
+    cols = list(purchase_covariate_cols)
+    scale = scale_prior or Prior("Weibull", alpha=2, beta=10)
+    coefficient = coefficient_prior or Prior("Normal", mu=0, sigma=1)
+    if hasattr(coefficient, "dims"):
+        coefficient.dims = "purchase_covariate"
+    expr = Parameter("alpha_scale", prior=scale, xdist=False) * Transform(
+        -Dot(
+            var_name="purchase_data",
+            name="purchase_coefficient_alpha",
+            prior=coefficient,
+        ),
+        func=ptx.math.exp,
+    )
+    return _Covariates("alpha", expr, dims="customer_id", cols=cols)
+
+
+def create_dropout_covariates(
+    dropout_covariate_cols: Sequence[str],
+    *,
+    a_prior: VariableFactory | None = None,
+    b_prior: VariableFactory | None = None,
+    coefficient_prior: VariableFactory | None = None,
+) -> tuple[_Covariates, _Covariates]:
+    """Create the standard nested BG/NBD dropout covariate recipes.
+
+    Composes ``a = a_scale * exp(X @ beta_a)`` and ``b = b_scale * exp(X @ beta_b)``
+    outside the model. The columns become part of the returned terms, so
+    passing these recipes replaces the deprecated ``dropout_covariate_cols``
+    config key.
+
+    Parameters
+    ----------
+    dropout_covariate_cols : sequence of str
+        DataFrame columns for the covariates.
+    a_prior : VariableFactory, optional
+        Prior for ``a_scale``. Defaults to ``Prior("Beta", alpha=2, beta=3)``.
+    b_prior : VariableFactory, optional
+        Prior for ``b_scale``. Defaults to ``Prior("Beta", alpha=3, beta=2)``.
+    coefficient_prior : VariableFactory, optional
+        Prior for the coefficients. Defaults to ``Prior("Normal", mu=0, sigma=1)``
+        with ``dims="dropout_covariate"``.
+
+    Returns
+    -------
+    tuple of _Covariates
+        The ``a`` and ``b`` recipes, in that order.
+    """
+    cols = list(dropout_covariate_cols)
+    a_scale = a_prior or Prior("Beta", alpha=2, beta=3)
+    b_scale = b_prior or Prior("Beta", alpha=3, beta=2)
+    coefficient = coefficient_prior or Prior("Normal", mu=0, sigma=1)
+    if hasattr(coefficient, "dims"):
+        coefficient.dims = "dropout_covariate"
+    a_expr = Parameter("a_scale", prior=a_scale, xdist=False) * Transform(
+        Dot(
+            var_name="dropout_data",
+            name="dropout_coefficient_a",
+            prior=coefficient,
+        ),
+        func=ptx.math.exp,
+    )
+    b_expr = Parameter("b_scale", prior=b_scale, xdist=False) * Transform(
+        Dot(
+            var_name="dropout_data",
+            name="dropout_coefficient_b",
+            prior=coefficient,
+        ),
+        func=ptx.math.exp,
+    )
+    return (
+        _Covariates("a", a_expr, dims="customer_id", cols=cols),
+        _Covariates("b", b_expr, dims="customer_id", cols=cols),
+    )
+
+
+def _default_purchase_recipe(config: ModelConfig) -> ModelTerm:
+    """Build the default ``alpha`` recipe from the model configuration."""
+    cols = list(config.get("purchase_covariate_cols") or [])
+    if cols:
+        coefficient_prior: Any = config.get("purchase_coefficient") or Prior(
+            "Normal", mu=0, sigma=1
+        )
+        coefficient_prior.dims = "purchase_covariate"
+        expr = Parameter("alpha_scale", prior=config["alpha"]) * Transform(
+            -Dot(
+                var_name="purchase_data",
+                name="purchase_coefficient_alpha",
+                prior=coefficient_prior,
+            ),
+            func=ptx.math.exp,
+        )
+        return _Covariates("alpha", expr, dims="customer_id", cols=cols)
+    return Parameter("alpha", prior=config["alpha"], xdist=False)
+
+
+def _default_nested_dropout_recipes(config: ModelConfig) -> dict[str, ModelTerm]:
+    """Build the default nested (``a``/``b``) dropout recipes from the model configuration."""
+    cols = list(config.get("dropout_covariate_cols") or [])
+    if cols:
+        coefficient_prior: Any = config.get("dropout_coefficient") or Prior(
+            "Normal", mu=0, sigma=1
+        )
+        coefficient_prior.dims = "dropout_covariate"
+        a_expr = Parameter("a_scale", prior=config["a"]) * Transform(
+            Dot(
+                var_name="dropout_data",
+                name="dropout_coefficient_a",
+                prior=coefficient_prior,
+            ),
+            func=ptx.math.exp,
+        )
+        b_expr = Parameter("b_scale", prior=config["b"]) * Transform(
+            Dot(
+                var_name="dropout_data",
+                name="dropout_coefficient_b",
+                prior=coefficient_prior,
+            ),
+            func=ptx.math.exp,
+        )
+        return {
+            "a": _Covariates("a", a_expr, dims="customer_id", cols=cols),
+            "b": _Covariates("b", b_expr, dims="customer_id", cols=cols),
+        }
+    return {
+        "a": Parameter("a", prior=config["a"], xdist=False),
+        "b": Parameter("b", prior=config["b"], xdist=False),
+    }
+
+
+def _default_hierarchical_dropout_recipes(config: ModelConfig) -> dict[str, ModelTerm]:
+    """Build the default hierarchical (``phi``/``kappa``) dropout recipes from the model configuration."""
+    cols = list(config.get("dropout_covariate_cols") or [])
+    recipes: dict[str, ModelTerm] = {
+        "phi_dropout": Parameter(
+            "phi_dropout", prior=config["phi_dropout"], xdist=False
+        ),
+        "kappa_dropout": Parameter(
+            "kappa_dropout", prior=config["kappa_dropout"], xdist=False
+        ),
+    }
+    if cols:
+        coefficient_prior: Any = config.get("dropout_coefficient") or Prior(
+            "Normal", mu=0, sigma=1
+        )
+        coefficient_prior.dims = "dropout_covariate"
+        recipes["a_scale"] = Named("a_scale", Ref("phi_dropout") * Ref("kappa_dropout"))
+        recipes["b_scale"] = Named(
+            "b_scale", (1 - Ref("phi_dropout")) * Ref("kappa_dropout")
+        )
+        recipes["a"] = _Covariates(
+            "a",
+            Ref("a_scale")
+            * Transform(
+                Dot(
+                    var_name="dropout_data",
+                    name="dropout_coefficient_a",
+                    prior=coefficient_prior,
+                ),
+                func=ptx.math.exp,
+            ),
+            dims="customer_id",
+            cols=cols,
+        )
+        recipes["b"] = _Covariates(
+            "b",
+            Ref("b_scale")
+            * Transform(
+                Dot(
+                    var_name="dropout_data",
+                    name="dropout_coefficient_b",
+                    prior=coefficient_prior,
+                ),
+                func=ptx.math.exp,
+            ),
+            dims="customer_id",
+            cols=cols,
+        )
+    else:
+        recipes["a"] = Named("a", Ref("phi_dropout") * Ref("kappa_dropout"))
+        recipes["b"] = Named("b", (1 - Ref("phi_dropout")) * Ref("kappa_dropout"))
+    return recipes
+
+
+def _iter_dots(term: Any):
+    """Yield every ``Dot`` reachable in a (possibly composed) term."""
+    if isinstance(term, Dot):
+        yield term
+    elif isinstance(term, Sum):
+        for child in term.terms:
+            yield from _iter_dots(child)
+    elif isinstance(term, Product):
+        yield from _iter_dots(term.left)
+        yield from _iter_dots(term.right)
+    elif isinstance(term, Transform):
+        yield from _iter_dots(term.inner)
+    elif isinstance(term, Named):
+        yield from _iter_dots(term.expr)
+
+
+def _validate_modeling_dataset(
+    ds: xarray.Dataset,
+    *,
+    purchase_cols: Sequence[str],
+    dropout_cols: Sequence[str],
+    data_bound: set[str],
+) -> None:
+    """Check a dataset has the variables the recipes need.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        The modeling dataset.
+    purchase_cols : sequence of str
+        Effective purchase covariate columns.
+    dropout_cols : sequence of str
+        Effective dropout covariate columns.
+    data_bound : set of str
+        Data variable names bound by the recipes (``Dot.var_name`` values).
+
+    Raises
+    ------
+    ValueError
+        If required variables or coordinates are missing, if the dataset
+        provides covariate data no recipe binds, or if the covariate
+        coordinate labels do not match the effective columns.
+    """
+    required = {"customer_id", "T", "recency", "frequency"}
+    if purchase_cols:
+        required.add("purchase_data")
+    if dropout_cols:
+        required.add("dropout_data")
+    missing = required - (set(ds.data_vars) | set(ds.coords))
+    if missing:
+        raise ValueError(
+            "The dataset is missing required variables: "
+            f"{sorted(missing)}. 'customer_id' must be a coordinate; "
+            "'T', 'recency', and 'frequency' must be variables with the "
+            "'customer_id' dimension."
+        )
+    if "customer_id" not in ds.coords:
+        raise ValueError("The dataset must have 'customer_id' as a coordinate.")
+    if (
+        not purchase_cols
+        and "purchase_data" in ds.data_vars
+        and "purchase_data" not in data_bound
+    ):
+        raise ValueError(
+            "The dataset provides 'purchase_data' but no purchase covariate "
+            "columns are configured. Pass a purchase covariate recipe "
+            "(create_purchase_covariates) or the deprecated "
+            "'purchase_covariate_cols' config key."
+        )
+    if (
+        not dropout_cols
+        and "dropout_data" in ds.data_vars
+        and "dropout_data" not in data_bound
+    ):
+        raise ValueError(
+            "The dataset provides 'dropout_data' but no dropout covariate "
+            "columns are configured. Pass a dropout covariate recipe "
+            "(create_dropout_covariates) or the deprecated "
+            "'dropout_covariate_cols' config key."
+        )
+    for dim, cols in (
+        ("purchase_covariate", purchase_cols),
+        ("dropout_covariate", dropout_cols),
+    ):
+        if cols and dim in ds.coords and list(ds.coords[dim].values) != list(cols):
+            raise ValueError(
+                f"The dataset's {dim!r} coordinate labels {list(ds.coords[dim].values)} "
+                f"do not match the configured covariate columns {list(cols)}."
+            )
+
+
+def _dataset_to_dataframe(
+    ds: xarray.Dataset,
+    *,
+    purchase_cols: Sequence[str],
+    dropout_cols: Sequence[str],
+) -> pd.DataFrame:
+    """Reconstruct the modeling DataFrame from a modeling dataset.
+
+    Prediction methods and serialization operate on DataFrames; the
+    covariate columns are unwound from the ``purchase_data`` /
+    ``dropout_data`` variables using their covariate coordinates.
+    """
+    data: dict[str, Any] = {
+        "customer_id": np.asarray(ds.coords["customer_id"]),
+        "T": np.asarray(ds["T"]),
+        "recency": np.asarray(ds["recency"]),
+        "frequency": np.asarray(ds["frequency"]),
+    }
+    for col, var, dim in [
+        *[(col, "purchase_data", "purchase_covariate") for col in purchase_cols],
+        *[(col, "dropout_data", "dropout_covariate") for col in dropout_cols],
+    ]:
+        data[col] = np.asarray(ds[var].sel({dim: col}))
+    return pd.DataFrame(data)
 
 
 class BetaGeoModel(CLVModel):
@@ -150,7 +558,14 @@ class BetaGeoModel(CLVModel):
     """  # noqa: E501
 
     _model_type = "BG/NBD"  # Beta-Geometric Negative Binomial Distribution
-    _skipped_config_keys = {"a", "b"}
+    _skipped_config_keys = {
+        "a",
+        "b",
+        "purchase_covariate_cols",
+        "dropout_covariate_cols",
+        "purchase_coefficient",
+        "dropout_coefficient",
+    }
 
     def __init__(
         self,
@@ -162,29 +577,98 @@ class BetaGeoModel(CLVModel):
             model_config=model_config,
             sampler_config=sampler_config,
         )
+        self._warn_deprecated_covariate_config()
+        self._resolve_parameter_recipes()
+
+    _DEPRECATED_CONFIG_KEYS = {
+        "purchase_covariate_cols": (
+            "Pass a term recipe instead, e.g. model_config={'alpha': "
+            "create_purchase_covariates(['cov'])}. The columns become part "
+            "of the term and are serialized with it."
+        ),
+        "dropout_covariate_cols": (
+            "Pass term recipes instead, e.g. model_config={'a': recipe, "
+            "'b': recipe} from create_dropout_covariates(['cov']). The "
+            "columns become part of the terms and are serialized with them."
+        ),
+        "purchase_coefficient": (
+            "Pass coefficient_prior= to create_purchase_covariates instead; "
+            "the prior becomes part of the serialized recipe."
+        ),
+        "dropout_coefficient": (
+            "Pass coefficient_prior= to create_dropout_covariates instead; "
+            "the prior becomes part of the serialized recipe."
+        ),
+    }
+
+    def _warn_deprecated_covariate_config(self) -> None:
+        """Warn when deprecated covariate configuration keys are used."""
+        for key, guidance in self._DEPRECATED_CONFIG_KEYS.items():
+            if self.model_config.get(key) or key in self.model_config:
+                warnings.warn(
+                    f"{key!r} in model_config is deprecated and will be removed "
+                    f"in a future release. {guidance}",
+                    DeprecationWarning,
+                    stacklevel=3,
+                )
+
+    def _resolve_parameter_recipes(self) -> None:
+        """Resolve the parameter terms for this instance, outside any PyMC context."""
+        config = self.model_config
+
+        alpha = config["alpha"]
+        self._alpha_recipe: ModelTerm = (
+            alpha if isinstance(alpha, ModelTerm) else _default_purchase_recipe(config)
+        )
+
+        a, b = config.get("a"), config.get("b")
+        if isinstance(a, ModelTerm) != isinstance(b, ModelTerm):
+            raise ValueError("Provide both 'a' and 'b' term recipes or neither.")
+        if isinstance(a, ModelTerm) and isinstance(b, ModelTerm):
+            self._dropout_recipes = {"a": a, "b": b}
+        elif "a" in config and "b" in config:
+            self._dropout_recipes = _default_nested_dropout_recipes(config)
+        else:
+            self._dropout_recipes = _default_hierarchical_dropout_recipes(config)
 
     @property
     def default_model_config(self) -> ModelConfig:
-        """Default model configuration."""
+        """Default model configuration.
+
+        The coefficient priors are part of the parameter recipes (and their
+        serialization); the deprecated ``purchase_coefficient`` /
+        ``dropout_coefficient`` keys still feed the legacy covariate path.
+        """
         return {
             "alpha": Prior("Weibull", alpha=2, beta=10),
             "r": Prior("Weibull", alpha=2, beta=1),
             "phi_dropout": Prior("Uniform", lower=0, upper=1),
             "kappa_dropout": Prior("Pareto", alpha=1, m=1),
-            "purchase_coefficient": Prior("Normal", mu=0, sigma=1),
-            "dropout_coefficient": Prior("Normal", mu=0, sigma=1),
-            "purchase_covariate_cols": [],
-            "dropout_covariate_cols": [],
         }
 
     @property
+    def _parameter_spec(self) -> dict[str, ModelTerm]:
+        """Ordered parameter terms for ``build_model``."""
+        spec: dict[str, ModelTerm] = {
+            "alpha": self._alpha_recipe,
+            **self._dropout_recipes,
+        }
+        spec["r"] = Parameter("r", prior=self.model_config["r"], xdist=False)
+        return spec
+
+    @property
     def purchase_covariate_cols(self) -> list[str]:
-        """Purchase covariate column names from model_config."""
+        """Purchase covariate column names from the recipe or model_config."""
+        if isinstance(self._alpha_recipe, _Covariates):
+            return list(self._alpha_recipe.cols)
         return list(self.model_config.get("purchase_covariate_cols", []))
 
     @property
     def dropout_covariate_cols(self) -> list[str]:
-        """Dropout covariate column names from model_config."""
+        """Dropout covariate column names from the recipes or model_config."""
+        for recipe in self._dropout_recipes.values():
+            if isinstance(recipe, _Covariates) and recipe.cols:
+                return list(recipe.cols)
         return list(self.model_config.get("dropout_covariate_cols", []))
 
     @property
@@ -207,16 +691,61 @@ class BetaGeoModel(CLVModel):
             must_be_unique=["customer_id"],
         )
 
-    def build_model(self, data: pd.DataFrame) -> None:  # type: ignore[override]
+    def build_model(self, data: pd.DataFrame | xarray.Dataset) -> None:  # type: ignore[override]
         """Build the model.
+
+        The parameter terms are composed outside the model context (see
+        ``_resolve_parameter_recipes``); this method only registers their
+        data, builds the variables, and attaches the likelihood.
 
         Parameters
         ----------
-        data : pd.DataFrame
+        data : pd.DataFrame or xr.Dataset
             Input data with customer_id, frequency, recency, and T columns.
+            A dataset may be passed instead. It must provide ``T``,
+            ``recency``, and ``frequency`` variables with the
+            ``customer_id`` coordinate, plus ``purchase_data`` /
+            ``dropout_data`` variables when the recipes use covariates
+            (covariate coordinates must match the configured columns). A
+            DataFrame is reconstructed from the dataset, so prediction
+            methods keep working on columns.
+
+        Raises
+        ------
+        ValueError
+            If the dataset is missing required variables, provides
+            covariate data without configured columns, or its covariate
+            coordinates do not match the configured columns.
         """
-        self._validate_data(data)
-        self.data = data
+        spec = self._parameter_spec
+        terms = collect_terms(list(spec.values()))
+        data_bound = {
+            dot.var_name for term in spec.values() for dot in _iter_dots(term)
+        }
+
+        if isinstance(data, xarray.Dataset):
+            ds = data
+            _validate_modeling_dataset(
+                ds,
+                purchase_cols=self.purchase_covariate_cols,
+                dropout_cols=self.dropout_covariate_cols,
+                data_bound=data_bound,
+            )
+            self.data = _dataset_to_dataframe(
+                ds,
+                purchase_cols=self.purchase_covariate_cols,
+                dropout_cols=self.dropout_covariate_cols,
+            )
+            self._validate_data(self.data)
+        else:
+            self._validate_data(data)
+            self.data = data
+            self._check_dataframe_recipe_support(data_bound)
+            ds = _covariate_dataset(
+                self.data,
+                purchase_cols=self.purchase_covariate_cols,
+                dropout_cols=self.dropout_covariate_cols,
+            )
 
         coords = {
             "purchase_covariate": self.purchase_covariate_cols,
@@ -224,138 +753,62 @@ class BetaGeoModel(CLVModel):
             "customer_id": self.data["customer_id"],
             "obs_var": ["recency", "frequency"],
         }
+        coords = {**coords, **collect_coords(*terms, ds=ds)}
+
         with pm.Model(coords=coords) as self.model:
-            # purchase rate priors
-            if self.purchase_covariate_cols:
-                purchase_data = pm.Data(
-                    "purchase_data",
-                    self.data[self.purchase_covariate_cols],
-                    dims=["customer_id", "purchase_covariate"],
-                )
-                self.model_config["purchase_coefficient"].dims = "purchase_covariate"
-                purchase_coefficient_alpha = self.model_config[
-                    "purchase_coefficient"
-                ].create_variable("purchase_coefficient_alpha")
+            for term in terms:
+                register_data(term, ds=ds)
 
-                alpha_scale = self.model_config["alpha"].create_variable("alpha_scale")
-                alpha = pm.Deterministic(
-                    "alpha",
-                    (
-                        alpha_scale
-                        * pm.math.exp(
-                            -pm.math.dot(purchase_data, purchase_coefficient_alpha)
-                        )
-                    ),
-                    dims="customer_id",
-                )
-            else:
-                alpha = self.model_config["alpha"].create_variable("alpha")
-
-            # dropout priors
-            if "a" in self.model_config and "b" in self.model_config:
-                if self.dropout_covariate_cols:
-                    dropout_data = pm.Data(
-                        "dropout_data",
-                        self.data[self.dropout_covariate_cols],
-                        dims=["customer_id", "dropout_covariate"],
-                    )
-
-                    self.model_config["dropout_coefficient"].dims = "dropout_covariate"
-                    dropout_coefficient_a = self.model_config[
-                        "dropout_coefficient"
-                    ].create_variable("dropout_coefficient_a")
-                    dropout_coefficient_b = self.model_config[
-                        "dropout_coefficient"
-                    ].create_variable("dropout_coefficient_b")
-
-                    a_scale = self.model_config["a"].create_variable("a_scale")
-                    b_scale = self.model_config["b"].create_variable("b_scale")
-                    a = pm.Deterministic(
-                        "a",
-                        a_scale
-                        * pm.math.exp(pm.math.dot(dropout_data, dropout_coefficient_a)),
-                        dims="customer_id",
-                    )
-                    b = pm.Deterministic(
-                        "b",
-                        b_scale
-                        * pm.math.exp(pm.math.dot(dropout_data, dropout_coefficient_b)),
-                        dims="customer_id",
-                    )
-                else:
-                    a = self.model_config["a"].create_variable("a")
-                    b = self.model_config["b"].create_variable("b")
-            else:
-                # hierarchical pooling of dropout rate priors
-                if self.dropout_covariate_cols:
-                    dropout_data = pm.Data(
-                        "dropout_data",
-                        self.data[self.dropout_covariate_cols],
-                        dims=["customer_id", "dropout_covariate"],
-                    )
-
-                    self.model_config["dropout_coefficient"].dims = "dropout_covariate"
-                    dropout_coefficient_a = self.model_config[
-                        "dropout_coefficient"
-                    ].create_variable("dropout_coefficient_a")
-                    dropout_coefficient_b = self.model_config[
-                        "dropout_coefficient"
-                    ].create_variable("dropout_coefficient_b")
-
-                    phi_dropout = self.model_config["phi_dropout"].create_variable(
-                        "phi_dropout"
-                    )
-                    kappa_dropout = self.model_config["kappa_dropout"].create_variable(
-                        "kappa_dropout"
-                    )
-
-                    a_scale = pm.Deterministic(
-                        "a_scale",
-                        phi_dropout * kappa_dropout,
-                    )
-                    b_scale = pm.Deterministic(
-                        "b_scale",
-                        (1.0 - phi_dropout) * kappa_dropout,
-                    )
-
-                    a = pm.Deterministic(
-                        "a",
-                        a_scale
-                        * pm.math.exp(pm.math.dot(dropout_data, dropout_coefficient_a)),
-                        dims="customer_id",
-                    )
-                    b = pm.Deterministic(
-                        "b",
-                        b_scale
-                        * pm.math.exp(pm.math.dot(dropout_data, dropout_coefficient_b)),
-                        dims="customer_id",
-                    )
-
-                else:
-                    phi_dropout = self.model_config["phi_dropout"].create_variable(
-                        "phi_dropout"
-                    )
-                    kappa_dropout = self.model_config["kappa_dropout"].create_variable(
-                        "kappa_dropout"
-                    )
-
-                    a = pm.Deterministic("a", phi_dropout * kappa_dropout)
-                    b = pm.Deterministic("b", (1.0 - phi_dropout) * kappa_dropout)
-
-            # r remains unchanged with or without covariates
-            r = self.model_config["r"].create_variable("r")
+            built = {name: build_param(term) for name, term in spec.items()}
 
             BetaGeoNBD(
                 name="recency_frequency",
-                a=a,
-                b=b,
-                r=r,
-                alpha=alpha,
+                alpha=_as_plain_tensor(built["alpha"]),
+                a=_as_plain_tensor(built["a"]),
+                b=_as_plain_tensor(built["b"]),
+                r=_as_plain_tensor(built["r"]),
                 T=self.data["T"],
                 observed=np.stack(
                     (self.data["recency"], self.data["frequency"]), axis=1
                 ),
                 dims=["customer_id", "obs_var"],
+            )
+
+    def _check_dataframe_recipe_support(self, data_bound: set[str]) -> None:
+        """Raise for custom recipes the DataFrame path cannot data-bind.
+
+        Recipes that bind data variables need discoverable columns: either
+        the columns embedded by the covariate helpers, the deprecated
+        config keys, or an ``xr.Dataset`` passed to ``build_model``.
+        """
+        expected = {
+            "purchase_data": self.purchase_covariate_cols,
+            "dropout_data": self.dropout_covariate_cols,
+        }
+        for var_name, cols in expected.items():
+            if var_name in data_bound and not cols:
+                raise ValueError(
+                    f"A recipe binds the data variable {var_name!r} but no "
+                    "covariate columns are configured. Pass columns via "
+                    "create_purchase_covariates / create_dropout_covariates, "
+                    "the deprecated config keys, or pass an xr.Dataset to "
+                    "build_model."
+                )
+
+    def _check_recipes_predictable(self) -> None:
+        """Raise for parameter recipes without a predictive evaluation."""
+        for name, recipe in [
+            ("alpha", self._alpha_recipe),
+            *self._dropout_recipes.items(),
+        ]:
+            if isinstance(recipe, (Parameter, _Covariates)):
+                continue
+            if not any(True for _ in _iter_dots(recipe)):
+                continue
+            raise NotImplementedError(
+                f"Predictive methods are not implemented for the {name!r} recipe "
+                f"({type(recipe).__name__}). Use the default recipes, "
+                "create_purchase_covariates, or create_dropout_covariates."
             )
 
     def _extract_predictive_variables(
@@ -368,6 +821,7 @@ class BetaGeoModel(CLVModel):
 
         Utility function assigning default customer arguments for predictive methods and converting to xarrays.
         """
+        self._check_recipes_predictable()
         self._validate_cols(
             data,
             required_cols=[

--- a/pymc_marketing/clv/models/modified_beta_geo.py
+++ b/pymc_marketing/clv/models/modified_beta_geo.py
@@ -21,10 +21,12 @@ import pandas as pd
 import pymc as pm
 import xarray
 from pymc.util import RandomState
+from pymc_extras.prior import Prior
 from scipy.special import hyp2f1
 
 from pymc_marketing.clv.distributions import ModifiedBetaGeoNBD
 from pymc_marketing.clv.models import BetaGeoModel
+from pymc_marketing.model_config import ModelConfig
 
 
 class ModifiedBetaGeoModel(BetaGeoModel):
@@ -141,6 +143,20 @@ class ModifiedBetaGeoModel(BetaGeoModel):
     """  # noqa: E501
 
     _model_type = "MBG/NBD"
+
+    @property
+    def default_model_config(self) -> ModelConfig:
+        """Default model configuration.
+
+        The MBG/NBD build path still reads the covariate coefficient priors
+        from ``model_config``; the keys are deprecated in favor of term
+        recipes as part of the BG/NBD terms port (issue #2962).
+        """
+        return {
+            **super().default_model_config,
+            "purchase_coefficient": Prior("Normal", mu=0, sigma=1),
+            "dropout_coefficient": Prior("Normal", mu=0, sigma=1),
+        }
 
     def build_model(self, data: pd.DataFrame) -> None:  # type: ignore[override]
         """Build the model.

--- a/pymc_marketing/terms.py
+++ b/pymc_marketing/terms.py
@@ -15,9 +15,9 @@
 """Composable model terms for building ``pymc.dims`` subgraphs from xarray data.
 
 ``pymc_marketing.terms`` provides a small set of built-in pieces
-(``Parameter`` / ``Intercept``, ``Dot``, ``Transform``) that compose with
-``+``, ``*``, and ``-`` into predictors.  **This module is not a full
-modeling toolkit** --- it does not ship complete hierarchical,
+(``Parameter`` / ``Intercept``, ``Dot``, ``Transform``, ``Named``, ``Ref``)
+that compose with ``+``, ``*``, and ``-`` into predictors.  **This module is
+not a full modeling toolkit** --- it does not ship complete hierarchical,
 domain-specific, or observation-model wrappers.  It is a **thin, expressive
 core** that lets you build what you need by subclassing ``ModelTerm`` and
 reusing the same helpers and operators that built-ins use.  If a term is
@@ -231,6 +231,23 @@ Gotchas
           model = pm.modelcontext(None)
           unique = list(dict.fromkeys(ds[self.data_source].values))
           model.add_coords({self.data_source: unique})
+
+- Built terms produce dimensional (``XTensorVariable``) tensors. Legacy
+  plain-tensor consumers (custom ``pm.Distribution`` subclasses whose
+  ``logp`` uses plain pytensor ops) require explicit conversion at the
+  boundary: ``pt.as_tensor_variable(x, allow_xtensor_conversion=True)``.
+- ``register_data`` must run before ``build_param``: building a term that
+  references a data variable before that variable is registered raises
+  ``KeyError``.
+- ``Parameter`` and ``Dot`` default to ``xdist=True`` (``pymc.dims``
+  variables). Not every PyMC distribution is available there (e.g.
+  ``Pareto``); pass ``xdist=False`` for a plain PyMC variable in that case.
+- Terms serialize via ``pymc_marketing.serialization`` (``to_dict`` /
+  ``from_dict`` are registered for the built-ins), so recipes stored in
+  ``model_config`` survive ``fit()`` (attrs are JSON-serialized at sampling
+  time) and ``save()`` / ``load()``. ``Transform`` functions must be in the
+  serializable-function registry (``exp``, ``log``, ``log1p``, ``sigmoid``,
+  ``sqrt``).
 """
 
 from __future__ import annotations
@@ -242,16 +259,23 @@ from typing import Any, cast
 import pymc as pm
 import pymc.dims as pmd
 import pytensor.tensor as pt
+import pytensor.xtensor as ptx
 import xarray as xr
+from pymc_extras.deserialize import DeserializableError
+from pymc_extras.deserialize import deserialize as pymc_extras_deserialize
 from pymc_extras.prior import Prior, VariableFactory
 from pytensor.xtensor.type import as_xtensor
+
+from pymc_marketing.serialization import SerializationError, serialization
 
 __all__ = [
     "Dot",
     "Intercept",
     "ModelTerm",
+    "Named",
     "Parameter",
     "Product",
+    "Ref",
     "Sum",
     "Transform",
     "build_param",
@@ -261,6 +285,82 @@ __all__ = [
     "register_data",
     "set_data",
 ]
+
+# Functions allowed inside ``Transform`` for serialization. Keys are stable
+# names; values must be ``pytensor.xtensor.math`` functions so composed
+# expressions round-trip through ``to_dict`` / ``from_dict``.
+_SERIALIZABLE_FUNCTIONS: dict[str, Callable] = {
+    "exp": ptx.math.exp,
+    "log": ptx.math.log,
+    "log1p": ptx.math.log1p,
+    "sigmoid": ptx.math.sigmoid,
+    "sqrt": ptx.math.sqrt,
+}
+
+
+def _as_plain_tensor(x: Any) -> pt.TensorVariable:
+    """Adapt a terms-built (xtensor) expression for plain-tensor consumers.
+
+    Plain pytensor consumers (custom ``pm.Distribution`` subclasses whose
+    ``logp`` uses plain pytensor ops) forbid implicit xtensor to tensor
+    conversion.
+    """
+    return cast(
+        "pt.TensorVariable", pt.as_tensor_variable(x, allow_xtensor_conversion=True)
+    )
+
+
+def _func_name(func: Callable) -> str:
+    """Look up the serializable name of a ``Transform`` function."""
+    for name, candidate in _SERIALIZABLE_FUNCTIONS.items():
+        if func is candidate:
+            return name
+    allowed = ", ".join(sorted(_SERIALIZABLE_FUNCTIONS))
+    raise SerializationError(
+        f"Function {func!r} is not serializable. Use one of: {allowed}, "
+        "or extend pymc_marketing.terms._SERIALIZABLE_FUNCTIONS."
+    )
+
+
+def _lookup_func(name: str) -> Callable:
+    """Resolve a serialized ``Transform`` function name."""
+    if name not in _SERIALIZABLE_FUNCTIONS:
+        allowed = ", ".join(sorted(_SERIALIZABLE_FUNCTIONS))
+        raise SerializationError(
+            f"Unknown serialized function {name!r}. Allowed: {allowed}."
+        )
+    return _SERIALIZABLE_FUNCTIONS[name]
+
+
+def _serialize_child(value: Any) -> Any:
+    """Serialize a child of a composed term to a JSON-safe value.
+
+    Numeric literals become ``{"__type__": "literal", ...}`` wrappers;
+    variable factories that are not registered in the type registry
+    (``Prior``, ``Censored``, ...) serialize via their own ``to_dict``.
+    """
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return {"__type__": "literal", "value": value}
+    try:
+        return serialization.serialize(value)
+    except KeyError:
+        if hasattr(value, "to_dict"):
+            return value.to_dict()
+        raise
+
+
+def _deserialize_child(value: Any) -> Any:
+    """Deserialize a serialized term child back to a live object."""
+    if isinstance(value, dict):
+        if value.get("__type__") == "literal":
+            return value["value"]
+        if "__type__" in value:
+            return serialization.deserialize(value)
+        try:
+            return pymc_extras_deserialize(value)
+        except DeserializableError as err:
+            raise SerializationError(f"Cannot deserialize term child: {value}") from err
+    return value
 
 
 @dataclass
@@ -352,6 +452,7 @@ class ModelTerm:
         return Product(-1, self)
 
 
+@serialization.register
 @dataclass
 class Sum:
     """Container for additive composition via ``+``.
@@ -406,7 +507,17 @@ class Sum:
         for term in self.terms:
             set_data(term, ds=ds, model=model)
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the sum and its children."""
+        return {"terms": [_serialize_child(term) for term in self.terms]}
 
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Sum:
+        """Reconstruct a sum from its serialized form."""
+        return cls(terms=[_deserialize_child(term) for term in data["terms"]])
+
+
+@serialization.register
 @dataclass
 class Product:
     """Container for multiplicative composition via ``*``.
@@ -448,7 +559,23 @@ class Product:
         set_data(self.left, ds=ds, model=model)
         set_data(self.right, ds=ds, model=model)
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the product and both operands."""
+        return {
+            "left": _serialize_child(self.left),
+            "right": _serialize_child(self.right),
+        }
 
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Product:
+        """Reconstruct a product from its serialized form."""
+        return cls(
+            left=_deserialize_child(data["left"]),
+            right=_deserialize_child(data["right"]),
+        )
+
+
+@serialization.register
 @dataclass
 class Parameter(ModelTerm):
     """Named free parameter (scalar or dimensional via ``prior.dims``).
@@ -471,6 +598,10 @@ class Parameter(ModelTerm):
         (``Prior``, ``Censored``, ``Scaled``, custom) is accepted.
         When the prior carries ``dims`` (e.g. ``Prior(..., dims="cohort")``),
         ``get_coords`` will extract those coordinates from the dataset.
+    xdist : bool, optional
+        Create the variable through ``pymc.dims`` (default). Set to ``False``
+        for a plain PyMC variable, e.g. when the distribution is not
+        available in ``pymc.dims``.
 
     Examples
     --------
@@ -498,6 +629,7 @@ class Parameter(ModelTerm):
 
     name: str
     prior: VariableFactory = field(default_factory=lambda: Prior("Normal"))
+    xdist: bool = True
 
     def get_coords(self, ds: xr.Dataset) -> dict[str, Any]:
         """Collect coordinates from ``prior.dims`` present in the dataset."""
@@ -511,9 +643,29 @@ class Parameter(ModelTerm):
 
     def create_variable(self) -> pt.TensorVariable:
         """Build a free parameter variable."""
-        return self.prior.create_variable(self.name, xdist=True)
+        return self.prior.create_variable(self.name, xdist=self.xdist)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the parameter name, prior, and xdist flag."""
+        data: dict[str, Any] = {
+            "name": self.name,
+            "prior": _serialize_child(self.prior),
+        }
+        if not self.xdist:
+            data["xdist"] = False
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Parameter:
+        """Reconstruct a parameter from its serialized form."""
+        return cls(
+            name=data["name"],
+            prior=_deserialize_child(data["prior"]),
+            xdist=data.get("xdist", True),
+        )
 
 
+@serialization.register
 @dataclass
 class Intercept(Parameter):
     """GLM-style intercept term; same as :class:`Parameter` with a default name.
@@ -534,6 +686,7 @@ class Intercept(Parameter):
     prior: VariableFactory = field(default_factory=lambda: Prior("Normal"))
 
 
+@serialization.register
 @dataclass(kw_only=True)
 class Dot(ModelTerm):
     """Linear predictor term: ``data @ beta``.
@@ -553,6 +706,10 @@ class Dot(ModelTerm):
         Provide a distinct ``name`` to reference the same ``var_name`` from
         multiple terms (e.g. separate alpha and beta coefficient branches)
         without colliding on the coefficient variable name.
+    xdist : bool, optional
+        Create the coefficient variable through ``pymc.dims`` (default).
+        Set to ``False`` for a plain PyMC variable, e.g. when the
+        distribution is not available in ``pymc.dims``.
 
     Examples
     --------
@@ -582,6 +739,7 @@ class Dot(ModelTerm):
     var_name: str
     prior: VariableFactory
     name: str | None = None
+    xdist: bool = True
 
     def __post_init__(self):
         """Set the default coefficient name to ``{var_name}_beta``."""
@@ -612,10 +770,32 @@ class Dot(ModelTerm):
         """Build ``data @ beta`` tensor."""
         model = pm.modelcontext(None)
         data = model[self.var_name]
-        beta = self.prior.create_variable(self.name, xdist=True)
+        beta = self.prior.create_variable(self.name, xdist=self.xdist)
         return data @ beta
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the data variable, coefficient prior, and name."""
+        data: dict[str, Any] = {
+            "var_name": self.var_name,
+            "prior": _serialize_child(self.prior),
+            "name": self.name,
+        }
+        if not self.xdist:
+            data["xdist"] = False
+        return data
 
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Dot:
+        """Reconstruct a dot term from its serialized form."""
+        return cls(
+            var_name=data["var_name"],
+            prior=_deserialize_child(data["prior"]),
+            name=data["name"],
+            xdist=data.get("xdist", True),
+        )
+
+
+@serialization.register
 @dataclass
 class Transform(ModelTerm):
     """Apply a pytensor function to a term's output.
@@ -673,6 +853,124 @@ class Transform(ModelTerm):
     def set_data(self, ds: xr.Dataset, model: pm.Model | None = None) -> None:
         """Update shared data for the inner expression."""
         set_data(self.inner, ds=ds, model=model)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the inner expression and the applied function."""
+        return {
+            "inner": _serialize_child(self.inner),
+            "func": _func_name(self.func),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Transform:
+        """Reconstruct a transform from its serialized form."""
+        return cls(
+            inner=_deserialize_child(data["inner"]),
+            func=_lookup_func(data["func"]),
+        )
+
+
+@serialization.register
+@dataclass
+class Named(ModelTerm):
+    """Compose an expression into a named deterministic variable.
+
+    The inner expression is built lazily within the model context:
+    ``build_param`` creates ``pm.Deterministic(name, value, dims=dims)``.
+    Coordinates, data registration, and data updating delegate to the
+    inner expression. Useful for naming intermediate effects (scales,
+    link outputs) that should appear in the posterior.
+
+    Parameters
+    ----------
+    name : str
+        Name of the deterministic variable.
+    expr : Any
+        Inner expression accepted by ``build_param``.
+    dims : str or tuple of str, optional
+        Dimensions for the deterministic variable.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        sigma = Named("sigma", Intercept(name="sigma_scale"), func=None)
+
+        # a scale built from other effects, referenced by later terms
+        a_scale = Named("a_scale", phi * kappa)
+        a = Named("a", Ref("a_scale") * effect, dims="customer_id")
+    """
+
+    name: str
+    expr: Any
+    dims: str | tuple[str, ...] | None = None
+
+    def get_coords(self, ds: xr.Dataset) -> dict[str, Any]:
+        """Collect coordinates from the inner expression."""
+        return get_coords(self.expr, ds)
+
+    def register_data(self, ds: xr.Dataset) -> None:
+        """Register shared data for the inner expression."""
+        register_data(self.expr, ds=ds)
+
+    def set_data(self, ds: xr.Dataset, model: pm.Model | None = None) -> None:
+        """Update shared data for the inner expression."""
+        set_data(self.expr, ds=ds, model=model)
+
+    def create_variable(self) -> pt.TensorVariable:
+        """Build the named deterministic from the inner expression."""
+        value = _as_plain_tensor(build_param(self.expr))
+        return pm.Deterministic(self.name, value, dims=self.dims)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the name, expression, and dims."""
+        data: dict[str, Any] = {
+            "name": self.name,
+            "expr": _serialize_child(self.expr),
+        }
+        if self.dims is not None:
+            data["dims"] = self.dims
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Named:
+        """Reconstruct a named term from its serialized form."""
+        return cls(
+            name=data["name"],
+            expr=_deserialize_child(data["expr"]),
+            dims=data.get("dims"),
+        )
+
+
+@serialization.register
+@dataclass
+class Ref(ModelTerm):
+    """Reference an already-built named variable in the active model.
+
+    Lets an effect expression composed outside the model depend on another
+    built effect (e.g. ``a`` on the ``a_scale`` deterministic) without
+    recreating its variables.
+
+    Parameters
+    ----------
+    name : str
+        Name of the referenced variable.
+    """
+
+    name: str
+
+    def create_variable(self) -> pt.TensorVariable:
+        """Resolve the referenced variable from the active model."""
+        return pm.modelcontext(None)[self.name]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the referenced name."""
+        return {"name": self.name}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Ref:
+        """Reconstruct a reference from its serialized form."""
+        return cls(name=data["name"])
 
 
 def get_coords(param: Any, ds: xr.Dataset) -> dict[str, Any]:

--- a/tests/clv/conftest.py
+++ b/tests/clv/conftest.py
@@ -71,7 +71,7 @@ def set_model_fit(model: CLVModel, fit: xr.DataTree | Dataset):
             category=UserWarning,
             message="The group fit_data is not defined in the DataTree scheme",
         )
-        model.idata["/fit_data"] = model.data.to_xarray()
+        model.idata["/fit_data"] = model.create_fit_data_group()
     model.set_idata_attrs(fit)
 
 

--- a/tests/clv/models/test_beta_geo.py
+++ b/tests/clv/models/test_beta_geo.py
@@ -712,8 +712,11 @@ class TestBetaGeoModel:
 
         # Check if the loaded model is indeed an instance of the class
         assert isinstance(self.model, BetaGeoModel)
-        # Check if the loaded data matches with the model data
-        pd.testing.assert_frame_equal(self.model.data, model2.data, check_names=False)
+        # Check if the loaded data matches with the model data (column order
+        # may differ: reconstructed from the modeling dataset)
+        pd.testing.assert_frame_equal(
+            self.model.data, model2.data, check_names=False, check_like=True
+        )
         assert self.model.model_config == model2.model_config
         assert self.model.sampler_config == model2.sampler_config
         assert self.model.idata == model2.idata
@@ -1477,7 +1480,9 @@ class TestAllCombinations:
         model = BetaGeoModel(model_config=config)
 
         if expect_error:
-            with pytest.raises(ValueError, match="covariate columns are configured"):
+            with pytest.raises(
+                ValueError, match="cannot be constructed from a DataFrame"
+            ):
                 model.build_model(data=covariate_data)
             return
 
@@ -1579,3 +1584,99 @@ class TestStructureAsData:
         assert serialization.serialize(tweaked.model_config["alpha"]) != spec
         coef_prior = next(_iter_dots(restored)).prior
         assert coef_prior.parameters["sigma"] == 10.0
+
+
+class TestPersistence:
+    """Recipes and their bound data survive fit/save/load."""
+
+    def _custom_alpha_with_extra_var(self):
+        """An alpha recipe binding a data variable no helper knows about."""
+        return Named(
+            "alpha",
+            Parameter("alpha_scale", prior=Prior("HalfFlat"), xdist=False)
+            * Transform(
+                Dot(
+                    var_name="spend_data",
+                    name="spend_coefficient",
+                    prior=Prior("Normal", mu=0, sigma=1),
+                ),
+                func=_ptx.math.exp,
+            ),
+            dims="customer_id",
+        )
+
+    @pytest.fixture
+    def custom_dataset(self, covariate_data):
+        """Modeling dataset with an extra variable bound by a custom recipe."""
+        extra = np.random.default_rng(7).normal(size=len(covariate_data))
+        ds = xr.Dataset(
+            {"spend_data": ("customer_id", extra)},
+            coords={"customer_id": covariate_data["customer_id"].to_numpy()},
+        )
+        ds["T"] = ("customer_id", covariate_data["T"].to_numpy())
+        ds["recency"] = ("customer_id", covariate_data["recency"].to_numpy())
+        ds["frequency"] = ("customer_id", covariate_data["frequency"].to_numpy())
+        return ds
+
+    def test_custom_bound_data_survives_save_load(self, custom_dataset, tmp_path):
+        model = BetaGeoModel(
+            model_config={"alpha": self._custom_alpha_with_extra_var()}
+        )
+        model.build_model(data=custom_dataset)
+        _mock_recipe_fit(model)
+
+        path = tmp_path / "custom"
+        model.save(path)
+        loaded = BetaGeoModel.load(path)
+
+        assert "spend_data" in loaded.model.named_vars
+        assert "alpha" in loaded.model.named_vars
+        # recipe-bound variables are carried into the customer-level frame
+        assert "spend_data" in loaded.data.columns
+        np.testing.assert_allclose(
+            loaded.model["spend_data"].get_value(),
+            custom_dataset["spend_data"].values,
+        )
+
+    def test_fit_data_group_is_merged(self, covariate_data):
+        model = BetaGeoModel(model_config=_recipe_config())
+        model.build_model(data=covariate_data)
+
+        fit_data = model.create_fit_data_group()
+        assert "customer_id" in fit_data.coords
+        for column in ("T", "recency", "frequency"):
+            assert column in fit_data.data_vars
+        for variable in ("purchase_data", "dropout_data"):
+            assert variable in fit_data.data_vars
+
+    def test_load_old_shape_fit_data(self, covariate_data):
+        """Saved models from before the merge keep loading through the DataFrame path."""
+        model = BetaGeoModel(model_config=_recipe_config())
+        model.build_model(data=covariate_data)
+        _mock_recipe_fit(model)
+
+        old_fit_data = model.data.to_xarray()
+        assert "customer_id" not in old_fit_data.coords
+
+        idata = model.idata.copy()
+        idata = idata.drop_nodes("fit_data")
+        idata["/fit_data"] = old_fit_data
+
+        loaded = BetaGeoModel.build_from_idata(idata)
+        assert set(loaded.model.named_vars) == set(model.model.named_vars)
+
+    def test_refit_with_same_dataset(self, covariate_data, modeling_dataset):
+        model = BetaGeoModel(model_config=_recipe_config())
+        model.build_model(data=modeling_dataset)
+        model._prepare_fit(data=modeling_dataset)  # must not raise
+
+    def test_refit_with_different_dataset_raises(
+        self, covariate_data, modeling_dataset
+    ):
+        model = BetaGeoModel(model_config=_recipe_config())
+        model.build_model(data=modeling_dataset)
+        changed = modeling_dataset.assign(
+            T=("customer_id", modeling_dataset["T"].values + 1.0)
+        )
+        with pytest.raises(ValueError, match="built with different data"):
+            model._prepare_fit(data=changed)

--- a/tests/clv/models/test_beta_geo.py
+++ b/tests/clv/models/test_beta_geo.py
@@ -11,16 +11,26 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+import warnings
+
 import arviz as az
 import numpy as np
 import pandas as pd
 import pymc as pm
+import pytensor.xtensor as _ptx
 import pytest
 import xarray as xr
 from pymc_extras.prior import Prior
 
 from pymc_marketing.clv.distributions import BetaGeoNBD
-from pymc_marketing.clv.models.beta_geo import BetaGeoModel
+from pymc_marketing.clv.models.beta_geo import (
+    BetaGeoModel,
+    _covariate_dataset,
+    create_dropout_covariates,
+    create_purchase_covariates,
+)
+from pymc_marketing.serialization import serialization
+from pymc_marketing.terms import Dot, Named, Parameter, Transform
 from tests.clv.conftest import create_mock_fit, mock_sample, set_model_fit
 
 
@@ -1092,3 +1102,298 @@ class TestBetaGeoModelWithCovariates:
                     err_msg=f"Tolerance exceeded for variable {var_name}",
                     rtol=0.2,
                 )
+
+
+PURCHASE_COLS = ["purchase_cov1", "purchase_cov2"]
+DROPOUT_COLS = ["dropout_cov"]
+
+
+@pytest.fixture
+def covariate_data():
+    rng = np.random.default_rng(42)
+    n = 10
+    frequency = rng.poisson(2.0, n).astype(float)
+    return pd.DataFrame(
+        {
+            "customer_id": range(n),
+            "frequency": frequency,
+            "recency": np.where(frequency > 0, rng.uniform(0, 20, n), 0.0),
+            "T": rng.uniform(20, 40, n),
+            "purchase_cov1": rng.normal(size=n),
+            "purchase_cov2": rng.normal(size=n),
+            "dropout_cov": rng.normal(size=n),
+        }
+    )
+
+
+def _mock_recipe_fit(model):
+    """Mock a fit for a covariate recipe model (nested a/b)."""
+    rng = np.random.default_rng(42)
+    chains, draws = 1, 20
+    mock_fit = az.from_dict(
+        {
+            "posterior": {
+                "r": rng.normal(2.0, 1e-2, size=(chains, draws)),
+                "alpha_scale": rng.normal(5.0, 1e-2, size=(chains, draws)),
+                "a_scale": rng.normal(0.5, 1e-2, size=(chains, draws)),
+                "b_scale": rng.normal(1.5, 1e-2, size=(chains, draws)),
+                "purchase_coefficient_alpha": rng.normal(
+                    0.0, 1e-2, size=(chains, draws, len(PURCHASE_COLS))
+                ),
+                "dropout_coefficient_a": rng.normal(
+                    0.0, 1e-2, size=(chains, draws, len(DROPOUT_COLS))
+                ),
+                "dropout_coefficient_b": rng.normal(
+                    0.0, 1e-2, size=(chains, draws, len(DROPOUT_COLS))
+                ),
+            }
+        },
+        dims={
+            "purchase_coefficient_alpha": ["purchase_covariate"],
+            "dropout_coefficient_a": ["dropout_covariate"],
+            "dropout_coefficient_b": ["dropout_covariate"],
+        },
+        coords={
+            "purchase_covariate": PURCHASE_COLS,
+            "dropout_covariate": DROPOUT_COLS,
+        },
+    )
+    set_model_fit(model, mock_fit)
+
+
+def _recipe_config(**overrides):
+    purchase, (a, b) = (
+        create_purchase_covariates(PURCHASE_COLS),
+        create_dropout_covariates(DROPOUT_COLS),
+    )
+    config = {"alpha": purchase, "a": a, "b": b}
+    config.update(overrides)
+    return {k: v for k, v in config.items() if v is not None}
+
+
+@pytest.fixture
+def modeling_dataset(covariate_data):
+    """Full modeling dataset: covariates plus the RFM variables."""
+    ds = _covariate_dataset(
+        covariate_data, purchase_cols=PURCHASE_COLS, dropout_cols=DROPOUT_COLS
+    )
+    ds["T"] = ("customer_id", covariate_data["T"].to_numpy())
+    ds["recency"] = ("customer_id", covariate_data["recency"].to_numpy())
+    ds["frequency"] = ("customer_id", covariate_data["frequency"].to_numpy())
+    return ds
+
+
+class TestParameterRecipes:
+    """Terms passed as parameter recipes through model_config."""
+
+    def test_recipes_build_without_deprecation_warning(self, covariate_data):
+        with pytest.warns(DeprecationWarning):
+            deprecated = BetaGeoModel(
+                model_config={
+                    "purchase_covariate_cols": PURCHASE_COLS,
+                    "dropout_covariate_cols": DROPOUT_COLS,
+                }
+            )
+        assert deprecated.purchase_covariate_cols == PURCHASE_COLS
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            model = BetaGeoModel(model_config=_recipe_config())
+            model.build_model(data=covariate_data)
+
+        assert model.purchase_covariate_cols == PURCHASE_COLS
+        assert model.dropout_covariate_cols == DROPOUT_COLS
+        names = model.model.named_vars
+        for name in (
+            "purchase_data",
+            "dropout_data",
+            "alpha_scale",
+            "a_scale",
+            "b_scale",
+            "purchase_coefficient_alpha",
+            "dropout_coefficient_a",
+            "dropout_coefficient_b",
+            "alpha",
+            "a",
+            "b",
+            "r",
+        ):
+            assert name in names
+
+    def test_deprecated_config_keys_warn(self, covariate_data):
+        with pytest.warns(DeprecationWarning) as record:
+            BetaGeoModel(
+                model_config={
+                    "purchase_covariate_cols": PURCHASE_COLS,
+                    "dropout_covariate_cols": DROPOUT_COLS,
+                    "purchase_coefficient": Prior("Normal"),
+                    "dropout_coefficient": Prior("Normal"),
+                }
+            )
+        messages = [str(w.message) for w in record]
+        for key in (
+            "purchase_covariate_cols",
+            "dropout_covariate_cols",
+            "purchase_coefficient",
+            "dropout_coefficient",
+        ):
+            assert any(key in message for message in messages)
+
+    def test_recipe_predictions(self, covariate_data):
+        model = BetaGeoModel(model_config=_recipe_config())
+        model.build_model(data=covariate_data)
+        _mock_recipe_fit(model)
+
+        result = model.expected_purchases_new_customer(t=10)
+        assert result.sizes["customer_id"] == len(covariate_data)
+        assert np.isfinite(result.values).all()
+
+    def test_ab_recipes_require_pair(self, covariate_data):
+        a, _ = create_dropout_covariates(DROPOUT_COLS)
+        with pytest.raises(ValueError, match="both 'a' and 'b'"):
+            BetaGeoModel(model_config={"a": a})
+
+    def test_custom_recipe_prediction_not_implemented(self, modeling_dataset):
+        alpha = Named(
+            "alpha",
+            Parameter("alpha_scale", prior=Prior("HalfFlat"), xdist=False)
+            * Transform(
+                Dot(
+                    var_name="purchase_data",
+                    name="purchase_coefficient_alpha",
+                    prior=Prior("Normal", dims="purchase_covariate"),
+                ),
+                func=_ptx.math.exp,
+            ),
+            dims="customer_id",
+        )
+        model = BetaGeoModel(model_config={"alpha": alpha})
+        model.build_model(data=modeling_dataset.drop_vars("dropout_data"))
+        _mock_recipe_fit(model)
+
+        with pytest.raises(NotImplementedError, match="Predictive methods"):
+            model.expected_purchases_new_customer(t=10)
+
+    def test_custom_recipe_on_dataframe_requires_columns(self, covariate_data):
+        alpha = Named(
+            "alpha",
+            Dot(
+                var_name="purchase_data",
+                name="purchase_coefficient_alpha",
+                prior=Prior("Normal", dims="purchase_covariate"),
+            ),
+            dims="customer_id",
+        )
+        model = BetaGeoModel(model_config={"alpha": alpha})
+        with pytest.raises(ValueError, match="purchase_data"):
+            model.build_model(data=covariate_data)
+
+    def test_save_load_recipe_roundtrip(self, covariate_data, tmp_path):
+        model = BetaGeoModel(model_config=_recipe_config())
+        model.build_model(data=covariate_data)
+        _mock_recipe_fit(model)
+
+        path = tmp_path / "recipe_model"
+        model.save(path)
+        loaded = BetaGeoModel.load(path)
+
+        assert loaded.model_config["alpha"] == model.model_config["alpha"]
+        assert loaded.model_config["a"] == model.model_config["a"]
+        assert loaded.model_config["b"] == model.model_config["b"]
+        assert loaded.purchase_covariate_cols == PURCHASE_COLS
+
+        loaded.build_model(data=covariate_data)
+        assert set(loaded.model.named_vars) == set(model.model.named_vars)
+
+    def test_xdist_false_roundtrip(self):
+        term = Parameter("kappa", prior=Prior("Pareto", alpha=1, m=1), xdist=False)
+        restored = serialization.deserialize(serialization.serialize(term))
+        assert restored == term
+        assert restored.xdist is False
+
+    def test_default_hierarchical_uses_named_and_ref(self, covariate_data):
+        model = BetaGeoModel()
+        model.build_model(data=covariate_data)
+        names = model.model.named_vars
+        for name in (
+            "phi_dropout",
+            "kappa_dropout",
+            "a",
+            "b",
+            "r",
+            "alpha",
+        ):
+            assert name in names
+        # no covariates: the scales are pooled directly into a and b
+        assert "a_scale" not in names
+
+    def test_custom_ab_recipes_self_contained(self, covariate_data):
+        recipes = {
+            "a": Named(
+                "a",
+                Parameter(
+                    "phi_a", prior=Prior("Uniform", lower=0, upper=1), xdist=False
+                )
+                * Parameter(
+                    "kappa_a", prior=Prior("Pareto", alpha=1, m=1), xdist=False
+                ),
+            ),
+            "b": Named(
+                "b",
+                (
+                    1
+                    - Parameter(
+                        "phi_b", prior=Prior("Uniform", lower=0, upper=1), xdist=False
+                    )
+                )
+                * Parameter(
+                    "kappa_b", prior=Prior("Pareto", alpha=1, m=1), xdist=False
+                ),
+            ),
+        }
+        model = BetaGeoModel(model_config=recipes)
+        model.build_model(data=covariate_data)
+        names = model.model.named_vars
+        for name in ("phi_a", "kappa_a", "phi_b", "kappa_b", "a", "b"):
+            assert name in names
+        free = {rv.name for rv in model.model.free_RVs}
+        assert {"phi_a", "kappa_a", "phi_b", "kappa_b"} <= free
+
+
+class TestDatasetInput:
+    """build_model accepts an xr.Dataset instead of a DataFrame."""
+
+    def test_dataset_builds_equivalent_model(self, covariate_data, modeling_dataset):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            from_df = BetaGeoModel(model_config=_recipe_config())
+            from_ds = BetaGeoModel(model_config=_recipe_config())
+        from_df.build_model(data=covariate_data)
+        from_ds.build_model(data=modeling_dataset)
+
+        assert set(from_ds.model.named_vars) == set(from_df.model.named_vars)
+        logp_df = float(from_df.model.compile_logp()(from_df.model.initial_point()))
+        logp_ds = float(from_ds.model.compile_logp()(from_ds.model.initial_point()))
+        assert logp_df == pytest.approx(logp_ds)
+
+        pd.testing.assert_frame_equal(
+            from_ds.data.reindex(columns=covariate_data.columns),
+            covariate_data,
+            check_names=False,
+        )
+
+    def test_dataset_missing_variable_raises(self, modeling_dataset):
+        model = BetaGeoModel(model_config=_recipe_config())
+        with pytest.raises(ValueError, match="missing required variables"):
+            model.build_model(data=modeling_dataset.drop_vars(["T"]))
+
+    def test_dataset_unconfigured_covariates_raises(self, modeling_dataset):
+        model = BetaGeoModel()
+        with pytest.raises(ValueError, match="purchase_data"):
+            model.build_model(data=modeling_dataset)
+
+    def test_dataset_coordinate_mismatch_raises(self, modeling_dataset):
+        ds = modeling_dataset.assign_coords(purchase_covariate=["x1", "x2"])
+        model = BetaGeoModel(model_config=_recipe_config())
+        with pytest.raises(ValueError, match="do not match"):
+            model.build_model(data=ds)

--- a/tests/clv/models/test_beta_geo.py
+++ b/tests/clv/models/test_beta_geo.py
@@ -1680,3 +1680,70 @@ class TestPersistence:
         )
         with pytest.raises(ValueError, match="built with different data"):
             model._prepare_fit(data=changed)
+
+    def test_shared_group_referenced_by_multiple_recipes(
+        self, covariate_data, tmp_path
+    ):
+        """Several branches referencing one data variable share a single pmd.Data."""
+        shared = xr.Dataset(
+            {
+                "shared_data": (
+                    ("customer_id", "shared_covariate"),
+                    np.random.default_rng(7).normal(size=(len(covariate_data), 1)),
+                )
+            },
+            coords={
+                "customer_id": covariate_data["customer_id"].to_numpy(),
+                "shared_covariate": ["income"],
+            },
+        )
+        shared["T"] = ("customer_id", covariate_data["T"].to_numpy())
+        shared["recency"] = ("customer_id", covariate_data["recency"].to_numpy())
+        shared["frequency"] = ("customer_id", covariate_data["frequency"].to_numpy())
+
+        def dot(name):
+            return Dot(
+                var_name="shared_data",
+                name=name,
+                prior=Prior("Normal", dims="shared_covariate"),
+            )
+
+        recipes = {
+            "alpha": Named(
+                "alpha",
+                Parameter("alpha_scale", prior=Prior("HalfFlat"), xdist=False)
+                * Transform(-dot("purchase_coefficient_alpha"), func=_ptx.math.exp),
+                dims="customer_id",
+            ),
+            "a": Named(
+                "a",
+                Parameter("a_scale", prior=Prior("Beta", alpha=2, beta=3), xdist=False)
+                * Transform(dot("dropout_coefficient_a"), func=_ptx.math.exp),
+                dims="customer_id",
+            ),
+            "b": Named(
+                "b",
+                Parameter("b_scale", prior=Prior("Beta", beta=3, alpha=2), xdist=False)
+                * Transform(dot("dropout_coefficient_b"), func=_ptx.math.exp),
+                dims="customer_id",
+            ),
+        }
+        model = BetaGeoModel(model_config=recipes)
+        model.build_model(data=shared)
+
+        # guarded registration: one shared variable for all three branches
+        assert [k for k in model.model.named_vars if k == "shared_data"] == [
+            "shared_data"
+        ]
+        fit_data = model.create_fit_data_group()
+        assert "shared_data" in fit_data.data_vars
+
+        _mock_recipe_fit(model)
+        path = tmp_path / "shared_group"
+        model.save(path)
+        loaded = BetaGeoModel.load(path)
+        assert [k for k in loaded.model.named_vars if k == "shared_data"] == [
+            "shared_data"
+        ]
+        # 2-D bound variables persist in the modeling dataset (not the frame)
+        assert "shared_data" in loaded._modeling_data.data_vars

--- a/tests/clv/models/test_beta_geo.py
+++ b/tests/clv/models/test_beta_geo.py
@@ -11,6 +11,7 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+import json
 import warnings
 
 import arviz as az
@@ -26,11 +27,20 @@ from pymc_marketing.clv.distributions import BetaGeoNBD
 from pymc_marketing.clv.models.beta_geo import (
     BetaGeoModel,
     _covariate_dataset,
+    _iter_dots,
     create_dropout_covariates,
     create_purchase_covariates,
 )
 from pymc_marketing.serialization import serialization
-from pymc_marketing.terms import Dot, Named, Parameter, Transform
+from pymc_marketing.terms import (
+    Dot,
+    ModelTerm,
+    Named,
+    Parameter,
+    Product,
+    Transform,
+    collect_terms,
+)
 from tests.clv.conftest import create_mock_fit, mock_sample, set_model_fit
 
 
@@ -1397,3 +1407,256 @@ class TestDatasetInput:
         model = BetaGeoModel(model_config=_recipe_config())
         with pytest.raises(ValueError, match="do not match"):
             model.build_model(data=ds)
+
+
+def _alpha_config(spec: str) -> dict:
+    """Recipe config for the ``alpha`` parameter, by combination-matrix value."""
+    if spec == "default":
+        return {}
+    if spec == "scalar":
+        return {"alpha": Parameter("alpha", prior=Prior("HalfFlat"), xdist=False)}
+    if spec == "helper":
+        return {"alpha": create_purchase_covariates(PURCHASE_COLS)}
+    if spec == "custom-dot":
+        return {
+            "alpha": Named(
+                "alpha",
+                Parameter("alpha_scale", prior=Prior("HalfFlat"), xdist=False)
+                * Transform(
+                    Dot(
+                        var_name="purchase_data",
+                        name="purchase_coefficient_alpha",
+                        prior=Prior("Normal", mu=0, sigma=1, dims="purchase_covariate"),
+                    ),
+                    func=_ptx.math.exp,
+                ),
+                dims="customer_id",
+            )
+        }
+    raise ValueError(spec)
+
+
+def _dropout_config(spec: str) -> dict:
+    """Recipe config for the dropout parameters, by combination-matrix value."""
+    if spec == "hierarchical":
+        return {}
+    if spec == "nested":
+        return {
+            "a": Parameter("a", prior=Prior("Beta", alpha=2, beta=3), xdist=False),
+            "b": Parameter("b", prior=Prior("Beta", beta=3, alpha=2), xdist=False),
+        }
+    if spec == "helper":
+        a, b = create_dropout_covariates(DROPOUT_COLS)
+        return {"a": a, "b": b}
+    if spec == "custom":
+        phi_a = Parameter(
+            "phi_a", prior=Prior("Uniform", lower=0, upper=1), xdist=False
+        )
+        kappa_a = Parameter("kappa_a", prior=Prior("Pareto", alpha=1, m=1), xdist=False)
+        phi_b = Parameter(
+            "phi_b", prior=Prior("Uniform", lower=0, upper=1), xdist=False
+        )
+        kappa_b = Parameter("kappa_b", prior=Prior("Pareto", alpha=1, m=1), xdist=False)
+        return {
+            "a": Named("a", phi_a * kappa_a),
+            "b": Named("b", (1 - phi_b) * kappa_b),
+        }
+    raise ValueError(spec)
+
+
+_EXPECTED_FREE_RVS = {
+    "r": {"r"},
+    "default": {"alpha"},
+    "scalar": {"alpha"},
+    "helper": {"alpha_scale", "purchase_coefficient_alpha"},
+    "custom-dot": {"alpha_scale", "purchase_coefficient_alpha"},
+    "hierarchical": {"phi_dropout", "kappa_dropout"},
+    "nested": {"a", "b"},
+    "dropout-helper": {
+        "a_scale",
+        "b_scale",
+        "dropout_coefficient_a",
+        "dropout_coefficient_b",
+    },
+    "custom": {"phi_a", "kappa_a", "phi_b", "kappa_b"},
+}
+
+
+class TestAllCombinations:
+    """Every alpha x dropout x data combination the config contract allows."""
+
+    @pytest.mark.parametrize("data_kind", ["dataframe", "dataset"])
+    @pytest.mark.parametrize(
+        "dropout_spec", ["hierarchical", "nested", "helper", "custom"]
+    )
+    @pytest.mark.parametrize(
+        "alpha_spec", ["default", "scalar", "helper", "custom-dot"]
+    )
+    def test_combination(
+        self, alpha_spec, dropout_spec, data_kind, covariate_data, modeling_dataset
+    ):
+        config = {**_alpha_config(alpha_spec), **_dropout_config(dropout_spec)}
+        expect_error = alpha_spec == "custom-dot" and data_kind == "dataframe"
+        model = BetaGeoModel(model_config=config)
+
+        if expect_error:
+            with pytest.raises(ValueError, match="covariate columns are configured"):
+                model.build_model(data=covariate_data)
+            return
+
+        if data_kind == "dataframe":
+            data = covariate_data
+        else:
+            data = modeling_dataset
+            if alpha_spec not in ("helper", "custom-dot"):
+                data = data.drop_vars("purchase_data")
+            if dropout_spec != "helper":
+                data = data.drop_vars("dropout_data")
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            model.build_model(data=data)
+
+        expected = set(_EXPECTED_FREE_RVS["r"])
+        expected |= _EXPECTED_FREE_RVS[alpha_spec]
+        dropout_key = "dropout-helper" if dropout_spec == "helper" else dropout_spec
+        expected |= _EXPECTED_FREE_RVS[dropout_key]
+        free = {rv.name for rv in model.model.free_RVs}
+        assert expected <= free, f"missing {expected - free}"
+
+    def test_mixed_recipe_and_deprecated_dropout_keys(self, covariate_data):
+        """Partial migration: recipe for alpha, deprecated keys for dropout."""
+        config = {**_alpha_config("helper"), "dropout_covariate_cols": DROPOUT_COLS}
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter("always", DeprecationWarning)
+            model = BetaGeoModel(model_config=config)
+        deprecations = [
+            str(w.message) for w in record if issubclass(w.category, DeprecationWarning)
+        ]
+        assert len(deprecations) == 1
+        assert "dropout_covariate_cols" in deprecations[0]
+
+        model.build_model(data=covariate_data)
+        free = {rv.name for rv in model.model.free_RVs}
+        assert {
+            "alpha_scale",
+            "purchase_coefficient_alpha",
+            "phi_dropout",
+            "kappa_dropout",
+        } <= free
+
+    def test_mixed_deprecated_purchase_keys_and_ab_recipes(self, covariate_data):
+        """Partial migration: deprecated purchase keys, recipes for dropout."""
+        a, b = create_dropout_covariates(DROPOUT_COLS)
+        config = {"purchase_covariate_cols": PURCHASE_COLS, "a": a, "b": b}
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter("always", DeprecationWarning)
+            model = BetaGeoModel(model_config=config)
+        deprecations = [
+            str(w.message) for w in record if issubclass(w.category, DeprecationWarning)
+        ]
+        assert len(deprecations) == 1
+        assert "purchase_covariate_cols" in deprecations[0]
+
+        model.build_model(data=covariate_data)
+        free = {rv.name for rv in model.model.free_RVs}
+        assert {
+            "alpha_scale",
+            "purchase_coefficient_alpha",
+            "a_scale",
+            "b_scale",
+            "dropout_coefficient_a",
+            "dropout_coefficient_b",
+        } <= free
+
+
+class TestStructureAsData:
+    """Model structure is data: inspect, serialize, tweak, rebuild."""
+
+    def test_term_tree_inspection(self):
+        """Recipes are pure dataclass trees, inspectable without a model."""
+        alpha = create_purchase_covariates(PURCHASE_COLS)
+        terms = collect_terms([alpha.expr])
+        assert [type(term).__name__ for term in terms] == ["Parameter", "Transform"]
+        transform = terms[1]
+        assert isinstance(transform.inner, Product)
+        dot = transform.inner.right
+        assert isinstance(dot, Dot)
+        assert dot.var_name == "purchase_data"
+        assert dot.name == "purchase_coefficient_alpha"
+
+    def test_structure_as_data_roundtrip(self, covariate_data):
+        """Serialize a recipe, tweak a prior in the dict, deserialize, rebuild."""
+        model = BetaGeoModel(model_config=_recipe_config())
+        spec = serialization.serialize(model.model_config["alpha"])
+
+        spec_json = json.loads(json.dumps(spec))
+        dot_spec = spec_json["expr"]["right"]["inner"]["right"]
+        assert dot_spec["__type__"].endswith("Dot")
+        dot_spec["prior"]["kwargs"]["sigma"] = 10.0
+
+        restored = serialization.deserialize(spec_json)
+        tweaked = BetaGeoModel(model_config={"alpha": restored})
+        tweaked.build_model(data=covariate_data)
+
+        assert serialization.serialize(tweaked.model_config["alpha"]) != spec
+        coef_prior = next(_iter_dots(restored)).prior
+        assert coef_prior.parameters["sigma"] == 10.0
+
+    def test_structure_swap_via_recipes(self, covariate_data):
+        """One model class, four graphs: structure is configuration."""
+        custom_ab = {
+            "a": Named(
+                "a",
+                Parameter(
+                    "phi_a", prior=Prior("Uniform", lower=0, upper=1), xdist=False
+                )
+                * Parameter(
+                    "kappa_a", prior=Prior("Pareto", alpha=1, m=1), xdist=False
+                ),
+            ),
+            "b": Named(
+                "b",
+                (
+                    1
+                    - Parameter(
+                        "phi_b", prior=Prior("Uniform", lower=0, upper=1), xdist=False
+                    )
+                )
+                * Parameter(
+                    "kappa_b", prior=Prior("Pareto", alpha=1, m=1), xdist=False
+                ),
+            ),
+        }
+        configs = [
+            {},
+            _recipe_config(),
+            _recipe_config(
+                alpha=create_purchase_covariates(
+                    PURCHASE_COLS, scale_prior=Prior("LogNormal", mu=0, sigma=1)
+                )
+            ),
+            custom_ab,
+        ]
+        structures = []
+        for config in configs:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                model = BetaGeoModel(model_config=dict(config))
+                model.build_model(data=covariate_data)
+            structures.append(
+                (
+                    frozenset(rv.name for rv in model.model.free_RVs),
+                    json.dumps(
+                        serialization.serialize(model.model_config["alpha"]),
+                        sort_keys=True,
+                    )
+                    if "alpha" in model.model_config
+                    and isinstance(model.model_config["alpha"], ModelTerm)
+                    else None,
+                )
+            )
+        # all four build; graphs and/or recipes differ structurally
+        assert structures[0] != structures[1]
+        assert structures[1] != structures[2]  # same names, different priors
+        assert structures[3] != structures[1]

--- a/tests/clv/models/test_beta_geo.py
+++ b/tests/clv/models/test_beta_geo.py
@@ -34,7 +34,6 @@ from pymc_marketing.clv.models.beta_geo import (
 from pymc_marketing.serialization import serialization
 from pymc_marketing.terms import (
     Dot,
-    ModelTerm,
     Named,
     Parameter,
     Product,
@@ -1315,28 +1314,6 @@ class TestParameterRecipes:
         loaded.build_model(data=covariate_data)
         assert set(loaded.model.named_vars) == set(model.model.named_vars)
 
-    def test_xdist_false_roundtrip(self):
-        term = Parameter("kappa", prior=Prior("Pareto", alpha=1, m=1), xdist=False)
-        restored = serialization.deserialize(serialization.serialize(term))
-        assert restored == term
-        assert restored.xdist is False
-
-    def test_default_hierarchical_uses_named_and_ref(self, covariate_data):
-        model = BetaGeoModel()
-        model.build_model(data=covariate_data)
-        names = model.model.named_vars
-        for name in (
-            "phi_dropout",
-            "kappa_dropout",
-            "a",
-            "b",
-            "r",
-            "alpha",
-        ):
-            assert name in names
-        # no covariates: the scales are pooled directly into a and b
-        assert "a_scale" not in names
-
     def test_custom_ab_recipes_self_contained(self, covariate_data):
         recipes = {
             "a": Named(
@@ -1602,61 +1579,3 @@ class TestStructureAsData:
         assert serialization.serialize(tweaked.model_config["alpha"]) != spec
         coef_prior = next(_iter_dots(restored)).prior
         assert coef_prior.parameters["sigma"] == 10.0
-
-    def test_structure_swap_via_recipes(self, covariate_data):
-        """One model class, four graphs: structure is configuration."""
-        custom_ab = {
-            "a": Named(
-                "a",
-                Parameter(
-                    "phi_a", prior=Prior("Uniform", lower=0, upper=1), xdist=False
-                )
-                * Parameter(
-                    "kappa_a", prior=Prior("Pareto", alpha=1, m=1), xdist=False
-                ),
-            ),
-            "b": Named(
-                "b",
-                (
-                    1
-                    - Parameter(
-                        "phi_b", prior=Prior("Uniform", lower=0, upper=1), xdist=False
-                    )
-                )
-                * Parameter(
-                    "kappa_b", prior=Prior("Pareto", alpha=1, m=1), xdist=False
-                ),
-            ),
-        }
-        configs = [
-            {},
-            _recipe_config(),
-            _recipe_config(
-                alpha=create_purchase_covariates(
-                    PURCHASE_COLS, scale_prior=Prior("LogNormal", mu=0, sigma=1)
-                )
-            ),
-            custom_ab,
-        ]
-        structures = []
-        for config in configs:
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", DeprecationWarning)
-                model = BetaGeoModel(model_config=dict(config))
-                model.build_model(data=covariate_data)
-            structures.append(
-                (
-                    frozenset(rv.name for rv in model.model.free_RVs),
-                    json.dumps(
-                        serialization.serialize(model.model_config["alpha"]),
-                        sort_keys=True,
-                    )
-                    if "alpha" in model.model_config
-                    and isinstance(model.model_config["alpha"], ModelTerm)
-                    else None,
-                )
-            )
-        # all four build; graphs and/or recipes differ structurally
-        assert structures[0] != structures[1]
-        assert structures[1] != structures[2]  # same names, different priors
-        assert structures[3] != structures[1]

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -20,12 +20,13 @@ import numpy as np
 import pymc as pm
 import pymc.dims as pmd
 import pytensor.tensor as pt
-import pytensor.xtensor.math as ptx
+import pytensor.xtensor as ptx
 import pytest
 import xarray as xr
 from pymc_extras.prior import Prior
 from pytensor.graph.basic import Variable as PTVariable
 
+from pymc_marketing.serialization import SerializationError, serialization
 from pymc_marketing.terms import (
     Dot,
     Intercept,
@@ -196,14 +197,14 @@ def test_dot_set_data(simple_ds):
 def test_transform_create_variable():
     with pm.Model():
         inner = Intercept(name="sigma")
-        transformed = Transform(inner, func=ptx.exp)
+        transformed = Transform(inner, func=ptx.math.exp)
         result = transformed.create_variable()
         assert isinstance(result, PTVariable)
 
 
 def test_transform_with_dot(simple_ds):
     dot = Dot(var_name="x", prior=Prior("Normal", dims="feature"))
-    transformed = Transform(dot, func=ptx.exp)
+    transformed = Transform(dot, func=ptx.math.exp)
     coords = transformed.get_coords(simple_ds)
     with pm.Model(coords=coords):
         transformed.register_data(simple_ds)
@@ -213,7 +214,7 @@ def test_transform_with_dot(simple_ds):
 
 def test_transform_set_data(simple_ds):
     inner = Dot(var_name="x", prior=Prior("Normal", dims="feature"))
-    transformed = Transform(inner, func=ptx.exp)
+    transformed = Transform(inner, func=ptx.math.exp)
     coords = transformed.get_coords(simple_ds)
     with pm.Model(coords=coords) as model:
         transformed.register_data(simple_ds)
@@ -273,7 +274,7 @@ def test_build_param_prior():
 
 def test_build_param_transform():
     with pm.Model():
-        result = build_param(Transform(Intercept(name="sigma"), func=ptx.exp))
+        result = build_param(Transform(Intercept(name="sigma"), func=ptx.math.exp))
         assert isinstance(result, PTVariable)
 
 
@@ -332,7 +333,7 @@ def test_collect_terms_skips_constants():
 
 
 def test_collect_terms_includes_transform():
-    terms = [Transform(Intercept(name="a"), func=ptx.exp)]
+    terms = [Transform(Intercept(name="a"), func=ptx.math.exp)]
     result = collect_terms(terms)
     assert len(result) == 1
 
@@ -340,7 +341,7 @@ def test_collect_terms_includes_transform():
 def test_collect_coords(simple_ds):
     """collect_coords merges coordinates from multiple term trees."""
     mu = Intercept(name="mu") + Dot(var_name="x", prior=Prior("Normal", dims="feature"))
-    sigma = Transform(Intercept(name="sigma"), func=ptx.exp)
+    sigma = Transform(Intercept(name="sigma"), func=ptx.math.exp)
     coords = collect_coords(mu, sigma, ds=simple_ds)
     assert "feature" in coords
 
@@ -521,7 +522,7 @@ def test_collect_coords_multiplication(simple_ds):
     """CLV gotcha: `a + b * c` must collect coordinates from the Product child."""
     mu = Intercept(name="a") + Dot(
         var_name="x", prior=Prior("Normal", dims="feature")
-    ) * Transform(Intercept(name="scale"), func=ptx.exp)
+    ) * Transform(Intercept(name="scale"), func=ptx.math.exp)
     coords = collect_coords(mu, ds=simple_ds)
     assert "feature" in coords
 
@@ -554,7 +555,7 @@ def test_set_data_multiplication(simple_ds):
     """
     mu = Intercept(name="a") + Dot(
         var_name="x", prior=Prior("Normal", dims="feature")
-    ) * Transform(Intercept(name="scale"), func=ptx.exp)
+    ) * Transform(Intercept(name="scale"), func=ptx.math.exp)
     coords = collect_coords(mu, ds=simple_ds)
     with pm.Model(coords=coords) as model:
         register_data(mu, ds=simple_ds)
@@ -651,3 +652,57 @@ def test_parameter_create_variable():
         with pm.Model(coords={"product": ["p1", "p2", "p3"]}):
             v = p.create_variable()
             assert v is not None
+
+
+def test_serialize_parameter_roundtrip():
+    term = Parameter("alpha", prior=Prior("Normal", mu=0, sigma=1, dims="product"))
+    restored = serialization.deserialize(serialization.serialize(term))
+    assert restored == term
+    assert restored.prior.dims == ("product",)
+
+
+def test_serialize_dot_roundtrip():
+    dot = Dot(var_name="x", prior=Prior("Normal", dims="feature"), name="x_coef")
+    restored = serialization.deserialize(serialization.serialize(dot))
+    assert restored == dot
+    assert restored.name == "x_coef"
+
+
+def test_serialize_intercept_subclass_roundtrip():
+    term = Intercept("baseline", prior=Prior("Normal"))
+    restored = serialization.deserialize(serialization.serialize(term))
+    assert isinstance(restored, Intercept)
+    assert restored == term
+
+
+def test_serialize_composition_roundtrip():
+    alpha = Parameter("alpha_scale", prior=Prior("HalfFlat")) * Transform(
+        -Dot(
+            var_name="purchase_data",
+            name="purchase_coefficient_alpha",
+            prior=Prior("Normal", mu=0, sigma=1, dims="purchase_covariate"),
+        ),
+        func=ptx.math.exp,
+    )
+    restored = serialization.deserialize(serialization.serialize(alpha))
+    assert restored == alpha
+
+
+def test_serialize_sum_with_literals_roundtrip():
+    expr = Intercept(name="a") + 5 - Intercept(name="b")
+    restored = serialization.deserialize(serialization.serialize(expr))
+    assert restored == expr
+
+
+def test_serialize_unregistered_func_raises():
+    with pytest.raises(SerializationError, match="not serializable"):
+        serialization.serialize(Transform(Parameter("x"), func=pt.sqrt))
+
+
+def test_restored_term_builds(simple_ds):
+    dot = Dot(var_name="x", prior=Prior("Normal", dims="feature"))
+    restored = serialization.deserialize(serialization.serialize(dot))
+    coords = collect_coords(restored, ds=simple_ds)
+    with pm.Model(coords=coords):
+        register_data(restored, ds=simple_ds)
+        assert isinstance(build_param(restored), PTVariable)

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -661,6 +661,13 @@ def test_serialize_parameter_roundtrip():
     assert restored.prior.dims == ("product",)
 
 
+def test_serialize_parameter_xdist_false_roundtrip():
+    term = Parameter("kappa", prior=Prior("Pareto", alpha=1, m=1), xdist=False)
+    restored = serialization.deserialize(serialization.serialize(term))
+    assert restored == term
+    assert restored.xdist is False
+
+
 def test_serialize_dot_roundtrip():
     dot = Dot(var_name="x", prior=Prior("Normal", dims="feature"), name="x_coef")
     restored = serialization.deserialize(serialization.serialize(dot))


### PR DESCRIPTION
Closes #2964 and starts the `Terms` milestone (#17): the first dogfooded consumer of `pymc_marketing.terms` (#2965).

`BetaGeoModel` now composes its parameters as terms **outside** the model context. The model block itself is reduced to register-data, build, and likelihood.

Parameter recipes pass through `model_config` and serialize with the model:

```python
from pymc_marketing.clv.models.beta_geo import (
    BetaGeoModel,
    create_purchase_covariates,
    create_dropout_covariates,
)

model = BetaGeoModel(
    model_config={
        "alpha": create_purchase_covariates(["income", "age"]),
        "a": a_recipe,
        "b": b_recipe,
    }
)
```

Details:

- `model_config["alpha" | "a" | "b"]` accepts terms (`Parameter`, `Named`, compositions). Missing recipes fall back to defaults derived from the existing priors, so current behavior is unchanged.
- `build_model` also accepts an `xr.Dataset` (with `T`/`recency`/`frequency` variables, `customer_id` coordinate, and `purchase_data`/`dropout_data`); a DataFrame is reconstructed for predictions.
- Deprecated and now warn: `purchase_covariate_cols`, `dropout_covariate_cols`, `purchase_coefficient`, `dropout_coefficient` config keys. The columns and coefficient priors become part of the recipe and its serialization instead.
- New terms vocabulary in `pymc_marketing.terms`: `Named` (expression into a named deterministic), `Ref` (reference a built variable, e.g. hierarchical `a_scale` -> `a`), `xdist=False` escape hatch (pymc.dims lacks some distributions, e.g. Pareto), and `to_dict`/`from_dict` registration so recipes survive `fit()` (attrs serialize at sampling time) and `save()`/`load()`.
- Recipes can reference the same data group: multiple `Dot` terms with one `var_name` share a single registered variable, persisted once in `fit_data`. The built-in helpers keep separate `purchase_data`/`dropout_data` variables (and dims) for posterior-name back-compat; cross-branch sharing is available through custom recipes.
- `fit_data` now stores the **merged modeling dataset**: the customer-level frame (with `customer_id` as a coordinate) merged with every recipe-bound variable, so custom recipes binding new data variables survive `fit()`/`save()`/`load()`. Old saved models (previous `fit_data` shape) keep loading through the DataFrame path.
- Stage 1 boundary: predictions keep the closed-form xarray path for default/helper recipes; arbitrary custom recipes raise `NotImplementedError`. Next milestone steps: recipe-driven predictions, then removing the deprecated keys; MBG/NBD keeps its legacy config surface until #2962 ports it.

Dogfooding findings so far: the xtensor -> tensor boundary for legacy distributions (`allow_xtensor_conversion`), register-before-build ordering, and the `pymc.dims` distribution coverage gap are all documented as Gotchas in the terms module docstring.

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2976.org.readthedocs.build/en/2976/

<!-- readthedocs-preview pymc-marketing end -->

## Flexibility

The config contract is exercised as a combination matrix in `TestAllCombinations`: every `alpha` (default / scalar `Parameter` / `create_purchase_covariates` / custom `Dot` recipe) x `dropout` (hierarchical / nested / helper / custom `Named`) x data (`DataFrame` / `Dataset`) combination builds, with per-cell expected free-RV structure and the one principled boundary (custom `Dot` recipes need a `Dataset` or helper-embedded columns on the `DataFrame` path). Migration mixes (recipe + deprecated keys) are covered too.

Model structure is data: inspect, serialize, tweak, rebuild:

```python
from pymc_marketing.serialization import serialization

model = BetaGeoModel(model_config={"alpha": create_purchase_covariates(["income"])})

# inspect the tree, no PyMC context needed
collect_terms(model.model_config["alpha"].expr)

# serialize -> tweak a prior -> deserialize -> rebuild
spec = json.loads(json.dumps(serialization.serialize(model.model_config["alpha"])))
spec["expr"]["right"]["inner"]["right"]["prior"]["kwargs"]["sigma"] = 10.0
swapped = BetaGeoModel(
    model_config={"alpha": serialization.deserialize(spec)}
)
```

The same class, different graphs: `BetaGeoModel()`, covariate helpers, custom priors, or hand-rolled `Named`/`Ref` compositions — `build_model` never changes. `TestAllCombinations` is the executable contract for this space; `TestStructureAsData` covers inspecting and rewriting the serialized tree.


