### PR TITLE
docs(mmm): say that DataDerivedScaling reductions are signed

### DIFF
--- a/pymc_marketing/mmm/scaling.py
+++ b/pymc_marketing/mmm/scaling.py
@@ -135,23 +135,42 @@ class VariableScaling(SerializableBaseModel, ABC):
 class DataDerivedScaling(VariableScaling):
     """Scale by a statistic of the data, computed at fit time.
 
+    Both reductions are **signed**: ``method="max"`` is ``data.max(...)`` and
+    ``method="mean"`` is ``data.mean(...)``, not the maximum or mean of the
+    absolute values.  Unlike :class:`FixedScaling`, which requires positive
+    values, nothing constrains the sign or magnitude of a computed scale, so
+    two cases are reachable and neither is reported:
+
+    * A slice whose reduction is **negative** gives a scale that flips the
+      sign of the scaled data.  The round trip still closes, because
+      ``original_scale_transform`` multiplies by the same scale again, but
+      the flip is invisible.
+    * A slice whose reduction is **exactly zero** gives a scale of zero, so
+      every scaled value is NaN or infinite.  ``MMM.build_model`` rewrites
+      those to ``0.0``, which replaces that slice's data with zeros rather
+      than scaling it.  Under a likelihood with positive support this raises
+      at build time; under ``Normal`` it fits on the zeros silently.
+
+    An all-zero target reaches the second case, which is what
+    ``sample_prior_predictive`` and ``fit`` produce when no ``y`` is given.
+
     Parameters
     ----------
     method : ``"max"`` | ``"mean"``
-        The scaling method.
+        The scaling method.  Signed, see above.
     dims : str or tuple of str
         The dimensions to perform the operation through (``"date"`` is always
         included implicitly).
 
     Examples
     --------
-    Max-absolute scaling (default behaviour):
+    Max scaling (default behaviour):
 
     .. code-block:: python
 
         DataDerivedScaling(method="max", dims=())
 
-    Mean-absolute scaling across a custom dimension:
+    Mean scaling across a custom dimension:
 
     .. code-block:: python
 


### PR DESCRIPTION
Step 1 of the sequencing agreed on #2973. Docs only, no behaviour change.

`DataDerivedScaling`'s docstring called `method="max"` "Max-absolute scaling", but `_compute_scale_for_variable` reduces with the plain reducer (`mmm/mmm.py:1926-1929`):

```python
method_fn = getattr(data, scaling.method)
scale = method_fn(dim=reduce_dims)
```

No absolute value. `FixedScaling` documents and enforces "All values must be positive"; nothing constrains a computed scale, so two things are reachable and neither is reported:

- A negative reduction gives a scale that flips the sign of the scaled data. The round trip closes, since `original_scale_transform` multiplies by the same scale again, but the flip is invisible.
- A zero reduction gives a scale of zero, so every ratio is NaN or infinite and the clamp in `build_model` rewrites them to `0.0`. That slice's data is replaced by zeros rather than scaled. Under a positive-support likelihood this now raises (#2975); under `Normal` it fits on the zeros silently.

The docstring now says all of that, including that an all-zero target reaches the second case, which is what `sample_prior_predictive` and `fit` produce when no `y` is given.

## What this deliberately does not do

Rejecting a non-positive computed scale is step 2 on #2973 and has to wait on #2956, because the no-`y` placeholder produces a scale of exactly zero by construction, so rejecting it today would make `mmm.sample_prior_predictive(X)` impossible under the default scaling.

Switching the reductions to `abs` stays off the table per that discussion: `target_scale` is baked into saved idata, so it would change what a reloaded model's `*_original_scale` means with nothing in the graph flagging it.

```console
$ uv run pytest tests/mmm/test_scaling.py -q
33 passed
```

Related: #2973, #2974, #2956.


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2978.org.readthedocs.build/en/2978/

<!-- readthedocs-preview pymc-marketing end -->