### PR TITLE
feat: serialize terms vocabulary

### DIFF
--- a/pymc_marketing/serialization.py
+++ b/pymc_marketing/serialization.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import importlib
 import inspect
-from dataclasses import dataclass
+from dataclasses import dataclass, fields, is_dataclass
 from typing import Any, Protocol, Self, runtime_checkable
 
 from pydantic import BaseModel, Field
@@ -192,6 +192,11 @@ class TypeRegistry:
                 actual_cls.to_dict = _wrapped_to_dict  # type: ignore[attr-defined]
 
         return actual_cls
+
+    def is_registered(self, obj: Any) -> bool:
+        """Check whether an object's type is registered in the registry."""
+        type_key = f"{obj.__class__.__module__}.{obj.__class__.__qualname__}"
+        return type_key in self._registry
 
     def serialize(self, obj: Serializable) -> dict[str, Any]:
         """Serialize an object to a JSON-safe dict with ``__type__`` key."""
@@ -387,6 +392,16 @@ def _merge_shared_decompositions(config: dict[str, Any]) -> dict[str, Any]:
             return obj
         if isinstance(obj, R2D2Sigma):
             obj.decomposition = walk(obj.decomposition)
+            return obj
+        if is_dataclass(obj) and not isinstance(obj, type):
+            # Term compositions (Sum, Product, Parameter, Dot, Transform)
+            # carry R2D2Split priors in their fields; descend so shared
+            # decompositions merge instead of duplicating per field.
+            dataclass_params = getattr(obj, "__dataclass_params__", None)
+            if dataclass_params is not None and dataclass_params.frozen:
+                return obj
+            for dc_field in fields(obj):
+                setattr(obj, dc_field.name, walk(getattr(obj, dc_field.name)))
             return obj
         if isinstance(obj, dict):
             return {k: walk(v) for k, v in obj.items()}

--- a/pymc_marketing/serialization.py
+++ b/pymc_marketing/serialization.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import importlib
 import inspect
-from dataclasses import dataclass, fields, is_dataclass
+from dataclasses import dataclass, fields, is_dataclass, replace
 from typing import Any, Protocol, Self, runtime_checkable
 
 from pydantic import BaseModel, Field
@@ -397,11 +397,14 @@ def _merge_shared_decompositions(config: dict[str, Any]) -> dict[str, Any]:
             # Term compositions (Sum, Product, Parameter, Dot, Transform)
             # carry R2D2Split priors in their fields; descend so shared
             # decompositions merge instead of duplicating per field.
-            dataclass_params = getattr(obj, "__dataclass_params__", None)
-            if dataclass_params is not None and dataclass_params.frozen:
-                return obj
-            for dc_field in fields(obj):
-                setattr(obj, dc_field.name, walk(getattr(obj, dc_field.name)))
+            walked = {
+                dc_field.name: walk(getattr(obj, dc_field.name))
+                for dc_field in fields(obj)
+            }
+            if obj.__dataclass_params__.frozen:  # type: ignore[attr-defined]
+                return replace(obj, **walked)
+            for key, value in walked.items():
+                setattr(obj, key, value)
             return obj
         if isinstance(obj, dict):
             return {k: walk(v) for k, v in obj.items()}

--- a/pymc_marketing/terms.py
+++ b/pymc_marketing/terms.py
@@ -231,6 +231,13 @@ Gotchas
           model = pm.modelcontext(None)
           unique = list(dict.fromkeys(ds[self.data_source].values))
           model.add_coords({self.data_source: unique})
+- The built-in terms serialize via ``pymc_marketing.serialization``
+  (``to_dict`` / ``from_dict`` are registered), so recipes stored in
+  ``model_config`` survive ``fit()`` (attrs are JSON-serialized at
+  sampling time) and ``save()`` / ``load()``. ``Transform`` functions are
+  serialized by name, resolved against ``pytensor.xtensor.math`` /
+  ``pytensor.xtensor.linalg`` and transforms registered with
+  ``pymc_extras.prior.register_tensor_transform``.
 """
 
 from __future__ import annotations
@@ -242,9 +249,14 @@ from typing import Any, cast
 import pymc as pm
 import pymc.dims as pmd
 import pytensor.tensor as pt
+import pytensor.xtensor as ptx
 import xarray as xr
-from pymc_extras.prior import Prior, VariableFactory
+from pymc_extras.deserialize import DeserializableError
+from pymc_extras.deserialize import deserialize as pymc_extras_deserialize
+from pymc_extras.prior import CUSTOM_TRANSFORMS, Prior, VariableFactory
 from pytensor.xtensor.type import as_xtensor
+
+from pymc_marketing.serialization import SerializationError, serialization
 
 __all__ = [
     "Dot",
@@ -261,6 +273,81 @@ __all__ = [
     "register_data",
     "set_data",
 ]
+
+# Modules searched when serializing ``Transform`` functions. Registered
+# custom transforms (``pymc_extras.prior.register_tensor_transform``) take
+# precedence; otherwise the function is looked up by name in these modules.
+_TRANSFORM_MODULES = ("math", "linalg")
+
+
+def _func_name(func: Callable) -> str:
+    """Resolve a transform function to its serializable name."""
+    for name, registered in CUSTOM_TRANSFORMS.items():
+        if registered is func:
+            return name
+    for module_name in _TRANSFORM_MODULES:
+        module = getattr(ptx, module_name)
+        for attr in dir(module):
+            if getattr(module, attr, None) is func:
+                return attr
+    name = getattr(func, "__name__", None)
+    if name is not None and getattr(ptx, name, None) is func:
+        return name
+    raise SerializationError(
+        f"Function {func!r} is not serializable. Use a "
+        "pytensor.xtensor.math function, or register it with "
+        "pymc_extras.prior.register_tensor_transform."
+    )
+
+
+def _lookup_func(name: str) -> Callable:
+    """Resolve a serialized transform function name."""
+    if name in CUSTOM_TRANSFORMS:
+        return CUSTOM_TRANSFORMS[name]
+    for module_name in _TRANSFORM_MODULES:
+        try:
+            return getattr(getattr(ptx, module_name), name)
+        except AttributeError:
+            continue
+    try:
+        return getattr(ptx, name)
+    except AttributeError as err:
+        raise SerializationError(
+            f"Unknown serialized function {name!r}. Use a "
+            "pytensor.xtensor.math function, or register it with "
+            "pymc_extras.prior.register_tensor_transform."
+        ) from err
+
+
+def _serialize_child(value: Any) -> Any:
+    """Serialize a child of a composed term to a JSON-safe value.
+
+    Numeric literals become ``{"__type__": "literal", ...}`` wrappers;
+    variable factories that are not registered in the type registry
+    (``Prior``, ``Censored``, ...) serialize via their own ``to_dict``.
+    """
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return {"__type__": "literal", "value": value}
+    try:
+        return serialization.serialize(value)
+    except KeyError:
+        if hasattr(value, "to_dict"):
+            return value.to_dict()
+        raise
+
+
+def _deserialize_child(value: Any) -> Any:
+    """Deserialize a serialized term child back to a live object."""
+    if isinstance(value, dict):
+        if value.get("__type__") == "literal":
+            return value["value"]
+        if "__type__" in value:
+            return serialization.deserialize(value)
+        try:
+            return pymc_extras_deserialize(value)
+        except DeserializableError as err:
+            raise SerializationError(f"Cannot deserialize term child: {value}") from err
+    return value
 
 
 @dataclass
@@ -352,6 +439,7 @@ class ModelTerm:
         return Product(-1, self)
 
 
+@serialization.register
 @dataclass
 class Sum:
     """Container for additive composition via ``+``.
@@ -406,7 +494,17 @@ class Sum:
         for term in self.terms:
             set_data(term, ds=ds, model=model)
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the sum and its children."""
+        return {"terms": [_serialize_child(term) for term in self.terms]}
 
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Sum:
+        """Reconstruct a sum from its serialized form."""
+        return cls(terms=[_deserialize_child(term) for term in data["terms"]])
+
+
+@serialization.register
 @dataclass
 class Product:
     """Container for multiplicative composition via ``*``.
@@ -448,7 +546,23 @@ class Product:
         set_data(self.left, ds=ds, model=model)
         set_data(self.right, ds=ds, model=model)
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the product and both operands."""
+        return {
+            "left": _serialize_child(self.left),
+            "right": _serialize_child(self.right),
+        }
 
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Product:
+        """Reconstruct a product from its serialized form."""
+        return cls(
+            left=_deserialize_child(data["left"]),
+            right=_deserialize_child(data["right"]),
+        )
+
+
+@serialization.register
 @dataclass
 class Parameter(ModelTerm):
     """Named free parameter (scalar or dimensional via ``prior.dims``).
@@ -513,7 +627,17 @@ class Parameter(ModelTerm):
         """Build a free parameter variable."""
         return self.prior.create_variable(self.name, xdist=True)
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the parameter name and prior."""
+        return {"name": self.name, "prior": _serialize_child(self.prior)}
 
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Parameter:
+        """Reconstruct a parameter from its serialized form."""
+        return cls(name=data["name"], prior=_deserialize_child(data["prior"]))
+
+
+@serialization.register
 @dataclass
 class Intercept(Parameter):
     """GLM-style intercept term; same as :class:`Parameter` with a default name.
@@ -534,6 +658,7 @@ class Intercept(Parameter):
     prior: VariableFactory = field(default_factory=lambda: Prior("Normal"))
 
 
+@serialization.register
 @dataclass(kw_only=True)
 class Dot(ModelTerm):
     """Linear predictor term: ``data @ beta``.
@@ -615,7 +740,25 @@ class Dot(ModelTerm):
         beta = self.prior.create_variable(self.name, xdist=True)
         return data @ beta
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the data variable, coefficient prior, and name."""
+        return {
+            "var_name": self.var_name,
+            "prior": _serialize_child(self.prior),
+            "name": self.name,
+        }
 
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Dot:
+        """Reconstruct a dot term from its serialized form."""
+        return cls(
+            var_name=data["var_name"],
+            prior=_deserialize_child(data["prior"]),
+            name=data["name"],
+        )
+
+
+@serialization.register
 @dataclass
 class Transform(ModelTerm):
     """Apply a pytensor function to a term's output.
@@ -673,6 +816,21 @@ class Transform(ModelTerm):
     def set_data(self, ds: xr.Dataset, model: pm.Model | None = None) -> None:
         """Update shared data for the inner expression."""
         set_data(self.inner, ds=ds, model=model)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the inner expression and the applied function."""
+        return {
+            "inner": _serialize_child(self.inner),
+            "func": _func_name(self.func),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Transform:
+        """Reconstruct a transform from its serialized form."""
+        return cls(
+            inner=_deserialize_child(data["inner"]),
+            func=_lookup_func(data["func"]),
+        )
 
 
 def get_coords(param: Any, ds: xr.Dataset) -> dict[str, Any]:

--- a/pymc_marketing/terms.py
+++ b/pymc_marketing/terms.py
@@ -334,10 +334,18 @@ def _resolve_func(name: str) -> Callable:
             "pytensor.xtensor.math function, or register it with "
             "pymc_extras.prior.register_tensor_transform."
         ) from err
-    if name.startswith("_") or not callable(func):
+    if name not in CUSTOM_TRANSFORMS:
+        # The underscore rule only guards module-scan noise (dunder and
+        # non-function attributes); explicitly registered names opt out.
+        if name.startswith("_") or not callable(func):
+            raise SerializationError(
+                f"Serialized function name {name!r} must resolve to a "
+                f"callable pytensor function, got {func!r}."
+            )
+    if not callable(func):
         raise SerializationError(
-            f"Serialized function name {name!r} must resolve to a callable "
-            f"pytensor function, got {func!r}."
+            f"Serialized transform {name!r} resolved to {func!r}, which is "
+            "not callable."
         )
     return func
 
@@ -379,7 +387,13 @@ def _deserialize_child(value: Any) -> Any:
         try:
             return pymc_extras_deserialize(value)
         except DeserializableError as err:
-            raise SerializationError(f"Cannot deserialize term child: {value}") from err
+            raise SerializationError(
+                f"Cannot deserialize term child: {value}. If it is a custom "
+                "factory, register it with "
+                "pymc_extras.deserialize.register_deserialization "
+                "(with a to_dict/from_dict counterpart to "
+                "@serialization.register)."
+            ) from err
     return value
 
 

--- a/pymc_marketing/terms.py
+++ b/pymc_marketing/terms.py
@@ -60,6 +60,24 @@ Rules
 - ``build_param`` accepts ``VariableFactory``, ``ModelTerm``, ``xr.DataArray``,
   or numeric literal.  ``Prior.create_variable`` is called with ``xdist=True``.
 
+Serialization
+^^^^^^^^^^^^^
+Built-in terms serialize through :mod:`pymc_marketing.serialization`
+(``to_dict`` / ``from_dict`` are registered), so recipes stored in
+``model_config`` survive ``fit()`` (attrs are JSON-serialized at sampling
+time) and ``save()`` / ``load()``. Custom terms are part of the same
+contract: decorate them with ``@serialization.register`` and implement
+``to_dict`` / ``from_dict`` --- serializing a composition that contains an
+unregistered term raises
+:class:`~pymc_marketing.serialization.SerializationError`.
+
+Children of composed terms (``Sum``, ``Product``, ``Transform``) must be
+registered terms, ``VariableFactory`` (``Prior``, ...), ``xr.DataArray``,
+``DeferredFactory``, or numeric literals. ``Transform`` functions serialize
+by name and are resolved with ``pymc_extras.prior._get_transform``:
+``pytensor.xtensor.math`` / ``pytensor.xtensor.linalg`` functions, or
+transforms registered with ``pymc_extras.prior.register_tensor_transform``.
+
 ``Parameter`` and ``Intercept``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 These are the same kind of term: a named free parameter whose shape
@@ -246,6 +264,7 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from typing import Any, cast
 
+import numpy as np
 import pymc as pm
 import pymc.dims as pmd
 import pytensor.tensor as pt
@@ -253,10 +272,20 @@ import pytensor.xtensor as ptx
 import xarray as xr
 from pymc_extras.deserialize import DeserializableError
 from pymc_extras.deserialize import deserialize as pymc_extras_deserialize
-from pymc_extras.prior import CUSTOM_TRANSFORMS, Prior, VariableFactory
+from pymc_extras.prior import (
+    CUSTOM_TRANSFORMS,
+    Prior,
+    UnknownTransformError,
+    VariableFactory,
+    _get_transform,
+)
 from pytensor.xtensor.type import as_xtensor
 
-from pymc_marketing.serialization import SerializationError, serialization
+from pymc_marketing.serialization import (
+    DeferredFactory,
+    SerializationError,
+    serialization,
+)
 
 __all__ = [
     "Dot",
@@ -274,25 +303,20 @@ __all__ = [
     "set_data",
 ]
 
-# Modules searched when serializing ``Transform`` functions. Registered
-# custom transforms (``pymc_extras.prior.register_tensor_transform``) take
-# precedence; otherwise the function is looked up by name in these modules.
-_TRANSFORM_MODULES = ("math", "linalg")
-
 
 def _func_name(func: Callable) -> str:
-    """Resolve a transform function to its serializable name."""
+    """Resolve a transform function to its serializable name.
+
+    Scans the same modules, in the same order, as
+    ``pymc_extras.prior._get_transform`` so serialized names round-trip.
+    """
     for name, registered in CUSTOM_TRANSFORMS.items():
         if registered is func:
             return name
-    for module_name in _TRANSFORM_MODULES:
-        module = getattr(ptx, module_name)
+    for module in (ptx.math, ptx.linalg, ptx):
         for attr in dir(module):
             if getattr(module, attr, None) is func:
                 return attr
-    name = getattr(func, "__name__", None)
-    if name is not None and getattr(ptx, name, None) is func:
-        return name
     raise SerializationError(
         f"Function {func!r} is not serializable. Use a "
         "pytensor.xtensor.math function, or register it with "
@@ -300,48 +324,57 @@ def _func_name(func: Callable) -> str:
     )
 
 
-def _lookup_func(name: str) -> Callable:
-    """Resolve a serialized transform function name."""
-    if name in CUSTOM_TRANSFORMS:
-        return CUSTOM_TRANSFORMS[name]
-    for module_name in _TRANSFORM_MODULES:
-        try:
-            return getattr(getattr(ptx, module_name), name)
-        except AttributeError:
-            continue
+def _resolve_func(name: str) -> Callable:
+    """Resolve a serialized transform function name to a live callable."""
     try:
-        return getattr(ptx, name)
-    except AttributeError as err:
+        func = _get_transform(name, xdist=True)
+    except UnknownTransformError as err:
         raise SerializationError(
             f"Unknown serialized function {name!r}. Use a "
             "pytensor.xtensor.math function, or register it with "
             "pymc_extras.prior.register_tensor_transform."
         ) from err
+    if name.startswith("_") or not callable(func):
+        raise SerializationError(
+            f"Serialized function name {name!r} must resolve to a callable "
+            f"pytensor function, got {func!r}."
+        )
+    return func
 
 
 def _serialize_child(value: Any) -> Any:
     """Serialize a child of a composed term to a JSON-safe value.
 
-    Numeric literals become ``{"__type__": "literal", ...}`` wrappers;
-    variable factories that are not registered in the type registry
-    (``Prior``, ``Censored``, ...) serialize via their own ``to_dict``.
+    Numeric literals (bools, ints, floats, numpy scalars) become
+    ``{"__literal__": value}`` wrappers; registered terms serialize
+    through the type registry; pymc-extras objects (``Prior``,
+    ``Censored``, ...), ``xr.DataArray``, and ``DeferredFactory``
+    serialize via their own ``to_dict``.
     """
-    if isinstance(value, (int, float)) and not isinstance(value, bool):
-        return {"__type__": "literal", "value": value}
-    try:
+    if isinstance(value, (bool, int, float)):
+        return {"__literal__": value}
+    if isinstance(value, np.bool_):
+        return {"__literal__": bool(value)}
+    if isinstance(value, np.number):
+        return {"__literal__": value.item()}
+    if serialization.is_registered(value):
         return serialization.serialize(value)
-    except KeyError:
-        if hasattr(value, "to_dict"):
-            return value.to_dict()
-        raise
+    if isinstance(value, (VariableFactory, xr.DataArray, DeferredFactory)):
+        return value.to_dict()
+    raise SerializationError(
+        f"Cannot serialize term child of type {type(value).__name__}. "
+        "Register it with @serialization.register and implement "
+        "to_dict/from_dict, or use a supported child type "
+        "(VariableFactory, xr.DataArray, DeferredFactory, numeric literal)."
+    )
 
 
 def _deserialize_child(value: Any) -> Any:
     """Deserialize a serialized term child back to a live object."""
     if isinstance(value, dict):
-        if value.get("__type__") == "literal":
-            return value["value"]
-        if "__type__" in value:
+        if "__literal__" in value:
+            return value["__literal__"]
+        if value.get("__deferred__") or "__type__" in value:
             return serialization.deserialize(value)
         try:
             return pymc_extras_deserialize(value)
@@ -634,7 +667,11 @@ class Parameter(ModelTerm):
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Parameter:
         """Reconstruct a parameter from its serialized form."""
-        return cls(name=data["name"], prior=_deserialize_child(data["prior"]))
+        prior = data.get("prior")
+        return cls(
+            name=data["name"],
+            prior=_deserialize_child(prior) if prior is not None else Prior("Normal"),
+        )
 
 
 @serialization.register
@@ -754,7 +791,7 @@ class Dot(ModelTerm):
         return cls(
             var_name=data["var_name"],
             prior=_deserialize_child(data["prior"]),
-            name=data["name"],
+            name=data.get("name"),
         )
 
 
@@ -774,7 +811,7 @@ class Transform(ModelTerm):
         (``ModelTerm``, ``Sum``, ``float``, ``Prior``, etc.).
     func : Callable
         A pytensor function applied to ``build_param(inner)``.
-        E.g., ``pytensor.xtensor.math.exp``, ``pt.math.sigmoid``.
+        E.g., ``pytensor.xtensor.math.exp``, ``ptx.math.sigmoid``.
 
     Examples
     --------
@@ -829,7 +866,7 @@ class Transform(ModelTerm):
         """Reconstruct a transform from its serialized form."""
         return cls(
             inner=_deserialize_child(data["inner"]),
-            func=_lookup_func(data["func"]),
+            func=_resolve_func(data["func"]),
         )
 
 

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -42,6 +42,8 @@ from pymc_marketing.terms import (
     Product,
     Sum,
     Transform,
+    _deserialize_child,
+    _serialize_child,
     build_param,
     collect_coords,
     collect_terms,
@@ -888,3 +890,73 @@ def test_model_builder_attrs_roundtrip_with_term():
     loaded = serialization.deserialize_model_config(json.loads(attrs["model_config"]))
 
     assert loaded["mu"] == term
+
+
+def test_frozen_term_dataclass_walk_shares_decomposition():
+    """Frozen custom terms do not bypass decomposition sharing (serialization walk)."""
+    from dataclasses import dataclass
+
+    r2d2 = R2D2(
+        r2=Prior("Beta", mu=0.8, sigma=0.4),
+        total_sigma=Prior("LogNormal", mu=0, sigma=1),
+        dims={"control": "control", "fourier": "fourier"},
+    )
+
+    @serialization.register
+    @dataclass(frozen=True)
+    class FrozenHolder:
+        prior: object
+
+        def to_dict(self):
+            return {"prior": _serialize_child(self.prior)}
+
+        @classmethod
+        def from_dict(cls, data):
+            return cls(prior=_deserialize_child(data["prior"]))
+
+    config = {
+        "a": Parameter("a", prior=r2d2.split("control")),
+        "b": FrozenHolder(prior=r2d2.split("fourier")),
+    }
+    loaded = serialization.deserialize_model_config(
+        json.loads(json.dumps(serialization.serialize_model_config(config)))
+    )
+
+    assert loaded["a"].prior.decomposition is loaded["b"].prior.decomposition
+
+
+def test_resolve_func_allows_registered_underscore_name(monkeypatch):
+    """Explicitly registered underscore names are loadable (not module noise)."""
+
+    def _secret(x):
+        return x
+
+    monkeypatch.setitem(CUSTOM_TRANSFORMS, "_secret", _secret)
+    term = Transform(Parameter("x"), func=_secret)
+    restored = serialization.deserialize(serialization.serialize(term))
+    assert restored.func is _secret
+
+
+def test_deserialize_custom_factory_error_names_register_deserialization():
+    """A VariableFactory pymc-extras cannot read back fails with guidance."""
+
+    class WriteOnlyFactory:
+        dims = None
+
+        def create_variable(self, name, xdist=False):
+            return pt.as_tensor_variable(1.0)
+
+        def to_dict(self):
+            return {"k": 2}
+
+    term = Parameter("a", prior=WriteOnlyFactory())
+    serialized = serialization.serialize(term)
+    with pytest.raises(SerializationError, match="register_deserialization"):
+        serialization.deserialize(serialized)
+
+
+def test_deserialize_child_passthrough_non_dict():
+    """Non-dict children pass through (defensive; _serialize_child emits dicts)."""
+    from pymc_marketing.terms import _deserialize_child
+
+    assert _deserialize_child(52) == 52

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -14,6 +14,7 @@
 
 """Tests for pymc_marketing.terms."""
 
+import json
 from dataclasses import dataclass
 
 import numpy as np
@@ -23,10 +24,16 @@ import pytensor.tensor as pt
 import pytensor.xtensor as ptx
 import pytest
 import xarray as xr
-from pymc_extras.prior import CUSTOM_TRANSFORMS, Prior, register_tensor_transform
+from pymc_extras.prior import CUSTOM_TRANSFORMS, Prior
 from pytensor.graph.basic import Variable as PTVariable
 
-from pymc_marketing.serialization import SerializationError, serialization
+from pymc_marketing.model_builder import ModelBuilder
+from pymc_marketing.r2d2 import R2D2
+from pymc_marketing.serialization import (
+    DeferredFactory,
+    SerializationError,
+    serialization,
+)
 from pymc_marketing.terms import (
     Dot,
     Intercept,
@@ -699,18 +706,15 @@ def test_serialize_unregistered_func_raises():
         serialization.serialize(Transform(Parameter("x"), func=pt.sqrt))
 
 
-def test_serialize_registered_custom_transform_roundtrip():
+def test_serialize_registered_custom_transform_roundtrip(monkeypatch):
     def square(x):
         return x**2
 
-    register_tensor_transform("square", square)
-    try:
-        term = Transform(Parameter("x"), func=square)
-        restored = serialization.deserialize(serialization.serialize(term))
-        assert restored == term
-        assert restored.func is square
-    finally:
-        CUSTOM_TRANSFORMS.pop("square")
+    monkeypatch.setitem(CUSTOM_TRANSFORMS, "square", square)
+    term = Transform(Parameter("x"), func=square)
+    restored = serialization.deserialize(serialization.serialize(term))
+    assert restored == term
+    assert restored.func is square
 
 
 def test_restored_term_builds(simple_ds):
@@ -720,3 +724,167 @@ def test_restored_term_builds(simple_ds):
     with pm.Model(coords=coords):
         register_data(restored, ds=simple_ds)
         assert isinstance(build_param(restored), PTVariable)
+
+
+def test_serialize_shared_r2d2_decomposition_through_parameter():
+    """Regression: R2D2 splits wrapped in terms must share one decomposition.
+
+    Each deserialized R2D2Split otherwise builds its own decomposition, and
+    the second ``create_variable`` call collides on the ``r2d2_*`` names.
+    """
+    r2d2 = R2D2(
+        r2=Prior("Beta", alpha=2, beta=2),
+        total_sigma=Prior("HalfNormal"),
+        dims={"control": "control", "fourier": "fourier"},
+    )
+    config = {
+        "a": Parameter("a", prior=r2d2.split("control")),
+        "b": Parameter("b", prior=r2d2.split("fourier")),
+    }
+    serialized = serialization.serialize_model_config(config)
+    loaded = serialization.deserialize_model_config(json.loads(json.dumps(serialized)))
+
+    assert loaded["a"].prior.decomposition is loaded["b"].prior.decomposition
+
+    with pm.Model(coords={"control": ["c1", "c2"], "fourier": ["f1", "f2"]}) as model:
+        loaded["a"].prior.create_variable("a_coef")
+        loaded["b"].prior.create_variable("b_coef")
+        assert model["a_coef"] is not None
+        assert model["b_coef"] is not None
+
+
+@pytest.mark.parametrize(
+    "literal",
+    [
+        True,
+        False,
+        5,
+        2.5,
+        np.int64(3),
+        np.float64(2.5),
+        np.bool_(True),
+    ],
+)
+def test_serialize_json_roundtrip_with_numpy_literals(literal):
+    """Term children that are numpy scalars or bools survive a JSON dump."""
+    term = Parameter("a") * literal
+    serialized = json.dumps(serialization.serialize(term))
+    restored = serialization.deserialize(json.loads(serialized))
+
+    assert restored == term
+    assert restored.right == literal
+    assert not isinstance(restored.right, (np.number, np.bool_))
+
+
+def test_serialize_model_config_with_term_roundtrip():
+    """Terms in model_config round-trip through serialize/deserialize_model_config."""
+    config = {
+        "mu": Intercept(name="a")
+        + Dot(var_name="x", prior=Prior("Normal", dims="feature")),
+        "sigma": Transform(Parameter("sigma"), func=ptx.math.exp),
+    }
+    serialized = serialization.serialize_model_config(config)
+    json.dumps(serialized)
+    loaded = serialization.deserialize_model_config(json.loads(json.dumps(serialized)))
+
+    assert loaded["mu"] == config["mu"]
+    assert loaded["sigma"] == config["sigma"]
+
+
+def test_deserialize_unknown_func_raises():
+    term = Transform(Parameter("x"), func=ptx.math.exp)
+    data = serialization.serialize(term)
+    data["func"] = "nope"
+    with pytest.raises(SerializationError, match="Unknown serialized function"):
+        serialization.deserialize(data)
+
+
+def test_deserialize_non_callable_func_raises():
+    """Function names from a file must resolve to callables, not modules."""
+    term = Transform(Parameter("x"), func=ptx.math.exp)
+    data = serialization.serialize(term)
+    data["func"] = "basic"
+    with pytest.raises(SerializationError, match="callable"):
+        serialization.deserialize(data)
+
+
+@dataclass
+class UnregisteredWithToDict(ModelTerm):
+    """Custom term with to_dict but no @serialization.register."""
+
+    def to_dict(self) -> dict:
+        return {"k": 3}
+
+
+@dataclass
+class UnregisteredBare(ModelTerm):
+    """Custom term without to_dict and no @serialization.register."""
+
+
+@pytest.mark.parametrize("term", [UnregisteredWithToDict(), UnregisteredBare()])
+def test_serialize_unregistered_custom_term_raises(term):
+    """Unregistered custom terms fail at serialize time, not load time."""
+    with pytest.raises(SerializationError, match=r"serialization\.register"):
+        serialization.serialize(Sum(terms=[term]))
+
+
+def test_serialize_deferred_factory_roundtrip():
+    deferred = DeferredFactory(factory="builtins.dict", kwargs={"a": 1})
+    term = Parameter("a", prior=deferred)
+    restored = serialization.deserialize(serialization.serialize(term))
+    assert restored.prior == deferred
+
+
+def test_serialize_data_array_child_roundtrip():
+    """xr.DataArray children serialize via to_dict and load via pymc-extras."""
+    da = xr.DataArray([1.0, 2.0], dims="d")
+    term = Parameter("a", prior=da)
+    serialized = serialization.serialize(term)
+    json.dumps(serialized)
+    restored = serialization.deserialize(json.loads(json.dumps(serialized)))
+    assert restored.prior.equals(da)
+
+
+class _TermAttrsModel(ModelBuilder):
+    """Minimal builder to exercise create_idata_attrs with terms in config."""
+
+    _model_type = "terms_attrs_test"
+    version = "0.1"
+
+    @property
+    def default_model_config(self) -> dict:
+        return {"mu": None}
+
+    @property
+    def default_sampler_config(self) -> dict:
+        return {}
+
+    @property
+    def output_var(self) -> str:
+        return "y"
+
+    @property
+    def _serializable_model_config(self) -> dict:
+        return self.model_config
+
+    def build_model(self, X=None, y=None, **kwargs):
+        pass
+
+    def build_from_idata(self, idata):
+        pass
+
+    def _data_setter(self, X, y=None):
+        pass
+
+
+def test_model_builder_attrs_roundtrip_with_term():
+    """Terms in model_config survive the create_idata_attrs JSON dump."""
+    term = Intercept(name="a") + Dot(
+        var_name="x", prior=Prior("Normal", dims="feature")
+    )
+    model = _TermAttrsModel(model_config={"mu": term})
+
+    attrs = model.create_idata_attrs()
+    loaded = serialization.deserialize_model_config(json.loads(attrs["model_config"]))
+
+    assert loaded["mu"] == term

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -20,12 +20,13 @@ import numpy as np
 import pymc as pm
 import pymc.dims as pmd
 import pytensor.tensor as pt
-import pytensor.xtensor.math as ptx
+import pytensor.xtensor as ptx
 import pytest
 import xarray as xr
-from pymc_extras.prior import Prior
+from pymc_extras.prior import CUSTOM_TRANSFORMS, Prior, register_tensor_transform
 from pytensor.graph.basic import Variable as PTVariable
 
+from pymc_marketing.serialization import SerializationError, serialization
 from pymc_marketing.terms import (
     Dot,
     Intercept,
@@ -196,14 +197,14 @@ def test_dot_set_data(simple_ds):
 def test_transform_create_variable():
     with pm.Model():
         inner = Intercept(name="sigma")
-        transformed = Transform(inner, func=ptx.exp)
+        transformed = Transform(inner, func=ptx.math.exp)
         result = transformed.create_variable()
         assert isinstance(result, PTVariable)
 
 
 def test_transform_with_dot(simple_ds):
     dot = Dot(var_name="x", prior=Prior("Normal", dims="feature"))
-    transformed = Transform(dot, func=ptx.exp)
+    transformed = Transform(dot, func=ptx.math.exp)
     coords = transformed.get_coords(simple_ds)
     with pm.Model(coords=coords):
         transformed.register_data(simple_ds)
@@ -213,7 +214,7 @@ def test_transform_with_dot(simple_ds):
 
 def test_transform_set_data(simple_ds):
     inner = Dot(var_name="x", prior=Prior("Normal", dims="feature"))
-    transformed = Transform(inner, func=ptx.exp)
+    transformed = Transform(inner, func=ptx.math.exp)
     coords = transformed.get_coords(simple_ds)
     with pm.Model(coords=coords) as model:
         transformed.register_data(simple_ds)
@@ -273,7 +274,7 @@ def test_build_param_prior():
 
 def test_build_param_transform():
     with pm.Model():
-        result = build_param(Transform(Intercept(name="sigma"), func=ptx.exp))
+        result = build_param(Transform(Intercept(name="sigma"), func=ptx.math.exp))
         assert isinstance(result, PTVariable)
 
 
@@ -332,7 +333,7 @@ def test_collect_terms_skips_constants():
 
 
 def test_collect_terms_includes_transform():
-    terms = [Transform(Intercept(name="a"), func=ptx.exp)]
+    terms = [Transform(Intercept(name="a"), func=ptx.math.exp)]
     result = collect_terms(terms)
     assert len(result) == 1
 
@@ -340,7 +341,7 @@ def test_collect_terms_includes_transform():
 def test_collect_coords(simple_ds):
     """collect_coords merges coordinates from multiple term trees."""
     mu = Intercept(name="mu") + Dot(var_name="x", prior=Prior("Normal", dims="feature"))
-    sigma = Transform(Intercept(name="sigma"), func=ptx.exp)
+    sigma = Transform(Intercept(name="sigma"), func=ptx.math.exp)
     coords = collect_coords(mu, sigma, ds=simple_ds)
     assert "feature" in coords
 
@@ -521,7 +522,7 @@ def test_collect_coords_multiplication(simple_ds):
     """CLV gotcha: `a + b * c` must collect coordinates from the Product child."""
     mu = Intercept(name="a") + Dot(
         var_name="x", prior=Prior("Normal", dims="feature")
-    ) * Transform(Intercept(name="scale"), func=ptx.exp)
+    ) * Transform(Intercept(name="scale"), func=ptx.math.exp)
     coords = collect_coords(mu, ds=simple_ds)
     assert "feature" in coords
 
@@ -554,7 +555,7 @@ def test_set_data_multiplication(simple_ds):
     """
     mu = Intercept(name="a") + Dot(
         var_name="x", prior=Prior("Normal", dims="feature")
-    ) * Transform(Intercept(name="scale"), func=ptx.exp)
+    ) * Transform(Intercept(name="scale"), func=ptx.math.exp)
     coords = collect_coords(mu, ds=simple_ds)
     with pm.Model(coords=coords) as model:
         register_data(mu, ds=simple_ds)
@@ -651,3 +652,71 @@ def test_parameter_create_variable():
         with pm.Model(coords={"product": ["p1", "p2", "p3"]}):
             v = p.create_variable()
             assert v is not None
+
+
+def test_serialize_parameter_roundtrip():
+    term = Parameter("alpha", prior=Prior("Normal", mu=0, sigma=1, dims="product"))
+    restored = serialization.deserialize(serialization.serialize(term))
+    assert restored == term
+    assert restored.prior.dims == ("product",)
+
+
+def test_serialize_dot_roundtrip():
+    dot = Dot(var_name="x", prior=Prior("Normal", dims="feature"), name="x_coef")
+    restored = serialization.deserialize(serialization.serialize(dot))
+    assert restored == dot
+    assert restored.name == "x_coef"
+
+
+def test_serialize_intercept_subclass_roundtrip():
+    term = Intercept("baseline", prior=Prior("Normal"))
+    restored = serialization.deserialize(serialization.serialize(term))
+    assert isinstance(restored, Intercept)
+    assert restored == term
+
+
+def test_serialize_composition_roundtrip():
+    alpha = Parameter("alpha_scale", prior=Prior("HalfFlat")) * Transform(
+        -Dot(
+            var_name="purchase_data",
+            name="purchase_coefficient_alpha",
+            prior=Prior("Normal", mu=0, sigma=1, dims="purchase_covariate"),
+        ),
+        func=ptx.math.exp,
+    )
+    restored = serialization.deserialize(serialization.serialize(alpha))
+    assert restored == alpha
+
+
+def test_serialize_sum_with_literals_roundtrip():
+    expr = Intercept(name="a") + 5 - Intercept(name="b")
+    restored = serialization.deserialize(serialization.serialize(expr))
+    assert restored == expr
+
+
+def test_serialize_unregistered_func_raises():
+    with pytest.raises(SerializationError, match="not serializable"):
+        serialization.serialize(Transform(Parameter("x"), func=pt.sqrt))
+
+
+def test_serialize_registered_custom_transform_roundtrip():
+    def square(x):
+        return x**2
+
+    register_tensor_transform("square", square)
+    try:
+        term = Transform(Parameter("x"), func=square)
+        restored = serialization.deserialize(serialization.serialize(term))
+        assert restored == term
+        assert restored.func is square
+    finally:
+        CUSTOM_TRANSFORMS.pop("square")
+
+
+def test_restored_term_builds(simple_ds):
+    dot = Dot(var_name="x", prior=Prior("Normal", dims="feature"))
+    restored = serialization.deserialize(serialization.serialize(dot))
+    coords = collect_coords(restored, ds=simple_ds)
+    with pm.Model(coords=coords):
+        register_data(restored, ds=simple_ds)
+        assert isinstance(build_param(restored), PTVariable)


### PR DESCRIPTION
Closes #2980. First PR in the terms stack (serialization → Bass components → Bass port).

The terms vocabulary serializes through `pymc_marketing.serialization`: `to_dict`/`from_dict` are registered for `Parameter`, `Intercept`, `Dot`, `Transform`, `Product`, and `Sum`, so recipes stored in `model_config` survive `fit()` (attrs serialize at sampling time) and `save()`/`load()`.

`Transform` functions resolve by name dynamically against `pytensor.xtensor.math` / `pytensor.xtensor.linalg` and transforms registered with `pymc_extras.prior.register_tensor_transform` — no hard-coded whitelist. Numeric literals inside compositions serialize as literals, and nested priors round-trip through `pymc_extras.deserialize`.

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2987.org.readthedocs.build/en/2987/

<!-- readthedocs-preview pymc-marketing end -->