### PR TITLE
docs: point budget docstrings at sample_response_distribution

### DIFF
--- a/pymc_marketing/mmm/plotting/budget.py
+++ b/pymc_marketing/mmm/plotting/budget.py
@@ -145,7 +145,7 @@ class BudgetPlots:
         Parameters
         ----------
         samples : xr.Dataset
-            Output of ``mmm.allocate_budget_to_maximize_response(...)`` or
+            Output of ``sample_response_distribution(...)`` or
             equivalent.  Must have:
 
             - a variable whose name contains ``"channel_contribution"``

--- a/pymc_marketing/mmm/summary/budget.py
+++ b/pymc_marketing/mmm/summary/budget.py
@@ -150,7 +150,7 @@ class BudgetSummaryFactory:
         Parameters
         ----------
         samples : xr.Dataset
-            Output of ``allocate_budget_to_maximize_response(...)`` or equivalent.
+            Output of ``sample_response_distribution(...)`` or equivalent.
             Must contain ``channel_contribution_original_scale`` with ``channel``,
             ``date``, and ``sample`` or ``(chain, draw)`` dimensions.
         hdi_probs : sequence of float, default (0.94,)


### PR DESCRIPTION
The `samples` argument of `BudgetPlots.contribution_over_time` and `BudgetSummaryFactory.contribution_over_time` is documented as the output of `allocate_budget_to_maximize_response(...)`. That method is not in the package. The current name is `sample_response_distribution`, which samples `channel_contribution_original_scale`, the variable both docstrings require.

Both files already use the current name in the `allocation_roas` docstring above, so this aligns the two remaining lines. The plotting one also loses its `mmm.` receiver, since the method is defined on `BudgetOptimizerWrapper`, not on `MMM`.

Docstrings only, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
