### PR TITLE
feat(r2d2): add non-centered parameterization

### DIFF
--- a/pymc_marketing/r2d2.py
+++ b/pymc_marketing/r2d2.py
@@ -117,8 +117,8 @@ class R2D2Split:
     wherever a Prior is accepted (e.g., in model_config priors).
 
     When create_variable() is called, auto-builds the decomposition
-    if not already built, then creates a pmd.Normal coefficient with
-    mu=0, sigma=split, dims=component_dim.
+    if not already built, then creates a coefficient with the selected
+    centered or non-centered parameterization.
 
     Parameters
     ----------
@@ -179,8 +179,16 @@ class R2D2Split:
         split = self.decomposition._splits[self.component_name]
         dims = self.decomposition.dims[self.component_name]
 
-        # Create coefficient: beta ~ pmd.Normal(mu=0, sigma=split, dims=dims)
-        return pmd.Normal(name, mu=0, sigma=split, dims=dims)
+        if self.decomposition.centered:
+            # Centered: beta ~ Normal(0, split). This is the historical
+            # parameterization and is retained as the default.
+            return pmd.Normal(name, mu=0, sigma=split, dims=dims)
+
+        # Non-centered: beta_offset ~ Normal(0, 1), beta = split * beta_offset.
+        # Sampling a scale-free offset avoids the funnel induced by very small
+        # Dirichlet weights while preserving the same marginal prior on beta.
+        offset = pmd.Normal(name + "_offset", mu=0, sigma=1, dims=dims)
+        return pmd.Deterministic(name, split * offset, dims=dims)
 
     def to_dict(self) -> dict:
         """Serialize to dictionary."""
@@ -294,6 +302,11 @@ class R2D2:
     dims : dict[str, str]
         Maps component name to dim name.
         E.g., {"control": "control", "fourier": "fourier"}.
+    centered : bool, default=True
+        Whether to sample coefficients directly with their stochastic local
+        scales. If False, sample standard-normal offsets and construct the
+        coefficients deterministically; this can improve sampling when
+        Dirichlet weights are small.
 
     Example
     -------
@@ -335,6 +348,9 @@ class R2D2:
     - The ``r2`` prior controls global shrinkage (how much variance the model explains).
     - The ``total_sigma`` prior controls the overall scale of coefficients.
     - The Dirichlet prior (currently flat, a_π=1) splits model variance across components.
+    - ``centered`` selects the historical centered coefficient parameterization or
+      a non-centered offset parameterization, which can improve sampling when
+      local Dirichlet scales are small.
     - Use ``split("component_name")`` to get a lazy reference to a component's variance.
     - Use ``error_sigma`` to get the residual standard deviation.
     - This is single-level R2D2 (no varying effects).
@@ -343,6 +359,7 @@ class R2D2:
     r2: Prior
     total_sigma: Prior
     dims: dict[str, str]  # component_name -> dim_name
+    centered: bool = True
 
     def __post_init__(self) -> None:
         """Validate parameters and initialize state."""
@@ -498,11 +515,14 @@ class R2D2:
 
     def to_dict(self) -> dict:
         """Serialize to dictionary."""
-        return {
+        result = {
             "r2": self.r2.to_dict(),
             "total_sigma": self.total_sigma.to_dict(),
             "dims": self.dims,
         }
+        if not self.centered:
+            result["centered"] = False
+        return result
 
     @classmethod
     def from_dict(cls, data: dict) -> "R2D2":
@@ -517,6 +537,7 @@ class R2D2:
             r2=_deserialize_prior(data["r2"]),
             total_sigma=_deserialize_prior(data["total_sigma"]),
             dims=data["dims"],
+            centered=data.get("centered", True),
         )
 
 

--- a/tests/test_r2d2.py
+++ b/tests/test_r2d2.py
@@ -354,6 +354,28 @@ class TestR2D2:
             actual_names = list(model.coords["r2d2_split"])
             assert actual_names == expected_names
 
+    @pytest.mark.parametrize("centered", [True, False])
+    def test_parameterization_variable_names(self, centered):
+        """Centered and non-centered forms expose stable coefficient names."""
+        r2d2 = R2D2(
+            r2=Prior("Beta", mu=0.8, sigma=0.2),
+            total_sigma=Prior("HalfNormal", sigma=1),
+            dims={"control": "control"},
+            centered=centered,
+        )
+
+        with pm.Model(coords={"control": ["a", "b"]}) as model:
+            coefficient = r2d2.split("control").create_variable("beta")
+
+            assert coefficient.name == "beta"
+            free_rv_names = {rv.name for rv in model.free_RVs}
+            if centered:
+                assert "beta" in free_rv_names
+                assert "beta_offset" not in model.named_vars
+            else:
+                assert "beta_offset" in free_rv_names
+                assert "beta" in {det.name for det in model.deterministics}
+
 
 class TestR2D2Serialization:
     """Tests for R2D2 serialization."""
@@ -378,6 +400,20 @@ class TestR2D2Serialization:
         assert restored.total_sigma == r2d2.total_sigma
         assert restored.dims == r2d2.dims
         assert not restored.built  # Should not be built after deserialization
+
+    def test_non_centered_round_trip(self):
+        """Serialization round-trip should preserve non-centered sampling."""
+        r2d2 = R2D2(
+            r2=Prior("Beta", mu=0.8, sigma=0.2),
+            total_sigma=Prior("LogNormal", mu=0, sigma=1),
+            dims={"control": "control"},
+            centered=False,
+        )
+
+        restored = serialization.deserialize(serialization.serialize(r2d2))
+
+        assert isinstance(restored, R2D2)
+        assert restored.centered is False
 
     def test_split_round_trip(self):
         """R2D2Split serialization round-trip."""


### PR DESCRIPTION
## Summary
- add an optional non-centered R2D2 parameterization
- retain centered behavior as the default
- add naming and serialization coverage

## Validation
- `uv run pytest tests/test_r2d2.py tests/test_serialization.py -q`
- `uv run ruff check pymc_marketing/r2d2.py tests/test_r2d2.py`

Needed by the control-dimensionality MMM case-study notebook, which will remain separate and merge after this API change.

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2986.org.readthedocs.build/en/2986/

<!-- readthedocs-preview pymc-marketing end -->