### PR TITLE
feat: add Named and Ref terms

### DIFF
--- a/pymc_marketing/terms.py
+++ b/pymc_marketing/terms.py
@@ -15,7 +15,8 @@
 """Composable model terms for building ``pymc.dims`` subgraphs from xarray data.
 
 ``pymc_marketing.terms`` provides a small set of built-in pieces
-(``Parameter`` / ``Intercept``, ``Dot``, ``Transform``) that compose with
+(``Parameter`` / ``Intercept``, ``Dot``, ``Transform``,
+``Named``, ``Ref``) that compose with
 ``+``, ``*``, and ``-`` into predictors.  **This module is not a full
 modeling toolkit** --- it does not ship complete hierarchical,
 domain-specific, or observation-model wrappers.  It is a **thin, expressive
@@ -236,7 +237,10 @@ Gotchas
   same covariate matrix).
 - ``build_param`` is not idempotent --- call it once to create PyMC
   variables, then sample. Calling it a second time tries to create
-  variables with the same name, causing a PyMC error.
+  variables with the same name, causing a PyMC error. ``Named`` is a
+  named wrapper with the same constraint: build once, reference
+  afterwards with ``Ref`` (which is freely reusable inside multiple
+  ``Named`` expressions).
 - Changing the number of observations in ``set_data`` requires rebuilding
   the model. This is a ``pmd.Data`` constraint (dimensional shared variables
   have fixed dimension sizes), not a framework limitation.
@@ -409,7 +413,8 @@ class ModelTerm:
 
     Subclass ``ModelTerm`` to define reusable PyMC subgraph recipes.
     Custom terms compose with the built-ins (``Parameter``, ``Intercept``,
-    ``Dot``, ``Transform``) via ``+``, ``*``, and ``-`` and use the same
+    ``Dot``, ``Transform``, ``Named``, ``Ref``) via ``+``, ``*``, and ``-``
+    and use the same
     helpers (``collect_coords``, ``register_data``, ``build_param``,
     ``set_data``) --- no framework changes required.  See the module
     docstring **Extending** section for the full contract and an example.
@@ -911,31 +916,53 @@ class Named(ModelTerm):
     expr : Any
         Inner expression accepted by ``build_param``.
     dims : str or tuple of str, optional
-        Dimensions for the deterministic variable.
+        Dimensions for the deterministic variable. These **align** the
+        built value onto ``dims`` (``pmd.Deterministic`` transposes), so
+        they must be a permutation of the inner value's dims, not a new
+        declaration - a value without those dims raises ``ValueError``.
 
     Examples
     --------
     .. code-block:: python
 
         from pymc_extras.prior import Prior
-        from pymc_marketing.terms import Named, Parameter
+        from pymc_marketing.terms import Named, Parameter, Ref
 
         scale = Named(
             "scale",
-            Parameter("scale", prior=Prior("HalfNormal"), dims="product"),
+            Parameter("scale_raw", prior=Prior("HalfNormal", dims="product")),
             dims="product",
         )
 
-        # an effect that references another built variable
-        effect = Named("effect", Ref("scale") * other_term, dims="customer_id")
+        # an effect that references another built variable: build once with
+        # ``Named``, reference afterwards with ``Ref``
+        effect = Named(
+            "effect",
+            Ref("scale") * Parameter("kappa", prior=Prior("Normal", dims="product")),
+            dims="product",
+        )
     """
 
     name: str
     expr: Any
     dims: str | tuple[str, ...] | None = None
 
+    def __post_init__(self):
+        """Normalize ``dims`` to a tuple, mirroring ``Prior``."""
+        if self.dims is None:
+            return
+        if isinstance(self.dims, str):
+            self.dims = (self.dims,)
+        elif not isinstance(self.dims, tuple):
+            self.dims = tuple(self.dims)
+
     def get_coords(self, ds: xr.Dataset) -> dict[str, Any]:
-        """Collect coordinates from the inner expression."""
+        """Collect coordinates from the inner expression.
+
+        ``Named`` does not declare its own coords: ``dims`` aligns the
+        built value onto an existing permutation, so coordinates arrive
+        from the inner expression's leaves.
+        """
         return get_coords(self.expr, ds)
 
     def register_data(self, ds: xr.Dataset) -> None:
@@ -947,8 +974,16 @@ class Named(ModelTerm):
         set_data(self.expr, ds=ds, model=model)
 
     def create_variable(self) -> pt.TensorVariable:
-        """Build the named deterministic from the inner expression."""
-        return pmd.Deterministic(self.name, build_param(self.expr), dims=self.dims)
+        """Build the named deterministic from the inner expression.
+
+        Bare ``VariableFactory`` children get a derived name (``<name>_param``)
+        so several ``Named`` terms do not collide on ``build_param``'s default.
+        """
+        return pmd.Deterministic(
+            self.name,
+            build_param(self.expr, name=f"{self.name}_param"),
+            dims=self.dims,
+        )
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize the name, expression, and dims."""
@@ -977,19 +1012,58 @@ class Ref(ModelTerm):
 
     Lets an effect expression composed outside the model depend on another
     built effect (e.g. ``a`` on the ``a_scale`` deterministic) without
-    recreating its variables.
+    recreating its variables. ``Ref`` resolves at **build time** and
+    requires the referenced term to be built earlier in traversal order -
+    build once with ``Named``, reference afterwards with ``Ref``.
 
     Parameters
     ----------
     name : str
         Name of the referenced variable.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        scale = Named("scale", Parameter("raw", prior=Prior("HalfNormal")))
+        effect = Named("effect", Ref("scale") * other_term)
     """
 
     name: str
 
     def create_variable(self) -> pt.TensorVariable:
-        """Resolve the referenced variable from the active model."""
-        return pm.modelcontext(None)[self.name]
+        """Resolve the referenced variable from the active model.
+
+        Raises
+        ------
+        ValueError
+            If the variable is not built yet, or if it is not
+            dims-native (referencing plain-tensor variables built by
+            non-terms model code fails later inside pytensor, so it is
+            rejected here with the offending name).
+        """
+        model = pm.modelcontext(None)
+        try:
+            variable = model[self.name]
+        except KeyError:
+            available = ", ".join(sorted(model.named_vars))
+            raise ValueError(
+                f"Ref({self.name!r}) cannot resolve: {self.name!r} is not "
+                "built yet. Terms build during build_param in traversal "
+                f"order, so a term referencing {self.name!r} must come "
+                f"after the term that builds it. Available named vars: "
+                f"{available}."
+            ) from None
+
+        if not isinstance(variable, pmd.XTensorVariable):
+            raise ValueError(
+                f"Ref({self.name!r}) resolved to {variable!r}, which is not "
+                "dims-native. Ref must reference a dims-native variable "
+                "(built by terms or pmd distributions) - plain-tensor "
+                "variables cannot compose into pytensor.xtensor "
+                "expressions."
+            )
+        return variable
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize the referenced name."""

--- a/pymc_marketing/terms.py
+++ b/pymc_marketing/terms.py
@@ -72,12 +72,13 @@ contract: decorate them with ``@serialization.register`` and implement
 unregistered term raises
 :class:`~pymc_marketing.serialization.SerializationError`.
 
-Children of composed terms (``Sum``, ``Product``, ``Transform``) must be
-registered terms, ``VariableFactory`` (``Prior``, ...), ``xr.DataArray``,
-``DeferredFactory``, or numeric literals. ``Transform`` functions serialize
-by name and are resolved with ``pymc_extras.prior._get_transform``:
-``pytensor.xtensor.math`` / ``pytensor.xtensor.linalg`` functions, or
-transforms registered with ``pymc_extras.prior.register_tensor_transform``.
+Children of composed terms (``Sum``, ``Product``, ``Transform``, ``Named``)
+must be registered terms, ``VariableFactory`` (``Prior``, ...),
+``xr.DataArray``, ``DeferredFactory``, or numeric literals. ``Transform``
+functions serialize by name and are resolved with
+``pymc_extras.prior._get_transform``: ``pytensor.xtensor.math`` /
+``pytensor.xtensor.linalg`` functions, or transforms registered with
+``pymc_extras.prior.register_tensor_transform``.
 
 ``Parameter`` and ``Intercept``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -915,11 +916,12 @@ class Named(ModelTerm):
         Name of the deterministic variable.
     expr : Any
         Inner expression accepted by ``build_param``.
-    dims : str or tuple of str, optional
+    dims : str or sequence of str, optional
         Dimensions for the deterministic variable. These **align** the
         built value onto ``dims`` (``pmd.Deterministic`` transposes), so
         they must be a permutation of the inner value's dims, not a new
         declaration - a value without those dims raises ``ValueError``.
+        Normalized to a tuple after construction.
 
     Examples
     --------
@@ -945,7 +947,7 @@ class Named(ModelTerm):
 
     name: str
     expr: Any
-    dims: str | tuple[str, ...] | None = None
+    dims: str | Sequence[str] | None = None
 
     def __post_init__(self):
         """Normalize ``dims`` to a tuple, mirroring ``Prior``."""
@@ -1014,7 +1016,9 @@ class Ref(ModelTerm):
     built effect (e.g. ``a`` on the ``a_scale`` deterministic) without
     recreating its variables. ``Ref`` resolves at **build time** and
     requires the referenced term to be built earlier in traversal order -
-    build once with ``Named``, reference afterwards with ``Ref``.
+    build once with ``Named``, reference afterwards with ``Ref``. Registered
+    ``pmd.Data`` variables also qualify as reference targets, since they
+    are dims-native; plain ``pm.Data`` tensors do not.
 
     Parameters
     ----------
@@ -1025,8 +1029,14 @@ class Ref(ModelTerm):
     --------
     .. code-block:: python
 
-        scale = Named("scale", Parameter("raw", prior=Prior("HalfNormal")))
-        effect = Named("effect", Ref("scale") * other_term)
+        from pymc_extras.prior import Prior
+        from pymc_marketing.terms import Named, Parameter, Ref
+
+        scale = Named("scale", Parameter("scale_raw", prior=Prior("HalfNormal")))
+        effect = Named(
+            "effect",
+            Ref("scale") * Parameter("kappa", prior=Prior("Normal")),
+        )
     """
 
     name: str
@@ -1046,13 +1056,15 @@ class Ref(ModelTerm):
         try:
             variable = model[self.name]
         except KeyError:
-            available = ", ".join(sorted(model.named_vars))
+            available = sorted(model.named_vars)
+            if len(available) > 20:
+                available = [*available[:20], f"... ({len(available) - 20} more)"]
             raise ValueError(
                 f"Ref({self.name!r}) cannot resolve: {self.name!r} is not "
                 "built yet. Terms build during build_param in traversal "
                 f"order, so a term referencing {self.name!r} must come "
                 f"after the term that builds it. Available named vars: "
-                f"{available}."
+                f"{', '.join(available)}."
             ) from None
 
         if not isinstance(variable, pmd.XTensorVariable):
@@ -1137,7 +1149,9 @@ def build_param(param: Any, name: str = "param") -> pt.TensorVariable | int | fl
         The term(s) or variable factory to build into a tensor.
     name : str
         Variable name used when building standalone ``VariableFactory``
-        objects. Terms handle their own naming internally.
+        objects (top level leaves get ``name`` directly; children of
+        ``Sum``/``Product`` get positional suffixes so siblings do not
+        collide). Terms handle their own naming internally.
 
     Returns
     -------
@@ -1152,11 +1166,13 @@ def build_param(param: Any, name: str = "param") -> pt.TensorVariable | int | fl
         return cast("pt.TensorVariable", param.create_variable())
     if isinstance(param, Sum):
         result: pt.TensorVariable | int | float = 0
-        for term in param.terms:
-            result = result + build_param(term)
+        for idx, term in enumerate(param.terms):
+            result = result + build_param(term, name=f"{name}_{idx}")
         return result
     if isinstance(param, Product):
-        return build_param(param.left) * build_param(param.right)
+        return build_param(param.left, name=f"{name}_left") * build_param(
+            param.right, name=f"{name}_right"
+        )
     if isinstance(param, VariableFactory):
         return param.create_variable(name, xdist=True)
     raise TypeError(f"Cannot build param from {type(param)}")

--- a/pymc_marketing/terms.py
+++ b/pymc_marketing/terms.py
@@ -249,6 +249,10 @@ Gotchas
           model = pm.modelcontext(None)
           unique = list(dict.fromkeys(ds[self.data_source].values))
           model.add_coords({self.data_source: unique})
+- ``Named`` builds a ``pmd.Deterministic``, so its expression leaves must
+  be dims-native: ``Parameter`` / ``Prior`` with ``xdist=True`` or
+  ``pytensor.xtensor`` expressions. Plain-tensor leaves (``xdist=False``)
+  will fail when the deterministic is built.
 - The built-in terms serialize via ``pymc_marketing.serialization``
   (``to_dict`` / ``from_dict`` are registered), so recipes stored in
   ``model_config`` survive ``fit()`` (attrs are JSON-serialized at
@@ -291,8 +295,10 @@ __all__ = [
     "Dot",
     "Intercept",
     "ModelTerm",
+    "Named",
     "Parameter",
     "Product",
+    "Ref",
     "Sum",
     "Transform",
     "build_param",
@@ -882,6 +888,117 @@ class Transform(ModelTerm):
             inner=_deserialize_child(data["inner"]),
             func=_resolve_func(data["func"]),
         )
+
+
+@serialization.register
+@dataclass
+class Named(ModelTerm):
+    """Compose an expression into a named deterministic variable.
+
+    The inner expression is built lazily within the model context:
+    ``build_param`` produces the value and ``pmd.Deterministic`` stores it
+    under ``name``. Coordinates, data registration, and data updating
+    delegate to the inner expression. Useful for naming intermediate
+    effects (scales, link outputs) that should appear in the posterior.
+
+    The expression leaves must be dims-native: ``Parameter`` / ``Prior``
+    with ``xdist=True`` or ``pytensor.xtensor`` expressions.
+
+    Parameters
+    ----------
+    name : str
+        Name of the deterministic variable.
+    expr : Any
+        Inner expression accepted by ``build_param``.
+    dims : str or tuple of str, optional
+        Dimensions for the deterministic variable.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from pymc_extras.prior import Prior
+        from pymc_marketing.terms import Named, Parameter
+
+        scale = Named(
+            "scale",
+            Parameter("scale", prior=Prior("HalfNormal"), dims="product"),
+            dims="product",
+        )
+
+        # an effect that references another built variable
+        effect = Named("effect", Ref("scale") * other_term, dims="customer_id")
+    """
+
+    name: str
+    expr: Any
+    dims: str | tuple[str, ...] | None = None
+
+    def get_coords(self, ds: xr.Dataset) -> dict[str, Any]:
+        """Collect coordinates from the inner expression."""
+        return get_coords(self.expr, ds)
+
+    def register_data(self, ds: xr.Dataset) -> None:
+        """Register shared data for the inner expression."""
+        register_data(self.expr, ds=ds)
+
+    def set_data(self, ds: xr.Dataset, model: pm.Model | None = None) -> None:
+        """Update shared data for the inner expression."""
+        set_data(self.expr, ds=ds, model=model)
+
+    def create_variable(self) -> pt.TensorVariable:
+        """Build the named deterministic from the inner expression."""
+        return pmd.Deterministic(self.name, build_param(self.expr), dims=self.dims)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the name, expression, and dims."""
+        data: dict[str, Any] = {
+            "name": self.name,
+            "expr": _serialize_child(self.expr),
+        }
+        if self.dims is not None:
+            data["dims"] = self.dims
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Named:
+        """Reconstruct a named term from its serialized form."""
+        return cls(
+            name=data["name"],
+            expr=_deserialize_child(data["expr"]),
+            dims=data.get("dims"),
+        )
+
+
+@serialization.register
+@dataclass
+class Ref(ModelTerm):
+    """Reference an already-built named variable in the active model.
+
+    Lets an effect expression composed outside the model depend on another
+    built effect (e.g. ``a`` on the ``a_scale`` deterministic) without
+    recreating its variables.
+
+    Parameters
+    ----------
+    name : str
+        Name of the referenced variable.
+    """
+
+    name: str
+
+    def create_variable(self) -> pt.TensorVariable:
+        """Resolve the referenced variable from the active model."""
+        return pm.modelcontext(None)[self.name]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the referenced name."""
+        return {"name": self.name}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Ref:
+        """Reconstruct a reference from its serialized form."""
+        return cls(name=data["name"])
 
 
 def get_coords(param: Any, ds: xr.Dataset) -> dict[str, Any]:

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -26,6 +26,7 @@ import pytest
 import xarray as xr
 from pymc_extras.prior import CUSTOM_TRANSFORMS, Prior
 from pytensor.graph.basic import Variable as PTVariable
+from pytensor.graph.traversal import ancestors
 
 from pymc_marketing.model_builder import ModelBuilder
 from pymc_marketing.r2d2 import R2D2
@@ -962,6 +963,8 @@ def test_deserialize_child_passthrough_non_dict():
     from pymc_marketing.terms import _deserialize_child
 
     assert _deserialize_child(52) == 52
+
+
 def test_named_builds_pmd_deterministic():
     coords = {"product": ["p1", "p2"]}
     with pm.Model(coords=coords) as model:
@@ -1039,8 +1042,6 @@ def test_ref_resolves_built_variable():
     assert model.named_vars_to_dims["a"] == ("product",)
 
     # the contract is the dependency edge, not just name existence
-    from pytensor.graph.traversal import ancestors
-
     assert model["a_scale"] in set(ancestors([model["a"]]))
 
 
@@ -1136,8 +1137,6 @@ def test_ref_reusable_in_multiple_named():
 
 def test_named_value_matches_expression():
     """The deterministic wraps the inner expression, not some other operand."""
-    import numpy as np
-
     with pm.Model() as model:
         term = Named(
             "doubled",
@@ -1164,6 +1163,52 @@ def test_named_bare_factory_named_not_param():
 
     assert "s_param" in model.named_vars
     assert "param" not in model.named_vars
+
+
+def test_named_nested_bare_factories_not_param():
+    """Bare factories nested in Sum/Product also avoid build_param's default.
+
+    Regression for the round-2 review: build_param's Sum/Product recursion
+    used to drop the threaded name, so any bare factory below the root was
+    built as ``param`` and two such ``Named`` terms collided.
+    """
+    with pm.Model(coords={"product": ["p1", "p2"]}) as model:
+        s1 = Named(
+            "s1",
+            Prior("HalfNormal", dims="product")
+            * Parameter("k1", prior=Prior("Normal", dims="product")),
+            dims="product",
+        )
+        s2 = Named(
+            "s2",
+            Prior("HalfNormal", dims="product")
+            * Parameter("k2", prior=Prior("Normal", dims="product")),
+            dims="product",
+        )
+        s1.create_variable()
+        s2.create_variable()
+
+    assert "param" not in model.named_vars
+    assert "s1_param_left" in model.named_vars
+    assert "s2_param_left" in model.named_vars
+    assert "kappa" not in model.named_vars
+
+
+def test_named_dims_permutation_transposes():
+    """dims aligns (transposes) the value; a permutation stays equal."""
+    coords = {"a": ["x", "y"], "b": [1, 2, 3]}
+    with pm.Model(coords=coords) as model:
+        term = Named(
+            "s",
+            Parameter("q", prior=Prior("Normal", dims=("a", "b"))),
+            dims=("b", "a"),
+        )
+        term.create_variable()
+
+    assert model.named_vars_to_dims["s"] == ("b", "a")
+    q_draw, s_draw = pm.draw([model["q"], model["s"]], draws=2, random_seed=42)
+    assert q_draw.shape == (2, 2, 3)  # (draws, a, b)
+    np.testing.assert_allclose(np.transpose(q_draw, (0, 2, 1)), s_draw)
 
 
 def test_named_reuse_raises():

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -38,8 +38,10 @@ from pymc_marketing.terms import (
     Dot,
     Intercept,
     ModelTerm,
+    Named,
     Parameter,
     Product,
+    Ref,
     Sum,
     Transform,
     _deserialize_child,
@@ -960,3 +962,110 @@ def test_deserialize_child_passthrough_non_dict():
     from pymc_marketing.terms import _deserialize_child
 
     assert _deserialize_child(52) == 52
+def test_named_builds_pmd_deterministic():
+    coords = {"product": ["p1", "p2"]}
+    with pm.Model(coords=coords) as model:
+        term = Named(
+            "sigma",
+            Parameter("scale", prior=Prior("HalfNormal", dims="product")),
+            dims="product",
+        )
+        term.create_variable()
+
+    assert "sigma" in model.named_vars
+    assert model.named_vars_to_dims["sigma"] == ("product",)
+
+
+def test_named_dims_none_scalar():
+    with pm.Model() as model:
+        term = Named(
+            "sigma",
+            Parameter("scale", prior=Prior("HalfNormal")),
+            dims=None,
+        )
+        term.create_variable()
+
+    assert "sigma" in model.named_vars
+    assert model.named_vars_to_dims["sigma"] == ()
+
+
+def test_named_delegates_lifecycle(simple_ds):
+    term = Named(
+        "effect",
+        Transform(
+            Dot(var_name="x", prior=Prior("Normal", dims="feature")),
+            func=ptx.math.exp,
+        ),
+        dims="obs",
+    )
+    coords = term.get_coords(simple_ds)
+    assert "feature" in coords
+
+    with pm.Model(coords=coords) as model:
+        term.register_data(simple_ds)
+        term.create_variable()
+
+    assert "effect" in model.named_vars
+    assert model.named_vars_to_dims["effect"] == ("obs",)
+
+    ds2 = simple_ds.copy()
+    ds2["x"] = xr.DataArray(
+        np.roll(simple_ds["x"].values, 1, axis=0), dims=("obs", "feature")
+    )
+    term.set_data(ds2, model=model)
+    assert np.allclose(model["x"].get_value(), ds2["x"].values)
+
+
+def test_ref_resolves_built_variable():
+    coords = {"product": ["p1", "p2"]}
+    with pm.Model(coords=coords) as model:
+        scale = Named(
+            "a_scale",
+            Parameter("phi", prior=Prior("Uniform", lower=0, upper=1, dims="product")),
+            dims="product",
+        )
+        scale.create_variable()
+
+        effect = Named(
+            "a",
+            Ref("a_scale")
+            * Parameter("kappa", prior=Prior("HalfNormal", sigma=1, dims="product")),
+            dims="product",
+        )
+        effect.create_variable()
+
+    assert "a_scale" in model.named_vars
+    assert "a" in model.named_vars
+    assert model.named_vars_to_dims["a"] == ("product",)
+
+
+def test_ref_missing_raises():
+    with pm.Model():
+        ref = Ref("missing")
+        with pytest.raises(KeyError):
+            ref.create_variable()
+
+
+def test_serialize_named_roundtrip():
+    term = Named(
+        "alpha",
+        Parameter("alpha_scale", prior=Prior("HalfFlat"))
+        * Transform(
+            Dot(
+                var_name="purchase_data",
+                name="purchase_coefficient_alpha",
+                prior=Prior("Normal", mu=0, sigma=1, dims="purchase_covariate"),
+            ),
+            func=ptx.math.exp,
+        ),
+        dims="customer_id",
+    )
+    restored = serialization.deserialize(serialization.serialize(term))
+    assert restored == term
+    assert restored.dims == "customer_id"
+
+
+def test_serialize_ref_roundtrip():
+    term = Ref("a_scale")
+    restored = serialization.deserialize(serialization.serialize(term))
+    assert restored == term

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -1038,11 +1038,16 @@ def test_ref_resolves_built_variable():
     assert "a" in model.named_vars
     assert model.named_vars_to_dims["a"] == ("product",)
 
+    # the contract is the dependency edge, not just name existence
+    from pytensor.graph.traversal import ancestors
+
+    assert model["a_scale"] in set(ancestors([model["a"]]))
+
 
 def test_ref_missing_raises():
     with pm.Model():
         ref = Ref("missing")
-        with pytest.raises(KeyError):
+        with pytest.raises(ValueError, match="is not built yet"):
             ref.create_variable()
 
 
@@ -1062,10 +1067,112 @@ def test_serialize_named_roundtrip():
     )
     restored = serialization.deserialize(serialization.serialize(term))
     assert restored == term
-    assert restored.dims == "customer_id"
+    assert restored.dims == ("customer_id",)
 
 
 def test_serialize_ref_roundtrip():
     term = Ref("a_scale")
     restored = serialization.deserialize(serialization.serialize(term))
     assert restored == term
+
+
+def test_named_dims_normalization():
+    """Named normalizes dims (str and list) to tuples, like Prior."""
+    assert Named("x", Parameter("p", prior=Prior("HalfNormal")), dims="a").dims == (
+        "a",
+    )
+    assert Named(
+        "x", Parameter("p", prior=Prior("HalfNormal")), dims=["a", "b"]
+    ).dims == ("a", "b")
+
+
+def test_serialize_named_json_roundtrip():
+    """A JSON hop keeps dims a tuple and round-trip equality (tuple dims)."""
+    term = Named(
+        "eff",
+        Parameter("p", prior=Prior("Normal", dims=("a", "b"))),
+        dims=("a", "b"),
+    )
+    restored = serialization.deserialize(
+        json.loads(json.dumps(serialization.serialize(term)))
+    )
+    assert restored == term
+    assert restored.dims == ("a", "b")
+
+
+def test_ref_not_dims_native_raises():
+    with pm.Model(coords={"product": ["p1"]}):
+        pm.Normal("plain", mu=0, sigma=1, dims="product")
+        with pytest.raises(ValueError, match=r"not dims-native.*plain"):
+            Ref("plain").create_variable()
+
+
+def test_ref_reusable_in_multiple_named():
+    coords = {"product": ["p1", "p2"]}
+    with pm.Model(coords=coords) as model:
+        scale = Named(
+            "base",
+            Parameter("raw", prior=Prior("HalfNormal", dims="product")),
+            dims="product",
+        )
+        scale.create_variable()
+
+        named = Named(
+            "e1",
+            Ref("base") * Parameter("kappa", prior=Prior("HalfNormal", dims="product")),
+            dims="product",
+        )
+        named.create_variable()
+        named2 = Named(
+            "e2",
+            Ref("base")
+            + Parameter("kappa2", prior=Prior("HalfNormal", dims="product")),
+            dims="product",
+        )
+        named2.create_variable()
+
+    assert {"base", "e1", "e2"} <= set(model.named_vars)
+
+
+def test_named_value_matches_expression():
+    """The deterministic wraps the inner expression, not some other operand."""
+    import numpy as np
+
+    with pm.Model() as model:
+        term = Named(
+            "doubled",
+            Parameter("scale", prior=Prior("HalfNormal")) * 2,
+            dims=None,
+        )
+        term.create_variable()
+
+    inner, doubled = pm.draw(
+        [model["scale"], model["doubled"]], draws=3, random_seed=42
+    )
+    np.testing.assert_allclose(doubled, inner * 2)
+
+
+def test_named_bare_factory_named_not_param():
+    """Bare factories get a derived name, not build_param's default."""
+    with pm.Model(coords={"product": ["p1", "p2"]}) as model:
+        term = Named(
+            "s",
+            Prior("HalfNormal", dims="product"),
+            dims="product",
+        )
+        term.create_variable()
+
+    assert "s_param" in model.named_vars
+    assert "param" not in model.named_vars
+
+
+def test_named_reuse_raises():
+    with pm.Model(coords={"product": ["p1"]}):
+        term = Named(
+            "q",
+            Parameter("q_scale", prior=Prior("Beta", alpha=2, beta=5, dims="product")),
+            dims="product",
+        )
+        term.create_variable()
+        with pytest.raises(ValueError, match="already exists"):
+            term.create_variable()


### PR DESCRIPTION
Second PR in the terms stack (serialization → Bass components → Bass port).

- `Named(name, expr, dims=None)` composes an expression into a `pmd.Deterministic` — dims-first, so expression leaves must be dims-native (`Parameter`/`Prior` with `xdist=True` or `pytensor.xtensor`). Coordinates, data registration, and data updates delegate to the inner expression.
- `Ref(name)` resolves an already-built named variable, letting later effects depend on earlier ones without recreating variables.

Both serialize through the terms registry from #2987, so components composed in `model_config` survive `fit()`/`save()`/`load()`.

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2991.org.readthedocs.build/en/2991/

<!-- readthedocs-preview pymc-marketing end -->