### PR TITLE
feat: add pymc_marketing.terms_gp

### DIFF
--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -28,5 +28,6 @@
   serialization_migration
   special_priors
   terms
+  terms_gp
   utils
 ```

--- a/pymc_marketing/__init__.py
+++ b/pymc_marketing/__init__.py
@@ -30,7 +30,15 @@ import pymc_marketing.r2d2  # noqa: E402
 
 # Register SpecialPrior deserializers (LogNormalPrior, LaplacePrior, etc.)
 import pymc_marketing.special_priors  # noqa: E402, F401
-from pymc_marketing import bass, clv, customer_choice, mmm, pie, terms  # noqa: E402
+from pymc_marketing import (  # noqa: E402
+    bass,
+    clv,
+    customer_choice,
+    mmm,
+    pie,
+    terms,
+    terms_gp,
+)
 from pymc_marketing.version import __version__  # noqa: E402
 
 __all__ = [
@@ -42,4 +50,5 @@ __all__ = [
     "pie",
     "r2d2",
     "terms",
+    "terms_gp",
 ]

--- a/pymc_marketing/terms.py
+++ b/pymc_marketing/terms.py
@@ -231,6 +231,10 @@ Gotchas
           model = pm.modelcontext(None)
           unique = list(dict.fromkeys(ds[self.data_source].values))
           model.add_coords({self.data_source: unique})
+- ``Named`` builds a ``pmd.Deterministic``, so its expression leaves must
+  be dims-native: ``Parameter`` / ``Prior`` with ``xdist=True`` or
+  ``pytensor.xtensor`` expressions. Plain-tensor leaves (``xdist=False``)
+  will fail when the deterministic is built.
 - The built-in terms serialize via ``pymc_marketing.serialization``
   (``to_dict`` / ``from_dict`` are registered), so recipes stored in
   ``model_config`` survive ``fit()`` (attrs are JSON-serialized at
@@ -262,8 +266,10 @@ __all__ = [
     "Dot",
     "Intercept",
     "ModelTerm",
+    "Named",
     "Parameter",
     "Product",
+    "Ref",
     "Sum",
     "Transform",
     "build_param",
@@ -831,6 +837,117 @@ class Transform(ModelTerm):
             inner=_deserialize_child(data["inner"]),
             func=_lookup_func(data["func"]),
         )
+
+
+@serialization.register
+@dataclass
+class Named(ModelTerm):
+    """Compose an expression into a named deterministic variable.
+
+    The inner expression is built lazily within the model context:
+    ``build_param`` produces the value and ``pmd.Deterministic`` stores it
+    under ``name``. Coordinates, data registration, and data updating
+    delegate to the inner expression. Useful for naming intermediate
+    effects (scales, link outputs) that should appear in the posterior.
+
+    The expression leaves must be dims-native: ``Parameter`` / ``Prior``
+    with ``xdist=True`` or ``pytensor.xtensor`` expressions.
+
+    Parameters
+    ----------
+    name : str
+        Name of the deterministic variable.
+    expr : Any
+        Inner expression accepted by ``build_param``.
+    dims : str or tuple of str, optional
+        Dimensions for the deterministic variable.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from pymc_extras.prior import Prior
+        from pymc_marketing.terms import Named, Parameter
+
+        scale = Named(
+            "scale",
+            Parameter("scale", prior=Prior("HalfNormal"), dims="product"),
+            dims="product",
+        )
+
+        # an effect that references another built variable
+        effect = Named("effect", Ref("scale") * other_term, dims="customer_id")
+    """
+
+    name: str
+    expr: Any
+    dims: str | tuple[str, ...] | None = None
+
+    def get_coords(self, ds: xr.Dataset) -> dict[str, Any]:
+        """Collect coordinates from the inner expression."""
+        return get_coords(self.expr, ds)
+
+    def register_data(self, ds: xr.Dataset) -> None:
+        """Register shared data for the inner expression."""
+        register_data(self.expr, ds=ds)
+
+    def set_data(self, ds: xr.Dataset, model: pm.Model | None = None) -> None:
+        """Update shared data for the inner expression."""
+        set_data(self.expr, ds=ds, model=model)
+
+    def create_variable(self) -> pt.TensorVariable:
+        """Build the named deterministic from the inner expression."""
+        return pmd.Deterministic(self.name, build_param(self.expr), dims=self.dims)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the name, expression, and dims."""
+        data: dict[str, Any] = {
+            "name": self.name,
+            "expr": _serialize_child(self.expr),
+        }
+        if self.dims is not None:
+            data["dims"] = self.dims
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Named:
+        """Reconstruct a named term from its serialized form."""
+        return cls(
+            name=data["name"],
+            expr=_deserialize_child(data["expr"]),
+            dims=data.get("dims"),
+        )
+
+
+@serialization.register
+@dataclass
+class Ref(ModelTerm):
+    """Reference an already-built named variable in the active model.
+
+    Lets an effect expression composed outside the model depend on another
+    built effect (e.g. ``a`` on the ``a_scale`` deterministic) without
+    recreating its variables.
+
+    Parameters
+    ----------
+    name : str
+        Name of the referenced variable.
+    """
+
+    name: str
+
+    def create_variable(self) -> pt.TensorVariable:
+        """Resolve the referenced variable from the active model."""
+        return pm.modelcontext(None)[self.name]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the referenced name."""
+        return {"name": self.name}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Ref:
+        """Reconstruct a reference from its serialized form."""
+        return cls(name=data["name"])
 
 
 def get_coords(param: Any, ds: xr.Dataset) -> dict[str, Any]:

--- a/pymc_marketing/terms_gp.py
+++ b/pymc_marketing/terms_gp.py
@@ -231,6 +231,13 @@ class GPDataTerm(ModelTerm):
         """Name of the registered numeric index data variable."""
         return f"{self.var_name}_index"
 
+    def __post_init__(self) -> None:
+        """Normalize ``dims`` to a tuple for stable serialization round-trips."""
+        if isinstance(self.dims, str):
+            self.dims = (self.dims,)
+        elif self.dims is not None:
+            self.dims = tuple(self.dims)
+
     @property
     def extra_dims(self) -> tuple[str, ...]:
         """Dims beyond the time dimension."""
@@ -525,9 +532,6 @@ class HSGPTerm(GPDataTerm):
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> HSGPTerm:
         """Reconstruct a term from its serialized form."""
-        dims = data.get("dims")
-        if isinstance(dims, list):
-            dims = tuple(dims)
         return cls(
             var_name=data["var_name"],
             name=data["name"],
@@ -535,7 +539,7 @@ class HSGPTerm(GPDataTerm):
             ls=_deserialize_optional(data.get("ls")),
             m=data.get("m"),
             L=data.get("L"),
-            dims=dims,
+            dims=data.get("dims"),
             centered=data["centered"],
             drop_first=data["drop_first"],
             demeaned_basis=data["demeaned_basis"],
@@ -694,9 +698,6 @@ class HSGPPeriodicTerm(GPDataTerm):
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> HSGPPeriodicTerm:
         """Reconstruct a term from its serialized form."""
-        dims = data.get("dims")
-        if isinstance(dims, list):
-            dims = tuple(dims)
         return cls(
             var_name=data["var_name"],
             name=data["name"],
@@ -704,7 +705,7 @@ class HSGPPeriodicTerm(GPDataTerm):
             ls=_deserialize_optional(data.get("ls")),
             period=data["period"],
             m=data["m"],
-            dims=dims,
+            dims=data.get("dims"),
             demeaned_basis=data["demeaned_basis"],
             time_resolution=data["time_resolution"],
         )

--- a/pymc_marketing/terms_gp.py
+++ b/pymc_marketing/terms_gp.py
@@ -28,6 +28,15 @@ resolved from the dataset inside the model context (cached on the instance
 once resolved, so repeated builds reuse them). Explicit values always win
 over the deferred resolution.
 
+The GP graph itself is **delegated** to the existing
+:mod:`pymc_marketing.mmm.hsgp` classes: at ``create_variable`` time the term
+builds a transient :class:`~pymc_marketing.mmm.hsgp.HSGP` (or ``HSGPPeriodic``
+/ ``SoftPlusHSGP``) spec from its resolved fields and delegates variable
+creation to it, so the two implementations cannot drift. These terms own the
+modeling lifecycle: time-reference resolution (datetime coordinates welcome),
+shared data registration, frozen centering, and the ``terms`` composition and
+serialization contract.
+
 Defaults follow the assumptions of the existing HSGP classes:
 ``eta_mass=0.05``, ``eta_upper=1.0``, ``ls_lower=1.0``, ``ls_upper=None``,
 ``ls_mass=0.9``, ``cov_func="expquad"``, ``centered=False``,
@@ -138,14 +147,15 @@ import numpy as np
 import pymc as pm
 import pymc.dims as pmd
 import pytensor.tensor as pt
-import pytensor.xtensor as ptx
 import xarray as xr
-from pymc_extras.prior import Prior, VariableFactory
-from pytensor.tensor import as_tensor
-from pytensor.xtensor.type import as_xtensor
+from pymc_extras.prior import VariableFactory
 
 from pymc_marketing.hsgp_kwargs import CovFunc
 from pymc_marketing.mmm.hsgp import (
+    HSGP,
+    HSGPBase,
+    HSGPPeriodic,
+    SoftPlusHSGP,
     create_complexity_penalizing_prior,
     create_constrained_inverse_gamma_prior,
     create_eta_prior,
@@ -156,16 +166,9 @@ from pymc_marketing.terms import (
     ModelTerm,
     _deserialize_child,
     _serialize_child,
-    build_param,
 )
 
 __all__ = ["HSGPPeriodicTerm", "HSGPTerm", "SoftPlusHSGPTerm"]
-
-_GP_COV_FUNCS = {
-    "expquad": pm.gp.cov.ExpQuad,
-    "matern52": pm.gp.cov.Matern52,
-    "matern32": pm.gp.cov.Matern32,
-}
 
 
 def _serialize_optional(value: Any) -> Any:
@@ -287,17 +290,32 @@ class GPDataTerm(ModelTerm):
         coords = {dim: ds[dim].values for dim in da.dims if dim in ds.coords}
         pm.set_data({self.index_var: self._time_values(da)}, model=model, coords=coords)
 
-    def _prepare_X(self) -> tuple[pt.TensorVariable, str]:
-        """Return the registered time-index tensor and time dim."""
+    def _check_registered(self) -> pm.Model:
+        """Return the active model, raising if the time reference is unregistered."""
         model = pm.modelcontext(None)
         if self.X_mid is None or self.time_dim is None:
             raise ValueError(
                 "The data must be registered before creating a variable. "
                 f"Call `register_data` with a dataset containing {self.var_name!r}."
             )
-        X = model[self.index_var]
-        X_tensor = as_tensor(X, allow_xtensor_conversion=True)
-        return X_tensor, self.time_dim
+        return model
+
+    def _spec(self) -> HSGPBase:
+        """Build the wrapped HSGP spec from the resolved fields."""
+        raise NotImplementedError
+
+    def create_variable(self) -> pt.TensorVariable:
+        """Build the GP curve through the wrapped HSGP class.
+
+        The wrapped spec owns the basis coordinate, hyperparameter variables,
+        and the final deterministic; this term feeds it the frozen centering
+        value and the shared time index.
+        """
+        model = self._check_registered()
+        spec = self._spec()
+        spec.X_mid = self.X_mid
+        spec.register_data(model[self.index_var])
+        return spec.create_variable(self.name, xdist=True)
 
 
 @serialization.register
@@ -450,56 +468,33 @@ class HSGPTerm(GPDataTerm):
                 )
 
     def add_coords(self, ds: xr.Dataset) -> None:
-        """Resolve deferred values, then add the basis coordinate."""
-        self._resolve(ds)
-        m = cast("int", self.m)
-        model = pm.modelcontext(None)
-        model.add_coords({f"{self.name}_m": np.arange(m - 1 if self.drop_first else m)})
+        """Resolve deferred values.
 
-    def _build_gp(self, prefix: str) -> pt.TensorVariable:
-        """Build the linearized GP expression under a variable-name prefix."""
-        X_tensor, time_dim = self._prepare_X()
+        The basis coordinate is added by the wrapped HSGP class at build
+        time, so this only triggers the deferred hyperparameter resolution.
+        """
+        self._resolve(ds)
+
+    def _spec_kwargs(self) -> dict[str, Any]:
+        """Keyword arguments for the wrapped HSGP spec."""
+        dims = (cast("str", self.time_dim), *self.extra_dims)
+        return {
+            "ls": self.ls,
+            "eta": self.eta,
+            "m": cast("int", self.m),
+            "L": cast("float", self.L),
+            "dims": dims,
+            "centered": self.centered,
+            "drop_first": self.drop_first,
+            "cov_func": self.cov_func,
+            "demeaned_basis": self.demeaned_basis,
+        }
+
+    def _spec(self) -> HSGPBase:
+        """Build the wrapped :class:`~pymc_marketing.mmm.hsgp.HSGP` spec."""
         _check_scalar("eta", self.eta)
         _check_scalar("ls", self.ls)
-
-        eta = as_tensor(
-            build_param(self.eta, name=f"{prefix}_eta"),
-            allow_xtensor_conversion=True,
-        )
-        ls = as_tensor(
-            build_param(self.ls, name=f"{prefix}_ls"),
-            allow_xtensor_conversion=True,
-        )
-
-        cov_func = eta**2 * _GP_COV_FUNCS[self.cov_func.value](input_dim=1, ls=ls)
-        gp = pm.gp.HSGP(m=[self.m], L=[self.L], cov_func=cov_func)
-        phi, sqrt_psd = gp.prior_linearized(X_tensor[:, None] - self.X_mid)
-
-        if self.drop_first:
-            phi = phi[:, 1:]
-            sqrt_psd = sqrt_psd[1:]
-
-        if self.demeaned_basis:
-            phi = phi - phi.mean(axis=0).eval()
-
-        coord_name = f"{prefix}_m"
-        phi_x = as_xtensor(phi, dims=(time_dim, coord_name))
-        sqrt_psd_x = as_xtensor(sqrt_psd, dims=(coord_name,))
-
-        hsgp_coefs = Prior(
-            "Normal",
-            mu=0,
-            sigma=sqrt_psd_x,
-            dims=(*self.extra_dims, coord_name),
-            centered=self.centered,
-        ).create_variable(f"{prefix}_hsgp_coefs", xdist=True)
-
-        return phi_x.dot(hsgp_coefs)
-
-    def create_variable(self) -> pt.TensorVariable:
-        """Build the GP curve as a named deterministic."""
-        f = self._build_gp(self.name)
-        return pmd.Deterministic(self.name, f, dims=(self.time_dim, *self.extra_dims))
+        return HSGP(**self._spec_kwargs())
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize the term recipe.
@@ -584,14 +579,9 @@ class SoftPlusHSGPTerm(HSGPTerm):
 
     name: str = "tvp"
 
-    def add_coords(self, ds: xr.Dataset) -> None:
-        """Resolve deferred values, then add the raw basis coordinate."""
-        self._resolve(ds)
-        m = cast("int", self.m)
-        model = pm.modelcontext(None)
-        model.add_coords(
-            {f"{self.name}_raw_m": np.arange(m - 1 if self.drop_first else m)}
-        )
+    def _spec(self) -> SoftPlusHSGP:
+        """Build the wrapped :class:`~pymc_marketing.mmm.hsgp.SoftPlusHSGP`."""
+        return SoftPlusHSGP(**self._spec_kwargs())
 
     @staticmethod
     def deterministics_to_replace(name: str) -> list[str]:
@@ -602,17 +592,7 @@ class SoftPlusHSGPTerm(HSGPTerm):
         continuous.
 
         """
-        return [f"{name}_f_mean"]
-
-    def create_variable(self) -> pt.TensorVariable:
-        """Build the positive, mean-one GP multiplier."""
-        f = self._build_gp(f"{self.name}_raw")
-        f = pmd.math.softplus(f)
-
-        f_mean = pmd.Deterministic(f"{self.name}_f_mean", f.mean(dim=self.time_dim))
-
-        centered_f = f / f_mean
-        return pmd.Deterministic(self.name, centered_f)
+        return SoftPlusHSGP.deterministics_to_replace(name)
 
 
 @serialization.register
@@ -675,57 +655,27 @@ class HSGPPeriodicTerm(GPDataTerm):
     m: int
 
     def add_coords(self, ds: xr.Dataset) -> None:
-        """Freeze the centering value, then add the basis coordinate."""
+        """Freeze the centering value.
+
+        The basis coordinate is added by the wrapped HSGPPeriodic class at
+        build time.
+        """
         if self.X_mid is None:
             self.X_mid = float(self._time_values(ds[self.var_name]).mean())
-        model = pm.modelcontext(None)
-        model.add_coords({f"{self.name}_m": np.arange((self.m * 2) - 1)})
 
-    def _build_gp(self, prefix: str) -> pt.TensorVariable:
-        """Build the linearized periodic GP expression under a prefix."""
-        X_tensor, time_dim = self._prepare_X()
+    def _spec(self) -> HSGPBase:
+        """Build the wrapped :class:`~pymc_marketing.mmm.hsgp.HSGPPeriodic`."""
         _check_scalar("scale", self.scale)
         _check_scalar("ls", self.ls)
-
-        scale = as_tensor(
-            build_param(self.scale, name=f"{prefix}_scale"),
-            allow_xtensor_conversion=True,
+        dims = (cast("str", self.time_dim), *self.extra_dims)
+        return HSGPPeriodic(
+            scale=self.scale,
+            ls=self.ls,
+            period=self.period,
+            m=self.m,
+            dims=dims,
+            demeaned_basis=self.demeaned_basis,
         )
-        ls = as_tensor(
-            build_param(self.ls, name=f"{prefix}_ls"),
-            allow_xtensor_conversion=True,
-        )
-
-        cov_func = pm.gp.cov.Periodic(1, period=self.period, ls=ls)
-        gp = pm.gp.HSGPPeriodic(m=self.m, scale=scale, cov_func=cov_func)
-        (phi_cos, phi_sin), psd = gp.prior_linearized(X_tensor[:, None] - self.X_mid)
-
-        if self.demeaned_basis:
-            phi_cos = phi_cos - phi_cos.mean(axis=0).eval()
-            phi_sin = phi_sin - phi_sin.mean(axis=0).eval()
-
-        coord_name = f"{prefix}_m"
-        phi_cos_x = as_xtensor(phi_cos, dims=(time_dim, coord_name))
-        phi_sin_x = as_xtensor(phi_sin, dims=(time_dim, coord_name))
-        psd_x = as_xtensor(psd, dims=(coord_name,))
-        slice_idx = {coord_name: slice(1, None)}
-
-        sigma = ptx.concat([psd_x, psd_x.isel(slice_idx)], dim=coord_name)
-        hsgp_coefs = Prior(
-            "Normal",
-            mu=0,
-            sigma=sigma,
-            dims=(*self.extra_dims, coord_name),
-            centered=False,
-        ).create_variable(f"{prefix}_hsgp_coefs", xdist=True)
-
-        phi = ptx.concat([phi_cos_x, phi_sin_x.isel(slice_idx)], dim=coord_name)
-        return phi.dot(hsgp_coefs)
-
-    def create_variable(self) -> pt.TensorVariable:
-        """Build the periodic GP curve as a named deterministic."""
-        f = self._build_gp(self.name)
-        return pmd.Deterministic(self.name, f, dims=(self.time_dim, *self.extra_dims))
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize the term recipe."""

--- a/pymc_marketing/terms_gp.py
+++ b/pymc_marketing/terms_gp.py
@@ -1,0 +1,760 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Gaussian process model terms.
+
+``pymc_marketing.terms_gp`` exposes the Hilbert Space Gaussian Process (HSGP)
+components from :mod:`pymc_marketing.mmm.hsgp` as composable
+:class:`~pymc_marketing.terms.ModelTerm` pieces: :class:`HSGPTerm`,
+:class:`HSGPPeriodicTerm`, and :class:`SoftPlusHSGPTerm`. They subclass the
+``ModelTerm`` lifecycle (``get_coords`` / ``add_coords`` / ``register_data`` /
+``create_variable`` / ``set_data``) so they compose with the other built-ins
+via ``+`` / ``*`` / ``-`` --- no framework changes required.
+
+The terms are fully deferred. Constructing one touches no data and computes
+nothing: ``m``, ``L``, ``X_mid``, and the default ``eta`` / ``ls`` priors are
+resolved from the dataset inside the model context (cached on the instance
+once resolved, so repeated builds reuse them). Explicit values always win
+over the deferred resolution.
+
+Defaults follow the assumptions of the existing HSGP classes:
+``eta_mass=0.05``, ``eta_upper=1.0``, ``ls_lower=1.0``, ``ls_upper=None``,
+``ls_mass=0.9``, ``cov_func="expquad"``, ``centered=False``,
+``drop_first=True``, and ``demeaned_basis=False``.
+
+Rules
+^^^^^
+- ``var_name`` names the time reference in the dataset and is read with
+  ``ds[var_name]``, which works for both **coordinates** (the common case,
+  e.g. ``coords={"date": ...}``) and data variables. Datetimes are
+  converted to **days since the anchored first training date**, divided by
+  ``time_resolution`` (the same convention as
+  :func:`pymc_marketing.mmm.tvp.infer_time_index`), and registered as
+  ``pmd.Data`` under ``{var_name}_index``.
+- ``register_data`` must run before ``create_variable``. The module-level
+  :func:`~pymc_marketing.terms.register_data` helper handles this.
+- ``X_mid`` is frozen at the first registration so out-of-sample predictions
+  via ``set_data`` stay centered on the training data. It is excluded from
+  serialization and re-derived from the data on rebuild.
+- Each random variable is prefixed with ``name`` (``{name}_eta``,
+  ``{name}_ls``, ``{name}_hsgp_coefs``) and the basis coordinate is
+  ``{name}_m``. Each term in an expression tree needs a unique ``name``;
+  two no-argument terms collide on every variable.
+- ``eta`` / ``ls`` priors must be scalar. Higher-dimensional coefficients
+  (e.g. one GP curve per group) are configured with ``dims``, whose
+  coordinates are collected from the dataset like
+  :class:`~pymc_marketing.terms.Parameter` does.
+
+Time-varying media
+^^^^^^^^^^^^^^^^^^
+The canonical time-varying media multiplier is :class:`SoftPlusHSGPTerm`,
+matching the time-varying parameters of the stable MMM classes. The GP
+output is one-dimensional over the time dimension, so it broadcasts across
+the channel dimension of a media term through ``*``:
+
+.. code-block:: python
+
+    tvp_media = SoftPlusHSGPTerm() * media
+
+Examples
+--------
+HSGP term with deferred defaults, composed into an outcome equation:
+
+.. code-block:: python
+
+    from pymc_extras.prior import Prior
+    from pymc_marketing.terms import (
+        Intercept,
+        Dot,
+        collect_coords,
+        register_data,
+        build_param,
+    )
+    from pymc_marketing.terms_gp import HSGPTerm
+
+    trend = HSGPTerm(var_name="time", name="trend")
+    mu = (
+        Intercept("intercept")
+        + trend
+        + Dot(var_name="x", prior=Prior("Normal", dims="feature"))
+    )
+
+    coords = collect_coords(mu, ds=ds)
+    with pm.Model(coords=coords) as model:
+        register_data(mu, ds=ds)
+        mu_value = build_param(mu)
+
+No-argument construction for a one-dimensional GP over the ``"date"``
+coordinate, then multiplied by a media term (dims ``(date, channel)``):
+
+.. code-block:: python
+
+    from pymc_marketing.terms_gp import SoftPlusHSGPTerm
+
+    tvp_media = SoftPlusHSGPTerm() * media
+
+Higher-dimensional coefficients, one GP curve per channel:
+
+.. code-block:: python
+
+    from pymc_marketing.terms_gp import HSGPTerm
+
+    trend = HSGPTerm(var_name="time", name="trend", dims="channel")
+
+Periodic seasonality term:
+
+.. code-block:: python
+
+    from pymc_extras.prior import Prior
+    from pymc_marketing.terms_gp import HSGPPeriodicTerm
+
+    seasonality = HSGPPeriodicTerm(
+        var_name="time",
+        name="seasonality",
+        scale=Prior("HalfNormal", sigma=1),
+        ls=Prior("InverseGamma", alpha=2, beta=1),
+        period=52,
+        m=20,
+    )
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+import numpy as np
+import pymc as pm
+import pymc.dims as pmd
+import pytensor.tensor as pt
+import pytensor.xtensor as ptx
+import xarray as xr
+from pymc_extras.prior import Prior, VariableFactory
+from pytensor.tensor import as_tensor
+from pytensor.xtensor.type import as_xtensor
+
+from pymc_marketing.hsgp_kwargs import CovFunc
+from pymc_marketing.mmm.hsgp import (
+    create_complexity_penalizing_prior,
+    create_constrained_inverse_gamma_prior,
+    create_eta_prior,
+    create_m_and_L_recommendations,
+)
+from pymc_marketing.serialization import serialization
+from pymc_marketing.terms import (
+    ModelTerm,
+    _deserialize_child,
+    _serialize_child,
+    build_param,
+)
+
+__all__ = ["HSGPPeriodicTerm", "HSGPTerm", "SoftPlusHSGPTerm"]
+
+_GP_COV_FUNCS = {
+    "expquad": pm.gp.cov.ExpQuad,
+    "matern52": pm.gp.cov.Matern52,
+    "matern32": pm.gp.cov.Matern32,
+}
+
+
+def _serialize_optional(value: Any) -> Any:
+    """Serialize an optional term field, passing ``None`` through."""
+    return None if value is None else _serialize_child(value)
+
+
+def _deserialize_optional(value: Any) -> Any:
+    """Deserialize an optional term field, passing ``None`` through."""
+    return None if value is None else _deserialize_child(value)
+
+
+def _normalize_dims(dims: str | tuple[str, ...] | None) -> tuple[str, ...]:
+    """Normalize a dims argument to a tuple."""
+    if dims is None:
+        return ()
+    if isinstance(dims, str):
+        return (dims,)
+    return tuple(dims)
+
+
+def _dims_to_list(dims: str | tuple[str, ...] | None) -> list[str] | None:
+    """Serialize dims as a JSON-safe list."""
+    normalized = _normalize_dims(dims)
+    return list(normalized) or None
+
+
+def _check_scalar(label: str, value: Any) -> None:
+    """Require a scalar prior for a GP hyperparameter."""
+    if getattr(value, "dims", None):
+        raise ValueError(f"The {label} prior must be a scalar random variable.")
+
+
+@dataclass(kw_only=True)
+class GPDataTerm(ModelTerm):
+    """Shared data lifecycle for GP terms.
+
+    Resolves the time reference ``var_name`` to a numeric index, registers
+    it as ``pmd.Data``, freezes the centering value (``X_mid``) at the
+    first registration, and collects coordinates for the time dimension
+    and any extra coefficient dims.
+
+    ``var_name`` names the time reference in the dataset and is read with
+    ``ds[var_name]``, which works for both coordinates and data variables.
+    The numeric index is always registered as ``pmd.Data`` under
+    ``{var_name}_index``; use :attr:`index_var` for that name.
+    """
+
+    var_name: str = "date"
+    name: str = "hsgp"
+    X_mid: float | None = None
+    dims: str | tuple[str, ...] | None = None
+    demeaned_basis: bool = False
+    time_resolution: int = 1
+    time_dim: str | None = field(default=None, init=False, repr=False)
+    first_date: Any = field(default=None, init=False, repr=False)
+
+    @property
+    def index_var(self) -> str:
+        """Name of the registered numeric index data variable."""
+        return f"{self.var_name}_index"
+
+    @property
+    def extra_dims(self) -> tuple[str, ...]:
+        """Dims beyond the time dimension."""
+        return _normalize_dims(self.dims)
+
+    def get_coords(self, ds: xr.Dataset) -> dict[str, Any]:
+        """Collect coordinates from the time reference and extra dims."""
+        da = ds[self.var_name]
+        coords = {cast("str", k): v.values.tolist() for k, v in da.coords.items()}
+        for dim in self.extra_dims:
+            if dim in ds.coords and dim not in coords:
+                coords[dim] = ds.coords[dim].values.tolist()
+        return coords
+
+    def _time_values(self, da: xr.DataArray) -> np.ndarray:
+        """Convert a time reference to numeric index values.
+
+        Datetimes become days since the anchored first training date,
+        divided by ``time_resolution``. Numeric values are passed through
+        as floats.
+        """
+        values = np.asarray(da.values)
+        if np.issubdtype(values.dtype, np.datetime64):
+            anchor = self.first_date if self.first_date is not None else values[0]
+            values = (values - anchor) / np.timedelta64(1, "D")
+            values = values / self.time_resolution
+        return np.asarray(values, dtype=float)
+
+    def _time_index(self, da: xr.DataArray) -> xr.DataArray:
+        """Numeric time index as a DataArray, preserving dims and coords."""
+        return xr.DataArray(self._time_values(da), dims=da.dims, coords=da.coords)
+
+    def register_data(self, ds: xr.Dataset) -> None:
+        """Register the numeric time index as ``pmd.Data`` and freeze ``X_mid``."""
+        model = pm.modelcontext(None)
+        da = ds[self.var_name]
+        values = np.asarray(da.values)
+        if np.issubdtype(values.dtype, np.datetime64) and self.first_date is None:
+            self.first_date = values[0]
+        if self.index_var not in model:
+            pmd.Data(self.index_var, self._time_index(da))
+        if self.X_mid is None:
+            self.X_mid = float(self._time_values(da).mean())
+        if self.time_dim is None:
+            self.time_dim = cast("str", da.dims[0])
+
+    def set_data(self, ds: xr.Dataset, model: pm.Model | None = None) -> None:
+        """Update the shared time index for out-of-sample prediction."""
+        if self.var_name not in ds:
+            return
+        if self.time_dim is None:
+            raise ValueError(
+                f"Nothing registered for {self.var_name!r}. "
+                "Call `register_data` before `set_data`."
+            )
+        da = ds[self.var_name]
+        coords = {dim: ds[dim].values for dim in da.dims if dim in ds.coords}
+        pm.set_data({self.index_var: self._time_values(da)}, model=model, coords=coords)
+
+    def _prepare_X(self) -> tuple[pt.TensorVariable, str]:
+        """Return the registered time-index tensor and time dim."""
+        model = pm.modelcontext(None)
+        if self.X_mid is None or self.time_dim is None:
+            raise ValueError(
+                "The data must be registered before creating a variable. "
+                f"Call `register_data` with a dataset containing {self.var_name!r}."
+            )
+        X = model[self.index_var]
+        X_tensor = as_tensor(X, allow_xtensor_conversion=True)
+        return X_tensor, self.time_dim
+
+
+@serialization.register
+@dataclass(kw_only=True)
+class HSGPTerm(GPDataTerm):
+    """Hilbert Space Gaussian Process term.
+
+    A one-dimensional GP over the time reference ``var_name`` with optional
+    higher-dimensional coefficients via ``dims``. Composes with the other
+    terms via ``+`` / ``*`` / ``-``.
+
+    All of ``m``, ``L``, ``X_mid``, ``eta``, and ``ls`` are deferred: when
+    ``None``, they are resolved from the dataset inside the model context
+    with the same heuristics and prior recommendations as
+    :meth:`pymc_marketing.mmm.hsgp.HSGP.parameterize_from_data`, then cached
+    on the instance. Explicit values always win.
+
+    Parameters
+    ----------
+    var_name : str, optional
+        Name of the time reference in the dataset, read with
+        ``ds[var_name]`` (works for both coordinates and data variables).
+        Datetimes are converted to days since the first date, divided by
+        ``time_resolution``, and registered as ``pmd.Data`` under
+        ``{var_name}_index``. Defaults to ``"date"``.
+    name : str, optional
+        Prefix for the variables and the output deterministic. Defaults to
+        ``"hsgp"``.
+    eta : VariableFactory or float, optional
+        Prior for the GP variance. Defaults to the Exponential prior from
+        :func:`pymc_marketing.mmm.hsgp.create_eta_prior`.
+    ls : VariableFactory or float, optional
+        Prior for the lengthscale. Defaults to the complexity-penalizing
+        Weibull prior, or a constrained InverseGamma when ``ls_upper`` is
+        set.
+    m : int, optional
+        Number of basis functions. Defaults to the Ruitort-Mayol et al.
+        recommendation from the data.
+    L : float, optional
+        Extent of the basis functions. Defaults to the recommendation from
+        the data.
+    dims : str or tuple of str, optional
+        Extra dims for the coefficients beyond the time dim, e.g.
+        ``"channel"`` for one GP curve per channel. Coordinates are
+        collected from the dataset.
+    time_resolution : int
+        Divisor applied to the day offsets of a datetime time reference.
+        Default ``1`` (plain day offsets). For weekly data pass ``7`` (the
+        stable MMM time-varying default uses ``5``) so the deferred ``m``
+        and ``L`` heuristics see weekly-scale lengthscales.
+    centered : bool
+        Whether the coefficient prior is centered. Default ``False``.
+    drop_first : bool
+        Whether to drop the first (constant) basis function. Default ``True``.
+    demeaned_basis : bool
+        Whether each basis has its mean subtracted. Default ``False``.
+    eta_mass, eta_upper, ls_lower, ls_upper, ls_mass : float
+        Knobs for the deferred prior resolution. Defaults mirror
+        ``HSGP.parameterize_from_data`` (``0.05``, ``1.0``, ``1.0``,
+        ``None``, ``0.9``).
+    cov_func : CovFunc
+        Covariance function. Default ``CovFunc.ExpQuad``.
+
+    Examples
+    --------
+    Deferred defaults composed into an outcome equation:
+
+    .. code-block:: python
+
+        from pymc_extras.prior import Prior
+        from pymc_marketing.terms import (
+            Intercept,
+            Dot,
+            collect_coords,
+            register_data,
+            build_param,
+        )
+        from pymc_marketing.terms_gp import HSGPTerm
+
+        trend = HSGPTerm(var_name="time", name="trend")
+        mu = (
+            Intercept("intercept")
+            + trend
+            + Dot(var_name="x", prior=Prior("Normal", dims="feature"))
+        )
+
+        coords = collect_coords(mu, ds=ds)
+        with pm.Model(coords=coords) as model:
+            register_data(mu, ds=ds)
+            mu_value = build_param(mu)
+
+    Explicit configuration:
+
+    .. code-block:: python
+
+        from pymc_extras.prior import Prior
+        from pymc_marketing.terms_gp import HSGPTerm
+
+        trend = HSGPTerm(
+            var_name="time",
+            name="trend",
+            eta=Prior("Exponential", lam=1),
+            ls=Prior("InverseGamma", alpha=2, beta=1),
+            m=20,
+            L=150,
+        )
+    """
+
+    eta: VariableFactory | float | None = None
+    ls: VariableFactory | float | None = None
+    m: int | None = None
+    L: float | None = None
+    centered: bool = False
+    drop_first: bool = True
+    eta_mass: float = 0.05
+    eta_upper: float = 1.0
+    ls_lower: float = 1.0
+    ls_upper: float | None = None
+    ls_mass: float = 0.9
+    cov_func: CovFunc = CovFunc.ExpQuad
+
+    def _resolve(self, ds: xr.Dataset) -> None:
+        """Resolve deferred hyperparameters from the dataset (fill-if-None)."""
+        X = self._time_values(ds[self.var_name])
+        if self.X_mid is None:
+            self.X_mid = float(X.mean())
+        if self.m is None or self.L is None:
+            m, L = create_m_and_L_recommendations(
+                X,
+                self.X_mid,
+                ls_lower=self.ls_lower,
+                ls_upper=self.ls_upper,
+                cov_func=self.cov_func,
+            )
+            self.m = self.m if self.m is not None else m
+            self.L = self.L if self.L is not None else L
+        if self.eta is None:
+            self.eta = create_eta_prior(mass=self.eta_mass, upper=self.eta_upper)
+        if self.ls is None:
+            if self.ls_upper is None:
+                self.ls = create_complexity_penalizing_prior(
+                    lower=self.ls_lower,
+                    alpha=self.ls_mass,
+                )
+            else:
+                self.ls = create_constrained_inverse_gamma_prior(
+                    lower=self.ls_lower,
+                    upper=self.ls_upper,
+                    mass=self.ls_mass,
+                )
+
+    def add_coords(self, ds: xr.Dataset) -> None:
+        """Resolve deferred values, then add the basis coordinate."""
+        self._resolve(ds)
+        m = cast("int", self.m)
+        model = pm.modelcontext(None)
+        model.add_coords({f"{self.name}_m": np.arange(m - 1 if self.drop_first else m)})
+
+    def _build_gp(self, prefix: str) -> pt.TensorVariable:
+        """Build the linearized GP expression under a variable-name prefix."""
+        X_tensor, time_dim = self._prepare_X()
+        _check_scalar("eta", self.eta)
+        _check_scalar("ls", self.ls)
+
+        eta = as_tensor(
+            build_param(self.eta, name=f"{prefix}_eta"),
+            allow_xtensor_conversion=True,
+        )
+        ls = as_tensor(
+            build_param(self.ls, name=f"{prefix}_ls"),
+            allow_xtensor_conversion=True,
+        )
+
+        cov_func = eta**2 * _GP_COV_FUNCS[self.cov_func.value](input_dim=1, ls=ls)
+        gp = pm.gp.HSGP(m=[self.m], L=[self.L], cov_func=cov_func)
+        phi, sqrt_psd = gp.prior_linearized(X_tensor[:, None] - self.X_mid)
+
+        if self.drop_first:
+            phi = phi[:, 1:]
+            sqrt_psd = sqrt_psd[1:]
+
+        if self.demeaned_basis:
+            phi = phi - phi.mean(axis=0).eval()
+
+        coord_name = f"{prefix}_m"
+        phi_x = as_xtensor(phi, dims=(time_dim, coord_name))
+        sqrt_psd_x = as_xtensor(sqrt_psd, dims=(coord_name,))
+
+        hsgp_coefs = Prior(
+            "Normal",
+            mu=0,
+            sigma=sqrt_psd_x,
+            dims=(*self.extra_dims, coord_name),
+            centered=self.centered,
+        ).create_variable(f"{prefix}_hsgp_coefs", xdist=True)
+
+        return phi_x.dot(hsgp_coefs)
+
+    def create_variable(self) -> pt.TensorVariable:
+        """Build the GP curve as a named deterministic."""
+        f = self._build_gp(self.name)
+        return pmd.Deterministic(self.name, f, dims=(self.time_dim, *self.extra_dims))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the term recipe.
+
+        The frozen ``X_mid`` is excluded; it is re-derived from the data on
+        rebuild.
+        """
+        return {
+            "var_name": self.var_name,
+            "name": self.name,
+            "eta": _serialize_optional(self.eta),
+            "ls": _serialize_optional(self.ls),
+            "m": self.m,
+            "L": self.L,
+            "dims": _dims_to_list(self.dims),
+            "centered": self.centered,
+            "drop_first": self.drop_first,
+            "demeaned_basis": self.demeaned_basis,
+            "time_resolution": self.time_resolution,
+            "eta_mass": self.eta_mass,
+            "eta_upper": self.eta_upper,
+            "ls_lower": self.ls_lower,
+            "ls_upper": self.ls_upper,
+            "ls_mass": self.ls_mass,
+            "cov_func": self.cov_func.value,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> HSGPTerm:
+        """Reconstruct a term from its serialized form."""
+        dims = data.get("dims")
+        if isinstance(dims, list):
+            dims = tuple(dims)
+        return cls(
+            var_name=data["var_name"],
+            name=data["name"],
+            eta=_deserialize_optional(data.get("eta")),
+            ls=_deserialize_optional(data.get("ls")),
+            m=data.get("m"),
+            L=data.get("L"),
+            dims=dims,
+            centered=data["centered"],
+            drop_first=data["drop_first"],
+            demeaned_basis=data["demeaned_basis"],
+            time_resolution=data["time_resolution"],
+            eta_mass=data["eta_mass"],
+            eta_upper=data["eta_upper"],
+            ls_lower=data["ls_lower"],
+            ls_upper=data.get("ls_upper"),
+            ls_mass=data["ls_mass"],
+            cov_func=CovFunc(data["cov_func"]),
+        )
+
+
+@serialization.register
+@dataclass(kw_only=True)
+class SoftPlusHSGPTerm(HSGPTerm):
+    """HSGP term with softplus transformation and mean-one centering.
+
+    Maps the latent GP to strictly positive values and normalizes
+    multiplicatively by the time-mean, so the resulting multiplier has mean
+    one over the time dimension while remaining strictly positive. This is
+    the canonical time-varying multiplier for media effects, matching the
+    time-varying parameters of the stable MMM classes.
+
+    The output broadcasts across a media term's channel dimension through
+    ``*``:
+
+    .. code-block:: python
+
+        tvp_media = SoftPlusHSGPTerm() * media
+
+    For out-of-sample prediction with
+    :func:`pymc_marketing.model_graph.deterministics_to_flat`, the
+    ``{name}_f_mean`` deterministic is the one to replace:
+
+    .. code-block:: python
+
+        SoftPlusHSGPTerm.deterministics_to_replace("tvp")
+        # ['tvp_f_mean']
+    """
+
+    name: str = "tvp"
+
+    def add_coords(self, ds: xr.Dataset) -> None:
+        """Resolve deferred values, then add the raw basis coordinate."""
+        self._resolve(ds)
+        m = cast("int", self.m)
+        model = pm.modelcontext(None)
+        model.add_coords(
+            {f"{self.name}_raw_m": np.arange(m - 1 if self.drop_first else m)}
+        )
+
+    @staticmethod
+    def deterministics_to_replace(name: str) -> list[str]:
+        """Deterministics to replace with ``pm.Flat`` for out-of-sample.
+
+        Required so out-of-sample predictions keep the training time-mean
+        of one. Without this, the training and test curves are not
+        continuous.
+
+        """
+        return [f"{name}_f_mean"]
+
+    def create_variable(self) -> pt.TensorVariable:
+        """Build the positive, mean-one GP multiplier."""
+        f = self._build_gp(f"{self.name}_raw")
+        f = pmd.math.softplus(f)
+
+        f_mean = pmd.Deterministic(f"{self.name}_f_mean", f.mean(dim=self.time_dim))
+
+        centered_f = f / f_mean
+        return pmd.Deterministic(self.name, centered_f)
+
+
+@serialization.register
+@dataclass(kw_only=True)
+class HSGPPeriodicTerm(GPDataTerm):
+    """Periodic HSGP term.
+
+    A one-dimensional periodic GP over the time reference ``var_name``, for
+    seasonality with a fixed ``period``. Mirrors
+    :class:`pymc_marketing.mmm.hsgp.HSGPPeriodic`: ``m``, ``scale``, ``ls``,
+    and ``period`` are required (there is no data-driven recommendation for
+    the periodic basis).
+
+    Parameters
+    ----------
+    var_name : str, optional
+        Name of the time reference in the dataset, read with
+        ``ds[var_name]`` (works for both coordinates and data variables).
+        Datetimes are converted to days since the first date, divided by
+        ``time_resolution``, and registered as ``pmd.Data`` under
+        ``{var_name}_index``. Defaults to ``"date"``.
+    name : str, optional
+        Prefix for the variables and the output deterministic. Defaults to
+        ``"hsgp_periodic"``.
+    scale : VariableFactory or float
+        Prior for the scale of the periodic GP.
+    ls : VariableFactory or float
+        Prior for the lengthscale of the periodic GP.
+    period : float
+        The period of the function, in units of the time index.
+    m : int
+        Number of basis functions.
+    dims : str or tuple of str, optional
+        Extra dims for the coefficients beyond the time dim.
+    demeaned_basis : bool
+        Whether each basis has its mean subtracted. Default ``False``.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from pymc_extras.prior import Prior
+        from pymc_marketing.terms_gp import HSGPPeriodicTerm
+
+        seasonality = HSGPPeriodicTerm(
+            var_name="time",
+            name="seasonality",
+            scale=Prior("HalfNormal", sigma=1),
+            ls=Prior("InverseGamma", alpha=2, beta=1),
+            period=52,
+            m=20,
+        )
+    """
+
+    var_name: str = "date"
+    name: str = "hsgp_periodic"
+    scale: VariableFactory | float
+    ls: VariableFactory | float
+    period: float
+    m: int
+
+    def add_coords(self, ds: xr.Dataset) -> None:
+        """Freeze the centering value, then add the basis coordinate."""
+        if self.X_mid is None:
+            self.X_mid = float(self._time_values(ds[self.var_name]).mean())
+        model = pm.modelcontext(None)
+        model.add_coords({f"{self.name}_m": np.arange((self.m * 2) - 1)})
+
+    def _build_gp(self, prefix: str) -> pt.TensorVariable:
+        """Build the linearized periodic GP expression under a prefix."""
+        X_tensor, time_dim = self._prepare_X()
+        _check_scalar("scale", self.scale)
+        _check_scalar("ls", self.ls)
+
+        scale = as_tensor(
+            build_param(self.scale, name=f"{prefix}_scale"),
+            allow_xtensor_conversion=True,
+        )
+        ls = as_tensor(
+            build_param(self.ls, name=f"{prefix}_ls"),
+            allow_xtensor_conversion=True,
+        )
+
+        cov_func = pm.gp.cov.Periodic(1, period=self.period, ls=ls)
+        gp = pm.gp.HSGPPeriodic(m=self.m, scale=scale, cov_func=cov_func)
+        (phi_cos, phi_sin), psd = gp.prior_linearized(X_tensor[:, None] - self.X_mid)
+
+        if self.demeaned_basis:
+            phi_cos = phi_cos - phi_cos.mean(axis=0).eval()
+            phi_sin = phi_sin - phi_sin.mean(axis=0).eval()
+
+        coord_name = f"{prefix}_m"
+        phi_cos_x = as_xtensor(phi_cos, dims=(time_dim, coord_name))
+        phi_sin_x = as_xtensor(phi_sin, dims=(time_dim, coord_name))
+        psd_x = as_xtensor(psd, dims=(coord_name,))
+        slice_idx = {coord_name: slice(1, None)}
+
+        sigma = ptx.concat([psd_x, psd_x.isel(slice_idx)], dim=coord_name)
+        hsgp_coefs = Prior(
+            "Normal",
+            mu=0,
+            sigma=sigma,
+            dims=(*self.extra_dims, coord_name),
+            centered=False,
+        ).create_variable(f"{prefix}_hsgp_coefs", xdist=True)
+
+        phi = ptx.concat([phi_cos_x, phi_sin_x.isel(slice_idx)], dim=coord_name)
+        return phi.dot(hsgp_coefs)
+
+    def create_variable(self) -> pt.TensorVariable:
+        """Build the periodic GP curve as a named deterministic."""
+        f = self._build_gp(self.name)
+        return pmd.Deterministic(self.name, f, dims=(self.time_dim, *self.extra_dims))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the term recipe."""
+        return {
+            "var_name": self.var_name,
+            "name": self.name,
+            "scale": _serialize_optional(self.scale),
+            "ls": _serialize_optional(self.ls),
+            "period": self.period,
+            "m": self.m,
+            "dims": _dims_to_list(self.dims),
+            "demeaned_basis": self.demeaned_basis,
+            "time_resolution": self.time_resolution,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> HSGPPeriodicTerm:
+        """Reconstruct a term from its serialized form."""
+        dims = data.get("dims")
+        if isinstance(dims, list):
+            dims = tuple(dims)
+        return cls(
+            var_name=data["var_name"],
+            name=data["name"],
+            scale=_deserialize_optional(data.get("scale")),
+            ls=_deserialize_optional(data.get("ls")),
+            period=data["period"],
+            m=data["m"],
+            dims=dims,
+            demeaned_basis=data["demeaned_basis"],
+            time_resolution=data["time_resolution"],
+        )

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -31,8 +31,10 @@ from pymc_marketing.terms import (
     Dot,
     Intercept,
     ModelTerm,
+    Named,
     Parameter,
     Product,
+    Ref,
     Sum,
     Transform,
     build_param,
@@ -720,3 +722,112 @@ def test_restored_term_builds(simple_ds):
     with pm.Model(coords=coords):
         register_data(restored, ds=simple_ds)
         assert isinstance(build_param(restored), PTVariable)
+
+
+def test_named_builds_pmd_deterministic():
+    coords = {"product": ["p1", "p2"]}
+    with pm.Model(coords=coords) as model:
+        term = Named(
+            "sigma",
+            Parameter("scale", prior=Prior("HalfNormal", dims="product")),
+            dims="product",
+        )
+        term.create_variable()
+
+    assert "sigma" in model.named_vars
+    assert model.named_vars_to_dims["sigma"] == ("product",)
+
+
+def test_named_dims_none_scalar():
+    with pm.Model() as model:
+        term = Named(
+            "sigma",
+            Parameter("scale", prior=Prior("HalfNormal")),
+            dims=None,
+        )
+        term.create_variable()
+
+    assert "sigma" in model.named_vars
+    assert model.named_vars_to_dims["sigma"] == ()
+
+
+def test_named_delegates_lifecycle(simple_ds):
+    term = Named(
+        "effect",
+        Transform(
+            Dot(var_name="x", prior=Prior("Normal", dims="feature")),
+            func=ptx.math.exp,
+        ),
+        dims="obs",
+    )
+    coords = term.get_coords(simple_ds)
+    assert "feature" in coords
+
+    with pm.Model(coords=coords) as model:
+        term.register_data(simple_ds)
+        term.create_variable()
+
+    assert "effect" in model.named_vars
+    assert model.named_vars_to_dims["effect"] == ("obs",)
+
+    ds2 = simple_ds.copy()
+    ds2["x"] = xr.DataArray(
+        np.roll(simple_ds["x"].values, 1, axis=0), dims=("obs", "feature")
+    )
+    term.set_data(ds2, model=model)
+    assert np.allclose(model["x"].get_value(), ds2["x"].values)
+
+
+def test_ref_resolves_built_variable():
+    coords = {"product": ["p1", "p2"]}
+    with pm.Model(coords=coords) as model:
+        scale = Named(
+            "a_scale",
+            Parameter("phi", prior=Prior("Uniform", lower=0, upper=1, dims="product")),
+            dims="product",
+        )
+        scale.create_variable()
+
+        effect = Named(
+            "a",
+            Ref("a_scale")
+            * Parameter("kappa", prior=Prior("HalfNormal", sigma=1, dims="product")),
+            dims="product",
+        )
+        effect.create_variable()
+
+    assert "a_scale" in model.named_vars
+    assert "a" in model.named_vars
+    assert model.named_vars_to_dims["a"] == ("product",)
+
+
+def test_ref_missing_raises():
+    with pm.Model():
+        ref = Ref("missing")
+        with pytest.raises(KeyError):
+            ref.create_variable()
+
+
+def test_serialize_named_roundtrip():
+    term = Named(
+        "alpha",
+        Parameter("alpha_scale", prior=Prior("HalfFlat"))
+        * Transform(
+            Dot(
+                var_name="purchase_data",
+                name="purchase_coefficient_alpha",
+                prior=Prior("Normal", mu=0, sigma=1, dims="purchase_covariate"),
+            ),
+            func=ptx.math.exp,
+        ),
+        dims="customer_id",
+    )
+    restored = serialization.deserialize(serialization.serialize(term))
+    assert restored == term
+    assert restored.dims == "customer_id"
+
+
+def test_serialize_ref_roundtrip():
+    term = Ref("a_scale")
+    restored = serialization.deserialize(serialization.serialize(term))
+    assert restored == term

--- a/tests/test_terms_gp.py
+++ b/tests/test_terms_gp.py
@@ -1,0 +1,500 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Tests for pymc_marketing.terms_gp."""
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pymc as pm
+import pymc.dims as pmd
+import pytest
+import xarray as xr
+from pymc_extras.prior import Prior, VariableFactory
+from pytensor.graph.basic import Variable as PTVariable
+
+from pymc_marketing.mmm.hsgp import HSGP, HSGPPeriodic, SoftPlusHSGP
+from pymc_marketing.serialization import serialization
+from pymc_marketing.terms import (
+    Intercept,
+    ModelTerm,
+    Named,
+    Sum,
+    build_param,
+    collect_coords,
+    register_data,
+    set_data,
+)
+from pymc_marketing.terms_gp import HSGPPeriodicTerm, HSGPTerm, SoftPlusHSGPTerm
+
+
+@pytest.fixture
+def ds():
+    """Dataset with a datetime date coordinate, media, and channel dims."""
+    rng = np.random.default_rng(42)
+    n = 40
+    dates = pd.date_range("2023-01-02", periods=n, freq="W-MON")
+    return xr.Dataset(
+        {
+            "media": (("date", "channel"), rng.normal(size=(n, 2)) ** 2),
+        },
+        coords={"date": dates, "channel": ["A", "B"]},
+    )
+
+
+@pytest.fixture
+def ds_num():
+    """Dataset with a numeric time data variable and features."""
+    rng = np.random.default_rng(42)
+    n = 52
+    return xr.Dataset(
+        {
+            "time": ("t", np.arange(n, dtype=float)),
+            "x": (("t", "feature"), rng.normal(size=(n, 3))),
+        },
+        coords={"t": np.arange(n)},
+    )
+
+
+@dataclass(kw_only=True)
+class ChannelScaled(ModelTerm):
+    """Media-like term: data * channel scale, output (date, channel)."""
+
+    var_name: str
+    name: str
+    prior: VariableFactory
+
+    def get_coords(self, ds: xr.Dataset) -> dict[str, Any]:
+        return {k: v.values.tolist() for k, v in ds[self.var_name].coords.items()}
+
+    def register_data(self, ds: xr.Dataset) -> None:
+        model = pm.modelcontext(None)
+        if self.var_name not in model:
+            pmd.Data(self.var_name, ds[self.var_name])
+
+    def set_data(self, ds: xr.Dataset, model: pm.Model | None = None) -> None:
+        if self.var_name in ds:
+            da = ds[self.var_name]
+            coords = {dim: ds[dim].values for dim in da.dims if dim in ds.coords}
+            pm.set_data({self.var_name: da.values}, model=model, coords=coords)
+
+    def create_variable(self) -> PTVariable:
+        model = pm.modelcontext(None)
+        data = model[self.var_name]
+        scale = self.prior.create_variable(self.name, xdist=True)
+        return data * scale
+
+
+def media_term(ds=None, name="scale"):
+    """A media-chain stand-in with (date, channel) output."""
+    return ChannelScaled(
+        var_name="media",
+        name=name,
+        prior=Prior("HalfNormal", sigma=1, dims="channel"),
+    )
+
+
+def test_no_arg_defaults():
+    term = HSGPTerm()
+    assert term.var_name == "date"
+    assert term.name == "hsgp"
+    assert term.m is None
+    assert term.L is None
+    assert term.eta is None
+    assert term.ls is None
+
+
+def test_softplus_defaults():
+    term = SoftPlusHSGPTerm()
+    assert term.var_name == "date"
+    assert term.name == "tvp"
+    assert term.m is None
+
+
+def test_coordinate_build(ds):
+    """No-arg term resolves the date coordinate into date_index."""
+    trend = HSGPTerm(name="trend")
+    mu = Intercept("intercept") + trend
+    coords = collect_coords(mu, ds=ds)
+    assert "date" in coords
+    with pm.Model(coords=coords) as model:
+        register_data(mu, ds=ds)
+        build_param(mu)
+        assert trend.index_var == "date_index"
+        assert "date_index" in model
+        assert "trend_m" in model.coords
+        assert trend.m is not None
+        assert trend.L is not None
+        assert trend.X_mid == pytest.approx(19.5 * 7)
+        assert trend.time_dim == "date"
+
+
+def test_numeric_data_var_build(ds_num):
+    """A numeric data variable is indexed under its own _index name."""
+    trend = HSGPTerm(var_name="time", name="trend")
+    with pm.Model(coords=collect_coords(trend, ds=ds_num)) as model:
+        register_data(trend, ds=ds_num)
+        effect = build_param(trend)
+        assert isinstance(effect, PTVariable)
+        assert trend.index_var == "time_index"
+        assert "time_index" in model
+        assert np.allclose(model["time_index"].get_value(), np.arange(52, dtype=float))
+        assert trend.time_dim == "t"
+
+
+def test_datetime_data_var_conversion():
+    """A datetime data variable (not coordinate) is converted too."""
+    n = 30
+    ds = xr.Dataset(
+        {"when": ("t", pd.date_range("2024-01-01", periods=n, freq="D"))},
+        coords={"t": np.arange(n)},
+    )
+    trend = HSGPTerm(var_name="when", name="trend")
+    with pm.Model(coords=collect_coords(trend, ds=ds)) as model:
+        register_data(trend, ds=ds)
+        build_param(trend)
+        assert trend.index_var == "when_index"
+        assert np.allclose(model["when_index"].get_value(), np.arange(n, dtype=float))
+
+
+def test_time_resolution(ds):
+    """time_resolution divides the day offsets."""
+    trend = HSGPTerm(name="trend", time_resolution=7)
+    with pm.Model(coords=collect_coords(trend, ds=ds)) as model:
+        register_data(trend, ds=ds)
+        build_param(trend)
+        assert trend.X_mid == pytest.approx(19.5)
+        assert np.allclose(model["date_index"].get_value(), np.arange(40) * 7 / 7)
+
+
+def test_deferred_values_cached(ds):
+    """Resolution happens once; later registrations reuse the values."""
+    trend = HSGPTerm(name="trend")
+    with pm.Model(coords=collect_coords(trend, ds=ds)):
+        register_data(trend, ds=ds)
+        build_param(trend)
+    m, L, X_mid = trend.m, trend.L, trend.X_mid
+
+    shifted = ds.assign_coords(date=ds.coords["date"].values + pd.Timedelta(days=1))
+    with pm.Model(coords=collect_coords(trend, ds=shifted)):
+        register_data(trend, ds=shifted)
+        build_param(trend)
+        assert trend.m == m
+        assert trend.L == L
+        assert trend.X_mid == X_mid
+
+
+def test_explicit_values_win(ds):
+    """Explicit m/L/eta/ls are kept during resolution."""
+    eta = Prior("Exponential", lam=1)
+    ls = Prior("InverseGamma", alpha=2, beta=1)
+    trend = HSGPTerm(name="trend", eta=eta, ls=ls, m=15, L=100)
+    with pm.Model(coords=collect_coords(trend, ds=ds)):
+        register_data(trend, ds=ds)
+        build_param(trend)
+        assert trend.m == 15
+        assert trend.L == 100
+        assert trend.eta is eta
+        assert trend.ls is ls
+
+
+def test_float_hyperparams(ds):
+    """Float eta/ls bypass the priors."""
+    trend = HSGPTerm(name="trend", eta=1.0, ls=2.0, m=15, L=100)
+    with pm.Model(coords=collect_coords(trend, ds=ds)):
+        register_data(trend, ds=ds)
+        effect = build_param(trend)
+        assert isinstance(effect, PTVariable)
+
+
+def test_register_data_dedup(ds):
+    """Two terms on the same time reference share one data variable."""
+    trend = HSGPTerm(name="trend")
+    seasonality = HSGPPeriodicTerm(
+        name="seasonality",
+        scale=Prior("HalfNormal", sigma=1),
+        ls=Prior("InverseGamma", alpha=2, beta=1),
+        period=52,
+        m=20,
+    )
+    mu = trend + seasonality
+    with pm.Model(coords=collect_coords(mu, ds=ds)) as model:
+        register_data(mu, ds=ds)
+        build_param(mu)
+        assert "date_index" in model
+
+
+def test_name_collision_raises(ds):
+    """Two no-argument terms collide on every prefixed variable."""
+    mu = HSGPTerm() + HSGPTerm()
+    coords = collect_coords(mu, ds=ds)
+    with pm.Model(coords=coords):
+        register_data(mu, ds=ds)
+        with pytest.raises(ValueError, match="already exists"):
+            build_param(mu)
+
+
+def test_non_scalar_prior_raises(ds):
+    """Dimensional eta/ls priors are rejected."""
+    trend = HSGPTerm(
+        name="trend", ls=Prior("InverseGamma", alpha=2, beta=1, dims="channel")
+    )
+    with pm.Model(coords=collect_coords(trend, ds=ds)):
+        register_data(trend, ds=ds)
+        with pytest.raises(ValueError, match="must be a scalar"):
+            build_param(trend)
+
+
+def test_create_variable_before_register_raises(ds):
+    """create_variable without registration fails clearly."""
+    trend = HSGPTerm(name="trend", m=15, L=100, eta=1.0, ls=1.0)
+    with pm.Model():
+        with pytest.raises(ValueError, match="register_data"):
+            trend.create_variable()
+
+
+def test_set_data_anchored_index(ds):
+    """set_data anchors shifted dates to the training first date."""
+    trend = HSGPTerm(name="trend", time_resolution=1)
+    mu = Intercept("intercept") + trend
+    with pm.Model(coords=collect_coords(mu, ds=ds)) as model:
+        register_data(mu, ds=ds)
+        build_param(mu)
+        X_mid = trend.X_mid
+
+        shifted = ds.assign_coords(date=ds.coords["date"].values + pd.Timedelta(days=7))
+        set_data(mu, ds=shifted, model=model)
+        assert trend.X_mid == X_mid
+        assert np.allclose(model["date_index"].get_value(), np.arange(40) * 7 + 7)
+        assert model.coords["date"][0] == shifted.coords["date"].values[0]
+
+
+def test_set_data_before_register_raises(ds):
+    trend = HSGPTerm(name="trend")
+    with pm.Model():
+        with pytest.raises(ValueError, match="register_data"):
+            set_data(trend, ds=ds, model=pm.modelcontext(None))
+
+
+def test_tvp_media_broadcasting(ds):
+    """SoftPlusHSGPTerm() * media broadcasts (date,) over (date, channel)."""
+    tvp_media = SoftPlusHSGPTerm(name="tvp") * media_term()
+    coords = collect_coords(tvp_media, ds=ds)
+    assert "date" in coords
+    assert "channel" in coords
+    with pm.Model(coords=coords):
+        register_data(tvp_media, ds=ds)
+        effect = build_param(tvp_media)
+        evaluated = effect.eval()
+        assert evaluated.shape == (40, 2)
+
+
+def test_outcome_equation_prior(ds):
+    """Full outcome equation: intercept + trend + Named(tvp * media)."""
+    trend = HSGPTerm(name="trend", m=20, L=300)
+    tvp_media = Named(
+        "tvp_media",
+        SoftPlusHSGPTerm(name="tvp", m=20, L=300) * media_term(),
+        dims=("date", "channel"),
+    )
+    mu = Intercept("intercept") + trend + tvp_media
+    coords = collect_coords(mu, ds=ds)
+    with pm.Model(coords=coords):
+        register_data(mu, ds=ds)
+        build_param(mu)
+        idata = pm.sample_prior_predictive(
+            random_seed=42, var_names=["tvp", "tvp_media"]
+        )
+
+    # the GP factor is positive with mean one over the time dim
+    gp = idata.prior["tvp"]
+    assert gp.dims == ("chain", "draw", "date")
+    gp_values = gp.values
+    assert (gp_values > 0).all()
+    assert np.allclose(gp_values.mean(axis=-1), 1.0)
+
+    # the product broadcasts across the channel dim
+    product = idata.prior["tvp_media"]
+    assert product.dims == ("chain", "draw", "date", "channel")
+    assert (product.values > 0).all()
+
+
+def test_higher_dim_coefs(ds):
+    """dims adds one GP curve per group."""
+    trend = HSGPTerm(name="trend", dims="channel", m=20, L=300, eta=1.0, ls=2.0)
+    with pm.Model(coords=collect_coords(trend, ds=ds)) as model:
+        register_data(trend, ds=ds)
+        effect = build_param(trend)
+        assert effect.eval().shape == (40, 2)
+        assert "trend_hsgp_coefs" in model.named_vars
+
+
+def test_periodic_requires_args():
+    with pytest.raises(TypeError):
+        HSGPPeriodicTerm()
+
+
+def test_periodic_build(ds):
+    seasonality = HSGPPeriodicTerm(
+        name="seasonality",
+        scale=Prior("HalfNormal", sigma=1),
+        ls=Prior("InverseGamma", alpha=2, beta=1),
+        period=52,
+        m=20,
+    )
+    with pm.Model(coords=collect_coords(seasonality, ds=ds)) as model:
+        register_data(seasonality, ds=ds)
+        effect = build_param(seasonality)
+        assert isinstance(effect, PTVariable)
+        assert len(model.coords["seasonality_m"]) == 20 * 2 - 1
+
+
+def test_serialize_hsgp_term_roundtrip():
+    term = HSGPTerm(
+        var_name="time",
+        name="trend",
+        eta=Prior("Exponential", lam=1),
+        m=15,
+        L=100,
+        dims=("channel",),
+    )
+    restored = serialization.deserialize(serialization.serialize(term))
+    assert restored == term
+
+
+def test_serialize_deferred_roundtrip():
+    term = HSGPTerm()
+    restored = serialization.deserialize(serialization.serialize(term))
+    assert restored.var_name == "date"
+    assert restored.name == "hsgp"
+    assert restored.m is None
+    assert restored.X_mid is None
+
+
+def test_serialize_resolved_keeps_m_l(ds):
+    """Resolved m/L persist; X_mid stays excluded."""
+    term = HSGPTerm(name="trend", m=15, L=100, eta=1.0, ls=1.0)
+    with pm.Model(coords=collect_coords(term, ds=ds)):
+        register_data(term, ds=ds)
+        build_param(term)
+    data = serialization.serialize(term)
+    assert data["m"] == 15
+    assert data["L"] == 100
+    assert "X_mid" not in data
+    restored = serialization.deserialize(data)
+    assert restored.m == 15
+    assert restored.L == 100
+
+
+def test_serialize_softplus_roundtrip():
+    term = SoftPlusHSGPTerm(m=15, L=100)
+    restored = serialization.deserialize(serialization.serialize(term))
+    assert restored == term
+    assert type(restored).__name__ == "SoftPlusHSGPTerm"
+
+
+def test_serialize_periodic_roundtrip():
+    term = HSGPPeriodicTerm(
+        scale=Prior("HalfNormal", sigma=1),
+        ls=Prior("InverseGamma", alpha=2, beta=1),
+        period=52,
+        m=20,
+    )
+    restored = serialization.deserialize(serialization.serialize(term))
+    assert restored == term
+
+
+def test_serialize_composition_roundtrip(ds):
+    expr = HSGPTerm(name="trend", m=15, L=100) + Intercept("intercept")
+    restored = serialization.deserialize(serialization.serialize(expr))
+    assert isinstance(restored, Sum)
+    assert isinstance(restored.terms[0], HSGPTerm)
+
+
+def _sample_prior_both(term, existing):
+    """Sample priors from the existing HSGP class and the term; compare."""
+    n = 52
+    X = np.arange(n, dtype=float)
+    coords = {"time": np.arange(n)}
+    ds = xr.Dataset({}, coords=coords)
+
+    with pm.Model(coords=coords):
+        existing.register_data(X)
+        existing.create_variable("f", xdist=True)
+        idata_existing = pm.sample_prior_predictive(random_seed=42)
+
+    with pm.Model(coords=collect_coords(term, ds=ds)):
+        register_data(term, ds=ds)
+        build_param(term)
+        idata_term = pm.sample_prior_predictive(random_seed=42)
+
+    return (
+        idata_existing.prior["f"].values,
+        idata_term.prior["f"].values,
+    )
+
+
+def test_equivalence_hsgp():
+    """Exact prior draws match the existing HSGP class."""
+    eta = Prior("Exponential", lam=1)
+    ls = Prior("InverseGamma", alpha=2, beta=1)
+    existing = HSGP(eta=eta, ls=ls, m=20, L=150, dims="time")
+    term = HSGPTerm(var_name="time", name="f", eta=eta, ls=ls, m=20, L=150)
+    draws_existing, draws_term = _sample_prior_both(term, existing)
+    np.testing.assert_allclose(draws_existing, draws_term)
+
+
+def test_equivalence_periodic():
+    """Exact prior draws match the existing HSGPPeriodic class."""
+    scale = Prior("HalfNormal", sigma=1)
+    ls = Prior("InverseGamma", alpha=2, beta=1)
+    existing = HSGPPeriodic(
+        scale=scale, ls=ls, m=20, cov_func="periodic", period=52, dims="time"
+    )
+    term = HSGPPeriodicTerm(
+        var_name="time", name="f", scale=scale, ls=ls, period=52, m=20
+    )
+    draws_existing, draws_term = _sample_prior_both(term, existing)
+    np.testing.assert_allclose(draws_existing, draws_term)
+
+
+def test_equivalence_softplus():
+    """Exact prior draws match the existing SoftPlusHSGP class."""
+    eta = Prior("Exponential", lam=1)
+    ls = Prior("InverseGamma", alpha=2, beta=1)
+    existing = SoftPlusHSGP(eta=eta, ls=ls, m=20, L=150, dims="time")
+    term = SoftPlusHSGPTerm(var_name="time", name="f", eta=eta, ls=ls, m=20, L=150)
+    draws_existing, draws_term = _sample_prior_both(term, existing)
+    np.testing.assert_allclose(draws_existing, draws_term)
+
+
+def test_defaults_match_parameterize_from_data():
+    """Deferred resolution mirrors HSGP.parameterize_from_data assumptions."""
+    n = 52
+    X = np.arange(n, dtype=float)
+    expected = HSGP.parameterize_from_data(X=X, dims="time")
+
+    ds = xr.Dataset({}, coords={"time": X})
+    term = HSGPTerm(var_name="time", name="f")
+    with pm.Model(coords=collect_coords(term, ds=ds)):
+        register_data(term, ds=ds)
+        build_param(term)
+
+    assert term.m == expected.m
+    assert term.L == expected.L
+    assert term.X_mid == expected.X_mid
+    assert type(term.eta).__name__ == "Prior"
+    assert type(term.ls).__name__ == "Prior"

--- a/tests/test_terms_gp.py
+++ b/tests/test_terms_gp.py
@@ -14,6 +14,7 @@
 
 """Tests for pymc_marketing.terms_gp."""
 
+import json
 from dataclasses import dataclass
 from typing import Any
 
@@ -373,6 +374,28 @@ def test_serialize_hsgp_term_roundtrip():
     )
     restored = serialization.deserialize(serialization.serialize(term))
     assert restored == term
+    assert restored.dims == ("channel",)
+
+
+@pytest.mark.parametrize("dims", ["channel", ("channel", "product")], ids=str)
+def test_serialize_json_roundtrip_dims(dims):
+    """string and tuple dims both survive a JSON hop as tuples."""
+    term = HSGPTerm(name="trend", dims=dims, m=15, L=100)
+    assert term.dims == (("channel",) if dims == "channel" else dims)
+    data = json.loads(json.dumps(serialization.serialize(term)))
+    restored = serialization.deserialize(data)
+    assert restored == term
+    assert restored.dims == (("channel",) if dims == "channel" else dims)
+
+
+@pytest.mark.parametrize("term_cls", [SoftPlusHSGPTerm, HSGPTerm])
+def test_serialize_json_roundtrip_no_dims(term_cls):
+    """JSON hop with no dims configured."""
+    term = term_cls(name="trend", m=15, L=100)
+    data = json.loads(json.dumps(serialization.serialize(term)))
+    restored = serialization.deserialize(data)
+    assert restored == term
+    assert restored.dims is None
 
 
 def test_serialize_deferred_roundtrip():


### PR DESCRIPTION
Stacked on #2991

Adds the HSGP components as composable model terms, so Gaussian processes
get the same lifecycle, operator composition, and serialization as the rest
of the terms vocabulary. The main motivation is time-varying media effects
for the experimental MMM (#2981).

    trend = HSGPTerm()
    tvp_media = SoftPlusHSGPTerm() * media
    mu = Intercept("intercept") + trend + tvp_media

Key properties:

- Fully deferred: m, L, X_mid, and the default eta/ls priors resolve from
  the dataset at build time (same assumptions as
  HSGP.parameterize_from_data) and cache on the instance. Explicit values
  win.
- The time reference is read with ds[var_name], so a datetime coordinate
  works directly. It converts to days since the anchored first training
  date divided by time_resolution (the infer_time_index convention) and
  registers as pmd.Data under {var_name}_index, shared across terms.
- X_mid freezes at first registration so set_data keeps out-of-sample
  curves continuous with training.
- Prior draws are exactly equivalent to the existing HSGP, HSGPPeriodic,
  and SoftPlusHSGP classes under identical configuration.

Equivalence with the existing classes means the terms can back the
experimental MMM's time-varying behavior without a behavior change. Once
merged, #2981 can consume tvp_media = SoftPlusHSGPTerm() * media directly.

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--3000.org.readthedocs.build/en/3000/

<!-- readthedocs-preview pymc-marketing end -->