### PR TITLE
docs: point user-facing links at /en/stable/ instead of /en/latest/

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ![Test Notebook](https://github.com/pymc-labs/pymc-marketing/actions/workflows/test_notebook.yml/badge.svg)
 [![codecov](https://codecov.io/gh/pymc-labs/pymc-marketing/branch/main/graph/badge.svg?token=OBV3BS5TYE)](https://codecov.io/gh/pymc-labs/pymc-marketing)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
-[![docs](https://readthedocs.org/projects/pymc-marketing/badge/?version=latest)](https://www.pymc-marketing.io/en/latest/)
+[![docs](https://readthedocs.org/projects/pymc-marketing/badge/?version=latest)](https://www.pymc-marketing.io/en/stable/)
 
 [![PyPI Version](https://img.shields.io/pypi/v/pymc-marketing.svg)](https://pypi.python.org/pypi/pymc-marketing)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
@@ -64,7 +64,7 @@ pip install pymc-marketing[dag]  # causal identification tooling
 pip install pymc-marketing[pie]  # Predicted Incrementality by Experimentation (PIE), requires pymc-bart
 ```
 
-For a comprehensive installation guide, refer to the [installation documentation](https://www.pymc-marketing.io/en/latest/getting_started/installation/index.html).
+For a comprehensive installation guide, refer to the [installation documentation](https://www.pymc-marketing.io/en/stable/getting_started/installation/index.html).
 
 ### Docker
 
@@ -89,8 +89,8 @@ Leverage our Bayesian MMM API to tailor your marketing strategies effectively. L
 | Out-of-sample Predictions                  | Forecast future marketing performance with credible intervals. Use this for simulations and scenario planning.                                                                                                                                                                                                                                                                          |
 | Budget Optimization                        | Allocate your marketing spend efficiently across various channels for maximum ROI. See the [budget optimization example notebook](https://www.pymc-marketing.io/en/stable/notebooks/mmm/mmm_budget_allocation_example.html)                                                                                                                                                             |
 | Experiment Calibration                     | Fine-tune your model based on empirical experiments for a more unified view of marketing. See the [lift test integration explanation](https://www.pymc-marketing.io/en/stable/notebooks/mmm/mmm_lift_test.html) for more details. [Here](https://www.pymc-marketing.io/en/stable/notebooks/mmm/mmm_roas.html) you can find a *Case Study: Unobserved Confounders, ROAS and Lift Tests*. |
-| ROAS / CAC Calibration                     | Calibrate your model with ROAS or cost-per-acquisition estimates via `add_cost_per_target_calibration`. See the [ROAS calibration notebook](https://www.pymc-marketing.io/en/latest/notebooks/mmm/mmm_roas_calibration.html) for a worked example.                                                                                                                                       |
-| Funnel Models                              | Model upper-funnel to lower-funnel mediation (e.g., awareness driving search and conversions) via custom `MuEffect`s. See the [introductory funnel-aware MMM notebook](https://www.pymc-marketing.io/en/latest/notebooks/mmm/mmm_funnel_mueffect.html) and the [advanced geo-level example](https://www.pymc-marketing.io/en/latest/notebooks/mmm/mmm_funnel_mueffect_advanced.html).     |
+| ROAS / CAC Calibration                     | Calibrate your model with ROAS or cost-per-acquisition estimates via `add_cost_per_target_calibration`. See the [ROAS calibration notebook](https://www.pymc-marketing.io/en/stable/notebooks/mmm/mmm_roas_calibration.html) for a worked example.                                                                                                                                       |
+| Funnel Models                              | Model upper-funnel to lower-funnel mediation (e.g., awareness driving search and conversions) via custom `MuEffect`s. See the [introductory funnel-aware MMM notebook](https://www.pymc-marketing.io/en/stable/notebooks/mmm/mmm_funnel_mueffect.html) and the [advanced geo-level example](https://www.pymc-marketing.io/en/stable/notebooks/mmm/mmm_funnel_mueffect_advanced.html).     |
 
 ### MMM Quickstart
 
@@ -147,7 +147,7 @@ Once the model is fitted, we can further optimize our budget allocation as we ar
 
 ### Long-Term Effects & Brand Metrics
 
-Media investments do not only drive short-term sales; they also build brand equity that pays off over longer horizons. PyMC-Marketing lets you measure long-term brand effects in MMMs by coupling brand-tracking metrics (e.g., awareness, consideration) with a Bayesian VARX model. See the [long-term brand effects notebook](https://www.pymc-marketing.io/en/latest/notebooks/mmm/mmm_brand_metrics_long_term.html) for a complete tutorial.
+Media investments do not only drive short-term sales; they also build brand equity that pays off over longer horizons. PyMC-Marketing lets you measure long-term brand effects in MMMs by coupling brand-tracking metrics (e.g., awareness, consideration) with a Bayesian VARX model. See the [long-term brand effects notebook](https://www.pymc-marketing.io/en/stable/notebooks/mmm/mmm_brand_metrics_long_term.html) for a complete tutorial.
 
 ### Essential Reading for Marketing Mix Modeling (MMM)
 
@@ -262,12 +262,12 @@ Discrete choice models come in various forms, but each aims to show how choosing
 
 Explore the full family of choice and preference models:
 
-- [Multinomial Logit](https://www.pymc-marketing.io/en/latest/notebooks/customer_choice/mnl_logit.html)
-- [Nested Logit](https://www.pymc-marketing.io/en/latest/notebooks/customer_choice/nested_logit.html)
-- [Mixed Logit](https://www.pymc-marketing.io/en/latest/notebooks/customer_choice/mixed_logit.html)
-- [Consideration Set Mixed Logit](https://www.pymc-marketing.io/en/latest/notebooks/customer_choice/consideration_set_logit.html)
-- [MaxDiff (Best-Worst Scaling)](https://www.pymc-marketing.io/en/latest/notebooks/customer_choice/maxdiff.html)
-- [Bayesian BLP: Structural Demand on Aggregate Shares](https://www.pymc-marketing.io/en/latest/notebooks/customer_choice/bayesian_blp.html) and its application to the [Nevo cereal panel](https://www.pymc-marketing.io/en/latest/notebooks/customer_choice/bayesian_blp_nevo.html)
+- [Multinomial Logit](https://www.pymc-marketing.io/en/stable/notebooks/customer_choice/mnl_logit.html)
+- [Nested Logit](https://www.pymc-marketing.io/en/stable/notebooks/customer_choice/nested_logit.html)
+- [Mixed Logit](https://www.pymc-marketing.io/en/stable/notebooks/customer_choice/mixed_logit.html)
+- [Consideration Set Mixed Logit](https://www.pymc-marketing.io/en/stable/notebooks/customer_choice/consideration_set_logit.html)
+- [MaxDiff (Best-Worst Scaling)](https://www.pymc-marketing.io/en/stable/notebooks/customer_choice/maxdiff.html)
+- [Bayesian BLP: Structural Demand on Aggregate Shares](https://www.pymc-marketing.io/en/stable/notebooks/customer_choice/bayesian_blp.html) and its application to the [Nevo cereal panel](https://www.pymc-marketing.io/en/stable/notebooks/customer_choice/bayesian_blp_nevo.html)
 
 ## Bass Diffusion Model
 
@@ -283,7 +283,7 @@ See the [Bass Diffusion Model example notebook](https://www.pymc-marketing.io/en
 
 Predict the *incremental* effect of ad campaigns that never ran an experiment with **PIE** (alpha). Randomized experiments — geo tests and ghost-ad holdouts — are the gold standard for measuring campaign incrementality, but they are costly and slow. PIE fits a Bayesian BART model on the corpus of campaigns that *did* run an experiment, learning the map from campaign features to measured incrementality, then predicts a full posterior of incrementality for the campaigns that never did. The approach follows [Gordon, Moakler & Zettelmeyer (2026)](https://www.nber.org/papers/w35044).
 
-The `pymc_marketing.pie` module is in **alpha**: the API and defaults may change between releases. It requires the `pie` extra (`pip install pymc-marketing[pie]`). See the [PIE example notebook](https://www.pymc-marketing.io/en/latest/notebooks/pie/pie_example.html) for a worked example, including where predictions beat last-click attribution.
+The `pymc_marketing.pie` module is in **alpha**: the API and defaults may change between releases. It requires the `pie` extra (`pip install pymc-marketing[pie]`). See the [PIE example notebook](https://www.pymc-marketing.io/en/stable/notebooks/pie/pie_example.html) for a worked example, including where predictions beat last-click attribution.
 
 ## Why PyMC-Marketing vs other solutions?
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -177,10 +177,10 @@ Leverage our Bayesian MMM API to tailor your marketing strategies effectively. L
 | Out-of-sample Predictions                  | Forecast future marketing performance with credible intervals. Use this for simulations and scenario planning.                                                                                                                                                                                                                                                                          |
 | Budget Optimization                        | Allocate your marketing spend efficiently across various channels for maximum ROI. See the [budget optimization example notebook](https://www.pymc-marketing.io/en/stable/notebooks/mmm/mmm_budget_allocation_example.html)                                                                                                                                                             |
 | Experiment Calibration                     | Fine-tune your model based on empirical experiments for a more unified view of marketing. See the [lift test integration explanation](https://www.pymc-marketing.io/en/stable/notebooks/mmm/mmm_lift_test.html) for more details. [Here](https://www.pymc-marketing.io/en/stable/notebooks/mmm/mmm_roas.html) you can find a *Case Study: Unobserved Confounders, ROAS and Lift Tests*. |
-| ROAS / CAC Calibration                     | Calibrate your model with ROAS or cost-per-acquisition estimates via `add_cost_per_target_calibration`. See the [ROAS calibration notebook](https://www.pymc-marketing.io/en/latest/notebooks/mmm/mmm_roas_calibration.html) for a worked example.                                                                                                                                       |
-| Funnel Models                              | Model upper-funnel to lower-funnel mediation (e.g., awareness driving search and conversions) via custom `MuEffect`s. See the [introductory funnel-aware MMM notebook](https://www.pymc-marketing.io/en/latest/notebooks/mmm/mmm_funnel_mueffect.html) and the [advanced geo-level example](https://www.pymc-marketing.io/en/latest/notebooks/mmm/mmm_funnel_mueffect_advanced.html).     |
+| ROAS / CAC Calibration                     | Calibrate your model with ROAS or cost-per-acquisition estimates via `add_cost_per_target_calibration`. See the [ROAS calibration notebook](https://www.pymc-marketing.io/en/stable/notebooks/mmm/mmm_roas_calibration.html) for a worked example.                                                                                                                                       |
+| Funnel Models                              | Model upper-funnel to lower-funnel mediation (e.g., awareness driving search and conversions) via custom `MuEffect`s. See the [introductory funnel-aware MMM notebook](https://www.pymc-marketing.io/en/stable/notebooks/mmm/mmm_funnel_mueffect.html) and the [advanced geo-level example](https://www.pymc-marketing.io/en/stable/notebooks/mmm/mmm_funnel_mueffect_advanced.html).     |
 
-Beyond short-term sales response, you can also measure long-term brand effects in MMMs by coupling brand-tracking metrics (e.g., awareness, consideration) with a Bayesian VARX model. See the [long-term brand effects notebook](https://www.pymc-marketing.io/en/latest/notebooks/mmm/mmm_brand_metrics_long_term.html) for a complete tutorial.
+Beyond short-term sales response, you can also measure long-term brand effects in MMMs by coupling brand-tracking metrics (e.g., awareness, consideration) with a Bayesian VARX model. See the [long-term brand effects notebook](https://www.pymc-marketing.io/en/stable/notebooks/mmm/mmm_brand_metrics_long_term.html) for a complete tutorial.
 
 ## Unlock Customer Lifetime Value (CLV) with PyMC
 
@@ -217,12 +217,12 @@ See our example notebooks for [saturated markets](https://www.pymc-marketing.io/
 
 The customer choice module also includes a full family of **discrete choice and preference models**:
 
-- [Multinomial Logit](https://www.pymc-marketing.io/en/latest/notebooks/customer_choice/mnl_logit.html)
-- [Nested Logit](https://www.pymc-marketing.io/en/latest/notebooks/customer_choice/nested_logit.html)
-- [Mixed Logit](https://www.pymc-marketing.io/en/latest/notebooks/customer_choice/mixed_logit.html)
-- [Consideration Set Mixed Logit](https://www.pymc-marketing.io/en/latest/notebooks/customer_choice/consideration_set_logit.html)
-- [MaxDiff (Best-Worst Scaling)](https://www.pymc-marketing.io/en/latest/notebooks/customer_choice/maxdiff.html)
-- [Bayesian BLP: Structural Demand on Aggregate Shares](https://www.pymc-marketing.io/en/latest/notebooks/customer_choice/bayesian_blp.html) and its application to the [Nevo cereal panel](https://www.pymc-marketing.io/en/latest/notebooks/customer_choice/bayesian_blp_nevo.html)
+- [Multinomial Logit](https://www.pymc-marketing.io/en/stable/notebooks/customer_choice/mnl_logit.html)
+- [Nested Logit](https://www.pymc-marketing.io/en/stable/notebooks/customer_choice/nested_logit.html)
+- [Mixed Logit](https://www.pymc-marketing.io/en/stable/notebooks/customer_choice/mixed_logit.html)
+- [Consideration Set Mixed Logit](https://www.pymc-marketing.io/en/stable/notebooks/customer_choice/consideration_set_logit.html)
+- [MaxDiff (Best-Worst Scaling)](https://www.pymc-marketing.io/en/stable/notebooks/customer_choice/maxdiff.html)
+- [Bayesian BLP: Structural Demand on Aggregate Shares](https://www.pymc-marketing.io/en/stable/notebooks/customer_choice/bayesian_blp.html) and its application to the [Nevo cereal panel](https://www.pymc-marketing.io/en/stable/notebooks/customer_choice/bayesian_blp_nevo.html)
 
 ## Bass Diffusion Model
 

--- a/docs/source/notebooks/clv/sbg.ipynb
+++ b/docs/source/notebooks/clv/sbg.ipynb
@@ -532,7 +532,7 @@
     "1. Individual customer lifetime durations are characterized by the (shifted) Geometric distribution, with cancellation probability $\\theta$.\n",
     "2. Heterogeneity in $\\theta$ follows a Beta distribution with shape parameters $\\alpha$ and $\\beta$.\n",
     "\n",
-    "If we take the expectation across the distribution of $\\theta$, we can derive a likelihood function to estimate parameters $\\alpha$ and $\\beta$ for the customer population. For more details on the `ShiftedBetaGeometric` mixture distribution, please refer to the [documentation](https://www.pymc-marketing.io/en/latest/api/generated/pymc_marketing.clv.distributions.ShiftedBetaGeometric.html#pymc_marketing.clv.distributions.ShiftedBetaGeometric).\n",
+    "If we take the expectation across the distribution of $\\theta$, we can derive a likelihood function to estimate parameters $\\alpha$ and $\\beta$ for the customer population. For more details on the `ShiftedBetaGeometric` mixture distribution, please refer to the [documentation](https://www.pymc-marketing.io/en/stable/api/generated/pymc_marketing.clv.distributions.ShiftedBetaGeometric.html#pymc_marketing.clv.distributions.ShiftedBetaGeometric).\n",
     "\n",
     "The original frequentist model assumes a single cohort of customers who all started their contracts in the same time period. This requires fitting a separate model for each cohort. However, in PyMC-Marketing we can fit all cohorts in a single hierarchical Bayesian model!\n",
     "\n",

--- a/docs/source/notebooks/mmm/mmm_fivetran_connectors.ipynb
+++ b/docs/source/notebooks/mmm/mmm_fivetran_connectors.ipynb
@@ -2216,9 +2216,9 @@
    "source": [
     "Just like that, you are ready to fit your model and unlock different insights from your data. If you want to know what to explore next, then take a look to the following documents:\n",
     "\n",
-    "1. [Multidimensional MMM Example (From Zero to Hero)](https://www.pymc-marketing.io/en/latest/notebooks/mmm/mmm_multidimensional_example.html).\n",
-    "2. [Marketing Mix Models and Budget allocation](https://www.pymc-marketing.io/en/latest/notebooks/mmm/mmm_budget_allocation_example.html).\n",
-    "3. [Risk allocation with Marketing Mix Models](https://www.pymc-marketing.io/en/latest/notebooks/mmm/mmm_allocation_assessment.html)."
+    "1. [Multidimensional MMM Example (From Zero to Hero)](https://www.pymc-marketing.io/en/stable/notebooks/mmm/mmm_multidimensional_example.html).\n",
+    "2. [Marketing Mix Models and Budget allocation](https://www.pymc-marketing.io/en/stable/notebooks/mmm/mmm_budget_allocation_example.html).\n",
+    "3. [Risk allocation with Marketing Mix Models](https://www.pymc-marketing.io/en/stable/notebooks/mmm/mmm_allocation_assessment.html)."
    ]
   },
   {

--- a/docs/source/notebooks/mmm/mmm_gam_options.ipynb
+++ b/docs/source/notebooks/mmm/mmm_gam_options.ipynb
@@ -16,7 +16,7 @@
     "\n",
     "This allows researchers and analysts to move seamlessly from standard MMMs to fully specified graphical models that capture richer causal and functional relationships across variables.\n",
     "\n",
-    "In the following notebook, we'll showing you several of these functionalities. You can [read more about individual components](https://www.pymc-marketing.io/en/latest/notebooks/mmm/mmm_components.html) and how to build MMM's in the components notebook.\n",
+    "In the following notebook, we'll showing you several of these functionalities. You can [read more about individual components](https://www.pymc-marketing.io/en/stable/notebooks/mmm/mmm_components.html) and how to build MMM's in the components notebook.\n",
     "\n",
     "## Import libraries"
    ]

--- a/skills/mmm-modeling/references/custom_model.md
+++ b/skills/mmm-modeling/references/custom_model.md
@@ -344,7 +344,7 @@ with pm.Model(coords=coords):
     event_curve = pm.Deterministic("effect", effect.apply(X), dims=("date", "event"))
 ```
 
-The basis matrix `X` contains day offsets relative to each event window. See the [MMM components notebook](https://www.pymc-marketing.io/en/latest/notebooks/mmm/mmm_components.html) for the full `create_basis_matrix` helper.
+The basis matrix `X` contains day offsets relative to each event window. See the [MMM components notebook](https://www.pymc-marketing.io/en/stable/notebooks/mmm/mmm_components.html) for the full `create_basis_matrix` helper.
 
 ### AsymmetricGaussianBasis
 


### PR DESCRIPTION
Part of #3008.

`/en/stable/` is a permanent alias, so ranking signal accrues to it and carries across releases, while `/en/latest/` scatters that signal and can show readers an unreleased API. This switches every user-facing docs link to stable.

Changed:
- `README.md` (13 links)
- `docs/source/index.md` (9 links)
- `docs/source/notebooks/mmm/mmm_gam_options.ipynb`
- `docs/source/notebooks/mmm/mmm_fivetran_connectors.ipynb` (3 links)
- `docs/source/notebooks/clv/sbg.ipynb`
- `skills/mmm-modeling/references/custom_model.md`

Deliberately unchanged: `.github/workflows/broken-link-checker.yml` and `.github/pull_request_template.md`, which target CI and contributors rather than search, and should keep tracking `latest`.

All 19 distinct rewritten URLs were checked and return 200 on stable, so nothing here points at a page that does not exist yet.

cc @juanitorduz @cluhmann

<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--3009.org.readthedocs.build/en/3009/

<!-- readthedocs-preview pymc-marketing end -->