### PR TITLE
feat(pie): express the PIE mean function as a terms recipe

### DIFF
--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -8,6 +8,7 @@
   :toctree: generated/
 
   bass
+  bart
   causal_utils
   clv
   customer_choice

--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -7,8 +7,8 @@
   :recursive:
   :toctree: generated/
 
-  bass
   bart
+  bass
   causal_utils
   clv
   customer_choice

--- a/pymc_marketing/__init__.py
+++ b/pymc_marketing/__init__.py
@@ -23,6 +23,8 @@ with _warnings.catch_warnings():
 del _warnings
 
 # Load the data accessor
+# Register the BART term serializer
+import pymc_marketing.bart  # noqa: E402
 import pymc_marketing.data.fivetran  # noqa: E402
 
 # Register R2D2 deserializers
@@ -35,6 +37,7 @@ from pymc_marketing.version import __version__  # noqa: E402
 
 __all__ = [
     "__version__",
+    "bart",
     "bass",
     "clv",
     "customer_choice",

--- a/pymc_marketing/bart.py
+++ b/pymc_marketing/bart.py
@@ -1,0 +1,316 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""BART term for the ``pymc_marketing.terms`` framework.
+
+``pymc_marketing.bart`` exposes :class:`Bart`, a :class:`~pymc_marketing.terms.ModelTerm`
+that wraps :func:`pymc_bart.pymc_bart.BART` so Bayesian Additive Regression Trees
+can be composed like any other term in the ``pymc_marketing.terms`` vocabulary,
+e.g. interchangeably with :class:`~pymc_marketing.terms.Dot`.
+
+``pymc_bart`` is an optional dependency (``pip install 'pymc-marketing[pie]'``).
+Importing this module never fails when ``pymc_bart`` is missing; constructing
+the tensor raises a ``ImportError`` with an install hint instead. This keeps
+models that swap the BART term for a linear :class:`~pymc_marketing.terms.Dot`
+term runnable without ``pymc_bart`` installed.
+
+Because ``pymc_bart`` does not yet operate on ``pymc.dims`` variables, the term
+bridges the two worlds following the standard recipe: the dimensional shared
+data variable is lowered to a plain tensor with ``.values`` before being handed
+to ``pymc_bart``, and the BART output is lifted back into the dimensional graph
+with ``pytensor.xtensor.type.as_xtensor``. See
+`pymc-labs/pymc-marketing#2017 <https://github.com/pymc-labs/pymc-marketing/issues/2017>`_.
+
+Examples
+--------
+Swap a BART mean function for a linear dot product:
+
+.. code-block:: python
+
+    import pymc.dims as pmd
+    import xarray as xr
+    from pymc_extras.prior import Prior
+
+    from pymc_marketing.bart import Bart
+    from pymc_marketing.terms import (
+        build_param,
+        collect_coords,
+        register_data,
+    )
+
+    ds = xr.Dataset(
+        {
+            "X": (("obs", "feature"), X),
+            "y_obs": (("obs",), y),
+        },
+    )
+    mu = Bart(var_name="X", m=200)
+    # ... or the plain linear alternative:
+    # mu = Dot(var_name="X", prior=Prior("Normal", dims="feature"))
+
+    coords = collect_coords(mu, ds=ds)
+    with pm.Model(coords=coords) as model:
+        register_data(mu, ds=ds)
+        model = pm.modelcontext(None)
+        sigma = Prior("HalfNormal", sigma=1.0).create_variable("sigma", xdist=True)
+        pmd.Normal(
+            "y",
+            mu=build_param(mu),
+            sigma=sigma,
+            observed=model["y_obs"],
+            dims="obs",
+        )
+
+Terms compose, so BART can also be an ingredient of a larger expression:
+
+.. code-block:: python
+
+    from pymc_marketing.terms import Intercept
+
+    mu = Intercept(name="intercept") + Bart(var_name="X", m=200)
+
+The term serializes through ``pymc_marketing.serialization`` (``to_dict`` /
+``from_dict``), so it can be stored in ``model_config`` and survive
+``save()`` / ``load()``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, cast
+
+import pymc as pm
+import pymc.dims as pmd
+import pytensor.tensor as pt
+import xarray as xr
+from pytensor.xtensor.type import as_xtensor
+
+from pymc_marketing.serialization import serialization
+from pymc_marketing.terms import ModelTerm
+
+try:
+    import pymc_bart as pmb
+except ImportError:  # pragma: no cover
+    pmb = None  # type: ignore[assignment]
+
+__all__ = ["Bart"]
+
+_DEFAULT_M: int = 200
+_DEFAULT_ALPHA: float = 0.95
+_DEFAULT_BETA: float = 2.0
+_DEFAULT_RESPONSE: str = "constant"
+
+
+def _serialize_split_rules(rules: list[Any] | None) -> list[str] | None:
+    """Serialize split rule instances to class names."""
+    if rules is None:
+        return None
+    return [rule.__class__.__name__ for rule in rules]
+
+
+def _load_split_rules(names: list[str] | None) -> list[Any] | None:
+    """Rebuild split rule instances from serialized class names."""
+    if names is None:
+        return None
+    if pmb is None:
+        raise ImportError(
+            "pymc-bart is required to rebuild split rules for a serialized "
+            "Bart term. Install it with: pip install 'pymc-marketing[pie]'"
+        )
+    from pymc_bart import split_rules
+
+    rules = []
+    for name in names:
+        if not hasattr(split_rules, name):
+            raise ValueError(
+                f"Unknown serialized split rule {name!r}. Split rules are "
+                "resolved by class name against pymc_bart.split_rules."
+            )
+        rules.append(getattr(split_rules, name)())
+    return rules
+
+
+@serialization.register
+@dataclass(kw_only=True)
+class Bart(ModelTerm):
+    """Bayesian Additive Regression Trees term.
+
+    Wraps :func:`pymc_bart.pymc_bart.BART` as a composable
+    :class:`~pymc_marketing.terms.ModelTerm`. Interchangeable with
+    :class:`~pymc_marketing.terms.Dot` --- swapping the two changes the model
+    graph but nothing else in the expression or lifecycle.
+
+    The data variable ``var_name`` is registered as ``pymc.dims`` shared data
+    and the target ``y_name`` must also be registered (BART uses ``Y`` to seed
+    the leaf-value prior with residual quantiles). Whoever registers the
+    observed data wins: registration is guarded by ``if name not in model``.
+
+    Parameters
+    ----------
+    var_name : str
+        Name of the feature variable in the dataset, with shape
+        ``(..., feature)``. Registered as ``pmd.Data`` for out-of-sample
+        prediction.
+    y_name : str, optional
+        Name of the target variable in the model. Used only to seed the
+        leaf-value prior at build time. Defaults to ``"y_obs"``.
+    m : int, optional
+        Number of trees. Defaults to 200.
+    alpha : float, optional
+        Tree prior parameter controlling depth. Defaults to 0.95.
+    beta : float, optional
+        Tree prior parameter controlling depth. Defaults to 2.0.
+    response : str, optional
+        Leaf response form, one of ``"constant"``, ``"linear"``, or ``"mix"``.
+        Defaults to ``"constant"``.
+    split_rules : list, optional
+        Split rules, one per feature column. Defaults to ``None``.
+    name : str, optional
+        Name for the PyMC variable. Defaults to ``"bart"``.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from pymc_extras.prior import Prior
+
+        from pymc_marketing.bart import Bart
+        from pymc_marketing.terms import Dot
+
+        bart_mean = Bart(var_name="X", m=200, name="bart")
+        linear_mean = Dot(
+            var_name="X", name="mu_coef", prior=Prior("Normal", dims="feature")
+        )
+    """
+
+    var_name: str
+    y_name: str = "y_obs"
+    m: int = _DEFAULT_M
+    alpha: float = _DEFAULT_ALPHA
+    beta: float = _DEFAULT_BETA
+    response: str = _DEFAULT_RESPONSE
+    split_rules: list[Any] | None = None
+    name: str = "bart"
+
+    def __post_init__(self) -> None:
+        """Validate configuration."""
+        if self.response not in ("constant", "linear", "mix"):
+            raise ValueError(
+                "Bart response must be 'constant', 'linear', or 'mix', "
+                f"got {self.response!r}."
+            )
+        if self.m < 1:
+            raise ValueError(f"Bart m must be >= 1, got {self.m}.")
+
+    def get_coords(self, ds: xr.Dataset) -> dict[str, Any]:
+        """Extract coordinates from the feature data variable."""
+        return {
+            cast("str", dim): da.coords[dim].values.tolist()
+            for dim, da in ds[self.var_name].coords.items()
+        }
+
+    def register_data(self, ds: xr.Dataset) -> None:
+        """Register the feature and target data variables as ``pmd.Data``."""
+        model = pm.modelcontext(None)
+        if self.var_name not in model:
+            pmd.Data(self.var_name, ds[self.var_name])
+        if self.y_name in ds and self.y_name not in model:
+            pmd.Data(self.y_name, ds[self.y_name])
+
+    def create_variable(self) -> pt.TensorVariable:
+        """Build the BART ensemble tensor.
+
+        Returns
+        -------
+        pt.TensorVariable
+            Dimensional tensor over the observation dimensions.
+        """
+        if pmb is None:
+            raise ImportError(
+                "pymc-bart is required to build a Bart term. "
+                "Install it with: pip install 'pymc-marketing[pie]'"
+            )
+        model = pm.modelcontext(None)
+        X = model[self.var_name]
+        if self.y_name not in model:
+            raise ValueError(
+                f"Bart term requires target data '{self.y_name}' in the model. "
+                "Register it as pmd.Data before building the term."
+            )
+        obs_dims = cast("tuple[str, ...]", X.dims)[:-1]
+        mu_plain = pmb.BART(
+            self.name,
+            X=X.values,
+            Y=model[self.y_name].values,
+            m=self.m,
+            alpha=self.alpha,
+            beta=self.beta,
+            response=self.response,
+            split_rules=self.split_rules,
+            dims=obs_dims,
+        )
+        return as_xtensor(mu_plain, dims=obs_dims)
+
+    def set_data(self, ds: xr.Dataset, model: pm.Model | None = None) -> None:
+        """Update shared data variables for out-of-sample prediction."""
+        if self.var_name in ds:
+            da = ds[self.var_name]
+            coords = {dim: ds[dim].values for dim in da.dims if dim in ds.coords}
+            pm.set_data({self.var_name: da.values}, model=model, coords=coords)
+        if self.y_name in ds:
+            da = ds[self.y_name]
+            coords = {dim: ds[dim].values for dim in da.dims if dim in ds.coords}
+            pm.set_data({self.y_name: da.values}, model=model, coords=coords)
+
+    @property
+    def sample_vars(self) -> list[str]:
+        """Unobserved variables that must be re-sampled in predictive mode.
+
+        The BART ensemble is conditioned on registered data, so when the data
+        are swapped for out-of-sample prediction the likelihood contribution
+        has to be recomputed rather than frozen from the trace.
+        """
+        return [self.name]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the term configuration.
+
+        Returns
+        -------
+        dict[str, Any]
+            JSON-safe configuration. ``split_rules`` serialize as class names.
+        """
+        return {
+            "var_name": self.var_name,
+            "y_name": self.y_name,
+            "m": self.m,
+            "alpha": self.alpha,
+            "beta": self.beta,
+            "response": self.response,
+            "split_rules": _serialize_split_rules(self.split_rules),
+            "name": self.name,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Bart:
+        """Reconstruct a ``Bart`` term from its serialized configuration."""
+        return cls(
+            var_name=data["var_name"],
+            y_name=data.get("y_name", "y_obs"),
+            m=data.get("m", _DEFAULT_M),
+            alpha=data.get("alpha", _DEFAULT_ALPHA),
+            beta=data.get("beta", _DEFAULT_BETA),
+            response=data.get("response", _DEFAULT_RESPONSE),
+            split_rules=_load_split_rules(data.get("split_rules")),
+            name=data.get("name", "bart"),
+        )

--- a/pymc_marketing/bart.py
+++ b/pymc_marketing/bart.py
@@ -14,7 +14,7 @@
 """BART term for the ``pymc_marketing.terms`` framework.
 
 ``pymc_marketing.bart`` exposes :class:`Bart`, a :class:`~pymc_marketing.terms.ModelTerm`
-that wraps :func:`pymc_bart.pymc_bart.BART` so Bayesian Additive Regression Trees
+that wraps :class:`pymc_bart.BART` so Bayesian Additive Regression Trees
 can be composed like any other term in the ``pymc_marketing.terms`` vocabulary,
 e.g. interchangeably with :class:`~pymc_marketing.terms.Dot`.
 
@@ -37,26 +37,32 @@ Swap a BART mean function for a linear dot product:
 
 .. code-block:: python
 
+    import numpy as np
+    import pymc as pm
     import pymc.dims as pmd
     import xarray as xr
     from pymc_extras.prior import Prior
 
     from pymc_marketing.bart import Bart
     from pymc_marketing.terms import (
+        Dot,
         build_param,
         collect_coords,
         register_data,
     )
 
+    X = np.random.normal(size=(100, 4))
+    y = X.sum(axis=1)
     ds = xr.Dataset(
         {
             "X": (("obs", "feature"), X),
             "y_obs": (("obs",), y),
         },
     )
+
     mu = Bart(var_name="X", m=200)
     # ... or the plain linear alternative:
-    # mu = Dot(var_name="X", prior=Prior("Normal", dims="feature"))
+    # mu = Dot(var_name="X", name="mu_coef", prior=Prior("Normal", dims="feature"))
 
     coords = collect_coords(mu, ds=ds)
     with pm.Model(coords=coords) as model:
@@ -115,7 +121,10 @@ def _serialize_split_rules(rules: list[Any] | None) -> list[str] | None:
     """Serialize split rule instances to class names."""
     if rules is None:
         return None
-    return [rule.__class__.__name__ for rule in rules]
+    return [
+        rule.__name__ if isinstance(rule, type) else rule.__class__.__name__
+        for rule in rules
+    ]
 
 
 def _load_split_rules(names: list[str] | None) -> list[Any] | None:
@@ -145,7 +154,7 @@ def _load_split_rules(names: list[str] | None) -> list[Any] | None:
 class Bart(ModelTerm):
     """Bayesian Additive Regression Trees term.
 
-    Wraps :func:`pymc_bart.pymc_bart.BART` as a composable
+    Wraps :class:`pymc_bart.BART` as a composable
     :class:`~pymc_marketing.terms.ModelTerm`. Interchangeable with
     :class:`~pymc_marketing.terms.Dot` --- swapping the two changes the model
     graph but nothing else in the expression or lifecycle.
@@ -211,6 +220,16 @@ class Bart(ModelTerm):
             )
         if self.m < 1:
             raise ValueError(f"Bart m must be >= 1, got {self.m}.")
+        if not (0 < self.alpha < 1):
+            raise ValueError(f"Bart alpha must be in (0, 1), got {self.alpha}.")
+        if self.beta <= 0:
+            raise ValueError(f"Bart beta must be > 0, got {self.beta}.")
+        # Normalize to instances so ``get_coords``/``create_variable`` and
+        # ``to_dict`` see one canonical form; pymc-bart itself accepts both.
+        self.split_rules = [
+            rule() if isinstance(rule, type) else rule
+            for rule in (self.split_rules or [])
+        ] or None
 
     def get_coords(self, ds: xr.Dataset) -> dict[str, Any]:
         """Extract coordinates from the feature data variable."""
@@ -247,10 +266,23 @@ class Bart(ModelTerm):
                 f"Bart term requires target data '{self.y_name}' in the model. "
                 "Register it as pmd.Data before building the term."
             )
-        obs_dims = cast("tuple[str, ...]", X.dims)[:-1]
+        # Derive observation dims from the target rather than positionally
+        # off X, so a transposed data variable cannot silently swap the
+        # feature axis into BART.
+        X_dims = cast("tuple[str, ...]", X.dims)
+        y_dims = tuple(model[self.y_name].dims)
+        obs_dims = tuple(dim for dim in X_dims if dim in y_dims)
+        feature_dims = tuple(dim for dim in X_dims if dim not in y_dims)
+        if len(feature_dims) != 1:
+            raise ValueError(
+                f"Data variable '{self.var_name}' with dims {X.dims} is "
+                f"incompatible with target '{self.y_name}' of dims {y_dims}: "
+                "exactly one trailing feature dimension is expected."
+            )
+        X_ordered = X.transpose(*obs_dims, *feature_dims)
         mu_plain = pmb.BART(
             self.name,
-            X=X.values,
+            X=X_ordered.values,
             Y=model[self.y_name].values,
             m=self.m,
             alpha=self.alpha,

--- a/pymc_marketing/pie/__init__.py
+++ b/pymc_marketing/pie/__init__.py
@@ -37,6 +37,6 @@ Fit on a corpus of past RCTs, then predict incrementality for new campaigns:
     predictions = model.predict(X_new)
 """
 
-from pymc_marketing.pie.model import PIEModel
+from pymc_marketing.pie.model import PIEModel, make_split_rules
 
-__all__ = ["PIEModel"]
+__all__ = ["PIEModel", "make_split_rules"]

--- a/pymc_marketing/pie/model.py
+++ b/pymc_marketing/pie/model.py
@@ -35,6 +35,16 @@ sum of regularised regression trees. Because :math:`f` is sampled rather than
 point-estimated, the predicted incrementality for a new campaign with features
 :math:`x_\star` is a full posterior over :math:`f(x_\star)`.
 
+The mean function is expressed with the **terms** framework
+(:mod:`pymc_marketing.terms`): by default a
+:class:`~pymc_marketing.bart.Bart` term wrapping ``pymc_bart`` built from the
+``"bart"`` configuration keys, but the mean function is configuration, not
+code — ``model_config['mu']`` takes any term recipe
+(:class:`~pymc_marketing.bart.Bart`, :class:`~pymc_marketing.terms.Dot`,
+compositions thereof), so the ensemble is swapped for a plain linear
+regression by passing a ``Dot`` recipe. See the :class:`PIEModel` docstring
+for details.
+
 The approach rests on three assumptions:
 
 1. the RCT corpus is representative of the campaigns being predicted (predictions
@@ -55,12 +65,14 @@ References
 from __future__ import annotations
 
 import json
+import warnings
 from typing import Any
 
 import arviz as az
 import numpy as np
 import pandas as pd
 import pymc as pm
+import pymc.dims as pmd
 import xarray as xr
 from pydantic import Field, validate_call
 from pymc_extras.prior import Prior
@@ -68,14 +80,15 @@ from sklearn.preprocessing import LabelEncoder
 
 from pymc_marketing.model_builder import RegressionModelBuilder
 from pymc_marketing.model_config import parse_model_config
-
-try:
-    import pymc_bart as pmb
-    from pymc_bart.split_rules import ContinuousSplitRule, OneHotSplitRule
-except ImportError:  # pragma: no cover
-    pmb = None  # type: ignore[assignment]
-    ContinuousSplitRule = None  # type: ignore[assignment,misc]
-    OneHotSplitRule = None  # type: ignore[assignment,misc]
+from pymc_marketing.serialization import serialization
+from pymc_marketing.terms import (
+    ModelTerm,
+    build_param,
+    collect_coords,
+    collect_terms,
+    register_data,
+)
+from pymc_marketing.terms import set_data as set_term_data
 
 
 def _is_categorical(series: pd.Series) -> bool:
@@ -88,6 +101,53 @@ def _is_categorical(series: pd.Series) -> bool:
     backend without first casting to ``object``/``category``.
     """
     return not pd.api.types.is_numeric_dtype(series)
+
+
+def make_split_rules(
+    categorical_split: str,
+    column_names: list[str],
+    encoders: dict[str, LabelEncoder] | None = None,
+) -> list[Any]:
+    """Build BART split rules matching the training column order.
+
+    Parameters
+    ----------
+    categorical_split : str
+        Split rule mode: ``"onehot"`` assigns
+        :class:`~pymc_bart.split_rules.OneHotSplitRule` to label-encoded
+        categorical columns so splits are "level X vs not-X" rather than
+        "encoded value < c", or ``"continuous"`` to use ordered splits
+        everywhere.
+    column_names : list[str]
+        Feature columns, in the order they are fed to BART.
+    encoders : dict, optional
+        Label encoders keyed by column name; the keys determine which
+        columns are categorical in the ``"onehot"`` mode.
+
+    Returns
+    -------
+    list
+        One split rule per column, in order.
+
+    Raises
+    ------
+    ValueError
+        If ``categorical_split`` is not ``"onehot"`` or ``"continuous"``.
+    """
+    from pymc_bart.split_rules import ContinuousSplitRule, OneHotSplitRule
+
+    if categorical_split not in ("onehot", "continuous"):
+        raise ValueError(
+            f"categorical_split must be 'onehot' or 'continuous', "
+            f"got {categorical_split!r}."
+        )
+    if categorical_split == "onehot":
+        encoders = encoders or {}
+        return [
+            OneHotSplitRule() if col in encoders else ContinuousSplitRule()
+            for col in column_names
+        ]
+    return [ContinuousSplitRule() for _ in column_names]
 
 
 class PIEModel(RegressionModelBuilder):
@@ -131,6 +191,15 @@ class PIEModel(RegressionModelBuilder):
         - ``"categorical_split"``: ``"onehot"`` (default) or ``"continuous"``.
           Controls how label-encoded categorical columns are split by BART
           — see Notes.
+        - ``"mu"``: a :class:`~pymc_marketing.terms.ModelTerm` recipe (or its
+          serialized dict) for the likelihood mean, taking precedence over the
+          default BART recipe built from ``"bart"``. Terms configure their own
+          hyperparameters, so the model is a plain linear regression by
+          passing e.g.
+          ``Dot(var_name="X", name="mu_coef", prior=Prior("Normal", dims="feature"))``
+          — which removes the ``pymc-bart`` requirement — or a custom
+          :class:`~pymc_marketing.bart.Bart` instance. See
+          :mod:`pymc_marketing.bart` for the swappable BART term.
     sampler_config : dict, optional
         Passed to :func:`pymc.sample`. Defaults to ``{}``.
 
@@ -197,7 +266,7 @@ class PIEModel(RegressionModelBuilder):
     """
 
     _model_type = "PIE Model"
-    version = "0.1.0"
+    version = "0.2.0"
 
     @property
     def output_var(self) -> str:
@@ -233,6 +302,8 @@ class PIEModel(RegressionModelBuilder):
         self._encoders: dict[str, LabelEncoder] = {}
         self._feature_columns: list[str] = []
         self._target_scale: float = 1.0
+        self._mu_recipe: ModelTerm | None = None
+        self._recipe_sample_vars: list[str] = []
 
     @property
     def default_model_config(self) -> dict:
@@ -260,11 +331,103 @@ class PIEModel(RegressionModelBuilder):
         # Build a fresh dict (not a view of ``self.model_config``) so a
         # downstream mutation of the result cannot leak back into the model,
         # and tolerate a partial override that dropped a top-level key.
-        return {
-            key: self.model_config[key]
-            for key in ("bart", "sigma", "categorical_split")
-            if key in self.model_config
-        }
+        keys = ("bart", "sigma", "categorical_split", "mu")
+        return {key: self.model_config[key] for key in keys if key in self.model_config}
+
+    def _make_split_rules(self, column_names: list[str]) -> list[Any]:
+        """Build the split rules from the deprecated method entry point.
+
+        .. deprecated:: 0.2.0
+            Use :func:`pymc_marketing.pie.model.make_split_rules` instead.
+        """
+        warnings.warn(
+            "PIEModel._make_split_rules is deprecated; use "
+            "pymc_marketing.pie.model.make_split_rules instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return make_split_rules(
+            self.model_config.get("categorical_split", "onehot"),
+            column_names,
+            self._encoders,
+        )
+
+    def _default_bart_recipe(self) -> ModelTerm:
+        """Build the default BART recipe from the ``"bart"`` config keys."""
+        from pymc_marketing import bart as bart_module
+
+        if bart_module.pmb is None:
+            raise ImportError(
+                "pymc-bart is required for PIEModel. "
+                "Install it with: pip install 'pymc-marketing[pie]'"
+            )
+
+        bart_cfg = self.model_config.get("bart", {})
+        missing_bart_keys = {"m", "alpha", "beta"} - set(bart_cfg)
+        if missing_bart_keys:
+            raise ValueError(
+                f"model_config['bart'] is missing required keys: "
+                f"{sorted(missing_bart_keys)}. Nested config dicts are replaced "
+                "wholesale rather than deep-merged, so a partial 'bart' override "
+                "must restate every required key (m, alpha, beta)."
+            )
+        response = bart_cfg.get("response", "constant")
+        if response not in ("constant", "linear", "mix"):
+            raise ValueError(
+                "model_config['bart']['response'] must be 'constant', 'linear', "
+                f"or 'mix', got {response!r}."
+            )
+
+        from pymc_marketing.bart import Bart
+
+        return Bart(
+            var_name="X",
+            y_name="y_obs",
+            m=bart_cfg["m"],
+            alpha=bart_cfg["alpha"],
+            beta=bart_cfg["beta"],
+            response=response,
+            split_rules=make_split_rules(
+                self.model_config.get("categorical_split", "onehot"),
+                self._feature_columns,
+                self._encoders,
+            ),
+            name="bart",
+        )
+
+    def _resolve_mu_recipe(self) -> ModelTerm:
+        """Resolve the likelihood mean recipe from the model configuration.
+
+        ``model_config["mu"]`` (a live term or serialized dict) takes
+        precedence; otherwise a :class:`~pymc_marketing.bart.Bart` recipe is
+        built from the ``"bart"`` configuration keys.
+
+        Returns
+        -------
+        ModelTerm
+            Recipe for the likelihood mean over the observation dimension.
+        """
+        config = self.model_config
+        if "mu" in config:
+            recipe = config["mu"]
+            if isinstance(recipe, ModelTerm):
+                return recipe
+            if isinstance(recipe, dict) and "__type__" in recipe:
+                from pymc_marketing import bart as bart_module
+
+                if bart_module.pmb is None:
+                    raise ImportError(
+                        "pymc-bart is required to rebuild the serialized 'mu' "
+                        "recipe of PIEModel. Install it with: "
+                        "pip install 'pymc-marketing[pie]'"
+                    )
+                return serialization.deserialize(recipe)
+            raise ValueError(
+                "model_config['mu'] must be a ModelTerm or a serialized term "
+                "dict with a '__type__' key, got "
+                f"{type(recipe).__name__}."
+            )
+        return self._default_bart_recipe()
 
     def build_model(  # type: ignore[override]
         self,
@@ -284,12 +447,6 @@ class PIEModel(RegressionModelBuilder):
         y : pd.Series or np.ndarray
             Measured incrementality (one value per campaign).
         """
-        if pmb is None:
-            raise ImportError(
-                "pymc-bart is required for PIEModel. "
-                "Install it with: pip install 'pymc-marketing[pie]'"
-            )
-
         feature_cols = self.pre_determined_features + self.post_determined_features
         missing = set(feature_cols) - set(X.columns)
         if missing:
@@ -300,7 +457,7 @@ class PIEModel(RegressionModelBuilder):
 
         # Train only on the declared pre/post features, in a deterministic
         # order. Any other columns in X are dropped here so they are never
-        # label-encoded or fed to BART.
+        # label-encoded or fed to the mean-function recipe.
         self._feature_columns = feature_cols
         X = X.loc[:, feature_cols]
         X_encoded = X.copy()
@@ -324,61 +481,44 @@ class PIEModel(RegressionModelBuilder):
         self._target_scale = abs_max if abs_max > 0.0 else 1.0
         y_scaled = (y_vals / self._target_scale).astype(float)
 
-        cfg = self.model_config
-        missing_bart_keys = {"m", "alpha", "beta"} - set(cfg["bart"])
-        if missing_bart_keys:
-            raise ValueError(
-                f"model_config['bart'] is missing required keys: "
-                f"{sorted(missing_bart_keys)}. Nested config dicts are replaced "
-                "wholesale rather than deep-merged, so a partial 'bart' override "
-                "must restate every required key (m, alpha, beta)."
-            )
-        response = cfg["bart"].get("response", "constant")
-        if response not in ("constant", "linear", "mix"):
-            raise ValueError(
-                "model_config['bart']['response'] must be 'constant', 'linear', "
-                f"or 'mix', got {response!r}."
-            )
-        categorical_split = cfg.get("categorical_split", "onehot")
-        if categorical_split not in ("onehot", "continuous"):
-            raise ValueError(
-                f"model_config['categorical_split'] must be 'onehot' or 'continuous', "
-                f"got {categorical_split!r}."
-            )
-        if categorical_split == "onehot":
-            split_rules = [
-                OneHotSplitRule() if col in self._encoders else ContinuousSplitRule()
-                for col in self._feature_columns
-            ]
-        else:
-            split_rules = [ContinuousSplitRule() for _ in self._feature_columns]
+        recipe = self._resolve_mu_recipe()
+        self._mu_recipe = recipe
+        self._recipe_sample_vars = [
+            sample_var
+            for term in collect_terms([recipe])
+            for sample_var in getattr(term, "sample_vars", [])
+        ]
 
-        coords: dict[str, list] = {
-            "obs": X.index.tolist(),
-            "feature": X.columns.tolist(),
-        }
+        ds = xr.Dataset(
+            {
+                "X": (("obs", "feature"), X_encoded.to_numpy(dtype=float)),
+                "y_obs": (("obs",), y_scaled),
+            },
+            coords={
+                "obs": X_encoded.index.tolist(),
+                "feature": X_encoded.columns.tolist(),
+            },
+        )
+        coords = collect_coords(recipe, ds=ds)
+        coords["obs"] = ds.coords["obs"].values.tolist()
 
         with pm.Model(coords=coords) as self.model:
-            X_data = pm.Data(
-                "X", X_encoded.values.astype(float), dims=("obs", "feature")
-            )
-            y_data = pm.Data("y_obs", y_scaled, dims="obs")
-            # `Y` here is only used by BART for the leaf-prior `initval`
-            # (frozen at fit time). The likelihood's `observed=y_data` is what
-            # gets dummy-zeroed by `_data_setter` for out-of-sample prediction.
-            mu = pmb.BART(
-                "bart",
-                X=X_data,
-                Y=y_scaled,
-                m=cfg["bart"]["m"],
-                alpha=cfg["bart"]["alpha"],
-                beta=cfg["bart"]["beta"],
-                response=response,
-                split_rules=split_rules,
+            register_data(recipe, ds=ds)
+            model = pm.modelcontext(None)
+            if "y_obs" not in model:
+                pmd.Data("y_obs", ds["y_obs"])
+            mu_det = pmd.Deterministic("mu", build_param(recipe), dims="obs")
+            # Plain (non-dims) free variables: PGBART's logp machinery can
+            # only replace plain-tensor values, so any xtensor free variable
+            # breaks BART sampling.
+            sigma = self.model_config["sigma"].create_variable("sigma")
+            pmd.Normal(
+                self.output_var,
+                mu=mu_det,
+                sigma=sigma,
+                observed=model["y_obs"],
                 dims="obs",
             )
-            sigma = cfg["sigma"].create_variable("sigma")
-            pm.Normal(self.output_var, mu=mu, sigma=sigma, observed=y_data, dims="obs")
 
     def _data_setter(  # type: ignore[override]
         self,
@@ -426,14 +566,21 @@ class PIEModel(RegressionModelBuilder):
         else:
             y_data = np.zeros(len(X_encoded), dtype=float)
 
-        with self.model:
-            pm.set_data(
-                {
-                    "X": X_encoded.values.astype(float),
-                    "y_obs": y_data,
-                },
-                coords={"obs": X_encoded.index.tolist()},
+        if self._mu_recipe is None:
+            raise RuntimeError(
+                "The model has no mean-function recipe; call fit() or "
+                "build_model() before setting prediction data."
             )
+        ds_pred = xr.Dataset(
+            {"X": (("obs", "feature"), X_encoded.to_numpy(dtype=float))},
+            coords={
+                "obs": X_encoded.index.tolist(),
+                "feature": self._feature_columns,
+            },
+        )
+        with self.model:
+            set_term_data(self._mu_recipe, ds=ds_pred, model=self.model)
+            pm.set_data({"y_obs": y_data}, coords={"obs": X_encoded.index.tolist()})
 
     def sample_posterior_predictive(  # type: ignore[override]
         self,
@@ -464,10 +611,13 @@ class PIEModel(RegressionModelBuilder):
         """
         self._data_setter(X)
 
+        sample_vars = list(
+            dict.fromkeys([*self._recipe_sample_vars, "mu", self.output_var])
+        )
         with self.model:
             post_pred = pm.sample_posterior_predictive(
                 self.idata,
-                sample_vars=["bart", self.output_var],
+                sample_vars=sample_vars,
                 **kwargs,
             )
 

--- a/pymc_marketing/pie/model.py
+++ b/pymc_marketing/pie/model.py
@@ -65,8 +65,7 @@ References
 from __future__ import annotations
 
 import json
-import warnings
-from typing import Any
+from typing import Any, cast
 
 import arviz as az
 import numpy as np
@@ -133,7 +132,25 @@ def make_split_rules(
     ------
     ValueError
         If ``categorical_split`` is not ``"onehot"`` or ``"continuous"``.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from pymc_bart.split_rules import OneHotSplitRule
+        from sklearn.preprocessing import LabelEncoder
+
+        from pymc_marketing.pie.model import make_split_rules
+
+        encoders = {"objective": LabelEncoder()}
+        rules = make_split_rules("onehot", ["objective", "budget"], encoders)
+        assert isinstance(rules[0], OneHotSplitRule)
     """
+    if categorical_split not in ("onehot", "continuous"):
+        raise ValueError(
+            f"categorical_split must be 'onehot' or 'continuous', "
+            f"got {categorical_split!r}."
+        )
     from pymc_bart.split_rules import ContinuousSplitRule, OneHotSplitRule
 
     if categorical_split not in ("onehot", "continuous"):
@@ -267,6 +284,7 @@ class PIEModel(RegressionModelBuilder):
 
     _model_type = "PIE Model"
     version = "0.2.0"
+    _skipped_config_keys: set[str] = {"mu"}
 
     @property
     def output_var(self) -> str:
@@ -295,6 +313,13 @@ class PIEModel(RegressionModelBuilder):
         # rejects legacy dict-format priors with a migration hint; without it
         # they fail much later with an opaque AttributeError.
         self.model_config = parse_model_config(self.model_config)
+
+        categorical_split = self.model_config.get("categorical_split", "onehot")
+        if categorical_split not in ("onehot", "continuous"):
+            raise ValueError(
+                f"model_config['categorical_split'] must be 'onehot' or "
+                f"'continuous', got {categorical_split!r}."
+            )
 
         self.pre_determined_features = list(pre_determined_features)
         self.post_determined_features = list(post_determined_features)
@@ -332,25 +357,24 @@ class PIEModel(RegressionModelBuilder):
         # downstream mutation of the result cannot leak back into the model,
         # and tolerate a partial override that dropped a top-level key.
         keys = ("bart", "sigma", "categorical_split", "mu")
-        return {key: self.model_config[key] for key in keys if key in self.model_config}
-
-    def _make_split_rules(self, column_names: list[str]) -> list[Any]:
-        """Build the split rules from the deprecated method entry point.
-
-        .. deprecated:: 0.2.0
-            Use :func:`pymc_marketing.pie.model.make_split_rules` instead.
-        """
-        warnings.warn(
-            "PIEModel._make_split_rules is deprecated; use "
-            "pymc_marketing.pie.model.make_split_rules instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return make_split_rules(
-            self.model_config.get("categorical_split", "onehot"),
-            column_names,
-            self._encoders,
-        )
+        config = {
+            key: self.model_config[key] for key in keys if key in self.model_config
+        }
+        recipe = config.get("mu")
+        if isinstance(recipe, ModelTerm):
+            try:
+                serialization.serialize(cast("Any", recipe))
+            except KeyError as err:
+                # Not registered: falling back to a bare __dict__ dump would
+                # write an artifact that cannot be loaded back, so refuse
+                # here instead.
+                raise NotImplementedError(
+                    f"{type(recipe).__name__} is not registered for "
+                    "serialization, so a PIEModel with this 'mu' recipe "
+                    "cannot be saved. Register the term with "
+                    "@serialization.register."
+                ) from err
+        return config
 
     def _default_bart_recipe(self) -> ModelTerm:
         """Build the default BART recipe from the ``"bart"`` config keys."""
@@ -413,14 +437,6 @@ class PIEModel(RegressionModelBuilder):
             if isinstance(recipe, ModelTerm):
                 return recipe
             if isinstance(recipe, dict) and "__type__" in recipe:
-                from pymc_marketing import bart as bart_module
-
-                if bart_module.pmb is None:
-                    raise ImportError(
-                        "pymc-bart is required to rebuild the serialized 'mu' "
-                        "recipe of PIEModel. Install it with: "
-                        "pip install 'pymc-marketing[pie]'"
-                    )
                 return serialization.deserialize(recipe)
             raise ValueError(
                 "model_config['mu'] must be a ModelTerm or a serialized term "
@@ -486,7 +502,7 @@ class PIEModel(RegressionModelBuilder):
         self._recipe_sample_vars = [
             sample_var
             for term in collect_terms([recipe])
-            for sample_var in getattr(term, "sample_vars", [])
+            for sample_var in term.sample_vars
         ]
 
         ds = xr.Dataset(
@@ -508,10 +524,14 @@ class PIEModel(RegressionModelBuilder):
             if "y_obs" not in model:
                 pmd.Data("y_obs", ds["y_obs"])
             mu_det = pmd.Deterministic("mu", build_param(recipe), dims="obs")
-            # Plain (non-dims) free variables: PGBART's logp machinery can
+            # Plain (non-xdist) free variables: PGBART's logp machinery can
             # only replace plain-tensor values, so any xtensor free variable
-            # breaks BART sampling.
-            sigma = self.model_config["sigma"].create_variable("sigma")
+            # breaks BART sampling. A prior that carries dims is lifted for
+            # the likelihood afterwards.
+            sigma_prior = self.model_config["sigma"]
+            sigma = sigma_prior.create_variable("sigma")
+            if sigma_dims := getattr(sigma_prior, "dims", None):
+                sigma = pmd.as_xtensor(sigma, dims=sigma_dims)
             pmd.Normal(
                 self.output_var,
                 mu=mu_det,
@@ -627,6 +647,8 @@ class PIEModel(RegressionModelBuilder):
         group = post_pred[variable_name]
         if self.output_var in group:
             group[self.output_var] = group[self.output_var] * self._target_scale
+        if "mu" in group:
+            group["mu"] = group["mu"] * self._target_scale
 
         if extend_idata:
             self.idata.update(post_pred)  # type: ignore[union-attr]

--- a/pymc_marketing/terms.py
+++ b/pymc_marketing/terms.py
@@ -40,12 +40,15 @@ with the built-ins via ``+`` / ``*`` / ``-`` --- no framework changes
 required.
 
 Lifecycle (per term)
-^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^
 - ``get_coords(ds)`` -- return coordinates from data variables (outside model)
 - ``add_coords(ds)`` -- add model-only coordinates, if not in dataset (inside model context)
 - ``register_data(ds)`` -- register ``pmd.Data`` shared variables (inside model)
 - ``create_variable()`` -- build a dimensional tensor **inside** a ``pm.Model`` context
 - ``set_data(ds, model)`` -- update shared variables for prediction
+- ``sample_vars`` (property) -- names of unobserved variables that must be
+  re-sampled rather than frozen from the trace when predictive data change
+  (e.g. the BART ensemble of ``pymc_marketing.bart``). Defaults to ``[]``.
 
 ``register_data`` calls ``add_coords`` before ``register_data`` on each
 ``ModelTerm``, so dynamic coordinates are handled automatically.
@@ -242,9 +245,18 @@ from typing import Any, cast
 import pymc as pm
 import pymc.dims as pmd
 import pytensor.tensor as pt
+import pytensor.xtensor as ptx
 import xarray as xr
-from pymc_extras.prior import Prior, VariableFactory
+from pymc_extras.prior import (
+    CUSTOM_TRANSFORMS,
+    Prior,
+    UnknownTransformError,
+    VariableFactory,
+    _get_transform,
+)
 from pytensor.xtensor.type import as_xtensor
+
+from pymc_marketing.serialization import SerializationError, serialization
 
 __all__ = [
     "Dot",
@@ -261,6 +273,86 @@ __all__ = [
     "register_data",
     "set_data",
 ]
+
+
+def _func_name(func: Callable) -> str:
+    """Resolve a transform function to its serializable name."""
+    for name, registered in CUSTOM_TRANSFORMS.items():
+        if registered is func:
+            return name
+    for module in (ptx.math, ptx.linalg, ptx):
+        for attr in dir(module):
+            if getattr(module, attr, None) is func:
+                return attr
+    raise SerializationError(
+        f"Function {func!r} is not serializable. Use a "
+        "pytensor.xtensor.math function, or register it with "
+        "pymc_extras.prior.register_tensor_transform."
+    )
+
+
+def _resolve_func(name: str) -> Callable:
+    """Resolve a serialized transform function name to a live callable."""
+    try:
+        func = _get_transform(name, xdist=True)
+    except UnknownTransformError as err:
+        raise SerializationError(
+            f"Unknown serialized function {name!r}. Use a "
+            "pytensor.xtensor.math function, or register it with "
+            "pymc_extras.prior.register_tensor_transform."
+        ) from err
+    if name not in CUSTOM_TRANSFORMS and (name.startswith("_") or not callable(func)):
+        raise SerializationError(
+            f"Serialized function name {name!r} must resolve to a "
+            f"callable pytensor function, got {func!r}."
+        )
+    return func
+
+
+def _serialize_child(value: Any) -> Any:
+    """Serialize a child of a composed term to a JSON-safe value.
+
+    Numeric literals become ``{"__literal__": value}`` wrappers; registered
+    terms serialize through the type registry; ``VariableFactory`` and
+    ``xr.DataArray`` children serialize via their own ``to_dict``.
+    """
+    if isinstance(value, (bool, int, float)):
+        return {"__literal__": value}
+    try:
+        return serialization.serialize(value)
+    except (KeyError, TypeError):
+        pass
+    if isinstance(value, (VariableFactory, xr.DataArray)):
+        return value.to_dict()
+    raise SerializationError(
+        f"Cannot serialize term child of type {type(value).__name__}. "
+        "Register it with @serialization.register and implement "
+        "to_dict/from_dict, or use a supported child type "
+        "(VariableFactory, xr.DataArray, numeric literal)."
+    )
+
+
+def _deserialize_child(value: Any) -> Any:
+    """Deserialize a serialized term child back to a live object."""
+    from pymc_extras.deserialize import (
+        DeserializableError,
+    )
+    from pymc_extras.deserialize import (
+        deserialize as pymc_extras_deserialize,
+    )
+
+    if isinstance(value, dict):
+        if "__literal__" in value:
+            return value["__literal__"]
+        if value.get("__deferred__") or "__type__" in value:
+            return serialization.deserialize(value)
+        try:
+            return pymc_extras_deserialize(value)
+        except DeserializableError as err:
+            raise SerializationError(
+                f"Cannot deserialize term child: {value}."
+            ) from err
+    return value
 
 
 @dataclass
@@ -321,6 +413,19 @@ class ModelTerm:
             The PyMC model to update.
         """
 
+    @property
+    def sample_vars(self) -> list[str]:
+        """Names of unobserved variables re-sampled in predictive mode.
+
+        Members of the sixth lifecycle step. When the registered data are
+        swapped for out-of-sample prediction, variables listed here are
+        re-sampled rather than frozen from the trace, so the term's
+        out-of-sample contribution stays conditioned on the new data. The
+        default of ``[]`` (nothing re-sampled) is correct for terms that
+        depend only on free parameters.
+        """
+        return []
+
     def __add__(self, other: Any) -> Sum:
         """Compose additively with another term."""
         return Sum([self, other])
@@ -352,6 +457,7 @@ class ModelTerm:
         return Product(-1, self)
 
 
+@serialization.register
 @dataclass
 class Sum:
     """Container for additive composition via ``+``.
@@ -386,6 +492,15 @@ class Sum:
         """Compose multiplicatively from the left."""
         return Product(other, self)
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the summed terms."""
+        return {"terms": [_serialize_child(term) for term in self.terms]}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Sum:
+        """Reconstruct a sum from its serialized terms."""
+        return cls(terms=[_deserialize_child(term) for term in data["terms"]])
+
     def get_coords(self, ds: xr.Dataset) -> dict[str, Any]:
         """Collect coordinates from all terms."""
         coords: dict[str, Any] = {}
@@ -407,6 +522,7 @@ class Sum:
             set_data(term, ds=ds, model=model)
 
 
+@serialization.register
 @dataclass
 class Product:
     """Container for multiplicative composition via ``*``.
@@ -439,6 +555,21 @@ class Product:
         """Compose multiplicatively from the left."""
         return Product(other, self)
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize both operands."""
+        return {
+            "left": _serialize_child(self.left),
+            "right": _serialize_child(self.right),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Product:
+        """Reconstruct a product from its serialized operands."""
+        return cls(
+            left=_deserialize_child(data["left"]),
+            right=_deserialize_child(data["right"]),
+        )
+
     def register_data(self, ds: xr.Dataset) -> None:
         """Register shared data for both operands."""
         register_data(self, ds=ds)
@@ -449,6 +580,7 @@ class Product:
         set_data(self.right, ds=ds, model=model)
 
 
+@serialization.register
 @dataclass
 class Parameter(ModelTerm):
     """Named free parameter (scalar or dimensional via ``prior.dims``).
@@ -513,7 +645,20 @@ class Parameter(ModelTerm):
         """Build a free parameter variable."""
         return self.prior.create_variable(self.name, xdist=True)
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the parameter name and prior."""
+        return {"name": self.name, "prior": _serialize_child(self.prior)}
 
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Parameter:
+        """Reconstruct a parameter from its serialized configuration."""
+        return cls(
+            name=data["name"],
+            prior=_deserialize_child(data["prior"]),
+        )
+
+
+@serialization.register
 @dataclass
 class Intercept(Parameter):
     """GLM-style intercept term; same as :class:`Parameter` with a default name.
@@ -534,6 +679,7 @@ class Intercept(Parameter):
     prior: VariableFactory = field(default_factory=lambda: Prior("Normal"))
 
 
+@serialization.register
 @dataclass(kw_only=True)
 class Dot(ModelTerm):
     """Linear predictor term: ``data @ beta``.
@@ -615,7 +761,25 @@ class Dot(ModelTerm):
         beta = self.prior.create_variable(self.name, xdist=True)
         return data @ beta
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the data variable name, prior, and coefficient name."""
+        return {
+            "var_name": self.var_name,
+            "prior": _serialize_child(self.prior),
+            "name": self.name,
+        }
 
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Dot:
+        """Reconstruct a dot product from its serialized configuration."""
+        return cls(
+            var_name=data["var_name"],
+            prior=_deserialize_child(data["prior"]),
+            name=data["name"],
+        )
+
+
+@serialization.register
 @dataclass
 class Transform(ModelTerm):
     """Apply a pytensor function to a term's output.
@@ -673,6 +837,21 @@ class Transform(ModelTerm):
     def set_data(self, ds: xr.Dataset, model: pm.Model | None = None) -> None:
         """Update shared data for the inner expression."""
         set_data(self.inner, ds=ds, model=model)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the inner expression and the transform function name."""
+        return {
+            "inner": _serialize_child(self.inner),
+            "func": _func_name(self.func),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Transform:
+        """Reconstruct a transform from its serialized configuration."""
+        return cls(
+            inner=_deserialize_child(data["inner"]),
+            func=_resolve_func(data["func"]),
+        )
 
 
 def get_coords(param: Any, ds: xr.Dataset) -> dict[str, Any]:
@@ -799,8 +978,10 @@ def collect_terms(params: list[Any]) -> list[ModelTerm]:
     """
     result: list[ModelTerm] = []
     for p in params:
-        if isinstance(p, ModelTerm):
+        if isinstance(p, ModelTerm) and not isinstance(p, Transform):
             result.append(p)
+        elif isinstance(p, Transform):
+            result.extend(collect_terms([p.inner]))
         elif isinstance(p, Sum):
             result.extend(collect_terms(p.terms))
         elif isinstance(p, Product):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dag = ["dowhy", "networkx", "osqp<1.0.0,>=0.6.2", "pygraphviz"]
-pie = ["pymc-bart>=0.12.0"]
+pie = ["pymc-bart>=0.12.0,<0.13"]
 docs = [
     "blackjax<1.6",
     "fastprogress",

--- a/tests/bart/__init__.py
+++ b/tests/bart/__init__.py
@@ -1,0 +1,13 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.

--- a/tests/bart/test_term.py
+++ b/tests/bart/test_term.py
@@ -75,33 +75,25 @@ def test_get_coords(ds: xr.Dataset) -> None:
 
 
 def test_register_data_is_guarded(ds: xr.Dataset) -> None:
+    import pymc as pm
+
     term = make_term()
-    with __import__("pymc").Model(coords=term.get_coords(ds)) as model:
+    with pm.Model(coords=term.get_coords(ds)) as model:
         term.register_data(ds)
         term.register_data(ds)
         assert "X" in model
         assert "y_obs" in model
 
 
-def test_set_data_resizes_obs(ds: xr.Dataset) -> None:
-    term = make_term()
+def test_set_data_resizes_obs_and_target(ds: xr.Dataset) -> None:
     import pymc as pm
     import pymc.dims as pmd
-    import pymc_bart as pmb
-    from pytensor.xtensor.type import as_xtensor
 
+    term = make_term()
     coords = term.get_coords(ds)
     with pm.Model(coords=coords) as model:
         term.register_data(ds)
-        mu_plain = pmb.BART(
-            "bart",
-            X=model["X"].values,
-            Y=model["y_obs"].values,
-            m=term.m,
-            split_rules=term.split_rules,
-            dims=("obs",),
-        )
-        mu_det = pmd.Deterministic("mu", as_xtensor(mu_plain, dims=("obs",)))
+        mu_det = pmd.Deterministic("mu", build_param(term), dims="obs")
         pmd.Normal("y", mu=mu_det, sigma=1.0, observed=model["y_obs"], dims="obs")
         term.set_data(ds, model=model)
 
@@ -110,6 +102,7 @@ def test_set_data_resizes_obs(ds: xr.Dataset) -> None:
     )
     term.set_data(ds_new, model=model)
     assert model["X"].values.eval().shape == (7, 3)
+    assert model["y_obs"].values.eval().shape == (7,)
 
 
 def test_sample_vars() -> None:
@@ -201,3 +194,32 @@ def test_bart_dot_swappable(ds: xr.Dataset) -> None:
             prior = pm.sample_prior_predictive(draws=2)
         assert prior.prior["mu"].dims == ("chain", "draw", "obs")
         assert prior.prior["mu"].shape[-1] == 40
+
+
+def test_transposed_data_var_is_ordered_before_bart(ds: xr.Dataset) -> None:
+    """A data variable declared (feature, obs) cannot transpose into BART."""
+    import pymc as pm
+
+    transposed_ds = ds.transpose("feature", "obs")
+    term = make_term()
+    coords = collect_coords(term, ds=transposed_ds)
+    coords["obs"] = transposed_ds.coords["obs"].values.tolist()
+
+    with pm.Model(coords=coords):
+        register_data(term, ds=transposed_ds)
+        contribution = build_param(term)
+
+    assert contribution.eval().shape == (40,)
+
+
+def test_split_rules_as_classes_roundtrip() -> None:
+    """The pymc-bart spelling (classes) normalizes to instances."""
+    import pymc_bart
+
+    from pymc_marketing.serialization import serialization
+
+    rule_types = (pymc_bart.split_rules.ContinuousSplitRule,)
+    term = make_term(split_rules=list(rule_types))
+    assert isinstance(term.split_rules[0], rule_types[0])
+    rebuilt = serialization.deserialize(serialization.serialize(term))
+    assert [type(rule) for rule in rebuilt.split_rules] == list(rule_types)

--- a/tests/bart/test_term.py
+++ b/tests/bart/test_term.py
@@ -1,0 +1,203 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Tests for the ``pymc_marketing.bart`` term."""
+
+import sys
+from typing import Any
+
+import numpy as np
+import pytest
+import xarray as xr
+from pymc_bart.split_rules import ContinuousSplitRule, OneHotSplitRule
+from pymc_extras.prior import Prior
+
+from pymc_marketing.bart import Bart
+from pymc_marketing.serialization import serialization
+from pymc_marketing.terms import (
+    Dot,
+    Intercept,
+    build_param,
+    collect_coords,
+    collect_terms,
+    register_data,
+)
+
+
+@pytest.fixture
+def ds() -> xr.Dataset:
+    rng = np.random.default_rng(42)
+    X = rng.normal(size=(40, 3))
+    y = X @ np.array([1.0, -2.0, 0.5]) + rng.normal(scale=0.1, size=40)
+    return xr.Dataset(
+        {"X": (("obs", "feature"), X), "y_obs": (("obs",), y)},
+        coords={"obs": np.arange(40), "feature": ["a", "b", "c"]},
+    )
+
+
+def make_term(**kwargs: Any) -> Bart:
+    defaults: dict[str, Any] = {
+        "var_name": "X",
+        "y_name": "y_obs",
+        "m": 20,
+        "split_rules": [ContinuousSplitRule()] * 3,
+        "name": "bart",
+    }
+    defaults.update(kwargs)
+    return Bart(**defaults)
+
+
+def test_invalid_response_raises() -> None:
+    with pytest.raises(ValueError, match="response"):
+        make_term(response="quadratic")
+
+
+def test_invalid_m_raises() -> None:
+    with pytest.raises(ValueError, match="m must be"):
+        make_term(m=0)
+
+
+def test_get_coords(ds: xr.Dataset) -> None:
+    term = make_term()
+    coords = term.get_coords(ds)
+    assert set(coords) == {"obs", "feature"}
+    assert coords["feature"] == ["a", "b", "c"]
+
+
+def test_register_data_is_guarded(ds: xr.Dataset) -> None:
+    term = make_term()
+    with __import__("pymc").Model(coords=term.get_coords(ds)) as model:
+        term.register_data(ds)
+        term.register_data(ds)
+        assert "X" in model
+        assert "y_obs" in model
+
+
+def test_set_data_resizes_obs(ds: xr.Dataset) -> None:
+    term = make_term()
+    import pymc as pm
+    import pymc.dims as pmd
+    import pymc_bart as pmb
+    from pytensor.xtensor.type import as_xtensor
+
+    coords = term.get_coords(ds)
+    with pm.Model(coords=coords) as model:
+        term.register_data(ds)
+        mu_plain = pmb.BART(
+            "bart",
+            X=model["X"].values,
+            Y=model["y_obs"].values,
+            m=term.m,
+            split_rules=term.split_rules,
+            dims=("obs",),
+        )
+        mu_det = pmd.Deterministic("mu", as_xtensor(mu_plain, dims=("obs",)))
+        pmd.Normal("y", mu=mu_det, sigma=1.0, observed=model["y_obs"], dims="obs")
+        term.set_data(ds, model=model)
+
+    ds_new = ds.isel(obs=slice(0, 7)).assign_coords(
+        obs=np.arange(7), feature=["a", "b", "c"]
+    )
+    term.set_data(ds_new, model=model)
+    assert model["X"].values.eval().shape == (7, 3)
+
+
+def test_sample_vars() -> None:
+    assert make_term().sample_vars == ["bart"]
+
+
+def test_compose_with_intercept(ds: xr.Dataset) -> None:
+    import pymc as pm
+    import pymc.dims as pmd
+
+    mu = Intercept(name="intercept") + make_term()
+    coords = collect_coords(mu, ds=ds)
+    coords["obs"] = ds.coords["obs"].values.tolist()
+    with pm.Model(coords=coords) as model:
+        register_data(mu, ds=ds)
+        pmd.Normal(
+            "y",
+            mu=build_param(mu),
+            sigma=Prior("HalfNormal", sigma=1.0).create_variable("sigma", xdist=True),
+            observed=model["y_obs"],
+            dims="obs",
+        )
+        prior = pm.sample_prior_predictive(draws=2)
+    assert prior.prior["intercept"].dims == ("chain", "draw")
+    assert set(prior.prior["bart"].dims) == {"chain", "draw", "obs"}
+
+
+def test_collect_terms_finds_bart(ds: xr.Dataset) -> None:
+    mu = Intercept(name="intercept") + make_term()
+    terms = collect_terms([mu])
+    bart_terms = [t for t in terms if isinstance(t, Bart)]
+    assert len(bart_terms) == 1
+
+
+def test_serialization_roundtrip() -> None:
+    term = make_term(split_rules=[OneHotSplitRule(), ContinuousSplitRule()])
+    data = serialization.serialize(term)
+    assert data["__type__"] == "pymc_marketing.bart.Bart"
+    rebuilt = serialization.deserialize(data)
+    assert isinstance(rebuilt, Bart)
+    assert rebuilt.m == term.m
+    assert rebuilt.alpha == term.alpha
+    assert rebuilt.beta == term.beta
+    assert rebuilt.response == term.response
+    assert rebuilt.name == term.name
+    assert rebuilt.var_name == term.var_name
+    assert rebuilt.y_name == term.y_name
+    rule_types = [type(rule) for rule in rebuilt.split_rules]
+    assert rule_types == [OneHotSplitRule, ContinuousSplitRule]
+
+
+def test_deserialize_unknown_split_rule_raises() -> None:
+    data = make_term().to_dict()
+    data["split_rules"] = ["NotASplitRule"]
+    with pytest.raises(ValueError, match="NotASplitRule"):
+        Bart.from_dict(data)
+
+
+def test_create_variable_without_pymc_bart_raises(ds: xr.Dataset, monkeypatch) -> None:
+    monkeypatch.setitem(sys.modules, "pymc_bart", None)
+
+    import pymc_marketing.bart as bart_module
+
+    monkeypatch.setattr(bart_module, "pmb", None)
+
+    term = make_term()
+    import pymc as pm
+
+    with pm.Model(coords=term.get_coords(ds)):
+        term.register_data(ds)
+        with pytest.raises(ImportError, match="pymc-marketing\\[pie\\]"):
+            build_param(term)
+
+
+def test_bart_dot_swappable(ds: xr.Dataset) -> None:
+    """Bart and Dot terms produce identically-dimensioned contributions."""
+    import pymc as pm
+    import pymc.dims as pmd
+
+    linear_mean = Dot(
+        var_name="X", name="mu_coef", prior=Prior("Normal", dims="feature")
+    )
+    for recipe in (make_term(), linear_mean):
+        coords = collect_coords(recipe, ds=ds)
+        coords["obs"] = ds.coords["obs"].values.tolist()
+        with pm.Model(coords=coords):
+            register_data(recipe, ds=ds)
+            pmd.Deterministic("mu", build_param(recipe), dims="obs")
+            prior = pm.sample_prior_predictive(draws=2)
+        assert prior.prior["mu"].dims == ("chain", "draw", "obs")
+        assert prior.prior["mu"].shape[-1] == 40

--- a/tests/pie/test_model.py
+++ b/tests/pie/test_model.py
@@ -11,13 +11,18 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+import sys
+
 import numpy as np
 import pandas as pd
 import pytest
+from pymc_bart.split_rules import ContinuousSplitRule, OneHotSplitRule
 from pymc_extras.prior import Prior
 from scipy.stats import pearsonr
 
+from pymc_marketing.bart import Bart
 from pymc_marketing.pie import PIEModel
+from pymc_marketing.terms import Dot
 
 EXPECTED_COLUMNS = [
     "campaign_id",
@@ -246,9 +251,11 @@ def test_negative_incrementality_is_allowed(default_model, small_corpus):
 
 def test_pymc_bart_missing_raises(small_corpus, monkeypatch):
     """build_model raises ImportError when pymc-bart is unavailable."""
-    import pymc_marketing.pie.model as pie_module
+    monkeypatch.setitem(sys.modules, "pymc_bart", None)
 
-    monkeypatch.setattr(pie_module, "pmb", None)
+    import pymc_marketing.bart as bart_module
+
+    monkeypatch.setattr(bart_module, "pmb", None)
 
     model = PIEModel(pre_determined_features=PRE, post_determined_features=POST)
     X, y = small_corpus
@@ -631,3 +638,141 @@ def test_pie_model_default_config_parses() -> None:
     assert isinstance(model.model_config["sigma"], Prior)
     assert model.model_config["bart"]["m"] == 200
     assert model.model_config["categorical_split"] == "onehot"
+
+
+def test_linear_mean_function_via_recipe(small_corpus):
+    """A Dot recipe in model_config['mu'] swaps BART for plain linear regression."""
+    X, y = small_corpus
+    model = PIEModel(
+        pre_determined_features=PRE,
+        post_determined_features=POST,
+        model_config={
+            "sigma": Prior("HalfNormal", sigma=1.0),
+            "mu": Dot(
+                var_name="X", name="mu_coef", prior=Prior("Normal", dims="feature")
+            ),
+        },
+    )
+    model.build_model(X, y)
+    assert model.model["mu_coef"] is not None
+    assert "bart" not in model.model.named_vars
+
+
+def test_linear_recipe_fit_and_predict(small_corpus):
+    """The linear (Dot) recipe fits and predicts without pymc-bart."""
+    X, y = small_corpus
+    model = PIEModel(
+        pre_determined_features=PRE,
+        post_determined_features=POST,
+        model_config={
+            "sigma": Prior("HalfNormal", sigma=1.0),
+            "mu": Dot(
+                var_name="X", name="mu_coef", prior=Prior("Normal", dims="feature")
+            ),
+        },
+    )
+    model.fit(X, y, draws=10, tune=5, chains=1, random_seed=0)
+    X_new = X.iloc[:20].reset_index(drop=True)
+    preds = model.predict(X_new)
+    assert len(preds) == 20
+    assert not np.isnan(preds).any()
+
+
+def test_custom_bart_recipe(small_corpus):
+    """A live Bart recipe in model_config['mu'] is honored."""
+    X, y = small_corpus
+    model = PIEModel(
+        pre_determined_features=PRE,
+        post_determined_features=POST,
+        model_config={
+            "sigma": Prior("HalfNormal", sigma=1.0),
+            "mu": Bart(
+                var_name="X",
+                y_name="y_obs",
+                m=10,
+                split_rules=[ContinuousSplitRule() for _ in PRE + POST],
+                name="bart",
+            ),
+        },
+    )
+    model.build_model(X, y)
+    assert "bart" in model.model.named_vars
+
+
+def test_mu_recipe_serialized_dict(small_corpus):
+    """A serialized term dict in model_config['mu'] is deserialized."""
+    X, y = small_corpus
+    bart = Bart(
+        var_name="X",
+        y_name="y_obs",
+        m=10,
+        split_rules=[
+            OneHotSplitRule() if col in PRE else ContinuousSplitRule()
+            for col in PRE + POST
+        ],
+        name="bart",
+    )
+    recipe = bart.to_dict()
+    model = PIEModel(
+        pre_determined_features=PRE,
+        post_determined_features=POST,
+        model_config={"sigma": Prior("HalfNormal", sigma=1.0), "mu": recipe},
+    )
+    model.build_model(X, y)
+    assert "bart" in model.model.named_vars
+
+
+def test_mu_recipe_dict_without_type_raises(small_corpus):
+    """A plain dict without '__type__' in model_config['mu'] raises ValueError."""
+    X, y = small_corpus
+    model = PIEModel(
+        pre_determined_features=PRE,
+        post_determined_features=POST,
+        model_config={"sigma": Prior("HalfNormal", sigma=1.0), "mu": {"m": 10}},
+    )
+    with pytest.raises(ValueError, match="ModelTerm or a serialized term dict"):
+        model.build_model(X, y)
+
+
+def test_make_split_rules_onehot_mode():
+    """The module helper maps encoders to OneHotSplitRule per column."""
+    from pymc_bart.split_rules import ContinuousSplitRule, OneHotSplitRule
+    from sklearn.preprocessing import LabelEncoder
+
+    import pymc_marketing.pie.model as pie_module
+
+    encoders = {"objective": LabelEncoder()}
+    rules = pie_module.make_split_rules("onehot", ["objective", "budget"], encoders)
+    assert isinstance(rules[0], OneHotSplitRule)
+    assert isinstance(rules[1], ContinuousSplitRule)
+
+
+def test_make_split_rules_continuous_mode():
+    """The module helper returns all-continuous rules in 'continuous' mode."""
+    from pymc_bart.split_rules import ContinuousSplitRule
+
+    import pymc_marketing.pie.model as pie_module
+
+    rules = pie_module.make_split_rules("continuous", ["a", "b"], {})
+    assert all(isinstance(rule, ContinuousSplitRule) for rule in rules)
+    assert len(rules) == 2
+
+
+def test_make_split_rules_invalid_mode_raises():
+    """The module helper validates the split mode."""
+    import pymc_marketing.pie.model as pie_module
+
+    with pytest.raises(ValueError, match="categorical_split"):
+        pie_module.make_split_rules("nope", ["a"], None)
+
+
+def test_deprecated_make_split_rules_wrapper(default_model, small_corpus):
+    """PIEModel._make_split_rules still works with a DeprecationWarning."""
+    X, y = small_corpus
+    default_model.build_model(X, y)
+    with pytest.warns(DeprecationWarning, match="make_split_rules"):
+        rules = default_model._make_split_rules(PRE + POST)
+    from pymc_bart.split_rules import OneHotSplitRule
+
+    assert isinstance(rules[0], OneHotSplitRule)
+    assert len(rules) == len(PRE + POST)

--- a/tests/pie/test_model.py
+++ b/tests/pie/test_model.py
@@ -22,7 +22,7 @@ from scipy.stats import pearsonr
 
 from pymc_marketing.bart import Bart
 from pymc_marketing.pie import PIEModel
-from pymc_marketing.terms import Dot
+from pymc_marketing.terms import Dot, Transform
 
 EXPECTED_COLUMNS = [
     "campaign_id",
@@ -110,6 +110,21 @@ def generate_synthetic_rct_corpus(
     )
 
 
+def read_bart_m(model: PIEModel) -> int:
+    """Read the tree count wired into the model's BART RV."""
+    bart_rv = next(r for r in model.model.free_RVs if r.name == "bart")
+    for inp in bart_rv.owner.inputs:
+        if not hasattr(inp, "eval"):
+            continue
+        out = inp.eval()
+        if getattr(out, "ndim", 1) != 0:
+            continue
+        value = float(out)
+        if value.is_integer() and 0 < value <= 256:
+            return int(value)
+    raise AssertionError("No tree count input found on the BART RV")
+
+
 def test_synthetic_corpus_schema():
     """Generated corpus has the documented columns, dtypes, and value ranges."""
     df = generate_synthetic_rct_corpus(n_campaigns=50, seed=0)
@@ -175,13 +190,7 @@ def test_build_model(default_model, small_corpus):
     default_model.build_model(X, y)
 
     model = default_model.model
-    var_names = {
-        v.name for v in model.free_RVs + model.observed_RVs + model.deterministics
-    }
-
-    assert any("bart" in n for n in var_names), "Expected 'bart' variable"
-    assert any("sigma" in n for n in var_names), "Expected 'sigma' variable"
-    assert any("y" in n for n in var_names), "Expected 'y' observed"
+    assert sorted(model.named_vars) == ["X", "bart", "mu", "sigma", "y", "y_obs"]
 
     assert "obs" in model.coords
     assert "feature" in model.coords
@@ -279,20 +288,18 @@ def test_build_model_non_finite_y_raises(default_model, small_corpus):
         default_model.build_model(X, y_bad)
 
 
-def test_build_model_invalid_categorical_split_raises(small_corpus):
-    """An invalid categorical_split raises ValueError."""
-    X, y = small_corpus
-    model = PIEModel(
-        pre_determined_features=PRE,
-        post_determined_features=POST,
-        model_config={
-            "bart": {"m": 10, "alpha": 0.95, "beta": 2.0},
-            "sigma": Prior("HalfNormal", sigma=1.0),
-            "categorical_split": "not_a_valid_choice",
-        },
-    )
+def test_build_model_invalid_categorical_split_raises():
+    """An invalid categorical_split raises ValueError at construction."""
     with pytest.raises(ValueError, match="categorical_split"):
-        model.build_model(X, y)
+        PIEModel(
+            pre_determined_features=PRE,
+            post_determined_features=POST,
+            model_config={
+                "bart": {"m": 10, "alpha": 0.95, "beta": 2.0},
+                "sigma": Prior("HalfNormal", sigma=1.0),
+                "categorical_split": "not_a_valid_choice",
+            },
+        )
 
 
 def test_build_model_continuous_split_rules(small_corpus):
@@ -697,6 +704,8 @@ def test_custom_bart_recipe(small_corpus):
     )
     model.build_model(X, y)
     assert "bart" in model.model.named_vars
+    # The recipe, not the default (m=200), must reach the graph.
+    assert read_bart_m(model) == 10
 
 
 def test_mu_recipe_serialized_dict(small_corpus):
@@ -720,6 +729,8 @@ def test_mu_recipe_serialized_dict(small_corpus):
     )
     model.build_model(X, y)
     assert "bart" in model.model.named_vars
+    # The recipe, not the default (m=200), must reach the graph.
+    assert read_bart_m(model) == 10
 
 
 def test_mu_recipe_dict_without_type_raises(small_corpus):
@@ -766,13 +777,134 @@ def test_make_split_rules_invalid_mode_raises():
         pie_module.make_split_rules("nope", ["a"], None)
 
 
-def test_deprecated_make_split_rules_wrapper(default_model, small_corpus):
-    """PIEModel._make_split_rules still works with a DeprecationWarning."""
+def test_dimensional_sigma_prior_builds_on_default_path(small_corpus):
+    """A sigma prior carrying dims builds again on the default BART path."""
     X, y = small_corpus
-    default_model.build_model(X, y)
-    with pytest.warns(DeprecationWarning, match="make_split_rules"):
-        rules = default_model._make_split_rules(PRE + POST)
-    from pymc_bart.split_rules import OneHotSplitRule
+    model = PIEModel(
+        pre_determined_features=PRE,
+        post_determined_features=POST,
+        model_config={
+            "bart": {"m": 10, "alpha": 0.95, "beta": 2.0},
+            "sigma": Prior("HalfNormal", sigma=1.0, dims="obs"),
+        },
+    )
+    model.build_model(X, y)
+    sigma = model.model["sigma"]
+    assert sigma.eval().shape == y.shape
 
-    assert isinstance(rules[0], OneHotSplitRule)
-    assert len(rules) == len(PRE + POST)
+
+def test_mu_recipe_key_is_ignored_without_warning(small_corpus):
+    """model_config['mu'] is a declared key: no 'not used' warning."""
+    import warnings
+
+    X, y = small_corpus
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        model = PIEModel(
+            pre_determined_features=PRE,
+            post_determined_features=POST,
+            model_config={
+                "sigma": Prior("HalfNormal", sigma=1.0),
+                "mu": Dot(
+                    var_name="X", name="mu_coef", prior=Prior("Normal", dims="feature")
+                ),
+            },
+        )
+        model.build_model(X, y)
+
+
+def test_save_unregistered_recipe_raises():
+    """Saving with an unregistered 'mu' recipe fails loudly on the write side."""
+    from pymc_marketing.terms import ModelTerm
+
+    class Unregistered(ModelTerm):
+        def get_coords(self, ds):
+            return {}
+
+    model = PIEModel(
+        pre_determined_features=PRE,
+        post_determined_features=POST,
+        model_config={
+            "sigma": Prior("HalfNormal", sigma=1.0),
+            "mu": Unregistered(),
+        },
+    )
+    with pytest.raises(NotImplementedError, match="Unregistered"):
+        model._serializable_model_config
+
+
+def test_registered_bart_recipe_is_serializable(small_corpus):
+    """A registered Bart recipe in model_config serializes with __type__."""
+    from pymc_marketing.serialization import serialization
+
+    model = PIEModel(
+        pre_determined_features=PRE,
+        post_determined_features=POST,
+        model_config={
+            "sigma": Prior("HalfNormal", sigma=1.0),
+            "mu": Bart(
+                var_name="X",
+                y_name="y_obs",
+                m=10,
+                split_rules=[
+                    OneHotSplitRule() if col in PRE else ContinuousSplitRule()
+                    for col in PRE + POST
+                ],
+                name="bart",
+            ),
+        },
+    )
+    recipe = serialization.serialize(model.model_config["mu"])
+    assert "__type__" in recipe
+    assert recipe["__type__"] == "pymc_marketing.bart.Bart"
+
+
+def test_save_load_roundtrip_linear_recipe(small_corpus, tmp_path):
+    """A linear (Dot) recipe fits, saves, loads, and still predicts."""
+    X, y = small_corpus
+    model = PIEModel(
+        pre_determined_features=PRE,
+        post_determined_features=POST,
+        model_config={
+            "sigma": Prior("HalfNormal", sigma=1.0),
+            "mu": Dot(
+                var_name="X", name="mu_coef", prior=Prior("Normal", dims="feature")
+            ),
+        },
+    )
+    model.fit(X, y, draws=10, tune=5, chains=1, random_seed=0)
+
+    fname = tmp_path / "linear_model.nc"
+    model.save(fname)
+    loaded = PIEModel.load(fname)
+
+    assert loaded._feature_columns == model._feature_columns
+    X_new = X.iloc[:10].reset_index(drop=True)
+    preds = loaded.predict(X_new)
+    assert not np.isnan(np.asarray(preds)).any()
+
+
+def test_transform_wrapped_bart_recipe_keeps_sample_vars(small_corpus):
+    """sample_vars survive a Transform-wrapped recipe."""
+    import pytensor.xtensor as ptx
+
+    X, y = small_corpus
+    model = PIEModel(
+        pre_determined_features=PRE,
+        post_determined_features=POST,
+        model_config={
+            "sigma": Prior("HalfNormal", sigma=1.0),
+            "mu": Transform(
+                Bart(
+                    var_name="X",
+                    y_name="y_obs",
+                    m=10,
+                    split_rules=[ContinuousSplitRule() for _ in PRE + POST],
+                    name="bart",
+                ),
+                func=ptx.math.exp,
+            ),
+        },
+    )
+    model.build_model(X, y)
+    assert model._recipe_sample_vars == ["bart"]

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -651,3 +651,49 @@ def test_parameter_create_variable():
         with pm.Model(coords={"product": ["p1", "p2", "p3"]}):
             v = p.create_variable()
             assert v is not None
+
+
+def test_serialization_parameter_and_dot_roundtrip():
+    """Parameter, Intercept, and Dot serialize through the registry."""
+    from pymc_extras.prior import Prior
+
+    from pymc_marketing.serialization import serialization
+
+    dot = Dot(var_name="x", name="coef", prior=Prior("Normal", dims="feature"))
+    for term in (
+        Parameter(name="alpha_scale", prior=Prior("HalfNormal", sigma=2.0)),
+        Intercept(name="nu"),
+        dot,
+    ):
+        rebuilt = serialization.deserialize(serialization.serialize(term))
+        assert type(rebuilt) is type(term)
+    assert rebuilt.to_dict() == serialization.serialize(dot)
+
+
+def test_serialization_sum_product_transform_roundtrip():
+    import pytensor.xtensor as ptx
+    from pymc_extras.prior import Prior
+
+    from pymc_marketing.serialization import serialization
+
+    sum_expr = Intercept(name="a") + Dot(
+        var_name="x", prior=Prior("Normal", dims="feature")
+    )
+    product = Product(-1, Parameter("scale", prior=Prior("HalfNormal")))
+    transform = Transform(
+        Parameter("sigma", prior=Prior("HalfNormal")), func=ptx.math.exp
+    )
+    for term in (sum_expr, product, transform):
+        rebuilt = serialization.deserialize(serialization.serialize(term))
+        assert type(rebuilt) is type(term)
+
+
+def test_serialization_unregistered_func_raises():
+    from pymc_marketing.serialization import SerializationError, serialization
+
+    transform = Transform(
+        Parameter("sigma", prior=Prior("HalfNormal")),
+        func=lambda x: ptx.math.exp(x),
+    )
+    with pytest.raises(SerializationError, match="not serializable"):
+        serialization.serialize(transform)

--- a/uv.lock
+++ b/uv.lock
@@ -1550,7 +1550,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/6e/4c37d51a2b7f82d2ff11bb6b5f7d766d9a011726624af255e843727627a3/greenlet-3.5.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:719757059f5a53fd0dde23f78cffeafcdd97b21c850ddb7ca684a3c1a1f122e2", size = 288685, upload-time = "2026-06-26T18:22:08.977Z" },
     { url = "https://files.pythonhosted.org/packages/7a/73/815dd90131c1b71ebdf53dbc7c276cafec2a1173b97559f97aba72724a87/greenlet-3.5.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:efa9f765dd09f9d0cdac651ffdf631ee59ec5dc6ee7a73e0c012ba9c52fbdf5b", size = 604761, upload-time = "2026-06-26T19:07:10.114Z" },
     { url = "https://files.pythonhosted.org/packages/9f/57/079cfe76bcef36b153b25607ee91c6fcb58f17f8b23c86bbbeabe0c88d72/greenlet-3.5.3-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7faba15ac005376e02a0384504e0243be3370ce010296a44a820feb342b505ab", size = 617044, upload-time = "2026-06-26T19:10:07.25Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/fb/d97dc261209c80744b7c8132693a30d70ec6e7315e632cb0a10b3fec94dd/greenlet-3.5.3-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5795cd1101371140551c645f2d408b8d3c01a5a29cf8a9bce6e759c983682d23", size = 622351, upload-time = "2026-06-26T19:24:16.32Z" },
     { url = "https://files.pythonhosted.org/packages/37/87/b4d095775a3fb1bcafbb483fc206b27ebb785724c83051447737085dc54e/greenlet-3.5.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:87142215824be6ac05e2e8e2786eec307ccbc27c36723c3881959df654af6861", size = 614244, upload-time = "2026-06-26T18:32:17.594Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ac/e5fee13cbbd0e8de312d9a146584b8a51891c68847330ef9dc8b5109d23f/greenlet-3.5.3-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:af4923b3096e26a36d7e9cf24ab88083a20f97d191e3b97f253731ce9b41b28c", size = 425395, upload-time = "2026-06-26T19:25:37.144Z" },
     { url = "https://files.pythonhosted.org/packages/8a/70/7559b609683650fa2b95b8ab84b4ab0b26556a635d19675e12aa832d826d/greenlet-3.5.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:215275b1b49320987352e6c1b054acca0064f965a2c66992bed9a6f7d913f149", size = 1574210, upload-time = "2026-06-26T19:09:03.077Z" },
     { url = "https://files.pythonhosted.org/packages/ae/73/be55392074c60fc37655ca40fa6022457bfbf6718e9e342a7b0b41f96dd2/greenlet-3.5.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6b1b0eed82364b0e32c4ea0f221452d33e6bb17ae094d9f72aed9851812747ea", size = 1638627, upload-time = "2026-06-26T18:31:44.748Z" },
     { url = "https://files.pythonhosted.org/packages/14/40/c57489acf8e37d74e2913d4eff63aa0dba17acccc4bdeef874dde2dbbec9/greenlet-3.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:cde8adafa2365676f74a979744629589999093bc86e2484214f58e61df08902c", size = 239882, upload-time = "2026-06-26T18:23:27.518Z" },
@@ -1558,7 +1560,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/ff/a620267401db30a50cc8450ee90730e2d4a85658c055c0e760d4ed47fb13/greenlet-3.5.3-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:c8d87c2134d871df96ecdea9cec7cbaab286dadab0f56476e57aaf9e8ac11550", size = 287609, upload-time = "2026-06-26T18:21:14.724Z" },
     { url = "https://files.pythonhosted.org/packages/d6/fa/5401ac78021c826a25b6dde0c705e0a8f29b617509f9185a31dac15fbe1b/greenlet-3.5.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2d185dd1621757e70c3861cceffd5317ab4e7ed7eb09c82994828468527ade5", size = 607435, upload-time = "2026-06-26T19:07:11.412Z" },
     { url = "https://files.pythonhosted.org/packages/e9/76/1dc144a2e56e65d36405078ed774224375ea520a1870a6e46e08bb4ac7bf/greenlet-3.5.3-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1c514a468149bf8fbbab874188a3535cd8a48a3e353eb53a3d424296f8dbacd3", size = 619787, upload-time = "2026-06-26T19:10:08.396Z" },
+    { url = "https://files.pythonhosted.org/packages/57/61/2f5b1adf256d039f5dab8005de8d3d7ad2b0070a3219c0e036b3fbfeb440/greenlet-3.5.3-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9ad04dd75458c6300b047c61b8639092433d205a25a14e310d6582a480efcca1", size = 625580, upload-time = "2026-06-26T19:24:18.344Z" },
     { url = "https://files.pythonhosted.org/packages/bf/87/c298cee62df1de4ad7fec32abda73526cff347fd143a6ed4ac369246668a/greenlet-3.5.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:915f887cf2682b66419b879423a2e072634aa7b7dce6f3ada4957cfced3f1e9a", size = 616786, upload-time = "2026-06-26T18:32:19.128Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d9/ab7fc9e543e44d6879b0a6ef9a4b2188940fd180cc65d6f646883ddf7201/greenlet-3.5.3-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:afaabdd554cd7ae9bbb3ca070b0d7fdfd207dbf1d16865f7233837709d354bda", size = 427933, upload-time = "2026-06-26T19:25:38.219Z" },
     { url = "https://files.pythonhosted.org/packages/9e/2e/e6f009885ed0705ccf33fe0583c117cfd03cde77e31a596dd5785a30762b/greenlet-3.5.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:766cfd421c13e450feb340cd472a3ed9957d438727b7b4593ad7c76c5d2b0deb", size = 1574316, upload-time = "2026-06-26T19:09:04.273Z" },
     { url = "https://files.pythonhosted.org/packages/ef/fe/43fd110b01e40da0adb7c90ac7ea744bef2d43dca00de5095fd2351c2a68/greenlet-3.5.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2ecda9ec22edf38fa389369eaed8c3d37c05f3c54e69f69438dbb2cc1de1458b", size = 1638614, upload-time = "2026-06-26T18:31:46.297Z" },
     { url = "https://files.pythonhosted.org/packages/0f/7c/062447147a61f8b4337b156fe70d32a165fcf2f89d7ca6255e572806705c/greenlet-3.5.3-cp313-cp313-win_amd64.whl", hash = "sha256:c82304750f057167ff60d188df1d0cc1764ce9567eadf03e6a7443bcedd0b30b", size = 239850, upload-time = "2026-06-26T18:21:54.613Z" },
@@ -1566,7 +1570,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/93/43e116ee114b28737ba7e12952a0d4e2f55944d0f84e42bc91ba7192a3c9/greenlet-3.5.3-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:fd2e02fa07485778536a036222d616ab957b1d533f36b3ed98ce725d9c9d3117", size = 288202, upload-time = "2026-06-26T18:23:49.604Z" },
     { url = "https://files.pythonhosted.org/packages/82/2f/146d218299046a43d1f029fd544b3d110d0f175a09c715c7e8da4a4a345d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df0a0628d1597eb0897b62f55d1343f772405fd25f3b2a796c76874b0c2e22e8", size = 654096, upload-time = "2026-06-26T19:07:12.71Z" },
     { url = "https://files.pythonhosted.org/packages/a0/cc/04738cafb3f45fa991ea44f9de94c47dcec964f5a972300988a6751f49d9/greenlet-3.5.3-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ebd933a6adabc298bab47731a130fe6bfb888bd934eee37810f151159544540d", size = 666304, upload-time = "2026-06-26T19:10:09.503Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a9/73fa62893d5b84b4205544e6b673c654cc43aa5b9899bac00f04d64af73d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8d19fe6c39ebff9259f07bcc685d3290f8fa4ea2278e51dd0008e4d6b0f2d814", size = 670657, upload-time = "2026-06-26T19:24:19.967Z" },
     { url = "https://files.pythonhosted.org/packages/ce/aa/4e0dad5e605c270c784ab911c43da6adb136ccd4d81180f763ca429a723d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b9d501b40e80b70e32323c799dd9b420a5577a9601469d362ae1ffb690f3a7c", size = 663635, upload-time = "2026-06-26T18:32:20.802Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7e/2ffce64929fb3cab7b65d5a0b20aaf9764e227681d731b041077fc9a525a/greenlet-3.5.3-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:962c5df2db8cb446da51edf1ca5296c389d93b99c9d8aa2ee4c7d0d8f1218260", size = 473497, upload-time = "2026-06-26T19:25:39.421Z" },
     { url = "https://files.pythonhosted.org/packages/d1/50/13efdbea246fe3d3b735e191fec08fb50809f53cd2383ebe123d0809e44b/greenlet-3.5.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a1fad1d11e7d6aab184107baa8e4ece11ccba3ec9599cd7efa5ff4d70d43256a", size = 1621252, upload-time = "2026-06-26T19:09:05.647Z" },
     { url = "https://files.pythonhosted.org/packages/f7/22/c0a336ae4a1410fd5f5121098e5bfbf1865f64c5ef80b4b5412886c4a332/greenlet-3.5.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fad5aec764399f1b5cc347ad250a59660f20c8f8888ea6bae1f93b769cce1154", size = 1684824, upload-time = "2026-06-26T18:31:47.738Z" },
     { url = "https://files.pythonhosted.org/packages/7a/94/91aec0030bea75c4b3244251d0de60a1f3432d1ecb53ab6c437fb5c3ba61/greenlet-3.5.3-cp314-cp314-win_amd64.whl", hash = "sha256:7669aa24cf2a1041d6f7899575b494a3ab4cf68bfcc8609b1dc0be7272db835e", size = 240754, upload-time = "2026-06-26T18:22:15.669Z" },
@@ -1574,14 +1580,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/91/95/3e161213d7f1d378d15aa9e792093e9bfe01844680d04b7fd6e0107c9098/greenlet-3.5.3-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:271a8ea7c1024e8a0d7dd2be66dd66dda8a07193f41a17b9e924f7600f5b62be", size = 296389, upload-time = "2026-06-26T18:22:20.657Z" },
     { url = "https://files.pythonhosted.org/packages/00/92/715c44721abe2b4d1ae9abde4179411868a5bff312479f54e105d372f131/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19131729ae0ddc3c2e1ef85e650169b5e37ee32e400f215f78b94d7b0d567310", size = 653382, upload-time = "2026-06-26T19:07:14.209Z" },
     { url = "https://files.pythonhosted.org/packages/a0/83/37a10372a1090a6624cca8e74c12df1a36c2dc36429ed0255b7fb1aeee23/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1540dd8e5fc2a5aec40fbb98ef8e149fa47c89a4b4a1cf2575a14d3d1869d7a8", size = 659401, upload-time = "2026-06-26T19:10:10.876Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/73/8faec206b851c22b1733545fda900829a1f3f5b1c78ae7e0fb3dba57d9f4/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b897d97759425953f69a9c0fac67f8fe333ec0ce7377ef186fb2b0c3ad5e354d", size = 659582, upload-time = "2026-06-26T19:24:21.357Z" },
     { url = "https://files.pythonhosted.org/packages/db/e2/d1509cad4207da559cc42986ecdd8fc67ad0d1bba2bf03023c467fd5e0f3/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e81fa194a1d20967877bdf9c7794db2bc99063e5be36aee710c08f04c5bb087f", size = 656969, upload-time = "2026-06-26T18:32:22.272Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/55/50c19e49f8045834ada71ef12f8ad048eba8517c6aa41161bed676328fae/greenlet-3.5.3-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:3236754d423955ea08e9bb5f6c04a7895f9e22c290b66aa7653fcb922d839eb0", size = 491037, upload-time = "2026-06-26T19:25:40.672Z" },
     { url = "https://files.pythonhosted.org/packages/86/7d/eaf70de20aadca3a5884aec58362861c64ce45e7b277f47ed026926a3b89/greenlet-3.5.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:55cf4d777485d43110e47133cbba6d74a8885a87ec1227ef0267f9ee80c5aa21", size = 1617822, upload-time = "2026-06-26T19:09:06.893Z" },
     { url = "https://files.pythonhosted.org/packages/8a/f9/414d38fc400ae4350d4185eaad1827676f7cf5287b9136e0ed1cbbe20a7f/greenlet-3.5.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:12a248ba75f6a9a236375f52296c498c89ff1d8badf32deb9eca7abd5853f7da", size = 1677983, upload-time = "2026-06-26T18:31:49.396Z" },
     { url = "https://files.pythonhosted.org/packages/e4/15/7edb977e08f9bff702fe42d6c902702786ff6b9694058b4e6a2a6ac90e57/greenlet-3.5.3-cp314-cp314t-win_amd64.whl", hash = "sha256:efc6bd60ea02e085862c74a3ef64b147ffc6f1a5ea7d9f26e7a939943f68c1e3", size = 243626, upload-time = "2026-06-26T18:24:41.485Z" },
     { url = "https://files.pythonhosted.org/packages/2c/8a/93928dce91e6b3598b5e779e8d1fd6576a504640c58e78627077f6a7a91a/greenlet-3.5.3-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:ea03f2f04367845d6b58eeed276e1e56e51f0b97d8ad5a88a7d20a91dc9056cc", size = 288860, upload-time = "2026-06-26T18:22:48.07Z" },
     { url = "https://files.pythonhosted.org/packages/4f/ca/69db42d447a1378043e2c8f19c09cbbd1263371505053c496b49066d3d16/greenlet-3.5.3-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78dbef602fda6d97d957eb7937f70c9ce9e9527330347f8f6b6f9e554a9e7a47", size = 659747, upload-time = "2026-06-26T19:07:15.565Z" },
     { url = "https://files.pythonhosted.org/packages/a8/0b/af7ac2ef8dd41e3da1a40dda6305c23b9a03e13ba975ec916357b50f8575/greenlet-3.5.3-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f73857adb8fee13fa56c172bd11262f888c0c648f9fea113e777bb2c7904a81", size = 670419, upload-time = "2026-06-26T19:10:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/25/aa/952cf28c2ff949a8c971134fb43854dd7eaa737218723aaef758f8c9aead/greenlet-3.5.3-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cefa9cef4b371f9844c6053db71f1138bc6807bab1578b0dae5149c1f1141357", size = 674261, upload-time = "2026-06-26T19:24:22.79Z" },
     { url = "https://files.pythonhosted.org/packages/51/1e/1d51640cacbfc455dbe9f9a9f594c49e4e244f63b9971a2f4764e46cc53d/greenlet-3.5.3-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:232fec92e823addaf02d9472cf7381e24a1d046a6ced1103c5caa4c21b9dfc1d", size = 668787, upload-time = "2026-06-26T18:32:24.298Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/f2/b00d6f5e63e531a93562b2ec1a4c320fbee91f580fc42e6417af69d706e5/greenlet-3.5.3-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:6219b6d04dbf6ba6084d77dc609e8473060dc55f759cbf626d512122781fa128", size = 480322, upload-time = "2026-06-26T19:25:41.852Z" },
     { url = "https://files.pythonhosted.org/packages/21/66/4030d5b0b5894500023f003bb054d9bb354dfbd1e186c3a296759172f5f5/greenlet-3.5.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:2421c3564da9429d5586d46ca31ebb26516b5498a802cf65c041a8e8a8980d34", size = 1626305, upload-time = "2026-06-26T19:09:08.281Z" },
     { url = "https://files.pythonhosted.org/packages/0e/50/5221371c7550108dfa3c378debc41d032aa9c78e89abb01d8011cfc93289/greenlet-3.5.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:e0f0d160f0b2e558e6c75f7930967183255dc9735e5f5b8cae58ee09c9576d8b", size = 1688631, upload-time = "2026-06-26T18:31:51.278Z" },
     { url = "https://files.pythonhosted.org/packages/68/5d/00d469daae3c65d2bf620b10eee82eb022127d483c6bc8c69fae6f3fbf17/greenlet-3.5.3-cp315-cp315-win_amd64.whl", hash = "sha256:dd99329bbc15ca78dcc583dba05d0b1b0bae01ab6c2174989f5aaee3e41ac930", size = 241027, upload-time = "2026-06-26T18:22:38.203Z" },
@@ -1589,7 +1599,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/da/4f4a8450962fad137c1c8981a3f1b8919d06c829993d4d476f9c525d5173/greenlet-3.5.3-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:176bc16a721fa5fc294d70b87b4dfa5fbdd251b3da5d5372735ecef9bd7d6d0c", size = 297221, upload-time = "2026-06-26T18:23:27.176Z" },
     { url = "https://files.pythonhosted.org/packages/57/66/b3bfae3e220a9b63ea539a0eea681800c69ab1aada757eae8789f183e7ce/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:629b614d2b786e89c50440e246f33eea78f58a962d0bdbbcc809e6d13605903f", size = 657221, upload-time = "2026-06-26T19:07:16.973Z" },
     { url = "https://files.pythonhosted.org/packages/7b/81/b6d4d73a709684fc77e7fa034d7c2fe82cffa9fc920fadcaa659c2626213/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2b2e857ae16f5f72142edf75f9f176fe7526ba19a2841df1420516f83831c9f2", size = 663226, upload-time = "2026-06-26T19:10:13.723Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/39/0e0938a75115b939d42733a2a12e1d349653c9531fe6fe563e8a681f04e6/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:16d192579ed281051396dddd7f7754dac6259e6b1fb26378c87b66622f8e3f91", size = 663706, upload-time = "2026-06-26T19:24:24.312Z" },
     { url = "https://files.pythonhosted.org/packages/f5/07/e210b02b589f16e74ff48b730690e4a34ffe984219fce4f3c1a0e7ec8545/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e515757e2e36bcbf1fad09a46e1557e8b1ae1797d4b44d09da7deed88ad28608", size = 660802, upload-time = "2026-06-26T18:32:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/41/35d1c678cdb3c3b9e6bee691728e563cfb294202b23c7a4c3c2ccc343589/greenlet-3.5.3-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:4399eb8d041f20b68d943918bc55502a93d6fdc0a37c14da7881c04139acee9d", size = 498803, upload-time = "2026-06-26T19:25:43.063Z" },
     { url = "https://files.pythonhosted.org/packages/eb/2e/5303eb3fa06bca089060f479707182a93e360683bc252acf846c3090d34e/greenlet-3.5.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:b363d46ed1ea431825fdb01471bb024fc08399bad1572a616e853c7684415adb", size = 1622157, upload-time = "2026-06-26T19:09:09.527Z" },
     { url = "https://files.pythonhosted.org/packages/54/70/50de47a488f14df260b50ae34fb5d56016e308b098eab02c878b5223c26a/greenlet-3.5.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:e44da2f5bbdaabaf7d80b73dbb430c7035771e9f244e3c8b769715c9d8fa0a16", size = 1681159, upload-time = "2026-06-26T18:31:52.986Z" },
     { url = "https://files.pythonhosted.org/packages/a7/13/1055e1dda7882073eda533e2b96c62e55bbd2db7fda6d5ece992febc7071/greenlet-3.5.3-cp315-cp315t-win_amd64.whl", hash = "sha256:8ff8bed3e3baa20a3ea261ce00526f1898ad4801d4886fd2220580ee0ad8fadf", size = 244007, upload-time = "2026-06-26T18:22:04.353Z" },
@@ -1601,7 +1613,7 @@ name = "gunicorn"
 version = "26.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging" },
+    { name = "packaging", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6d/b7/a4a3f632f823e432ce6bc65f62961b7980c898c77f075a2f7118cb3846fe/gunicorn-26.0.0.tar.gz", hash = "sha256:ca9346f85e3a4aeeb64d491045c16b9a35647abd37ea15efe53080eb8b090baf", size = 727286, upload-time = "2026-05-05T06:38:25.529Z" }
 wheels = [
@@ -3306,7 +3318,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -4125,7 +4137,7 @@ requires-dist = [
     { name = "pygraphviz", marker = "extra == 'test'" },
     { name = "pylint", marker = "extra == 'docs'" },
     { name = "pymc", specifier = ">=6.2.0,<6.3.0" },
-    { name = "pymc-bart", marker = "extra == 'pie'", specifier = ">=0.12.0" },
+    { name = "pymc-bart", marker = "extra == 'pie'", specifier = ">=0.12.0,<0.13" },
     { name = "pymc-bart", marker = "extra == 'test'", specifier = ">=0.12.0" },
     { name = "pymc-extras", specifier = ">=0.14.0,<0.15.0" },
     { name = "pyprojroot" },
@@ -4717,7 +4729,7 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -4766,7 +4778,7 @@ resolution-markers = [
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version >= '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [


### PR DESCRIPTION
Dogsfood the terms framework (#2965) with the model that motivated the swappable-mean-function API in #2017: PIE is now literally a regression with helpers and configuration.

The likelihood mean is a `ModelTerm` recipe. Default stays a BART term, so nothing changes for current users. Swap it out for a plain dot product with:

```python
from pymc_marketing.pie import PIEModel
from pymc_marketing.terms import Dot
from pymc_extras.prior import Prior

model = PIEModel(
    pre_determined_features=[...],
    post_determined_features=[...],
    model_config={
        "sigma": Prior("HalfNormal", sigma=1.0),
        "mu": Dot(var_name="X", name="mu_coef", prior=Prior("Normal", dims="feature")),
    },
)
```

Where else this will impact in the repo:
- New module `pymc_marketing/bart.py`: `Bart` ModelTerm wrapping pymc_bart via the dims bridge (`.values` / `as_xtensor`) from https://github.com/pymc-labs/pymc-marketing/issues/2017#issuecomment-5602576216. Optional pymc-bart dependency, serialization-registered.
- Minimal `to_dict`/`from_dict` for the built-in terms vocabulary (`Parameter`, `Intercept`, `Dot`, `Sum`, `Product`, `Transform`), so recipe artifacts round-trip through `model_config`. Unregistered custom terms fail loudly with `NotImplementedError` at save instead of writing unloadable artifacts.
- `sample_vars` is now a documented `ModelTerm` lifecycle member and `collect_terms` descends into `Transform`.
- `make_split_rules` is a module-level helper; the old private method never shipped so no deprecation cycle was needed.

Release note: `PIEModel` bumped to 0.2.0. Checkpoints saved under 0.1.0 raise `DifferentModelError` on load (`check=False` loads them); rebuild and re-save is recommended. `pymc-bart` now capped at `<0.13`.

Details worth knowing:
- PGBART's logp machinery chokes on xtensor free variables, so `sigma` is a plain (non-xdist) variable lifted dimensionally for the likelihood; verified fit + resized-obs posterior predictive end-to-end for both BART and Dot flavors.
- BART observation dims are derived from the target (with an explicit transpose), so transposed data variables cannot silently swap the feature axis into the trees.
- Saves with an unregistered live recipe fail at `save()` time with a clear message, matching the review's write-side guard.