### PR TITLE
fix(utility): make `diversification_ratio` callable

### DIFF
--- a/pymc_marketing/mmm/utility.py
+++ b/pymc_marketing/mmm/utility.py
@@ -593,16 +593,22 @@ def diversification_ratio(
     """
     samples = as_xtensor(samples)
     budgets = as_xtensor(budgets)
-    samples = _check_samples_dimensionality(samples)
+    if samples.type.ndim != 2:
+        raise ValueError(
+            "Function expected samples to be a 2D tensor variable with a 'sample' "
+            f"dim and an asset dim. Got {samples.type.ndim} dimensions."
+        )
     weights = budgets / budgets.sum()
     individual_volatilities = samples.std(dim="sample", ddof=1)
 
     [asset_dim] = weights.dims
     cov_matrix = _covariance_matrix(samples, asset_dim=asset_dim)
 
-    # w'Σw
+    # w'Σw: rename one copy of the weights so the two asset axes of the
+    # covariance matrix are contracted separately.
     portfolio_var = ptx.dot(
-        weights.rename({asset_dim: f"{asset_dim}'"}, ptx.dot(cov_matrix, weights)),
+        weights.rename({asset_dim: f"{asset_dim}'"}),
+        ptx.dot(cov_matrix, weights),
     )
     portfolio_volatility = ptx.math.sqrt(portfolio_var)
     weighted_avg_volatility = (weights * individual_volatilities).sum()

--- a/pymc_marketing/mmm/utility.py
+++ b/pymc_marketing/mmm/utility.py
@@ -557,7 +557,8 @@ def diversification_ratio(
     The Diversification Ratio measures the effectiveness of diversification by comparing
     the weighted average volatility of individual assets to the overall portfolio volatility.
     A higher ratio indicates better diversification, as it reflects lower correlations among
-    assets, leading to reduced portfolio risk.
+    assets, leading to reduced portfolio risk. It provides insight into how individual asset
+    volatilities and their correlations contribute to the overall portfolio risk.
 
     The Diversification Ratio is calculated as:
 
@@ -583,8 +584,12 @@ def diversification_ratio(
     XTensorVariable
         Diversification Ratio.
 
-    This ratio provides insight into how individual asset volatilities and their correlations
-    contribute to the overall portfolio risk.
+    Raises
+    ------
+    ValueError
+        If ``samples`` is not 2D with a ``sample`` dim, if ``budgets`` is not
+        1D, or if the dim ``budgets`` is labelled with is not a dim of
+        ``samples``.
 
     Notes
     -----
@@ -594,29 +599,42 @@ def diversification_ratio(
     utility function do not have that shape out of the box: the default
     ``response_variable`` is a 1D ``(sample,)`` total, and per-channel
     variables carry a ``date`` dim as well. Reduce over ``date`` before calling
-    this function.
+    this function. The optimizer invokes the utility with keyword arguments,
+    so a wrapper's parameters must be named ``samples`` and ``budgets``.
 
-    Examples
-    --------
-    Optimize for diversification of the per-channel contribution:
-
-    .. code-block:: python
-
-        from pymc_marketing.mmm.utility import diversification_ratio
-
-        optimizer = BudgetOptimizer(
-            model=model,
-            num_periods=num_periods,
-            response_variable="channel_contribution",
-            utility_function=lambda samples, budgets: diversification_ratio(
-                samples.sum(dim="date"), budgets
-            ),
-        )
+    The ratio is undefined when the portfolio volatility is zero: a channel at
+    exactly zero budget contributes zero in every sample, and a channel driven
+    deep into saturation is numerically constant. Both give ``0 / 0`` for the
+    value and an infinite gradient, which the optimizer reports as an opaque
+    solver failure. The default bounds allow zero budgets, so pass
+    ``budget_bounds`` with strictly positive lower bounds when optimizing for
+    diversification.
 
     References
     ----------
     - Choueifaty, Y., & Coignard, Y. (2008). Toward Maximum Diversification. *Journal of Portfolio Management*.
     - Meucci, A. (2009). Managing Diversification. *Risk*, 22(5), 74-79.
+
+    Examples
+    --------
+    Optimize a fitted MMM for diversification of the per-channel contribution:
+
+    .. code-block:: python
+
+        from pymc_marketing.mmm.utility import diversification_ratio
+
+        optimizer = mmm.budget_optimizer(
+            start_date="2025-01-06",
+            end_date="2025-03-31",
+            response_variable="channel_contribution",
+            utility_function=lambda samples, budgets: diversification_ratio(
+                samples.sum(dim="date"), budgets
+            ),
+        )
+        result = optimizer.allocate_budget(
+            total_budget=100.0,
+            budget_bounds={channel: (1.0, 100.0) for channel in mmm.channel_columns},
+        )
     """
     samples = as_xtensor(samples)
     budgets = as_xtensor(budgets)

--- a/pymc_marketing/mmm/utility.py
+++ b/pymc_marketing/mmm/utility.py
@@ -586,6 +586,33 @@ def diversification_ratio(
     This ratio provides insight into how individual asset volatilities and their correlations
     contribute to the overall portfolio risk.
 
+    Notes
+    -----
+    ``samples`` must have exactly two dims: ``sample`` and the asset dim that
+    ``budgets`` is labelled with. The response distributions
+    :class:`~pymc_marketing.mmm.budget_optimizer.BudgetOptimizer` passes to a
+    utility function do not have that shape out of the box: the default
+    ``response_variable`` is a 1D ``(sample,)`` total, and per-channel
+    variables carry a ``date`` dim as well. Reduce over ``date`` before calling
+    this function.
+
+    Examples
+    --------
+    Optimize for diversification of the per-channel contribution:
+
+    .. code-block:: python
+
+        from pymc_marketing.mmm.utility import diversification_ratio
+
+        optimizer = BudgetOptimizer(
+            model=model,
+            num_periods=num_periods,
+            response_variable="channel_contribution",
+            utility_function=lambda samples, budgets: diversification_ratio(
+                samples.sum(dim="date"), budgets
+            ),
+        )
+
     References
     ----------
     - Choueifaty, Y., & Coignard, Y. (2008). Toward Maximum Diversification. *Journal of Portfolio Management*.
@@ -593,15 +620,24 @@ def diversification_ratio(
     """
     samples = as_xtensor(samples)
     budgets = as_xtensor(budgets)
-    if samples.type.ndim != 2:
+    if samples.type.ndim != 2 or "sample" not in samples.dims:
         raise ValueError(
             "Function expected samples to be a 2D tensor variable with a 'sample' "
-            f"dim and an asset dim. Got {samples.type.ndim} dimensions."
+            f"dim and an asset dim. Got dims {samples.dims}."
         )
+    if budgets.type.ndim != 1:
+        raise ValueError(
+            "Function expected budgets to be a 1D tensor variable over the asset "
+            f"dim. Got dims {budgets.dims}."
+        )
+    [asset_dim] = budgets.dims
+    if asset_dim not in samples.dims:
+        raise ValueError(
+            f"budgets dim {asset_dim!r} not found in samples dims {samples.dims}."
+        )
+
     weights = budgets / budgets.sum()
     individual_volatilities = samples.std(dim="sample", ddof=1)
-
-    [asset_dim] = weights.dims
     cov_matrix = _covariance_matrix(samples, asset_dim=asset_dim)
 
     # w'Σw: rename one copy of the weights so the two asset axes of the
@@ -612,5 +648,4 @@ def diversification_ratio(
     )
     portfolio_volatility = ptx.math.sqrt(portfolio_var)
     weighted_avg_volatility = (weights * individual_volatilities).sum()
-    diversification_ratio = weighted_avg_volatility / portfolio_volatility
-    return diversification_ratio
+    return weighted_avg_volatility / portfolio_volatility

--- a/tests/mmm/test_budget_optimizer.py
+++ b/tests/mmm/test_budget_optimizer.py
@@ -740,11 +740,17 @@ def test_constraint_history_keyed_by_constraint(mmm_wrapper):
 
 
 def test_diversification_ratio_through_optimizer(mmm_wrapper):
-    """The docstring recipe runs through BudgetOptimizer to a finite optimum.
+    """The docstring recipe runs through BudgetOptimizer and actually optimizes.
 
     The utility sees the response as ``(sample, date, channel)``; reducing
     over ``date`` gives the ``(sample, channel)`` shape the ratio needs.
+
+    ``total_budget=10`` is deliberate: at 100 the fixture's saturation is so
+    flat that the gradient at the equal split is already within SLSQP's
+    tolerance, and the solver stops at the initial guess, which every
+    assertion here would then satisfy for free.
     """
+    total_budget = 10.0
     optimizer = BudgetOptimizer(
         model=mmm_wrapper,
         num_periods=30,
@@ -753,13 +759,20 @@ def test_diversification_ratio_through_optimizer(mmm_wrapper):
             samples.sum(dim="date"), budgets
         ),
     )
-    result = optimizer.allocate_budget(total_budget=100.0)
+    result = optimizer.allocate_budget(total_budget=total_budget)
 
     assert result.scipy_result.success
     assert np.isfinite(result.scipy_result.fun)
+    np.testing.assert_allclose(result.budgets.sum(), total_budget, atol=1e-3)
+
+    # The solution is not the initial guess (the equal split), and the
+    # utility there is genuinely higher than at the initial guess.
+    x0 = np.full(result.budgets.size, total_budget / result.budgets.size)
+    assert not np.allclose(result.budgets.values, x0)
+    objective_at_x0, _ = optimizer._objective_and_grad(x0)
+    assert result.scipy_result.fun < objective_at_x0
     # The objective is the negated utility, and DR is bounded below by 1.
     assert -result.scipy_result.fun >= 1.0 - 1e-6
-    np.testing.assert_allclose(result.budgets.sum(), 100.0, atol=1e-3)
 
 
 def test_allocate_budget_result_object(mmm_wrapper):

--- a/tests/mmm/test_budget_optimizer.py
+++ b/tests/mmm/test_budget_optimizer.py
@@ -40,7 +40,10 @@ from pymc_marketing.mmm.budget_optimizer import (
 from pymc_marketing.mmm.components.adstock import GeometricAdstock
 from pymc_marketing.mmm.components.saturation import LogisticSaturation
 from pymc_marketing.mmm.constraints import Constraint, build_default_sum_constraint
-from pymc_marketing.mmm.utility import _check_samples_dimensionality
+from pymc_marketing.mmm.utility import (
+    _check_samples_dimensionality,
+    diversification_ratio,
+)
 
 
 @pytest.fixture(scope="module")
@@ -734,6 +737,29 @@ def test_constraint_history_keyed_by_constraint(mmm_wrapper):
     assert history["spend_floor"][-1]["type"] == "ineq"
     assert history["default"][-1]["type"] == "eq"
     assert np.isclose(history["default"][-1]["value"], 0.0, atol=1e-6)
+
+
+def test_diversification_ratio_through_optimizer(mmm_wrapper):
+    """The docstring recipe runs through BudgetOptimizer to a finite optimum.
+
+    The utility sees the response as ``(sample, date, channel)``; reducing
+    over ``date`` gives the ``(sample, channel)`` shape the ratio needs.
+    """
+    optimizer = BudgetOptimizer(
+        model=mmm_wrapper,
+        num_periods=30,
+        response_variable="channel_contribution",
+        utility_function=lambda samples, budgets: diversification_ratio(
+            samples.sum(dim="date"), budgets
+        ),
+    )
+    result = optimizer.allocate_budget(total_budget=100.0)
+
+    assert result.scipy_result.success
+    assert np.isfinite(result.scipy_result.fun)
+    # The objective is the negated utility, and DR is bounded below by 1.
+    assert -result.scipy_result.fun >= 1.0 - 1e-6
+    np.testing.assert_allclose(result.budgets.sum(), 100.0, atol=1e-3)
 
 
 def test_allocate_budget_result_object(mmm_wrapper):

--- a/tests/mmm/test_utility.py
+++ b/tests/mmm/test_utility.py
@@ -17,7 +17,6 @@ import pytensor.xtensor as ptx
 import pytest
 from pytensor import function
 from pytensor.xtensor import as_xtensor
-from scipy.linalg import hadamard
 
 from pymc_marketing.mmm.utility import (
     _calculate_roas_distribution_for_allocation,
@@ -309,15 +308,26 @@ def test_covariance_matrix_matches_numpy(data):
     )
 
 
+_dr_rng = np.random.default_rng(0)  # local so the module-level rng stream is untouched
+
+
+def _diversification_ratio_numpy(data: np.ndarray, budgets: np.ndarray) -> float:
+    weights = budgets / budgets.sum()
+    return (weights * data.std(axis=0, ddof=1)).sum() / np.sqrt(
+        weights @ np.cov(data, rowvar=False) @ weights
+    )
+
+
 @pytest.mark.parametrize(
     "data, budgets",
     [
         (np.array([[1.0, 2.0], [3.0, 5.0], [5.0, 4.0]]), np.array([1.0, 3.0])),
         (
-            rng.normal(size=(500, 3)) @ np.array([[1, 0.5, 0], [0, 1, 0.2], [0, 0, 1]]),
+            _dr_rng.normal(size=(500, 3))
+            @ np.array([[1, 0.5, 0], [0, 1, 0.2], [0, 0, 1]]),
             np.array([1.0, 2.0, 3.0]),
         ),
-        (rng.normal(size=(200, 4)), np.array([10.0, 20.0, 30.0, 40.0])),
+        (_dr_rng.normal(size=(200, 4)), np.array([10.0, 20.0, 30.0, 40.0])),
     ],
 )
 def test_diversification_ratio_matches_numpy(data, budgets):
@@ -328,30 +338,71 @@ def test_diversification_ratio_matches_numpy(data, budgets):
         [pt_data, pt_budgets], diversification_ratio(pt_data, pt_budgets)
     )
 
-    weights = budgets / budgets.sum()
-    numpy_result = (weights * data.std(axis=0, ddof=1)).sum() / np.sqrt(
-        weights @ np.cov(data, rowvar=False) @ weights
+    np.testing.assert_allclose(
+        dr_func(data, budgets), _diversification_ratio_numpy(data, budgets), rtol=1e-6
     )
 
-    np.testing.assert_allclose(dr_func(data, budgets), numpy_result, rtol=1e-6)
+
+def _diversification_ratio_eval(data: np.ndarray, budgets: np.ndarray) -> float:
+    return float(
+        diversification_ratio(
+            as_xtensor(data, dims=("sample", "channel")),
+            as_xtensor(budgets, dims=("channel",)),
+        ).eval()
+    )
 
 
 def test_diversification_ratio_independent_assets_is_sqrt_n():
     """Uncorrelated assets with equal volatility and equal weights give sqrt(n)."""
-    # Columns 1.. of a Hadamard matrix sum to zero and are mutually orthogonal
-    # with equal norms, so the covariance matrix is a multiple of the identity.
-    data = hadamard(8)[:, 1:].astype(float)
-    budgets = np.ones(data.shape[1])
-    result = diversification_ratio(
-        as_xtensor(data, dims=("sample", "channel")),
-        as_xtensor(budgets, dims=("channel",)),
-    ).eval()
-    np.testing.assert_allclose(result, np.sqrt(data.shape[1]), rtol=1e-6)
+    # Columns of a Hadamard matrix (minus the all-ones one) sum to zero and are
+    # mutually orthogonal with equal norms, so the covariance is a multiple of
+    # the identity.
+    data = np.array(
+        [
+            [1.0, 1.0, 1.0],
+            [-1.0, 1.0, -1.0],
+            [1.0, -1.0, -1.0],
+            [-1.0, -1.0, 1.0],
+        ]
+    )
+    np.testing.assert_allclose(
+        _diversification_ratio_eval(data, np.ones(3)), np.sqrt(3), rtol=1e-6
+    )
 
 
-def test_diversification_ratio_rejects_1d_samples(test_data):
-    samples, budgets = test_data
-    with pytest.raises(ValueError, match="2D tensor variable"):
+def test_diversification_ratio_lower_bound_is_one():
+    """Perfectly correlated assets, and a single asset, sit at the floor DR = 1."""
+    x = np.array([1.0, 2.0, 4.0, 7.0, 11.0])
+    correlated = np.column_stack([x, 2 * x])
+    np.testing.assert_allclose(
+        _diversification_ratio_eval(correlated, np.array([1.0, 3.0])), 1.0, rtol=1e-6
+    )
+    np.testing.assert_allclose(
+        _diversification_ratio_eval(x[:, None], np.array([5.0])), 1.0, rtol=1e-6
+    )
+
+
+@pytest.mark.parametrize(
+    "samples_dims, budgets_dims, match",
+    [
+        (("sample",), ("channel",), "2D tensor variable"),
+        (("sample", "channel", "date"), ("channel",), "2D tensor variable"),
+        (("chain", "channel"), ("channel",), "'sample' dim"),
+        (("sample", "channel"), ("media",), "not found in samples dims"),
+        (("sample", "channel"), ("sample", "channel"), "budgets to be a 1D"),
+    ],
+    ids=[
+        "1d-samples",
+        "3d-samples",
+        "no-sample-dim",
+        "asset-dim-mismatch",
+        "2d-budgets",
+    ],
+)
+def test_diversification_ratio_rejects_bad_dims(samples_dims, budgets_dims, match):
+    samples = ptx.xtensor("samples", dims=samples_dims)
+    budgets = ptx.xtensor("budgets", dims=budgets_dims)
+    with pytest.raises(ValueError, match=match):
         diversification_ratio(samples, budgets)
 
 

--- a/tests/mmm/test_utility.py
+++ b/tests/mmm/test_utility.py
@@ -17,6 +17,7 @@ import pytensor.xtensor as ptx
 import pytest
 from pytensor import function
 from pytensor.xtensor import as_xtensor
+from scipy.linalg import hadamard
 
 from pymc_marketing.mmm.utility import (
     _calculate_roas_distribution_for_allocation,
@@ -25,6 +26,7 @@ from pymc_marketing.mmm.utility import (
     adjusted_value_at_risk_score,
     average_response,
     conditional_value_at_risk,
+    diversification_ratio,
     mean_tightness_score,
     portfolio_entropy,
     raroc,
@@ -305,6 +307,52 @@ def test_covariance_matrix_matches_numpy(data):
         atol=1e-8,
         err_msg=f"Mismatch for input data:\n{data}",
     )
+
+
+@pytest.mark.parametrize(
+    "data, budgets",
+    [
+        (np.array([[1.0, 2.0], [3.0, 5.0], [5.0, 4.0]]), np.array([1.0, 3.0])),
+        (
+            rng.normal(size=(500, 3)) @ np.array([[1, 0.5, 0], [0, 1, 0.2], [0, 0, 1]]),
+            np.array([1.0, 2.0, 3.0]),
+        ),
+        (rng.normal(size=(200, 4)), np.array([10.0, 20.0, 30.0, 40.0])),
+    ],
+)
+def test_diversification_ratio_matches_numpy(data, budgets):
+    """(w . sigma).sum() / sqrt(w' Sigma w) against a numpy reference."""
+    pt_data = ptx.xtensor("pt_data", dims=("sample", "channel"))
+    pt_budgets = ptx.xtensor("pt_budgets", dims=("channel",))
+    dr_func = function(
+        [pt_data, pt_budgets], diversification_ratio(pt_data, pt_budgets)
+    )
+
+    weights = budgets / budgets.sum()
+    numpy_result = (weights * data.std(axis=0, ddof=1)).sum() / np.sqrt(
+        weights @ np.cov(data, rowvar=False) @ weights
+    )
+
+    np.testing.assert_allclose(dr_func(data, budgets), numpy_result, rtol=1e-6)
+
+
+def test_diversification_ratio_independent_assets_is_sqrt_n():
+    """Uncorrelated assets with equal volatility and equal weights give sqrt(n)."""
+    # Columns 1.. of a Hadamard matrix sum to zero and are mutually orthogonal
+    # with equal norms, so the covariance matrix is a multiple of the identity.
+    data = hadamard(8)[:, 1:].astype(float)
+    budgets = np.ones(data.shape[1])
+    result = diversification_ratio(
+        as_xtensor(data, dims=("sample", "channel")),
+        as_xtensor(budgets, dims=("channel",)),
+    ).eval()
+    np.testing.assert_allclose(result, np.sqrt(data.shape[1]), rtol=1e-6)
+
+
+def test_diversification_ratio_rejects_1d_samples(test_data):
+    samples, budgets = test_data
+    with pytest.raises(ValueError, match="2D tensor variable"):
+        diversification_ratio(samples, budgets)
 
 
 # Test Cases


### PR DESCRIPTION
## Description

Closes #2994.

`diversification_ratio` could not be called with any valid input. Two independent defects:

1. **Wrong dimensionality guard (since 0.11.0).** The body called `_check_samples_dimensionality`, which requires 1D, but the function needs a 2D `(sample, asset)` array for the per-asset volatilities and the covariance matrix. Every valid call raised `ValueError`.
2. **Misplaced parenthesis (since 0.19.0).** In the `w'Σw` line, `rename(` closed after the inner `ptx.dot(cov_matrix, weights)`, so that product went to `rename` as a second positional argument and the outer `ptx.dot` received one operand. Defect 1 meant this line never executed.

## Changes

- Replace the 1D guard with a 2D check and a message that names the expected dims.
- Close `rename(...)` before the inner dot product, so the outer `ptx.dot` contracts the renamed weights against `Σw`.
- Tests in `tests/mmm/test_utility.py`:
  - three parametrised cases against a numpy reference `(w·σ).sum() / sqrt(wᵀ Σ w)`, including a correlated 500×3 sample;
  - a property test: uncorrelated assets with equal volatility and equal weights give exactly `sqrt(n)`, built from a Hadamard matrix so the covariance is a multiple of the identity;
  - 1D input is rejected.

The function had no tests before and no notebook uses it, so there is no caller impact beyond making it work.

## Checks

- `tests/mmm/test_utility.py` passes locally (51 tests).
- pre-commit passes on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LH4AVWy1kchzW9WihWHUvE


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2995.org.readthedocs.build/en/2995/

<!-- readthedocs-preview pymc-marketing end -->