### PR TITLE
feat: use terms for Bass priors

### DIFF
--- a/pymc_marketing/bass/model.py
+++ b/pymc_marketing/bass/model.py
@@ -168,7 +168,7 @@ from pymc_marketing.bass import plotting
 from pymc_marketing.bass.data import to_bass_dataset
 from pymc_marketing.model_builder import ModelBuilder, SamplingMethod
 from pymc_marketing.model_config import parse_model_config
-from pymc_marketing.terms import ModelTerm, Parameter, build_param
+from pymc_marketing.terms import ModelTerm, Product, Sum, build_param
 from pymc_marketing.version import __version__
 
 #: What :func:`F` and :func:`f` accept for ``t``: a labelled xtensor, or any
@@ -388,28 +388,10 @@ def _observed_dims(
 class BassPriors(TypedDict):
     """Priors for the Bass diffusion model."""
 
-    m: Prior | Censored | VariableFactory | ModelTerm
-    p: Prior | Censored | VariableFactory | ModelTerm
-    q: Prior | Censored | VariableFactory | ModelTerm
+    m: Prior | Censored | VariableFactory | ModelTerm | Sum | Product
+    p: Prior | Censored | VariableFactory | ModelTerm | Sum | Product
+    q: Prior | Censored | VariableFactory | ModelTerm | Sum | Product
     likelihood: Prior | Censored
-
-
-def _build_prior(prior: Any, name: str) -> pmd.XTensorVariable:
-    """Build a prior or term recipe into its tensor.
-
-    ``Parameter(name, prior)`` builds exactly like the previous
-    ``prior.create_variable(name, xdist=True)``, so models configured with
-    plain priors keep an identical graph. Priors must be dims-native:
-    Bass composes them into ``pmd.Deterministic`` outputs.
-    """
-    if isinstance(prior, ModelTerm):
-        return cast("pmd.XTensorVariable", build_param(prior))
-    return cast("pmd.XTensorVariable", build_param(Parameter(name, prior=prior)))
-
-
-def _term_dims(value: Any) -> Any:
-    """Dims declared by a prior or term (``None`` when not annotated)."""
-    return getattr(value, "dims", None)
 
 
 def create_bass_model(
@@ -456,6 +438,11 @@ def create_bass_model(
         - 'p': Innovation coefficient prior or term
         - 'q': Imitation coefficient prior or term
         - 'likelihood': Observation likelihood model
+
+        Terms must build free random variables (``Parameter`` /
+        ``Named``) - data-carrying terms (``Dot``) need
+        ``register_data``/``set_data`` wiring this model does not
+        perform yet.
     coords : dict[str, Any]
         Coordinate values for dimensions in the model, including
         'date' for the time dimension and any other dimensions
@@ -487,26 +474,27 @@ def create_bass_model(
     """
     model = model or pm.Model(coords=coords)
     with model:
+        time = pmd.as_xtensor(t, dims=("T",))
+        m = cast("pmd.XTensorVariable", build_param(priors["m"], "m"))
+        p = cast("pmd.XTensorVariable", build_param(priors["p"], "p"))
+        q = cast("pmd.XTensorVariable", build_param(priors["q"], "q"))
+
         # Declaration order, not set order: `combined_dims` labels the axes of
         # `observed` positionally, so an order that varies between processes
         # would silently mislabel the data. The likelihood comes first because
-        # it is the variable `observed` has to line up with, so an unlabelled
-        # array laid out the way the likelihood declares it is read that way.
+        # it is the variable `observed` has to line up with. `p`, `q` and `m`
+        # report the dims they actually built with, so a term recipe does not
+        # have to re-declare them.
         declared_dims = (
             *(priors["likelihood"].dims or ()),
-            *(_term_dims(priors["p"]) or ()),
-            *(_term_dims(priors["q"]) or ()),
-            *(_term_dims(priors["m"]) or ()),
+            *getattr(p, "dims", ()),
+            *getattr(q, "dims", ()),
+            *getattr(m, "dims", ()),
         )
         combined_dims = (
             "T",
             *(dim for dim in dict.fromkeys(declared_dims) if dim != "T"),
         )
-
-        time = pmd.as_xtensor(t, dims=("T",))
-        m = _build_prior(priors["m"], "m")
-        p = _build_prior(priors["p"], "p")
-        q = _build_prior(priors["q"], "q")
 
         def deterministic(name: str, value: XTensorVariable) -> XTensorVariable:
             """Store ``value`` with the dims it has, in ``combined_dims`` order."""
@@ -549,7 +537,9 @@ class BassModel(ModelBuilder):
     ----------
     model_config : dict, optional
         Dictionary with keys ``"m"``, ``"p"``, ``"q"``, ``"likelihood"``
-        mapping to :class:`~pymc_extras.prior.Prior` (or equivalent dict).
+        mapping to :class:`~pymc_extras.prior.Prior` or a punch-in term
+        recipe (``Parameter`` / ``Named`` composition). The names must
+        match the config keys to keep ``m``/``p``/``q`` in the model.
         See :meth:`default_model_config` for defaults.
     sampler_config : dict, optional
         Dictionary of sampler settings (draws, tune, chains, …).
@@ -690,6 +680,9 @@ class BassModel(ModelBuilder):
         ``model_config``, so every fit is scaled to the data it is looking at. Pass an
         ``m`` prior that differs from the default in ``model_config`` to opt out; a
         prior identical to the default is indistinguishable from not passing one.
+        Wrapping the default prior in a ``Parameter`` term counts as passing one,
+        so the rescale does not apply - the fitted ``m`` scale is the prior's own
+        sigma, not ``2 * observed.sum()``.
         """
         return {
             "m": Prior("HalfNormal", sigma=10),
@@ -863,11 +856,9 @@ class BassModel(ModelBuilder):
         # identical either side of a save/load round trip, since `build_model` recomputes
         # the same sigma from `fit_data`.
         priors = dict(self.model_config)
-        if (
-            observed is not None
-            and not isinstance(priors["m"], ModelTerm)
-            and priors["m"] == self.default_model_config["m"]
-        ):
+        # `Prior.__eq__` is already `False` for any term, so the comparison
+        # below opts term recipes out of the rescale on its own.
+        if observed is not None and priors["m"] == self.default_model_config["m"]:
             total_adopters = max(float(observed.sum()), 1.0)
             priors["m"] = Prior("HalfNormal", sigma=2 * total_adopters)
 

--- a/pymc_marketing/bass/model.py
+++ b/pymc_marketing/bass/model.py
@@ -168,6 +168,7 @@ from pymc_marketing.bass import plotting
 from pymc_marketing.bass.data import to_bass_dataset
 from pymc_marketing.model_builder import ModelBuilder, SamplingMethod
 from pymc_marketing.model_config import parse_model_config
+from pymc_marketing.terms import ModelTerm, Parameter, build_param
 from pymc_marketing.version import __version__
 
 #: What :func:`F` and :func:`f` accept for ``t``: a labelled xtensor, or any
@@ -387,10 +388,28 @@ def _observed_dims(
 class BassPriors(TypedDict):
     """Priors for the Bass diffusion model."""
 
-    m: Prior | Censored | VariableFactory
-    p: Prior | Censored | VariableFactory
-    q: Prior | Censored | VariableFactory
+    m: Prior | Censored | VariableFactory | ModelTerm
+    p: Prior | Censored | VariableFactory | ModelTerm
+    q: Prior | Censored | VariableFactory | ModelTerm
     likelihood: Prior | Censored
+
+
+def _build_prior(prior: Any, name: str) -> pmd.XTensorVariable:
+    """Build a prior or term recipe into its tensor.
+
+    ``Parameter(name, prior)`` builds exactly like the previous
+    ``prior.create_variable(name, xdist=True)``, so models configured with
+    plain priors keep an identical graph. Priors must be dims-native:
+    Bass composes them into ``pmd.Deterministic`` outputs.
+    """
+    if isinstance(prior, ModelTerm):
+        return cast("pmd.XTensorVariable", build_param(prior))
+    return cast("pmd.XTensorVariable", build_param(Parameter(name, prior=prior)))
+
+
+def _term_dims(value: Any) -> Any:
+    """Dims declared by a prior or term (``None`` when not annotated)."""
+    return getattr(value, "dims", None)
 
 
 def create_bass_model(
@@ -432,10 +451,10 @@ def create_bass_model(
         priors, in that order. An array laid out the way the ``likelihood``
         prior declares it is therefore read the way it is laid out.
     priors : BassPriors
-        Dictionary containing priors for:
-        - 'm': Market potential prior
-        - 'p': Innovation coefficient prior
-        - 'q': Imitation coefficient prior
+        Dictionary containing priors or term recipes for:
+        - 'm': Market potential prior or term
+        - 'p': Innovation coefficient prior or term
+        - 'q': Imitation coefficient prior or term
         - 'likelihood': Observation likelihood model
     coords : dict[str, Any]
         Coordinate values for dimensions in the model, including
@@ -475,9 +494,9 @@ def create_bass_model(
         # array laid out the way the likelihood declares it is read that way.
         declared_dims = (
             *(priors["likelihood"].dims or ()),
-            *(priors["p"].dims or ()),
-            *(priors["q"].dims or ()),
-            *(priors["m"].dims or ()),
+            *(_term_dims(priors["p"]) or ()),
+            *(_term_dims(priors["q"]) or ()),
+            *(_term_dims(priors["m"]) or ()),
         )
         combined_dims = (
             "T",
@@ -485,9 +504,9 @@ def create_bass_model(
         )
 
         time = pmd.as_xtensor(t, dims=("T",))
-        m = priors["m"].create_variable("m", xdist=True)
-        p = priors["p"].create_variable("p", xdist=True)
-        q = priors["q"].create_variable("q", xdist=True)
+        m = _build_prior(priors["m"], "m")
+        p = _build_prior(priors["p"], "p")
+        q = _build_prior(priors["q"], "q")
 
         def deterministic(name: str, value: XTensorVariable) -> XTensorVariable:
             """Store ``value`` with the dims it has, in ``combined_dims`` order."""
@@ -844,7 +863,11 @@ class BassModel(ModelBuilder):
         # identical either side of a save/load round trip, since `build_model` recomputes
         # the same sigma from `fit_data`.
         priors = dict(self.model_config)
-        if observed is not None and priors["m"] == self.default_model_config["m"]:
+        if (
+            observed is not None
+            and not isinstance(priors["m"], ModelTerm)
+            and priors["m"] == self.default_model_config["m"]
+        ):
             total_adopters = max(float(observed.sum()), 1.0)
             priors["m"] = Prior("HalfNormal", sigma=2 * total_adopters)
 

--- a/pymc_marketing/terms.py
+++ b/pymc_marketing/terms.py
@@ -15,7 +15,8 @@
 """Composable model terms for building ``pymc.dims`` subgraphs from xarray data.
 
 ``pymc_marketing.terms`` provides a small set of built-in pieces
-(``Parameter`` / ``Intercept``, ``Dot``, ``Transform``) that compose with
+(``Parameter`` / ``Intercept``, ``Dot``, ``Transform``,
+``Named``, ``Ref``) that compose with
 ``+``, ``*``, and ``-`` into predictors.  **This module is not a full
 modeling toolkit** --- it does not ship complete hierarchical,
 domain-specific, or observation-model wrappers.  It is a **thin, expressive
@@ -218,7 +219,10 @@ Gotchas
   same covariate matrix).
 - ``build_param`` is not idempotent --- call it once to create PyMC
   variables, then sample. Calling it a second time tries to create
-  variables with the same name, causing a PyMC error.
+  variables with the same name, causing a PyMC error. ``Named`` is a
+  named wrapper with the same constraint: build once, reference
+  afterwards with ``Ref`` (which is freely reusable inside multiple
+  ``Named`` expressions).
 - Changing the number of observations in ``set_data`` requires rebuilding
   the model. This is a ``pmd.Data`` constraint (dimensional shared variables
   have fixed dimension sizes), not a framework limitation.
@@ -362,7 +366,8 @@ class ModelTerm:
 
     Subclass ``ModelTerm`` to define reusable PyMC subgraph recipes.
     Custom terms compose with the built-ins (``Parameter``, ``Intercept``,
-    ``Dot``, ``Transform``) via ``+``, ``*``, and ``-`` and use the same
+    ``Dot``, ``Transform``, ``Named``, ``Ref``) via ``+``, ``*``, and ``-``
+    and use the same
     helpers (``collect_coords``, ``register_data``, ``build_param``,
     ``set_data``) --- no framework changes required.  See the module
     docstring **Extending** section for the full contract and an example.
@@ -865,23 +870,31 @@ class Named(ModelTerm):
     expr : Any
         Inner expression accepted by ``build_param``.
     dims : str or tuple of str, optional
-        Dimensions for the deterministic variable.
+        Dimensions for the deterministic variable. These **align** the
+        built value onto ``dims`` (``pmd.Deterministic`` transposes), so
+        they must be a permutation of the inner value's dims, not a new
+        declaration - a value without those dims raises ``ValueError``.
 
     Examples
     --------
     .. code-block:: python
 
         from pymc_extras.prior import Prior
-        from pymc_marketing.terms import Named, Parameter
+        from pymc_marketing.terms import Named, Parameter, Ref
 
         scale = Named(
             "scale",
-            Parameter("scale", prior=Prior("HalfNormal"), dims="product"),
+            Parameter("scale_raw", prior=Prior("HalfNormal", dims="product")),
             dims="product",
         )
 
-        # an effect that references another built variable
-        effect = Named("effect", Ref("scale") * other_term, dims="customer_id")
+        # an effect that references another built variable: build once with
+        # ``Named``, reference afterwards with ``Ref``
+        effect = Named(
+            "effect",
+            Ref("scale") * Parameter("kappa", prior=Prior("Normal", dims="product")),
+            dims="product",
+        )
     """
 
     name: str
@@ -898,7 +911,12 @@ class Named(ModelTerm):
             self.dims = tuple(self.dims)
 
     def get_coords(self, ds: xr.Dataset) -> dict[str, Any]:
-        """Collect coordinates from the inner expression."""
+        """Collect coordinates from the inner expression.
+
+        ``Named`` does not declare its own coords: ``dims`` aligns the
+        built value onto an existing permutation, so coordinates arrive
+        from the inner expression's leaves.
+        """
         return get_coords(self.expr, ds)
 
     def register_data(self, ds: xr.Dataset) -> None:
@@ -910,8 +928,16 @@ class Named(ModelTerm):
         set_data(self.expr, ds=ds, model=model)
 
     def create_variable(self) -> pt.TensorVariable:
-        """Build the named deterministic from the inner expression."""
-        return pmd.Deterministic(self.name, build_param(self.expr), dims=self.dims)
+        """Build the named deterministic from the inner expression.
+
+        Bare ``VariableFactory`` children get a derived name (``<name>_param``)
+        so several ``Named`` terms do not collide on ``build_param``'s default.
+        """
+        return pmd.Deterministic(
+            self.name,
+            build_param(self.expr, name=f"{self.name}_param"),
+            dims=self.dims,
+        )
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize the name, expression, and dims."""
@@ -940,19 +966,58 @@ class Ref(ModelTerm):
 
     Lets an effect expression composed outside the model depend on another
     built effect (e.g. ``a`` on the ``a_scale`` deterministic) without
-    recreating its variables.
+    recreating its variables. ``Ref`` resolves at **build time** and
+    requires the referenced term to be built earlier in traversal order -
+    build once with ``Named``, reference afterwards with ``Ref``.
 
     Parameters
     ----------
     name : str
         Name of the referenced variable.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        scale = Named("scale", Parameter("raw", prior=Prior("HalfNormal")))
+        effect = Named("effect", Ref("scale") * other_term)
     """
 
     name: str
 
     def create_variable(self) -> pt.TensorVariable:
-        """Resolve the referenced variable from the active model."""
-        return pm.modelcontext(None)[self.name]
+        """Resolve the referenced variable from the active model.
+
+        Raises
+        ------
+        ValueError
+            If the variable is not built yet, or if it is not
+            dims-native (referencing plain-tensor variables built by
+            non-terms model code fails later inside pytensor, so it is
+            rejected here with the offending name).
+        """
+        model = pm.modelcontext(None)
+        try:
+            variable = model[self.name]
+        except KeyError:
+            available = ", ".join(sorted(model.named_vars))
+            raise ValueError(
+                f"Ref({self.name!r}) cannot resolve: {self.name!r} is not "
+                "built yet. Terms build during build_param in traversal "
+                f"order, so a term referencing {self.name!r} must come "
+                f"after the term that builds it. Available named vars: "
+                f"{available}."
+            ) from None
+
+        if not isinstance(variable, pmd.XTensorVariable):
+            raise ValueError(
+                f"Ref({self.name!r}) resolved to {variable!r}, which is not "
+                "dims-native. Ref must reference a dims-native variable "
+                "(built by terms or pmd distributions) - plain-tensor "
+                "variables cannot compose into pytensor.xtensor "
+                "expressions."
+            )
+        return variable
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize the referenced name."""

--- a/pymc_marketing/terms.py
+++ b/pymc_marketing/terms.py
@@ -619,6 +619,11 @@ class Parameter(ModelTerm):
     name: str
     prior: VariableFactory = field(default_factory=lambda: Prior("Normal"))
 
+    @property
+    def dims(self) -> Any:
+        """Dims of the underlying prior (``None`` when it has none)."""
+        return getattr(self.prior, "dims", None)
+
     def get_coords(self, ds: xr.Dataset) -> dict[str, Any]:
         """Collect coordinates from ``prior.dims`` present in the dataset."""
         dims = getattr(self.prior, "dims", None)
@@ -882,6 +887,15 @@ class Named(ModelTerm):
     name: str
     expr: Any
     dims: str | tuple[str, ...] | None = None
+
+    def __post_init__(self):
+        """Normalize ``dims`` to a tuple, mirroring ``Prior``."""
+        if self.dims is None:
+            return
+        if isinstance(self.dims, str):
+            self.dims = (self.dims,)
+        elif not isinstance(self.dims, tuple):
+            self.dims = tuple(self.dims)
 
     def get_coords(self, ds: xr.Dataset) -> dict[str, Any]:
         """Collect coordinates from the inner expression."""

--- a/pymc_marketing/terms.py
+++ b/pymc_marketing/terms.py
@@ -231,6 +231,10 @@ Gotchas
           model = pm.modelcontext(None)
           unique = list(dict.fromkeys(ds[self.data_source].values))
           model.add_coords({self.data_source: unique})
+- ``Named`` builds a ``pmd.Deterministic``, so its expression leaves must
+  be dims-native: ``Parameter`` / ``Prior`` with ``xdist=True`` or
+  ``pytensor.xtensor`` expressions. Plain-tensor leaves (``xdist=False``)
+  will fail when the deterministic is built.
 - The built-in terms serialize via ``pymc_marketing.serialization``
   (``to_dict`` / ``from_dict`` are registered), so recipes stored in
   ``model_config`` survive ``fit()`` (attrs are JSON-serialized at
@@ -262,8 +266,10 @@ __all__ = [
     "Dot",
     "Intercept",
     "ModelTerm",
+    "Named",
     "Parameter",
     "Product",
+    "Ref",
     "Sum",
     "Transform",
     "build_param",
@@ -831,6 +837,117 @@ class Transform(ModelTerm):
             inner=_deserialize_child(data["inner"]),
             func=_lookup_func(data["func"]),
         )
+
+
+@serialization.register
+@dataclass
+class Named(ModelTerm):
+    """Compose an expression into a named deterministic variable.
+
+    The inner expression is built lazily within the model context:
+    ``build_param`` produces the value and ``pmd.Deterministic`` stores it
+    under ``name``. Coordinates, data registration, and data updating
+    delegate to the inner expression. Useful for naming intermediate
+    effects (scales, link outputs) that should appear in the posterior.
+
+    The expression leaves must be dims-native: ``Parameter`` / ``Prior``
+    with ``xdist=True`` or ``pytensor.xtensor`` expressions.
+
+    Parameters
+    ----------
+    name : str
+        Name of the deterministic variable.
+    expr : Any
+        Inner expression accepted by ``build_param``.
+    dims : str or tuple of str, optional
+        Dimensions for the deterministic variable.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from pymc_extras.prior import Prior
+        from pymc_marketing.terms import Named, Parameter
+
+        scale = Named(
+            "scale",
+            Parameter("scale", prior=Prior("HalfNormal"), dims="product"),
+            dims="product",
+        )
+
+        # an effect that references another built variable
+        effect = Named("effect", Ref("scale") * other_term, dims="customer_id")
+    """
+
+    name: str
+    expr: Any
+    dims: str | tuple[str, ...] | None = None
+
+    def get_coords(self, ds: xr.Dataset) -> dict[str, Any]:
+        """Collect coordinates from the inner expression."""
+        return get_coords(self.expr, ds)
+
+    def register_data(self, ds: xr.Dataset) -> None:
+        """Register shared data for the inner expression."""
+        register_data(self.expr, ds=ds)
+
+    def set_data(self, ds: xr.Dataset, model: pm.Model | None = None) -> None:
+        """Update shared data for the inner expression."""
+        set_data(self.expr, ds=ds, model=model)
+
+    def create_variable(self) -> pt.TensorVariable:
+        """Build the named deterministic from the inner expression."""
+        return pmd.Deterministic(self.name, build_param(self.expr), dims=self.dims)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the name, expression, and dims."""
+        data: dict[str, Any] = {
+            "name": self.name,
+            "expr": _serialize_child(self.expr),
+        }
+        if self.dims is not None:
+            data["dims"] = self.dims
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Named:
+        """Reconstruct a named term from its serialized form."""
+        return cls(
+            name=data["name"],
+            expr=_deserialize_child(data["expr"]),
+            dims=data.get("dims"),
+        )
+
+
+@serialization.register
+@dataclass
+class Ref(ModelTerm):
+    """Reference an already-built named variable in the active model.
+
+    Lets an effect expression composed outside the model depend on another
+    built effect (e.g. ``a`` on the ``a_scale`` deterministic) without
+    recreating its variables.
+
+    Parameters
+    ----------
+    name : str
+        Name of the referenced variable.
+    """
+
+    name: str
+
+    def create_variable(self) -> pt.TensorVariable:
+        """Resolve the referenced variable from the active model."""
+        return pm.modelcontext(None)[self.name]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the referenced name."""
+        return {"name": self.name}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Ref:
+        """Reconstruct a reference from its serialized form."""
+        return cls(name=data["name"])
 
 
 def get_coords(param: Any, ds: xr.Dataset) -> dict[str, Any]:

--- a/tests/bass/test_model.py
+++ b/tests/bass/test_model.py
@@ -37,6 +37,7 @@ from pytensor.graph import rewrite_graph
 
 from pymc_marketing.bass import BassModel
 from pymc_marketing.bass.model import F, create_bass_model, f
+from pymc_marketing.terms import Named, Parameter
 
 
 class BassModelComponents(BaseModel):
@@ -1476,3 +1477,65 @@ class TestBassModelClass:
         )
         assert isinstance(pp, xr.DataArray)
         assert "posterior_predictive" not in fitted_model.idata
+
+
+class TestBassModelTerms:
+    """Parameter recipes through BassPriors / model_config."""
+
+    def test_recipe_priors_build(self) -> None:
+        """m/p/q as term recipes compose through create_bass_model."""
+        priors = {
+            "m": Parameter("m", prior=Prior("HalfNormal", sigma=500)),
+            "p": Parameter(
+                "p", prior=Prior("Beta", alpha=1.5, beta=20, dims="product")
+            ),
+            "q": Named(
+                "q",
+                Parameter(
+                    "q_scale", prior=Prior("Beta", alpha=2, beta=5, dims="product")
+                )
+                * 2,
+                dims="product",
+            ),
+            "likelihood": Prior("NegativeBinomial", n=1.5, dims="product"),
+        }
+        model = create_bass_model(
+            t=np.arange(40),
+            observed=None,
+            priors=priors,
+            coords={"T": np.arange(40), "product": ["A", "B"]},
+        )
+
+        for var in ("m", "p", "q", "adopters", "innovators", "imitators", "peak"):
+            assert var in model.named_vars
+        assert model.named_vars_to_dims["adopters"] == ("T", "product")
+
+    def test_m_recipe_opts_out_of_rescale(self) -> None:
+        """A term recipe for ``m`` is the user's own prior: no data rescale."""
+        y = np.random.default_rng(42).poisson(lam=100, size=20)
+        model = BassModel(
+            model_config={"m": Parameter("m", prior=Prior("LogNormal", mu=3, sigma=1))}
+        )
+        model.build_model(data=y)
+
+        op = str(model.model["m"].owner.op)
+        assert "lognormal" in op
+        assert "halfnormal" not in op
+
+    def test_recipe_config_survives_save_load(self, mock_pymc_sample, tmp_path) -> None:
+        """Recipes serialize through the model attrs and survive save/load."""
+        y = np.random.default_rng(42).poisson(lam=100, size=20)
+        config = {
+            "m": Parameter("m", prior=Prior("HalfNormal", sigma=500)),
+            "p": Parameter("p", prior=Prior("Beta", alpha=1.5, beta=20)),
+            "q": Parameter("q", prior=Prior("Beta", alpha=2, beta=5)),
+        }
+        model = BassModel(model_config=dict(config))
+        model.fit(data=y, draws=5, tune=5, chains=1, random_seed=42)
+        path = tmp_path / "bass_terms.nc"
+        model.save(path)
+
+        loaded = BassModel.load(path)
+        assert isinstance(loaded.model_config["m"], Parameter)
+        assert loaded.model_config["m"] == config["m"]
+        assert loaded.id == model.id

--- a/tests/bass/test_model.py
+++ b/tests/bass/test_model.py
@@ -1482,6 +1482,11 @@ class TestBassModelClass:
 class TestBassModelTerms:
     """Parameter recipes through BassPriors / model_config."""
 
+    @staticmethod
+    def _graph_m_sigma(model: BassModel) -> float:
+        """Read the `m` prior scale out of the built graph."""
+        return float(model.model["m"].owner.inputs[-1].eval())
+
     def test_recipe_priors_build(self) -> None:
         """m/p/q as term recipes compose through create_bass_model."""
         priors = {
@@ -1511,16 +1516,19 @@ class TestBassModelTerms:
         assert model.named_vars_to_dims["adopters"] == ("T", "product")
 
     def test_m_recipe_opts_out_of_rescale(self) -> None:
-        """A term recipe for ``m`` is the user's own prior: no data rescale."""
+        """The only configuration where the rescale could bite.
+
+        Wrapping the *identical* default prior in a ``Parameter`` looks like a
+        no-op refactor but changes the fitted ``m`` scale from
+        ``2 * observed.sum()`` to the prior's own sigma.
+        """
         y = np.random.default_rng(42).poisson(lam=100, size=20)
         model = BassModel(
-            model_config={"m": Parameter("m", prior=Prior("LogNormal", mu=3, sigma=1))}
+            model_config={"m": Parameter("m", prior=Prior("HalfNormal", sigma=10))}
         )
         model.build_model(data=y)
 
-        op = str(model.model["m"].owner.op)
-        assert "lognormal" in op
-        assert "halfnormal" not in op
+        assert self._graph_m_sigma(model) == pytest.approx(10.0)
 
     def test_recipe_config_survives_save_load(self, mock_pymc_sample, tmp_path) -> None:
         """Recipes serialize through the model attrs and survive save/load."""

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -824,7 +824,7 @@ def test_serialize_named_roundtrip():
     )
     restored = serialization.deserialize(serialization.serialize(term))
     assert restored == term
-    assert restored.dims == "customer_id"
+    assert restored.dims == ("customer_id",)
 
 
 def test_serialize_ref_roundtrip():

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -14,6 +14,7 @@
 
 """Tests for pymc_marketing.terms."""
 
+import json
 from dataclasses import dataclass
 
 import numpy as np
@@ -800,11 +801,16 @@ def test_ref_resolves_built_variable():
     assert "a" in model.named_vars
     assert model.named_vars_to_dims["a"] == ("product",)
 
+    # the contract is the dependency edge, not just name existence
+    from pytensor.graph.traversal import ancestors
+
+    assert model["a_scale"] in set(ancestors([model["a"]]))
+
 
 def test_ref_missing_raises():
     with pm.Model():
         ref = Ref("missing")
-        with pytest.raises(KeyError):
+        with pytest.raises(ValueError, match="is not built yet"):
             ref.create_variable()
 
 
@@ -831,3 +837,105 @@ def test_serialize_ref_roundtrip():
     term = Ref("a_scale")
     restored = serialization.deserialize(serialization.serialize(term))
     assert restored == term
+
+
+def test_named_dims_normalization():
+    """Named normalizes dims (str and list) to tuples, like Prior."""
+    assert Named("x", Parameter("p", prior=Prior("HalfNormal")), dims="a").dims == (
+        "a",
+    )
+    assert Named(
+        "x", Parameter("p", prior=Prior("HalfNormal")), dims=["a", "b"]
+    ).dims == ("a", "b")
+
+
+def test_serialize_named_json_roundtrip():
+    """A JSON hop keeps dims a tuple and round-trip equality (tuple dims)."""
+    term = Named(
+        "eff",
+        Parameter("p", prior=Prior("Normal", dims=("a", "b"))),
+        dims=("a", "b"),
+    )
+    restored = serialization.deserialize(
+        json.loads(json.dumps(serialization.serialize(term)))
+    )
+    assert restored == term
+    assert restored.dims == ("a", "b")
+
+
+def test_ref_not_dims_native_raises():
+    with pm.Model(coords={"product": ["p1"]}):
+        pm.Normal("plain", mu=0, sigma=1, dims="product")
+        with pytest.raises(ValueError, match=r"not dims-native.*plain"):
+            Ref("plain").create_variable()
+
+
+def test_ref_reusable_in_multiple_named():
+    coords = {"product": ["p1", "p2"]}
+    with pm.Model(coords=coords) as model:
+        scale = Named(
+            "base",
+            Parameter("raw", prior=Prior("HalfNormal", dims="product")),
+            dims="product",
+        )
+        scale.create_variable()
+
+        named = Named(
+            "e1",
+            Ref("base") * Parameter("kappa", prior=Prior("HalfNormal", dims="product")),
+            dims="product",
+        )
+        named.create_variable()
+        named2 = Named(
+            "e2",
+            Ref("base")
+            + Parameter("kappa2", prior=Prior("HalfNormal", dims="product")),
+            dims="product",
+        )
+        named2.create_variable()
+
+    assert {"base", "e1", "e2"} <= set(model.named_vars)
+
+
+def test_named_value_matches_expression():
+    """The deterministic wraps the inner expression, not some other operand."""
+    import numpy as np
+
+    with pm.Model() as model:
+        term = Named(
+            "doubled",
+            Parameter("scale", prior=Prior("HalfNormal")) * 2,
+            dims=None,
+        )
+        term.create_variable()
+
+    inner, doubled = pm.draw(
+        [model["scale"], model["doubled"]], draws=3, random_seed=42
+    )
+    np.testing.assert_allclose(doubled, inner * 2)
+
+
+def test_named_bare_factory_named_not_param():
+    """Bare factories get a derived name, not build_param's default."""
+    with pm.Model(coords={"product": ["p1", "p2"]}) as model:
+        term = Named(
+            "s",
+            Prior("HalfNormal", dims="product"),
+            dims="product",
+        )
+        term.create_variable()
+
+    assert "s_param" in model.named_vars
+    assert "param" not in model.named_vars
+
+
+def test_named_reuse_raises():
+    with pm.Model(coords={"product": ["p1"]}):
+        term = Named(
+            "q",
+            Parameter("q_scale", prior=Prior("Beta", alpha=2, beta=5, dims="product")),
+            dims="product",
+        )
+        term.create_variable()
+        with pytest.raises(ValueError, match="already exists"):
+            term.create_variable()

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -31,8 +31,10 @@ from pymc_marketing.terms import (
     Dot,
     Intercept,
     ModelTerm,
+    Named,
     Parameter,
     Product,
+    Ref,
     Sum,
     Transform,
     build_param,
@@ -720,3 +722,112 @@ def test_restored_term_builds(simple_ds):
     with pm.Model(coords=coords):
         register_data(restored, ds=simple_ds)
         assert isinstance(build_param(restored), PTVariable)
+
+
+def test_named_builds_pmd_deterministic():
+    coords = {"product": ["p1", "p2"]}
+    with pm.Model(coords=coords) as model:
+        term = Named(
+            "sigma",
+            Parameter("scale", prior=Prior("HalfNormal", dims="product")),
+            dims="product",
+        )
+        term.create_variable()
+
+    assert "sigma" in model.named_vars
+    assert model.named_vars_to_dims["sigma"] == ("product",)
+
+
+def test_named_dims_none_scalar():
+    with pm.Model() as model:
+        term = Named(
+            "sigma",
+            Parameter("scale", prior=Prior("HalfNormal")),
+            dims=None,
+        )
+        term.create_variable()
+
+    assert "sigma" in model.named_vars
+    assert model.named_vars_to_dims["sigma"] == ()
+
+
+def test_named_delegates_lifecycle(simple_ds):
+    term = Named(
+        "effect",
+        Transform(
+            Dot(var_name="x", prior=Prior("Normal", dims="feature")),
+            func=ptx.math.exp,
+        ),
+        dims="obs",
+    )
+    coords = term.get_coords(simple_ds)
+    assert "feature" in coords
+
+    with pm.Model(coords=coords) as model:
+        term.register_data(simple_ds)
+        term.create_variable()
+
+    assert "effect" in model.named_vars
+    assert model.named_vars_to_dims["effect"] == ("obs",)
+
+    ds2 = simple_ds.copy()
+    ds2["x"] = xr.DataArray(
+        np.roll(simple_ds["x"].values, 1, axis=0), dims=("obs", "feature")
+    )
+    term.set_data(ds2, model=model)
+    assert np.allclose(model["x"].get_value(), ds2["x"].values)
+
+
+def test_ref_resolves_built_variable():
+    coords = {"product": ["p1", "p2"]}
+    with pm.Model(coords=coords) as model:
+        scale = Named(
+            "a_scale",
+            Parameter("phi", prior=Prior("Uniform", lower=0, upper=1, dims="product")),
+            dims="product",
+        )
+        scale.create_variable()
+
+        effect = Named(
+            "a",
+            Ref("a_scale")
+            * Parameter("kappa", prior=Prior("HalfNormal", sigma=1, dims="product")),
+            dims="product",
+        )
+        effect.create_variable()
+
+    assert "a_scale" in model.named_vars
+    assert "a" in model.named_vars
+    assert model.named_vars_to_dims["a"] == ("product",)
+
+
+def test_ref_missing_raises():
+    with pm.Model():
+        ref = Ref("missing")
+        with pytest.raises(KeyError):
+            ref.create_variable()
+
+
+def test_serialize_named_roundtrip():
+    term = Named(
+        "alpha",
+        Parameter("alpha_scale", prior=Prior("HalfFlat"))
+        * Transform(
+            Dot(
+                var_name="purchase_data",
+                name="purchase_coefficient_alpha",
+                prior=Prior("Normal", mu=0, sigma=1, dims="purchase_covariate"),
+            ),
+            func=ptx.math.exp,
+        ),
+        dims="customer_id",
+    )
+    restored = serialization.deserialize(serialization.serialize(term))
+    assert restored == term
+    assert restored.dims == "customer_id"
+
+
+def test_serialize_ref_roundtrip():
+    term = Ref("a_scale")
+    restored = serialization.deserialize(serialization.serialize(term))
+    assert restored == term


### PR DESCRIPTION
Closes #2961. Third PR in the terms stack (serialization → Bass components → Bass).

`m`, `p`, and `q` accept term recipes through `BassPriors` /`model_config` and serialize through the terms registry:

```python
from pymc_marketing.terms import Named, Parameter

priors = {
    "m": Parameter("m", prior=Prior("HalfNormal", sigma=500)),
    "p": Parameter("p", prior=Prior("Beta", alpha=1.5, beta=20, dims="product")),
    "q": Named("q", Parameter("q_scale", ...) * 2, dims="product"),
}
model = create_bass_model(t=t, observed=observed, priors=priors, coords=coords)
```

Defaults keep an identical graph: `Parameter(name, prior)` builds exactly like `prior.create_variable(name, xdist=True)`, and the data-driven `m` rescale still applies unless a recipe opts out. `Parameter` gains a `dims` passthrough and `Named` normalizes dims to tuples (mirroring `Prior`) so the existing observed-labeling bookkeeping reads terms transparently — pymc.dims handles all coordination.

Closes the non-CLV consumer story: Bass (dims-native already), then BG/NBD (#2976) and the #2962 slices follow.

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--2996.org.readthedocs.build/en/2996/

<!-- readthedocs-preview pymc-marketing end -->